### PR TITLE
Preserve order of supplied bcs in Matrix

### DIFF
--- a/tests/regression/test_matrix.py
+++ b/tests/regression/test_matrix.py
@@ -59,18 +59,17 @@ def test_adding_bcs(a, V):
     bc1 = DirichletBC(V, 0, 1)
     A = assemble(a, bcs=[bc1])
 
-    for bc in A.bcs:
-        assert bc is bc1
+    assert set(A.bcs) == set([bc1])
 
     bc2 = DirichletBC(V, 1, 1)
     bc2.apply(A)
-    for bc in A.bcs:
-        assert bc is bc2
+
+    assert set(A.bcs) == set([bc2])
 
     bc3 = DirichletBC(V, 1, 0)
 
     bc3.apply(A)
-    assert A.bcs == set([bc2, bc3])
+    assert set(A.bcs) == set([bc2, bc3])
 
 
 def test_assemble_with_bcs(a, V):


### PR DESCRIPTION
We shouldn't use a set to hold the bcs, because the iteration order may
not be the same on all processes in parallel, which might lead to
deadlocks.  Instead, just maintain the bcs in a list with deterministic
iteration order.
