### PR TITLE
DirichletBC.homogenize() not implemented

### DIFF
--- a/python/firedrake/bcs.py
+++ b/python/firedrake/bcs.py
@@ -20,6 +20,7 @@ class DirichletBC(object):
 
         self._function_space = V
         self.function_arg = g
+        self._original_arg = g
         self.sub_domain = sub_domain
 
     def function_space(self):
@@ -35,6 +36,20 @@ class DirichletBC(object):
 
         '''
         self.function_arg = 0
+
+    def restore(self):
+        '''Restore the original value of this boundary condition.
+
+        This uses the value passed on instantiation of the object.'''
+        self.function_arg = self._original_arg
+
+    def set_value(self, val):
+        '''Set the value of this boundary condition.
+
+        :arg val: The boundary condition values.  See
+            :class:`DirichletBC` for valid values.
+        '''
+        self.function_arg = val
 
     @utils.cached_property
     def nodes(self):

--- a/tests/test_bcs.py
+++ b/tests/test_bcs.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from firedrake import *
 
 
@@ -41,6 +42,32 @@ def test_homogenize_doesnt_overwrite_function(a, u, V):
 
     solve(a == 0, u, bcs=[bc])
     assert max(abs(u.vector().array())) == 0.0
+
+
+def test_restore_bc_value(a, u, V):
+    f = Function(V)
+    f.assign(10)
+    bc = DirichletBC(V, f, 1)
+    bc.homogenize()
+
+    solve(a == 0, u, bcs=[bc])
+    assert max(abs(u.vector().array())) == 0.0
+
+    bc.restore()
+    solve(a == 0, u, bcs=[bc])
+    assert np.allclose(u.vector().array(), 10.0)
+
+
+def test_set_bc_value(a, u, V):
+    f = Function(V)
+    f.assign(10)
+    bc = DirichletBC(V, f, 1)
+
+    bc.set_value(7)
+
+    solve(a == 0, u, bcs=[bc])
+
+    assert np.allclose(u.vector().array(), 7.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Firedrake is currently lacking the functionality to generate homogeneous version of a Dirichlet boundary condition.

Dolfin implements that functionality in DirichletBC.homogenize(). Following piece of code demonstrates how a compatible implementation should work:

```
from firedrake import *

# Create mesh and define function space
mesh = UnitSquareMesh(10, 10)
V = FunctionSpace(mesh, "CG", 1)

# Define variational problem
u = Function(V)
v = TestFunction(V)
a = dot(grad(v), grad(u)) * dx

bcs = [DirichletBC(V, 32, 1)]

[bc.homogenize() for bc in bcs]
# Compute solution - this should have the solution u = 0
solve(a == 0, u, bcs=bcs)

assert max(abs(u.vector().array())) == 0.0
```

I need this since the adjoint boundary conditions of a Dirichlet bc is its homogeneous version (expect of the special case where the parameter of interest is the boundary value itself).
