### PR TITLE
Fix Expression(0.0) bug

### DIFF
--- a/firedrake/expression.py
+++ b/firedrake/expression.py
@@ -120,7 +120,7 @@ class Expression(ufl.Coefficient):
         utils._init()
         self.code = code
         self._shape = ()
-        if code:
+        if code is not None:
             shape = np.array(code).shape
             self._shape = shape
             if self.rank() == 0:

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -138,6 +138,7 @@ common_tests = [
     'assigntest(f, one - one, 0)']
 
 scalar_tests = common_tests + [
+    'interpolatetest(f, 0.0, 0)',
     'interpolatetest(f, "sin(pi/2)", 1)',
     'exprtest(ufl.ln(one), 0)',
     'exprtest(two ** minusthree, 0.125)',


### PR DESCRIPTION
Irritatingly, 0.0 is boolean false in Python. This works around this.
