### PR TITLE
Add basic tests of mixed matrix assembly

### DIFF
--- a/tests/test_extrusion_mixed_mats.py
+++ b/tests/test_extrusion_mixed_mats.py
@@ -1,0 +1,125 @@
+import pytest
+
+from firedrake import *
+
+
+xfail = pytest.mark.xfail
+
+
+@pytest.fixture(scope='module')
+def m(request):
+    return ExtrudedMesh(UnitTriangleMesh(), layers=3, layer_height=0.5)
+
+
+@pytest.fixture(scope='module')
+def V(m):
+    return FunctionSpace(m, 'DG', 0)
+
+
+@pytest.fixture(scope='module')
+def Q(m):
+    return FunctionSpace(m, 'DG', 0)
+
+
+@pytest.fixture(scope='module')
+def W(V, Q):
+    return V*Q
+
+
+@xfail(reason='Not implemented correctly')
+def test_massVW0(V, W):
+    u = TrialFunction(V)
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 1)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block (0, since test function was restricted to DG block)
+    assert np.allclose(A.M[1, 0].values, 0.0)
+
+
+@xfail(reason='Not implemented correctly')
+def test_massVW1(V, W):
+    u = TrialFunction(V)
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 1)
+    # DGxDG block (0, since test function was restricted to DG block)
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert not np.allclose(A.M[1, 0].values, 0.0)
+
+
+def test_massW0W0(W):
+    u = TrialFunction(W)[0]
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW1W1(W):
+    u = TrialFunction(W)[1]
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert not np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW0W1(W):
+    u = TrialFunction(W)[0]
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert not np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW1W0(W):
+    u = TrialFunction(W)[1]
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert not np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massWW(W):
+    u = TrialFunction(W)
+    v = TestFunction(W)
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert not np.allclose(A.M[1, 1].values, 0.0)

--- a/tests/test_mixed_mats.py
+++ b/tests/test_mixed_mats.py
@@ -1,0 +1,120 @@
+import pytest
+
+from firedrake import *
+
+
+@pytest.fixture(scope='module')
+def m(request):
+    return UnitTriangleMesh()
+
+
+@pytest.fixture(scope='module')
+def V(m):
+    return FunctionSpace(m, 'DG', 0)
+
+
+@pytest.fixture(scope='module')
+def Q(m):
+    return FunctionSpace(m, 'RT', 1)
+
+
+@pytest.fixture(scope='module')
+def W(V, Q):
+    return V*Q
+
+
+def test_massVW0(V, W):
+    u = TrialFunction(V)
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 1)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block (0, since test function was restricted to DG block)
+    assert np.allclose(A.M[1, 0].values, 0.0)
+
+
+def test_massVW1(V, W):
+    u = TrialFunction(V)
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 1)
+    # DGxDG block (0, since test function was restricted to DG block)
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert not np.allclose(A.M[1, 0].values, 0.0)
+
+
+def test_massW0W0(W):
+    u = TrialFunction(W)[0]
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW1W1(W):
+    u = TrialFunction(W)[1]
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert not np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW0W1(W):
+    u = TrialFunction(W)[0]
+    v = TestFunction(W)[1]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert not np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massW1W0(W):
+    u = TrialFunction(W)[1]
+    v = TestFunction(W)[0]
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert not np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert np.allclose(A.M[1, 1].values, 0.0)
+
+
+def test_massWW(W):
+    u = TrialFunction(W)
+    v = TestFunction(W)
+    A = assemble(inner(u, v)*dx)
+    assert A.M.sparsity.shape == (2, 2)
+    # DGxDG block
+    assert not np.allclose(A.M[0, 0].values, 0.0)
+    # DGxRT block
+    assert np.allclose(A.M[1, 0].values, 0.0)
+    # RTxDG block
+    assert np.allclose(A.M[0, 1].values, 0.0)
+    # RTxRT block
+    assert not np.allclose(A.M[1, 1].values, 0.0)


### PR DESCRIPTION
These don't check values, just for zero or non-zero as appropriate to
the coupling of the problem.  These are mainly to iron out issues in the
code generation in PyOP2 land.
