### PR TITLE
Interior facet mfs/vfs test

### DIFF
--- a/tests/regression/test_mixed_interior_facets.py
+++ b/tests/regression/test_mixed_interior_facets.py
@@ -1,0 +1,49 @@
+import pytest
+from firedrake import *
+
+
+@pytest.fixture(scope='module')
+def mesh2D():
+    # .---.
+    # |\  |
+    # | \ |
+    # |  \|
+    # '---'
+    return UnitSquareMesh(1, 1)
+
+
+@pytest.mark.parametrize('degree', [1, 2, 3])
+def test_vfs(mesh2D, degree):
+    V = VectorFunctionSpace(mesh2D, 'CG', degree)
+    u = Function(V)
+    u.interpolate(Expression(('1.0', '1.0')))
+    n = FacetNormal(mesh2D)
+
+    # Unit '+' normal is (1, 1)/sqrt2, and diagonal has length sqrt2.
+    assert abs(assemble(dot(u('-'), n('-'))*dS) + 2.0) < 1e-10
+    assert abs(assemble(dot(u('+'), n('-'))*dS) + 2.0) < 1e-10
+    assert abs(assemble(dot(u('+'), n('+'))*dS) - 2.0) < 1e-10
+
+    u.interpolate(Expression(('1.0', '-1.0')))
+    assert abs(assemble(dot(u('+'), n('+'))*dS)) < 1e-10
+
+
+def test_mfs(mesh2D):
+    V1 = FunctionSpace(mesh2D, 'BDM', 1)
+    V2 = FunctionSpace(mesh2D, 'CG', 2)
+    V3 = FunctionSpace(mesh2D, 'CG', 3)
+    W = V3 * V1 * V2
+    u = project(Expression(('1.0', '-1.0', '-1.0', '1.0')), W)
+    n = FacetNormal(mesh2D)
+
+    # Unit '+' normal is (1, 1)/sqrt2, and diagonal has length sqrt2.
+    # This is (dot((1, 1), n+) + 10*dot((-1, -1), n-)) * dS = 2 + 20 = 22
+    a = (u[0]('+')*n[0]('+') + u[3]('-')*n[1]('+')
+         + 10*u[1]('+')*n[0]('-') + 10*u[2]('-')*n[1]('-'))*dS
+
+    assert abs(assemble(a) - 22.0) < 1e-9
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Waiting on
https://bitbucket.org/mapdes/ffc/pull-request/24/fix-zero-form-integrals-with-vector-mixed/diff

An exposition of the fix is in this link.
This is a partial fix for https://github.com/firedrakeproject/firedrake/issues/165 -- the other part needed is fixing the assembly of linear/bilinear forms for VectorFunctionSpaces given in https://bitbucket.org/mapdes/ffc/pull-request/26/fix-assembly-of-linear-bilinear-forms-with/diff (MixedFunctionSpaces happen to be intercepted by the form splitter)
