### PR TITLE
Boundary condition zero

### DIFF
--- a/python/firedrake/bcs.py
+++ b/python/firedrake/bcs.py
@@ -102,7 +102,7 @@ class DirichletBC(object):
         """Apply this boundary condition to ``r``.
 
         :arg r: a :class:`.Function` or :class:`.Matrix` to which the
-            boundary condition should be applied
+            boundary condition should be applied.
 
         :arg u: an optional current state.  If ``u`` is supplied then
             ``r`` is taken to be a residual and the boundary condition
@@ -133,3 +133,17 @@ class DirichletBC(object):
             r.assign(u - self.function_arg, subset=self.node_set)
         else:
             r.assign(self.function_arg, subset=self.node_set)
+
+    def zero(self, r):
+        """Zero the boundary condition nodes on ``r``.
+
+        :arg r: a :class:`.Function` to which the
+            boundary condition should be applied.
+
+        """
+        if isinstance(r, types.Matrix):
+            raise NotImplementedError("Zeroing bcs on a Matrix is not supported")
+
+        self.homogenize()
+        self.apply(r)
+        self.restore()

--- a/python/firedrake/solving.py
+++ b/python/firedrake/solving.py
@@ -161,7 +161,7 @@ class NonlinearVariationalSolver(object):
         self._x.dat.needs_halo_update = True
         assemble(self._problem.F_ufl, tensor=self._F_tensor)
         for bc in self._problem.bcs:
-            bc.apply(self._F_tensor, self._problem.u_ufl)
+            bc.zero(self._F_tensor)
 
         # F_ may not be the same vector as self._F_tensor, so copy
         # residual out to F_.


### PR DESCRIPTION
This branch changes the behaviour of the nonlinear solver when applying boundary conditions to the RHS. Instead of setting the boundary condition nodes to bc-value, they are set to zero. This is consistent with the way we treat the LHS and with the documentation of boundary conditions.
