### PR TITLE
Adapt uses of Dat.vec{_ro}: now returns a context manager

### DIFF
--- a/python/firedrake/vector.py
+++ b/python/firedrake/vector.py
@@ -68,9 +68,10 @@ class Vector(object):
             v = PETSc.Vec().createSeq(N, comm=PETSc.COMM_SELF)
             is_ = PETSc.IS().createGeneral(global_indices, comm=PETSc.COMM_SELF)
 
-        vscat = PETSc.Scatter().create(self.dat.vec, is_, v, None)
-        vscat.scatterBegin(self.dat.vec_ro, v, addv=PETSc.InsertMode.INSERT_VALUES)
-        vscat.scatterEnd(self.dat.vec_ro, v, addv=PETSc.InsertMode.INSERT_VALUES)
+        with self.dat.vec as vec:
+            vscat = PETSc.Scatter().create(vec, is_, v, None)
+            vscat.scatterBegin(vec, v, addv=PETSc.InsertMode.INSERT_VALUES)
+            vscat.scatterEnd(vec, v, addv=PETSc.InsertMode.INSERT_VALUES)
         return v.array
 
     def __setitem__(self, idx, value):


### PR DESCRIPTION
This is due to a change in the PyOP2 API to accommodate scattering
arrays on MixedDats into a contiguous vector.
