### PR TITLE
add test for mixed Coefficient Piola transforms

### DIFF
--- a/tests/regression/test_piola_mixed_fn.py
+++ b/tests/regression/test_piola_mixed_fn.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+from firedrake import *
+from tests.common import *
+
+
+def test_project(mesh):
+    U = FunctionSpace(mesh, "RT", 1)
+    V = FunctionSpace(mesh, "N1curl", 1)
+    W = U*V
+
+    f = Function(W)
+    f.assign(1)
+
+    out = Function(W)
+    u1, u2 = TrialFunctions(W)
+    v1, v2 = TestFunctions(W)
+    f1, f2 = split(f)
+    a = dot(u1, v1)*dx + dot(u2, v2)*dx
+    L = dot(f1, v1)*dx + dot(f2, v2)*dx
+
+    solve(a == L, out)
+
+    assert np.allclose(out.dat.data[0], f.dat.data[0], rtol=1e-5)
+    assert np.allclose(out.dat.data[1], f.dat.data[1], rtol=1e-5)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
It turns out that a surprising number of tests still pass if Piola transforms aren't applied to subelements of a MixedElement (mixed Poisson tests, mixed Helmholtz tests, ...).  Although a few of the more complicated tests do fail, here is a more simple test.

Note that rtol can be jacked up if the right solver_parameters are passed in (we're mixed so can't use the usual pre_only/LU)
