### PR TITLE
Non linear solver builds incorrect Mat sparsity if form contains facet integrals

### DIFF
--- a/tests/test_poisson_strong_bcs_nitsche.py
+++ b/tests/test_poisson_strong_bcs_nitsche.py
@@ -78,7 +78,6 @@ def run_test(x, degree):
     return sqrt(assemble(dot(u - f, u - f)*dx))
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('degree', (1, 2))
 def test_poisson_nitsche(degree):
     assert run_test(2, degree) < 1e-3


### PR DESCRIPTION
In a similar vein to #69, the matrix built to hold the jacobian in the NLVS only thinks we'll ever do cell integrals.  We should fix this to do the same thing as assemble now does.
