### PR TITLE
Reduce overhead

### DIFF
--- a/firedrake/matrix.py
+++ b/firedrake/matrix.py
@@ -141,8 +141,6 @@ class Matrix(object):
             just need a handle on the :class:`pyop2.Mat` object it's
             wrapping, use :attr:`_M` instead."""
         self.assemble()
-        # User wants to see it, so force the evaluation.
-        self._M._force_evaluation()
         return self._M
 
     @property

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -454,49 +454,49 @@ def _assemble(f, tensor=None, bcs=None):
         cell_domains = []
         exterior_facet_domains = []
         interior_facet_domains = []
-        # For horizontal facets of extrded meshes, the corresponding domain
-        # in the base mesh is the cell domain. Hence all the maps used for top
-        # bottom and interior horizontal facets will use the cell to dofs map
-        # coming from the base mesh as a starting point for the actual dynamic map
-        # computation.
-        for integral in integrals:
-            integral_type = integral.integral_type()
-            if integral_type == "cell":
-                cell_domains.append(op2.ALL)
-            elif integral_type == "exterior_facet":
-                exterior_facet_domains.append(op2.ALL)
-            elif integral_type == "interior_facet":
-                interior_facet_domains.append(op2.ALL)
-            elif integral_type == "exterior_facet_bottom":
-                cell_domains.append(op2.ON_BOTTOM)
-            elif integral_type == "exterior_facet_top":
-                cell_domains.append(op2.ON_TOP)
-            elif integral_type == "exterior_facet_vert":
-                exterior_facet_domains.append(op2.ALL)
-            elif integral_type == "interior_facet_horiz":
-                cell_domains.append(op2.ON_INTERIOR_FACETS)
-            elif integral_type == "interior_facet_vert":
-                interior_facet_domains.append(op2.ALL)
-            else:
-                raise RuntimeError('Unknown integral type "%s"' % integral_type)
-
-        # To avoid an extra check for extruded domains, the maps that are being passed in
-        # are DecoratedMaps. For the non-extruded case the DecoratedMaps don't restrict the
-        # space over which we iterate as the domains are dropped at Sparsity construction
-        # time. In the extruded case the cell domains are used to identify the regions of the
-        # mesh which require allocation in the sparsity.
-        if cell_domains:
-            map_pairs.append((op2.DecoratedMap(test.cell_node_map(), cell_domains),
-                              op2.DecoratedMap(trial.cell_node_map(), cell_domains)))
-        if exterior_facet_domains:
-            map_pairs.append((op2.DecoratedMap(test.exterior_facet_node_map(), exterior_facet_domains),
-                              op2.DecoratedMap(trial.exterior_facet_node_map(), exterior_facet_domains)))
-        if interior_facet_domains:
-            map_pairs.append((op2.DecoratedMap(test.interior_facet_node_map(), interior_facet_domains),
-                              op2.DecoratedMap(trial.interior_facet_node_map(), interior_facet_domains)))
-
-        map_pairs = tuple(map_pairs)
         if tensor is None:
+            # For horizontal facets of extruded meshes, the corresponding domain
+            # in the base mesh is the cell domain. Hence all the maps used for top
+            # bottom and interior horizontal facets will use the cell to dofs map
+            # coming from the base mesh as a starting point for the actual dynamic map
+            # computation.
+            for integral in integrals:
+                integral_type = integral.integral_type()
+                if integral_type == "cell":
+                    cell_domains.append(op2.ALL)
+                elif integral_type == "exterior_facet":
+                    exterior_facet_domains.append(op2.ALL)
+                elif integral_type == "interior_facet":
+                    interior_facet_domains.append(op2.ALL)
+                elif integral_type == "exterior_facet_bottom":
+                    cell_domains.append(op2.ON_BOTTOM)
+                elif integral_type == "exterior_facet_top":
+                    cell_domains.append(op2.ON_TOP)
+                elif integral_type == "exterior_facet_vert":
+                    exterior_facet_domains.append(op2.ALL)
+                elif integral_type == "interior_facet_horiz":
+                    cell_domains.append(op2.ON_INTERIOR_FACETS)
+                elif integral_type == "interior_facet_vert":
+                    interior_facet_domains.append(op2.ALL)
+                else:
+                    raise RuntimeError('Unknown integral type "%s"' % integral_type)
+
+            # To avoid an extra check for extruded domains, the maps that are being passed in
+            # are DecoratedMaps. For the non-extruded case the DecoratedMaps don't restrict the
+            # space over which we iterate as the domains are dropped at Sparsity construction
+            # time. In the extruded case the cell domains are used to identify the regions of the
+            # mesh which require allocation in the sparsity.
+            if cell_domains:
+                map_pairs.append((op2.DecoratedMap(test.cell_node_map(), cell_domains),
+                                  op2.DecoratedMap(trial.cell_node_map(), cell_domains)))
+            if exterior_facet_domains:
+                map_pairs.append((op2.DecoratedMap(test.exterior_facet_node_map(), exterior_facet_domains),
+                                  op2.DecoratedMap(trial.exterior_facet_node_map(), exterior_facet_domains)))
+            if interior_facet_domains:
+                map_pairs.append((op2.DecoratedMap(test.interior_facet_node_map(), interior_facet_domains),
+                                  op2.DecoratedMap(trial.interior_facet_node_map(), interior_facet_domains)))
+
+            map_pairs = tuple(map_pairs)
             # Construct OP2 Mat to assemble into
             fs_names = (
                 test.function_space().name, trial.function_space().name)

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -555,7 +555,7 @@ def _assemble(f, tensor=None, bcs=None):
             tensor.zero()
         except AttributeError:
             pass
-        for (i, j), integral_type, subdomain_id, coords, coefficients, needs_orientations, kernel in kernels:
+        for (i, j), integral_type, subdomain_id, coords, coefficients, needs_orientations, kernel, pl in kernels:
             m = coords.function_space().mesh()
             if needs_orientations:
                 cell_orientations = m.cell_orientations()

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -241,12 +241,12 @@ class NonlinearVariationalSolver(object):
         assemble(self._problem.J_ufl,
                  tensor=self._jac_tensor,
                  bcs=self._problem.bcs)
-        self._jac_tensor.M._force_evaluation()
+        self._jac_tensor.M
         if self._problem.Jp is not None:
             assemble(self._problem.Jp,
                      tensor=self._jac_ptensor,
                      bcs=self._problem.bcs)
-            self._jac_ptensor.M._force_evaluation()
+            self._jac_ptensor.M
             return PETSc.Mat.Structure.DIFFERENT_NONZERO_PATTERN
         return PETSc.Mat.Structure.SAME_NONZERO_PATTERN
 

--- a/tests/extrusion/test_extrusion_1_assembly.py
+++ b/tests/extrusion/test_extrusion_1_assembly.py
@@ -19,8 +19,8 @@ def test_scalar_assembly(hfamily, hdegree, vfamily, vdegree):
     u = TrialFunction(fspace)
     v = TestFunction(fspace)
 
-    assemble(u*v*dx).M._force_evaluation()
-    assemble(dot(grad(u), grad(v))*dx).M._force_evaluation()
+    assemble(u*v*dx).M
+    assemble(dot(grad(u), grad(v))*dx).M
 
 
 # three valid combinations for hdiv: 1) hdiv x DG, 2) hcurl x DG, 3) DG x CG
@@ -39,8 +39,8 @@ def test_hdiv_assembly(hfamily, hdegree, vfamily, vdegree):
     u = TrialFunction(fspace)
     v = TestFunction(fspace)
 
-    assemble(dot(u, v)*dx).M._force_evaluation()
-    assemble(inner(grad(u), grad(v))*dx).M._force_evaluation()
+    assemble(dot(u, v)*dx).M
+    assemble(inner(grad(u), grad(v))*dx).M
 
 
 # three valid combinations for hcurl: 1) hcurl x CG, 1) hdiv x CG, 3) CG x DG
@@ -59,8 +59,8 @@ def test_hcurl_assembly(hfamily, hdegree, vfamily, vdegree):
     u = TrialFunction(fspace)
     v = TestFunction(fspace)
 
-    assemble(dot(u, v)*dx).M._force_evaluation()
-    assemble(inner(grad(u), grad(v))*dx).M._force_evaluation()
+    assemble(dot(u, v)*dx).M
+    assemble(inner(grad(u), grad(v))*dx).M
 
 if __name__ == '__main__':
     import os

--- a/tests/test_ffc_interface.py
+++ b/tests/test_ffc_interface.py
@@ -101,16 +101,16 @@ class TestFFCCache:
 
     def test_ffc_cell_kernel(self, mass):
         k = ffc_interface.compile_form(mass, 'mass')
-        assert 'cell_integral' in k[0][-1].code and len(k) == 1
+        assert 'cell_integral' in k[0][-2].code and len(k) == 1
 
     def test_ffc_exterior_facet_kernel(self, rhs):
         k = ffc_interface.compile_form(rhs, 'rhs')
-        assert 'exterior_facet_integral' in k[0][-1].code and len(k) == 1
+        assert 'exterior_facet_integral' in k[0][-2].code and len(k) == 1
 
     def test_ffc_cell_exterior_facet_kernel(self, rhs2):
         k = ffc_interface.compile_form(rhs2, 'rhs2')
-        assert 'cell_integral' in k[0][-1].code and \
-            'exterior_facet_integral' in k[1][-1].code and len(k) == 2
+        assert 'cell_integral' in k[0][-2].code and \
+            'exterior_facet_integral' in k[1][-2].code and len(k) == 2
 
 if __name__ == '__main__':
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Reduce overhead in repeated reassembly of the same form (optionally into the same tensor).  This is exactly what we have when solving nonlinear problems, or anything with timestepping.  This takes advantage of the changes in OP2/PyOP2#404 to save ParLoop objects on a form and just re-execute them immediately rather than building new ones when we reassemble.

We also adapt to the change that removes lazy evaluation in pyop2.