### PR TITLE
Memory leak when creating a FunctionSpace

### DIFF
--- a/femtools/Fields_Allocates.F90
+++ b/femtools/Fields_Allocates.F90
@@ -511,16 +511,16 @@ contains
     call free(mesh%faces%boundary_ids_c)
     mesh%faces%boundary_ids => null()
 
-    if (.not.c_associated(mesh%faces%interior_local_facet_number)) then
+    if (c_associated(mesh%faces%interior_local_facet_number)) then
        call free(mesh%faces%interior_local_facet_number)
     end if
-    if (.not.c_associated(mesh%faces%exterior_local_facet_number)) then
+    if (c_associated(mesh%faces%exterior_local_facet_number)) then
        call free(mesh%faces%exterior_local_facet_number)
     end if
-    if (.not.c_associated(mesh%faces%exterior_facet_cell)) then
+    if (c_associated(mesh%faces%exterior_facet_cell)) then
        call free(mesh%faces%exterior_facet_cell)
     end if
-    if (.not.c_associated(mesh%faces%interior_facet_cell)) then
+    if (c_associated(mesh%faces%interior_facet_cell)) then
        call free(mesh%faces%interior_facet_cell)
     end if
 
@@ -614,10 +614,10 @@ contains
        deallocate(mesh%colourings)
     end if
 
-    if (.not.c_associated(mesh%interior_facet_dof_list)) then
+    if (c_associated(mesh%interior_facet_dof_list)) then
        call free(mesh%interior_facet_dof_list)
     end if
-    if (.not.c_associated(mesh%exterior_facet_dof_list)) then
+    if (c_associated(mesh%exterior_facet_dof_list)) then
        call free(mesh%exterior_facet_dof_list)
     end if
 


### PR DESCRIPTION
It seems that each time a new `FunctionSpace` is created, some memory is leaked. I've left a simple test program and the output from `valgrind` in `/scratch/ctj10/firedrake_valgrind`.

I decided to look into this after running a simulation with a relatively fine mesh and encountering the following error after a few hundred time-steps:

```
t = 119400
Adding bottom drag...
Adding momentum SU stabilisation...
Applying FreeSurfacePerturbation BC #0
Traceback (most recent call last):
  File "/data/ctj10/firedrake-fluids/models/shallow_water.py", line 444, in <module>
    sw.run()
  File "/data/ctj10/firedrake-fluids/models/shallow_water.py", line 384, in run
    bc = DirichletBC(self.W.sub(dimension), Expression(expr.code[0]), surface_ids)
  File "/data/ctj10/firedrake/python/firedrake/bcs.py", line 30, in __init__
    g = Function(V).interpolate(g)
  File "core_types.pyx", line 1755, in firedrake.core_types.Function.interpolate (firedrake/core_types.c:32295)
  File "core_types.pyx", line 1822, in firedrake.core_types.Function._interpolate (firedrake/core_types.c:33527)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.9.0-py2.7-linux-x86_64.egg/pyop2/backends.py", line 118, in __call__
    return t(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.9.0-py2.7-linux-x86_64.egg/pyop2/caching.py", line 117, in __new__
    obj = super(KernelCached, cls).__new__(cls, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.9.0-py2.7-linux-x86_64.egg/pyop2/caching.py", line 71, in __new__
    obj.__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.9.0-py2.7-linux-x86_64.egg/pyop2/base.py", line 2898, in __init__
    self._code = preprocess(code)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.9.0-py2.7-linux-x86_64.egg/pyop2/utils.py", line 276, in preprocess
    stdout=PIPE, universal_newlines=True)
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1143, in _execute_child
    self.pid = os.fork()
OSError: [Errno 12] Cannot allocate memory
```

I think this was the result of a Python function which computed a diagnostic field. The function was called once per time-step and a new `FunctionSpace` object was created each time.
