### PR TITLE
shorten extruded convergence tests to halve total test runtime

### DIFF
--- a/tests/test_extrusion_3_galerkinproj.py
+++ b/tests/test_extrusion_3_galerkinproj.py
@@ -11,7 +11,7 @@ from common import *
                           (("DG", 0), 0.9), (("DG", 1), 1.98)])
 def test_scalar_convergence(testcase, convrate):
     family, degree = testcase
-    l2err = np.zeros(3)
+    l2err = np.zeros(2)
     for ii in range(len(l2err)):
         mesh = extmesh(2**(ii+1), 2**(ii+1), 2**ii)
 
@@ -39,7 +39,7 @@ def test_scalar_convergence(testcase, convrate):
                           (("DG", 2, "CG", 2, "v"), 2.98)])
 def test_hdiv_convergence(testcase, convrate):
     hfamily, hdegree, vfamily, vdegree, orientation = testcase
-    l2err = np.zeros(3)
+    l2err = np.zeros(2)
     for ii in range(len(l2err)):
         mesh = extmesh(2**(ii+1), 2**(ii+1), 2**(ii+1))
 
@@ -74,7 +74,7 @@ def test_hdiv_convergence(testcase, convrate):
                           (("CG", 2, "DG", 2, "v"), 2.7)])
 def test_hcurl_convergence(testcase, convrate):
     hfamily, hdegree, vfamily, vdegree, orientation = testcase
-    l2err = np.zeros(3)
+    l2err = np.zeros(2)
     for ii in range(len(l2err)):
         mesh = extmesh(2**(ii+1), 2**(ii+1), 2**(ii+1))
 

--- a/tests/test_extrusion_4_helmholtz_scalar.py
+++ b/tests/test_extrusion_4_helmholtz_scalar.py
@@ -7,14 +7,14 @@ from common import *
 
 
 @pytest.mark.parametrize(('testcase', 'convrate'),
-                         [(("CG", 1, (3, 6)), 1.7),
-                          (("CG", 2, (2, 5)), 2.9),
-                          (("CG", 3, (0, 3)), 3.9)])
+                         [(("CG", 1, (4, 6)), 1.9),
+                          (("CG", 2, (3, 5)), 2.9),
+                          (("CG", 3, (1, 3)), 3.9)])
 def test_scalar_convergence(testcase, convrate):
     family, degree, (start, end) = testcase
     l2err = np.zeros(end - start)
     for ii in [i + start for i in range(len(l2err))]:
-        mesh = extmesh(2**(ii+1), 2**(ii+1), 2**(ii+1))
+        mesh = extmesh(2**ii, 2**ii, 2**ii)
 
         fspace = FunctionSpace(mesh, family, degree, vfamily=family, vdegree=degree)
 

--- a/tests/test_extrusion_5_helmholtz_vector.py
+++ b/tests/test_extrusion_5_helmholtz_vector.py
@@ -8,7 +8,7 @@ from common import *
 
 @pytest.mark.parametrize(('testcase', 'convrate'),
                          [(("RT", 1, "DG", 0, "h", "DG", 0, (2, 5)), 0.9),
-                          (("RT", 2, "DG", 0, "h", "DG", 1, (2, 5)), 1.65),
+                          (("RT", 2, "DG", 0, "h", "DG", 1, (2, 4)), 1.65),
                           (("RT", 3, "DG", 0, "h", "DG", 2, (2, 4)), 2.6),
                           (("BDM", 1, "DG", 0, "h", "DG", 0, (2, 5)), 0.9),
                           (("DG", 0, "CG", 1, "v", "DG", 0, (2, 5)), 0.9),


### PR DESCRIPTION
dofcount increases pretty quickly in 3 dimensions...
