### PR TITLE
Compilation failures for some compound forms

### DIFF
--- a/python/firedrake/core_types.pyx
+++ b/python/firedrake/core_types.pyx
@@ -329,10 +329,11 @@ class _Facets(object):
         either be for all the interior or exterior (as appropriate)
         facets, or for a particular numbered subdomain.'''
 
-        if measure.domain_id() == measure.DOMAIN_ID_EVERYWHERE:
+        if measure.domain_id() in [measure.DOMAIN_ID_EVERYWHERE,
+                                   measure.DOMAIN_ID_OTHERWISE]:
             return self.set
         else:
-            return self.subset(measure.domain_id().subdomain_ids()[0])
+            return self.subset(measure.domain_id())
 
     def subset(self, i):
         """Return the subset corresponding to a marker value of i."""

--- a/python/firedrake/solving.py
+++ b/python/firedrake/solving.py
@@ -328,8 +328,9 @@ def _assemble(f, tensor=None, bcs=None):
     is_mat = fd.rank == 2
     is_vec = fd.rank == 1
 
+    integrals = fd.preprocessed_form.integrals()
     # Extract coordinate field
-    coords = f.integrals()[0].measure().domain_data()
+    coords = integrals[0].measure().domain_data()
 
     def get_rank(arg):
         return arg.function_space().rank
@@ -340,7 +341,7 @@ def _assemble(f, tensor=None, bcs=None):
 
         m = test.function_space().mesh()
         map_pairs = []
-        for integral in f.integrals():
+        for integral in integrals:
             domain_type = integral.measure().domain_type()
             if domain_type == "cell":
                 map_pairs.append((test.cell_node_map(), trial.cell_node_map()))
@@ -412,7 +413,7 @@ def _assemble(f, tensor=None, bcs=None):
     # solve, we funcall the closure with any bcs the Matrix now has to
     # assemble it.
     def thunk(bcs):
-        for kernel, integral in zip(kernels, f.integrals()):
+        for kernel, integral in zip(kernels, integrals):
             domain_type = integral.measure().domain_type()
             if domain_type == 'cell':
                 if is_mat:


### PR DESCRIPTION
The following errors in compilation.

``` python
from firedrake import *
m = UnitSquareMesh(1, 1)

V = FunctionSpace(m, 'CG', 1)

u = TrialFunction(V)
v = TestFunction(V)

u_0 = Function(V)
u_1 = Function(V)
out = Function(V)

a = u*v*dx

form = ufl.action(a, out) + u_0*v*ds + u_1*v*dx

assemble(form).dat.data

=> RuntimeError: In instant.recompile: The module did not compile with command


```

The problem is that when pulling the integrals out of a multi-component form, we do so on the unpreprocessed form.  Thus, our integrals do not match the kernels that ffc throws back:

``` python

len(form.integrals()) => 3
from pyop2.ffc_interface import compile_form
len(compile_form(form, 'a')) => 2
# oops
```

Using the preprocessed form, the measure's domain ids change (from dxeverywhere and so forth to dxotherwise), so I think this needs changes for facet handling.
