### PR TITLE
Cannot create a VectorFunctionSpace with the 'Mini' element

### DIFF
--- a/firedrake/types.py
+++ b/firedrake/types.py
@@ -228,7 +228,8 @@ class VectorFunctionSpace(FunctionSpaceBase):
     :arg degree: degree of the function space (ignored in the case an
         element is passed for ``family``)
     :arg dim: function space dimension (optional, defaults to the
-        geometric dimension of the mesh)
+        geometric dimension of the mesh, ignored in the case an element
+        is passed for ``family``)
     :arg name: name of the function space (optional)
     :arg vfamily: family of function space in vertical dimension
         (:class:`.ExtrudedMesh`\es only)
@@ -258,6 +259,8 @@ class VectorFunctionSpace(FunctionSpaceBase):
         #       OuterProductElement and so on
         if isinstance(family, ufl.FiniteElementBase):
             element = family
+            # Ignore given dim argument and extract it from the UFL element
+            dim = element.cell().geometric_dimension()
         # 2) pass in mesh, family, degree to generate a simple function space
         elif isinstance(mesh, ExtrudedMesh):
             if isinstance(family, ufl.OuterProductElement):

--- a/firedrake/types.py
+++ b/firedrake/types.py
@@ -145,9 +145,10 @@ class FunctionSpace(FunctionSpaceBase):
 
     :arg mesh: :class:`.Mesh` to build the function space on
     :arg family: string describing function space family, or a
-        :class:`ufl.OuterProductElement`
-    :arg degree: degree of the function space
-    :arg name: (optional) name of the function space
+        :class:`ufl.FiniteElement` or :class:`ufl.OuterProductElement`
+    :arg degree: degree of the function space (optional in the case an
+        element is passed for ``family``)
+    :arg name: name of the function space (optional)
     :arg vfamily: family of function space in vertical dimension
         (:class:`.ExtrudedMesh`\es only)
     :arg vdegree: degree of function space in vertical dimension
@@ -161,10 +162,8 @@ class FunctionSpace(FunctionSpaceBase):
     the `vfamily` and `vdegree` are not provided, the vertical element
     will be the same as the provided (`family`, `degree`) pair.
 
-    If the mesh is not an :class:`.ExtrudedMesh`, the `family` must be
-    a string describing the finite element family to use, and the
-    `degree` must be provided, `vfamily` and `vdegree` are ignored in
-    this case.
+    If the mesh is not an :class:`.ExtrudedMesh`, `vfamily` and
+    `vdegree` are ignored.
     """
 
     def __init__(self, mesh, family, degree=None, name=None, vfamily=None, vdegree=None):
@@ -221,7 +220,32 @@ class FunctionSpace(FunctionSpaceBase):
 
 
 class VectorFunctionSpace(FunctionSpaceBase):
-    """A vector finite element :class:`FunctionSpace`."""
+    """A vector finite element :class:`FunctionSpace`.
+
+    :arg mesh: :class:`.Mesh` to build the function space on
+    :arg family: string describing function space family, or a
+        :class:`ufl.VectorElement` or :class:`ufl.OuterProductElement`
+    :arg degree: degree of the function space (ignored in the case an
+        element is passed for ``family``)
+    :arg dim: function space dimension (optional, defaults to the
+        geometric dimension of the mesh)
+    :arg name: name of the function space (optional)
+    :arg vfamily: family of function space in vertical dimension
+        (:class:`.ExtrudedMesh`\es only)
+    :arg vdegree: degree of function space in vertical dimension
+        (:class:`.ExtrudedMesh`\es only)
+
+    If the mesh is an :class:`.ExtrudedMesh`, and the `family` argument
+    is a :class:`ufl.OuterProductElement`, `degree`, `vfamily` and
+    `vdegree` are ignored, since the `family` provides all necessary
+    information. Otherwise a :class:`ufl.OuterProductElement` is built
+    from the (`family`, `degree`) and (`vfamily`, `vdegree`) pair.  If
+    the `vfamily` and `vdegree` are not provided, the vertical element
+    will be the same as the provided (`family`, `degree`) pair.
+
+    If the mesh is not an :class:`.ExtrudedMesh`, `vfamily` and
+    `vdegree` are ignored.
+    """
 
     def __init__(self, mesh, family, degree=None, dim=None, name=None, vfamily=None, vdegree=None):
         if self._initialized:

--- a/firedrake/types.py
+++ b/firedrake/types.py
@@ -223,13 +223,19 @@ class FunctionSpace(FunctionSpaceBase):
 class VectorFunctionSpace(FunctionSpaceBase):
     """A vector finite element :class:`FunctionSpace`."""
 
-    def __init__(self, mesh, family, degree, dim=None, name=None, vfamily=None, vdegree=None):
+    def __init__(self, mesh, family, degree=None, dim=None, name=None, vfamily=None, vdegree=None):
         if self._initialized:
             return
         # VectorFunctionSpace dimension defaults to the geometric dimension of the mesh.
         dim = dim or mesh.ufl_cell().geometric_dimension()
 
-        if isinstance(mesh, ExtrudedMesh):
+        # Two choices:
+        # 1) set up the function space using VectorElement, EnrichedElement,
+        #       OuterProductElement and so on
+        if isinstance(family, ufl.FiniteElementBase):
+            element = family
+        # 2) pass in mesh, family, degree to generate a simple function space
+        elif isinstance(mesh, ExtrudedMesh):
             if isinstance(family, ufl.OuterProductElement):
                 raise NotImplementedError("Not yet implemented")
             la = ufl.FiniteElement(family,

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -16,6 +16,20 @@ def fs(request, cg1cg1, cg1vcg1, cg1dg0, cg2dg1):
             'cg2dg1': cg2dg1}[request.param]
 
 
+def test_function_space_from_element(mesh):
+    "FunctionSpaces can be initialsed from an existing element."
+    e = FiniteElement("CG", mesh.ufl_cell(), 1)
+    assert FunctionSpace(mesh, "CG", 1).ufl_element() == e
+    assert FunctionSpace(mesh, e).ufl_element() == e
+
+
+def test_vector_function_space_from_element(mesh):
+    "VectorFunctionSpaces can be initialsed from an existing element."
+    e = VectorElement("CG", mesh.ufl_cell(), 1)
+    assert VectorFunctionSpace(mesh, "CG", 1).ufl_element() == e
+    assert VectorFunctionSpace(mesh, e).ufl_element() == e
+
+
 def test_function_space_cached(mesh):
     "FunctionSpaces defined on the same mesh and element are cached."
     assert FunctionSpace(mesh, "CG", 1) is FunctionSpace(mesh, "CG", 1)


### PR DESCRIPTION
I would like to use the 'Mini' element (a P1 function space + a Bubble function space) for some of my simulations. For a `FunctionSpace` in DOLFIN I can do

```
mesh = UnitSquareMesh(10, 10)
fs = FunctionSpace(mesh, "CG", 1) + FunctionSpace(mesh, "Bubble", 3)
```

Trying to do this in Firedrake gives an error: `TypeError: unsupported operand type(s) for +: 'FunctionSpace' and 'FunctionSpace'`, but after looking at test_bubble.py, I realised that I could do

```
mesh = UnitSquareMesh(10, 10)
P1 = FiniteElement("CG", mesh.ufl_cell(), 1)
B = FiniteElement("Bubble", mesh.ufl_cell(), 3)
V = FunctionSpace(mesh, P1 + B)
```

I am trying to do the same with a `VectorFunctionSpace`, but I get the following error:

```
christian@elevate ~ $ python test2.py 
WARNING: Creating an EnrichedElement,
         if you intended to create a MixedElement use '*' instead of '+'.
Traceback (most recent call last):
  File "test2.py", line 6, in <module>
    V = VectorFunctionSpace(mesh, P1 + B)
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.10.0-py2.7-linux-x86_64.egg/pyop2/caching.py", line 160, in __new__
    obj = make_obj()
  File "/usr/local/lib/python2.7/dist-packages/PyOP2-0.10.0-py2.7-linux-x86_64.egg/pyop2/caching.py", line 141, in make_obj
    obj.__init__(*args, **kwargs)
TypeError: __init__() takes at least 4 arguments (3 given)
```
I think the missing argument is the `degree`, but I shouldn't have to provide this.