### PR TITLE
Fix/mfs bcs

### DIFF
--- a/python/firedrake/solving.py
+++ b/python/firedrake/solving.py
@@ -489,9 +489,15 @@ def _assemble(f, tensor=None, bcs=None):
 
         if bcs is not None and is_mat:
             for bc in bcs:
-                for i, fs in enumerate(bc.function_space()):
-                    if fs.index is None or fs.index == i:
-                        tensor[i, i].zero_rows(bc.nodes)
+                fs = bc.function_space()
+                if isinstance(fs, core_types.MixedFunctionSpace):
+                    raise RuntimeError("""Cannot apply boundary conditions to full mixed space. Did you forget to index it?""")
+                if fs.index is None:
+                    # Non-mixed case
+                    tensor.zero_rows(bc.nodes)
+                else:
+                    # Mixed case with indexed FS, zero appropriate block
+                    tensor[fs.index, fs.index].zero_rows(bc.nodes)
 
         return result()
 

--- a/tests/test_mixed_mats.py
+++ b/tests/test_mixed_mats.py
@@ -122,7 +122,6 @@ def test_massWW(W):
     assert not np.allclose(A.M[1, 1].values, 0.0)
 
 
-@pytest.mark.xfail
 def test_bcs_ordering():
     """Check that application of boundary conditions zeros the correct
     rows and columns of a mixed matrix.


### PR DESCRIPTION
boundary condition application on mixed spaces was doing the wrong thing if we weren't applying to the first space.

Add a noddy test.  Swapping over the mixed poisson/helmholtz examples doesn't seem to cause failure (huh?), don't understand why.
