### PR TITLE
Explicitly ask for ILU shifts on singular solves

### DIFF
--- a/tests/regression/test_poisson_mixed_no_bcs.py
+++ b/tests/regression/test_poisson_mixed_no_bcs.py
@@ -63,6 +63,8 @@ def poisson_mixed(size, parameters={}):
                                'ksp_type': 'gmres',
                                'pc_fieldsplit_schur_fact_type': 'FULL',
                                'fieldsplit_0_ksp_type': 'cg',
+                               'fieldsplit_0_pc_factor_shift_type': 'INBLOCKS',
+                               'fieldsplit_1_pc_factor_shift_type': 'INBLOCKS',
                                'fieldsplit_1_ksp_type': 'cg'}])
 def test_poisson_mixed(parameters):
     """Test second-order convergence of the mixed poisson formulation."""

--- a/tests/regression/test_poisson_mixed_strong_bcs.py
+++ b/tests/regression/test_poisson_mixed_strong_bcs.py
@@ -66,6 +66,8 @@ def poisson_mixed(size, parameters={}):
                                'pc_fieldsplit_type': 'schur',
                                'ksp_type': 'gmres',
                                'pc_fieldsplit_schur_fact_type': 'FULL',
+                               'fieldsplit_0_pc_factor_shift_type': 'INBLOCKS',
+                               'fieldsplit_1_pc_factor_shift_type': 'INBLOCKS',
                                'fieldsplit_0_ksp_type': 'cg',
                                'fieldsplit_1_ksp_type': 'cg'}])
 def test_poisson_mixed(parameters):

--- a/tests/regression/test_poisson_sphere.py
+++ b/tests/regression/test_poisson_sphere.py
@@ -31,6 +31,7 @@ def run_hdiv_l2(refinement, hdiv_space, degree):
                                                              'pc_fieldsplit_type': 'schur',
                                                              'fieldsplit_0_pc_type': 'lu',
                                                              'pc_fieldsplit_schur_fact_type': 'FULL',
+                                                             'fieldsplit_1_pc_factor_shift_type': 'INBLOCKS',
                                                              'fieldsplit_0_ksp_max_it': 100})
 
     sigma, u = w.split()


### PR DESCRIPTION
PETSc changed their ILU defaults to no longer do any shifts to avoid
zero pivots.
