### PR TITLE
Cache fiat element on ufl element.

### DIFF
--- a/firedrake/core_types.pyx
+++ b/firedrake/core_types.pyx
@@ -20,6 +20,7 @@ import utils
 import dmplex
 from dmplex import _from_cell_list
 from collections import defaultdict
+from weakref import WeakKeyDictionary
 
 np.import_array()
 
@@ -61,10 +62,13 @@ def _init():
     global types
     import types
 
+_fiat_element_cache = WeakKeyDictionary()
+
+
 def fiat_from_ufl_element(ufl_element):
     try:
-        return ufl_element._fiat_element
-    except AttributeError:
+        return _fiat_element_cache[ufl_element]
+    except KeyError:
         if isinstance(ufl_element, ufl.EnrichedElement):
             fiat_element = FIAT.EnrichedElement(fiat_from_ufl_element(ufl_element._elements[0]), fiat_from_ufl_element(ufl_element._elements[1]))
         elif isinstance(ufl_element, ufl.HDiv):
@@ -76,8 +80,10 @@ def fiat_from_ufl_element(ufl_element):
         else:
             fiat_element = FIAT.supported_elements[ufl_element.family()]\
                 (_FIAT_cells[ufl_element.cell().cellname()](), ufl_element.degree())
-    ufl_element._fiat_element = fiat_element
-    return fiat_element
+
+        _fiat_element_cache[ufl_element] = fiat_element
+        return fiat_element
+
 
 # Functions related to the extruded case
 def extract_offset(offset, facet_map, base_map):


### PR DESCRIPTION
This trivial change causes fiat_from_ufl_element to drop from 5s to
nothing on the wave demo.
