### PR TITLE
Add instructions for installing Cython

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -110,6 +110,10 @@ examples on the :doc:`documentation page <documentation>`.
 Git instructions for developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Cython >= 0.17 is required to build Firedrake. Install it using pip ::
+
+ pip install "Cython>=0.17"
+
 Next, obtain the Firedrake source from GitHub_ ::
 
  git clone https://github.com/firedrakeproject/firedrake.git

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -110,9 +110,9 @@ examples on the :doc:`documentation page <documentation>`.
 Git instructions for developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Cython >= 0.17 is required to build Firedrake. Install it using pip ::
+Cython >= 0.20 is required to build Firedrake. Install it using pip ::
 
- pip install "Cython>=0.17"
+ pip install "Cython>=0.20"
 
 Next, obtain the Firedrake source from GitHub_ ::
 


### PR DESCRIPTION
Cython is required for building from the Git repo as `dmplex.c` etc are not committed. Although most people would already have Cython installed from building PyOP2, in the case where the environment has PyOP2 installed from a package Cython is not necessarily present.

This PR adds a mention that Cython should be installed when building from the Git repo.