### PR TITLE
Shorten MMS convergence tests

### DIFF
--- a/tests/test_helmholtz.py
+++ b/tests/test_helmholtz.py
@@ -43,7 +43,7 @@ def helmholtz(x, degree=2):
 
 def test_firedrake_helmholtz():
     import numpy as np
-    diff = np.array([helmholtz(i)[0] for i in range(3, 7)])
+    diff = np.array([helmholtz(i)[0] for i in range(3, 6)])
     print "l2 error norms:", diff
     conv = np.log2(diff[:-1] / diff[1:])
     print "convergence order:", conv

--- a/tests/test_helmholtz_mixed.py
+++ b/tests/test_helmholtz_mixed.py
@@ -44,7 +44,7 @@ def helmholtz_mixed(x, V1, V2):
                           (('BDFM', 2), ('DG', 1), 1.9)])
 def test_firedrake_helmholtz(V1, V2, threshold):
     import numpy as np
-    diff = np.array([helmholtz_mixed(i, V1, V2) for i in range(3, 7)])
+    diff = np.array([helmholtz_mixed(i, V1, V2) for i in range(3, 6)])
     print "l2 error norms:", diff
     conv = np.log2(diff[:-1] / diff[1:])
     print "convergence order:", conv

--- a/tests/test_helmholtz_nonlinear_diffusion.py
+++ b/tests/test_helmholtz_nonlinear_diffusion.py
@@ -60,7 +60,7 @@ def helmholtz(x, parameters={}):
 
 def run_convergence_test(parameters={}):
     import numpy as np
-    l2_diff = np.array([helmholtz(i, parameters) for i in range(3, 8)])
+    l2_diff = np.array([helmholtz(i, parameters) for i in range(3, 6)])
     return np.log2(l2_diff[:-1] / l2_diff[1:])
 
 

--- a/tests/test_nonlinear_helmholtz.py
+++ b/tests/test_nonlinear_helmholtz.py
@@ -40,7 +40,7 @@ def run_test(x, parameters={}):
 
 def run_convergence_test(parameters={}):
     import numpy as np
-    diff = np.array([run_test(i, parameters) for i in range(3, 7)])
+    diff = np.array([run_test(i, parameters) for i in range(3, 6)])
     return np.log2(diff[:-1] / diff[1:])
 
 

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -52,7 +52,7 @@ def run_test(x, degree=1, family='CG'):
     (1, 'DG', 1.8),
     (2, 'DG', 2.8)])
 def test_convergence(degree, family, expected_convergence):
-    l2_diff = np.array([run_test(x, degree, family) for x in range(2, 7)])
+    l2_diff = np.array([run_test(x, degree, family) for x in range(2, 5)])
     conv = np.log2(l2_diff[:-1] / l2_diff[1:])
     assert (conv > expected_convergence).all()
 
@@ -65,7 +65,7 @@ def test_convergence(degree, family, expected_convergence):
     (1, 'DG', 1.8),
     (2, 'DG', 2.8)])
 def test_vector_convergence(degree, family, expected_convergence):
-    l2_diff = np.array([run_vector_test(x, degree, family) for x in range(2, 7)])
+    l2_diff = np.array([run_vector_test(x, degree, family) for x in range(2, 5)])
     conv = np.log2(l2_diff[:-1] / l2_diff[1:])
     assert (conv > expected_convergence).all()
 
@@ -79,7 +79,7 @@ def test_vector_convergence(degree, family, expected_convergence):
     (3, 'BDM', 3.8)])
 def test_vector_valued_convergence(degree, family, expected_convergence):
     l2_diff = np.array([run_vector_valued_test(x, degree, family)
-                        for x in range(2, 7)])
+                        for x in range(2, 6)])
     conv = np.log2(l2_diff[:-1] / l2_diff[1:])
     assert (conv > expected_convergence).all()
 


### PR DESCRIPTION
Some of the convergence tests were taking a "long" time.  Shorten them (no slackening of tolerances required).
