### PR TITLE
restructured FunctionSpace __init__ logic

### DIFF
--- a/tests/test_extrusion_rhs.py
+++ b/tests/test_extrusion_rhs.py
@@ -16,8 +16,8 @@ def integrate_rhs(family, degree):
 
     mesh = firedrake.ExtrudedMesh(m, layers, layer_height=0.1)
 
-    horiz = ufl.FiniteElement(family, None, degree)
-    vert = ufl.FiniteElement(family, None, degree)
+    horiz = ufl.FiniteElement(family, "triangle", degree)
+    vert = ufl.FiniteElement(family, "interval", degree)
     prod = ufl.OuterProductElement(horiz, vert)
 
     fs = firedrake.FunctionSpace(mesh, prod, name="fs")


### PR DESCRIPTION
Little rearrangement.  Essentially, the main condition in the `__init__` is whether or not we're passing in a UFL element, or the family and degree as a string/int.  This commit rearranges the code accordingly.

In addition, in the UFL element case, we were previously pulling apart the element and replacing it using the mesh's detected cell type.  This gets even more painful once HDiv/HCurl and EnrichedElement are added.  I think we can trust that, if the user goes to the trouble of making their own UFL element, they know what cell they want.
