### PR TITLE
Dolfin compatibility for FacetNormal

### DIFF
--- a/python/firedrake/ufl_expr.py
+++ b/python/firedrake/ufl_expr.py
@@ -158,3 +158,6 @@ def CellSize(mesh):
     """
     cell = mesh.ufl_cell()
     return 2.0 * cell.circumradius
+
+def FacetNormal(mesh):
+    return ufl.FacetNormal(mesh.ufl_cell())

--- a/tests/test_facet_normal.py
+++ b/tests/test_facet_normal.py
@@ -9,7 +9,7 @@ def test_facet_normal_unit_interval():
     m = UnitIntervalMesh(2)
     V = VectorFunctionSpace(m, 'CG', 1)
     x_hat = Function(V).interpolate(Expression(('1.0',)))
-    n = FacetNormal(m.ufl_cell())
+    n = FacetNormal(m)
 
     assert assemble(dot(x_hat, n)*ds(1)) == -1.0   # x = 0
     assert assemble(dot(x_hat, n)*ds(2)) == 1.0  # x = 1
@@ -22,7 +22,7 @@ def test_facet_normal_unit_square():
     V = VectorFunctionSpace(m, 'CG', 1)
     x_hat = Function(V).interpolate(Expression(('1', '0')))
     y_hat = Function(V).interpolate(Expression(('0', '1')))
-    n = FacetNormal(m.ufl_cell())
+    n = FacetNormal(m)
 
     assert assemble(dot(x_hat, n)*ds(1)) == -1.0  # x = 0
     assert assemble(dot(x_hat, n)*ds(2)) == 1.0   # x = 1
@@ -43,7 +43,7 @@ def test_facet_normal_unit_cube():
     x_hat = Function(V).interpolate(Expression(('1', '0', '0')))
     y_hat = Function(V).interpolate(Expression(('0', '1', '0')))
     z_hat = Function(V).interpolate(Expression(('0', '0', '1')))
-    n = FacetNormal(m.ufl_cell())
+    n = FacetNormal(m)
 
     assert abs(assemble(dot(x_hat, n)*ds(1)) + 1.0) < 1e-14  # x = 0
     assert abs(assemble(dot(x_hat, n)*ds(2)) - 1.0) < 1e-14  # x = 1

--- a/tests/test_poisson_mixed_strong_bcs.py
+++ b/tests/test_poisson_mixed_strong_bcs.py
@@ -45,7 +45,7 @@ def poisson_mixed(size):
 
     # Define variational form
     a = (dot(sigma, tau) + div(tau)*u + div(sigma)*v)*dx
-    n = FacetNormal(mesh.ufl_cell())
+    n = FacetNormal(mesh)
     L = -f*v*dx + 42*dot(tau, n)*ds(4)
 
     # Apply dot(sigma, n) == 0 on left and right boundaries strongly

--- a/tests/test_poisson_strong_bcs_nitsche.py
+++ b/tests/test_poisson_strong_bcs_nitsche.py
@@ -53,7 +53,7 @@ def run_test(x, degree):
     h = 0.25
     gamma = 0.00001
 
-    n = FacetNormal(mesh.ufl_cell())
+    n = FacetNormal(mesh)
 
     B = a - \
         inner(dot(grad(u), n), v)*(ds(3) + ds(4)) - \


### PR DESCRIPTION
We now call FacetNormal directly on the mesh, rather than the mesh's
ufl_cell.
