### PR TITLE
vtk output fails for P0 functions

### DIFF
--- a/firedrake/io.py
+++ b/firedrake/io.py
@@ -102,7 +102,10 @@ class _VTUFile(object):
     def __init__(self, filename, warnings=None):
         #_filename : full path to the file without extension.
         self._filename = filename
-        self._warnings = warnings
+        if warnings:
+            self._warnings = warnings
+        else:
+            self._warnings = [None, None]
         if MPI.parallel:
             self._time_step = -1
             # If _generate_time, _time_step would be incremented by


### PR DESCRIPTION
vtk output fails if function space of plotted function does not match coordinate function space.

Example code:

``` python
from firedrake import *
m = UnitSquareMesh(2, 2)
output = File('volume.vtu')
output << project(m._coordinate_field, VectorFunctionSpace(m, 'DG', 1))
```

output:

```
eikemueller@dyn898-216 $ python AreaOfTriangle.py 
[ 0.98117818]
Traceback (most recent call last):
  File "AreaOfTriangle.py", line 55, in <module>
    output << cell_volume
  File "/Users/eikemueller/PostDocBath/EllipticSolvers/firedrake/python/firedrake/io.py", line 95, in __lshift__
    self._file << data
  File "/Users/eikemueller/PostDocBath/EllipticSolvers/firedrake/python/firedrake/io.py", line 192, in __lshift__
    if not self._warnings[0]:
TypeError: 'NoneType' object has no attribute '__getitem__'
```
