### PR TITLE
Fix SNES option setting

### DIFF
--- a/python/firedrake/solving.py
+++ b/python/firedrake/solving.py
@@ -159,7 +159,13 @@ class NonlinearVariationalSolver(object):
         opts = PETSc.Options(opt_prefix)
         self.snes.setOptionsPrefix(opt_prefix)
         for k,v in self.parameters.iteritems():
-            opts[k] = v
+            if type(v) is bool:
+                if v:
+                    opts[k] = None
+                else:
+                    continue
+            else:
+                opts[k] = v
         self.snes.setFromOptions()
         for k in self.parameters.iterkeys():
             del opts[k]


### PR DESCRIPTION
We need to pass flag options with value None to petsc4py otherwise the
value is converted into a string and used as an output file name. So
convert options where the type of the value is boolean to None if True
and empty if False.
