### PR TITLE
Use new inc_local_diagonal_entries to set bc nodes in Matrix

### DIFF
--- a/python/firedrake/solving.py
+++ b/python/firedrake/solving.py
@@ -527,12 +527,13 @@ def _assemble(f, tensor=None, bcs=None):
                 fs = bc.function_space()
                 if isinstance(fs, core_types.MixedFunctionSpace):
                     raise RuntimeError("""Cannot apply boundary conditions to full mixed space. Did you forget to index it?""")
+                # Set diagonal entries on bc nodes to 1.
                 if fs.index is None:
                     # Non-mixed case
-                    tensor.zero_rows(bc.nodes)
+                    tensor.inc_local_diagonal_entries(bc.nodes)
                 else:
                     # Mixed case with indexed FS, zero appropriate block
-                    tensor[fs.index, fs.index].zero_rows(bc.nodes)
+                    tensor[fs.index, fs.index].inc_local_diagonal_entries(bc.nodes)
 
         return result()
 

--- a/tests/test_poisson_strong_bcs.py
+++ b/tests/test_poisson_strong_bcs.py
@@ -153,7 +153,6 @@ def test_poisson_analytic_preassembled(params, degree):
     assert (run_test_preassembled(2, degree, parameters=params) < 5.e-6).all()
 
 
-@pytest.mark.xfail
 @pytest.mark.parallel(nprocs=2)
 def test_poisson_analytic_linear_parallel():
     from mpi4py import MPI


### PR DESCRIPTION
In parallel, we can't use zero_rows since the row indices are sent
through a map.  Instead, given that we only actually need to set a value
on the diagonal, use new PyOP2 functionality to do that.
