### PR TITLE
BCs on zero block

### DIFF
--- a/tests/regression/test_bcs.py
+++ b/tests/regression/test_bcs.py
@@ -311,7 +311,6 @@ def test_assemble_mass_bcs_2d(V):
     assert assemble(dot((w - f), (w - f))*dx) < 1e-12
 
 
-@pytest.mark.xfail
 def test_mixed_bcs(V):
     W = V*V
     u, p = TrialFunctions(W)


### PR DESCRIPTION
If FFC simplifies an integrand to zero and doesn't give us a kernel, we should still make sure we apply any bcs to that block, do so by applying bcs outside the loop over kernels.
