### PR TITLE
Fix/parallel ext facets

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -101,8 +101,13 @@ def _get_msh_file(source, name, dimension, meshed=False):
 
 
 class _Facets(object):
-    """Wrapper class for facet interation information on a :class:`Mesh`"""
-    def __init__(self, mesh, classes, kind, facet_cell, local_facet_number, markers=None):
+    """Wrapper class for facet interation information on a :class:`Mesh`
+
+    .. warning::
+
+       The unique_markers argument **must** be the same on all processes."""
+    def __init__(self, mesh, classes, kind, facet_cell, local_facet_number, markers=None,
+                 unique_markers=None):
 
         self.mesh = mesh
 
@@ -121,6 +126,7 @@ class _Facets(object):
         self.local_facet_number = local_facet_number
 
         self.markers = markers
+        self.unique_markers = [] if unique_markers is None else unique_markers
         self._subsets = {}
 
     @utils.cached_property
@@ -309,14 +315,6 @@ class Mesh(object):
         self._cell_closure = None
         self.interior_facets = None
         self.exterior_facets = None
-
-        # Exterior facets
-        if self._plex.getStratumSize("exterior_facets", 1) <= 0:
-            self.exterior_facets = _Facets(self, 0, "exterior", None, None)
-
-        # Interior facets
-        if self._plex.getStratumSize("interior_facets", 1) <= 0:
-            self.interior_facets = _Facets(self, 0, "interior", None, None)
 
         # Note that for bendy elements, this needs to change.
         if periodic_coords is not None:


### PR DESCRIPTION
Fix two bugs in exterior facet integrals in parallel.
1. Facet labelling must be carried out in serial
2. The set of unique facet markers must be the same on all processes.
