### PR TITLE
Refactor quadrilaterals across Firedrake/UFL/FFC/FIAT 

### DIFF
--- a/firedrake/fiat_utils.py
+++ b/firedrake/fiat_utils.py
@@ -19,34 +19,3 @@ def fiat_from_ufl_element(ufl_element):
         fiat_element = ffc.create_actual_fiat_element(ufl_element)
         _fiat_element_cache[ufl_element] = fiat_element
         return fiat_element
-
-
-def flat_entity_dofs(fiat_element):
-    """Returns entity dofs with flattened dimensions.
-
-    For outer product elements, dimensions are pairs instead of integers.
-    Parts of the pairs are added, and their corresponding values are merged.
-
-    For example:
-
-    {(0, 0): {0: [0], 1: [1], 2: [2], 3: [3]},
-     (0, 1): {0: [4], 1: [5]},
-     (1, 0): {0: [6], 1: [7]},
-     (1, 1): {0: [8]}}
-
-    is flattened into:
-
-    {0: {0: [0], 1: [1], 2: [2], 3: [3]},
-     1: {0: [4], 1: [5], 2: [6], 3: [7]},
-     2: {0: [8]}}
-
-    Maps with integer dimensions are unaffected.
-    """
-    entity_dofs = fiat_element.entity_dofs()
-
-    f = lambda x: sum(x) if isinstance(x, tuple) else x
-    indexless = dict((dim, []) for dim in set(map(f, entity_dofs.keys())))
-    for (dim, entity) in sorted(entity_dofs.iteritems()):
-        indexless[f(dim)].extend(entity.itervalues())
-    return dict((dim, dict((i, indices) for i, indices in enumerate(e)))
-                for dim, e in indexless.iteritems())

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -365,16 +365,10 @@ class FunctionSpaceBase(ObjectCached):
 
         el = self.fiat_element
 
-        # Facet dimension becomes a bit more complicated
-        # for quadrilaterals, as their dimension is (1, 1),
-        # so facets have dimensions (0, 1) AND (1, 0),
-        # which forces us to deal with multiple dimension values.
-        dims = self._mesh.facet_dimensions()
+        dim = self._mesh.facet_dimension()
 
         if method == "topological":
-            boundary_dofs = dict(enumerate(value
-                                           for dim in dims
-                                           for value in el.entity_closure_dofs()[dim].values()))
+            boundary_dofs = el.entity_closure_dofs()[dim]
         elif method == "geometric":
             boundary_dofs = el.facet_support_dofs()
 
@@ -403,9 +397,8 @@ class FunctionSpaceBase(ObjectCached):
         c_array = lambda xs: "{"+", ".join(map(str, xs))+"}"
 
         body = ast.Block([ast.Decl("int",
-                                   ast.Symbol("l_nodes",
-                                              (sum(len(el.get_reference_element().topology[dim]) for dim in dims),
-                                               nodes_per_facet)),
+                                   ast.Symbol("l_nodes", (len(el.get_reference_element().topology[dim]),
+                                                          nodes_per_facet)),
                                    init=ast.ArrayInit(c_array(map(c_array, local_facet_nodes))),
                                    qualifiers=["const"]),
                           ast.For(ast.Decl("int", "n", 0),

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -83,7 +83,7 @@ class FunctionSpaceBase(ObjectCached):
             self.dofs_per_column = np.zeros(1, np.int32)
             self.extruded = False
 
-            entity_dofs = fiat_utils.flat_entity_dofs(self.fiat_element)
+            entity_dofs = self.fiat_element.entity_dofs()
             self._dofs_per_entity = [len(entity[0]) for d, entity in entity_dofs.iteritems()]
 
         self.name = name

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -520,22 +520,15 @@ class FunctionSpace(FunctionSpaceBase):
             element = family.reconstruct(domain=mesh.ufl_domain())
         else:
             # First case...
-            if isinstance(mesh, mesh_t.ExtrudedMesh):
+            if isinstance(mesh, mesh_t.ExtrudedMesh) and vfamily is not None and vdegree is not None:
                 # if extruded mesh, make the OPE
                 la = ufl.FiniteElement(family,
                                        domain=mesh._old_mesh.ufl_cell(),
                                        degree=degree)
-                if vfamily is None or vdegree is None:
-                    # if second element was not passed in, assume same as first
-                    # (only makes sense for CG or DG)
-                    lb = ufl.FiniteElement(family,
-                                           domain=ufl.Cell("interval", 1),
-                                           degree=degree)
-                else:
-                    # if second element was passed in, use in
-                    lb = ufl.FiniteElement(vfamily,
-                                           domain=ufl.Cell("interval", 1),
-                                           degree=vdegree)
+                # if second element was passed in, use in
+                lb = ufl.FiniteElement(vfamily,
+                                       domain=ufl.Cell("interval", 1),
+                                       degree=vdegree)
                 # now make the OPE
                 element = ufl.OuterProductElement(la, lb, domain=mesh.ufl_domain())
             else:
@@ -571,18 +564,15 @@ class VectorFunctionSpace(FunctionSpaceBase):
         # VectorFunctionSpace dimension defaults to the geometric dimension of the mesh.
         dim = dim or mesh.ufl_cell().geometric_dimension()
 
-        if isinstance(mesh, mesh_t.ExtrudedMesh):
-            if isinstance(family, ufl.OuterProductElement):
-                raise NotImplementedError("Not yet implemented")
+        if isinstance(mesh, mesh_t.ExtrudedMesh) and isinstance(family, ufl.OuterProductElement):
+            raise NotImplementedError("Not yet implemented")
+
+        if isinstance(mesh, mesh_t.ExtrudedMesh) and vfamily is not None and vdegree is not None:
             la = ufl.FiniteElement(family,
                                    domain=mesh._old_mesh.ufl_cell(),
                                    degree=degree)
-            if vfamily is None or vdegree is None:
-                lb = ufl.FiniteElement(family, domain=ufl.Cell("interval", 1),
-                                       degree=degree)
-            else:
-                lb = ufl.FiniteElement(vfamily, domain=ufl.Cell("interval", 1),
-                                       degree=vdegree)
+            lb = ufl.FiniteElement(vfamily, domain=ufl.Cell("interval", 1),
+                                   degree=vdegree)
             element = ufl.OuterProductVectorElement(la, lb, dim=dim, domain=mesh.ufl_domain())
         else:
             element = ufl.VectorElement(family, domain=mesh.ufl_domain(),

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -635,6 +635,15 @@ class MeshBase(object):
         return self.parent.cell_set if self.parent else \
             op2.Set(size, "%s_cells" % self.name)
 
+    def facet_dimension(self):
+        """Returns the facet dimension."""
+        # Facets have co-dimension 1
+        return self.ufl_cell().topological_dimension() - 1
+
+    def cell_dimension(self):
+        """Return the cell dimension"""
+        return self.ufl_cell().topological_dimension()
+
 
 class SimplexMesh(MeshBase):
     """A mesh class providing functionality specific to simplex meshes.
@@ -662,15 +671,6 @@ class SimplexMesh(MeshBase):
 
         return dmplex.closure_ordering(dm, vertex_numbering,
                                        self._cell_numbering, entity_per_cell)
-
-    def facet_dimensions(self):
-        """Returns a singleton list containing the facet dimension."""
-        # Facets have co-dimension 1
-        return [self.ufl_cell().topological_dimension() - 1]
-
-    def cell_dimension(self):
-        """Return the cell dimension"""
-        return self.ufl_cell().topological_dimension()
 
 
 class QuadrilateralMesh(MeshBase):
@@ -707,14 +707,6 @@ class QuadrilateralMesh(MeshBase):
 
         return dmplex.quadrilateral_closure_ordering(
             plex, vertex_numbering, cell_numbering, cell_orientations)
-
-    def facet_dimensions(self):
-        """Returns a list containing the facet dimensions."""
-        return [1]
-
-    def cell_dimension(self):
-        """Return the cell dimension"""
-        return (1, 1)
 
 
 class ExtrudedMesh(MeshBase):
@@ -932,8 +924,8 @@ class ExtrudedMesh(MeshBase):
             raise RuntimeError("Dimension computation not supported for gdim %d",
                                self.geometric_dimension)
 
-    def facet_dimensions(self):
-        """Returns a singleton list containing the facet dimension.
+    def facet_dimension(self):
+        """Returns the facet dimension.
 
         .. note::
 
@@ -947,8 +939,8 @@ class ExtrudedMesh(MeshBase):
         # triangle x interval interval x interval it's (1, 1) and
         # (0, 1) respectively.
         if self.geometric_dimension == 3:
-            return [(1, 1)]
+            return (1, 1)
         elif self.geometric_dimension == 2:
-            return [(0, 1)]
+            return (0, 1)
         else:
             raise RuntimeError("Dimension computation for other than 2D or 3D extruded meshes not supported.")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -710,7 +710,7 @@ class QuadrilateralMesh(MeshBase):
 
     def facet_dimensions(self):
         """Returns a list containing the facet dimensions."""
-        return [(0, 1), (1, 0)]
+        return [1]
 
     def cell_dimension(self):
         """Return the cell dimension"""

--- a/tests/extrusion/test_fs_abbreviations.py
+++ b/tests/extrusion/test_fs_abbreviations.py
@@ -1,0 +1,94 @@
+import pytest
+from firedrake import *
+from tests.common import *
+
+
+@pytest.fixture
+def opc_quad():
+    return OuterProductCell(interval, interval)
+
+
+@pytest.mark.parametrize('degree', [1, 2])
+def test_rtce_expansion(opc_quad, degree):
+    actual = FiniteElement("RTCE", opc_quad, degree)
+
+    C_elt = FiniteElement("CG", interval, degree)
+    D_elt = FiniteElement("DG", interval, degree - 1)
+    expected = HCurl(OuterProductElement(C_elt, D_elt)) + HCurl(OuterProductElement(D_elt, C_elt))
+    assert expected == actual
+
+
+@pytest.mark.parametrize('degree', [1, 2])
+def test_rtcf_expansion(opc_quad, degree):
+    actual = FiniteElement("RTCF", opc_quad, degree)
+
+    C_elt = FiniteElement("CG", interval, degree)
+    D_elt = FiniteElement("DG", interval, degree - 1)
+    expected = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
+    assert expected == actual
+
+
+@pytest.mark.parametrize('base_cell', [interval, triangle])
+@pytest.mark.parametrize('fs', ["CG", "DG"])
+@pytest.mark.parametrize('degree', [1, 2])
+def test_cg_dg_expansion(base_cell, fs, degree):
+    cell = OuterProductCell(base_cell, interval)
+    actual = FiniteElement(fs, cell, degree)
+
+    expected = OuterProductElement(FiniteElement(fs, base_cell, degree),
+                                   FiniteElement(fs, interval, degree),
+                                   domain=cell)
+    assert expected == actual
+
+
+@pytest.mark.parametrize('base_cell', [interval, triangle])
+@pytest.mark.parametrize('fs', ["CG", "DG"])
+@pytest.mark.parametrize('degree', [1, 2])
+def test_cg_dg_vector_expansion(base_cell, fs, degree):
+    cell = OuterProductCell(base_cell, interval)
+    actual = VectorElement(fs, cell, degree, dim=3)
+
+    expected = OuterProductVectorElement(FiniteElement(fs, base_cell, degree),
+                                         FiniteElement(fs, interval, degree),
+                                         domain=cell, dim=3)
+    assert expected == actual
+
+
+@pytest.mark.parametrize(('base_mesh_thunk', 'fs', 'degree'),
+                         [(lambda: UnitIntervalMesh(10), "CG", 1),
+                          (lambda: UnitIntervalMesh(10), "CG", 2),
+                          (lambda: UnitIntervalMesh(10), "DG", 1),
+                          (lambda: UnitIntervalMesh(10), "DG", 2),
+                          (lambda: UnitIntervalMesh(10), "RTCE", 1),
+                          (lambda: UnitIntervalMesh(10), "RTCE", 2),
+                          (lambda: UnitIntervalMesh(10), "RTCF", 1),
+                          (lambda: UnitIntervalMesh(10), "RTCF", 2),
+                          (lambda: UnitSquareMesh(10, 10), "CG", 1),
+                          (lambda: UnitSquareMesh(10, 10), "CG", 2),
+                          (lambda: UnitSquareMesh(10, 10), "DG", 1),
+                          (lambda: UnitSquareMesh(10, 10), "DG", 2)])
+def test_ufl_element_assembly(base_mesh_thunk, fs, degree):
+    mesh = ExtrudedMesh(base_mesh_thunk(), 10)
+    V = FunctionSpace(mesh, fs, degree)
+
+    assert V.ufl_element() == FiniteElement(fs, mesh.ufl_domain(), degree)
+
+
+@pytest.mark.parametrize(('base_mesh_thunk', 'fs', 'degree'),
+                         [(lambda: UnitIntervalMesh(10), "CG", 1),
+                          (lambda: UnitIntervalMesh(10), "CG", 2),
+                          (lambda: UnitIntervalMesh(10), "DG", 1),
+                          (lambda: UnitIntervalMesh(10), "DG", 2),
+                          (lambda: UnitSquareMesh(10, 10), "CG", 1),
+                          (lambda: UnitSquareMesh(10, 10), "CG", 2),
+                          (lambda: UnitSquareMesh(10, 10), "DG", 1),
+                          (lambda: UnitSquareMesh(10, 10), "DG", 2)])
+def test_ufl_vector_element_assembly(base_mesh_thunk, fs, degree):
+    mesh = ExtrudedMesh(base_mesh_thunk(), 10)
+    V = VectorFunctionSpace(mesh, fs, degree, dim=3)
+
+    assert V.ufl_element() == VectorElement(fs, mesh.ufl_domain(), degree, dim=3)
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_helmholtz_sphere.py
+++ b/tests/regression/test_helmholtz_sphere.py
@@ -32,10 +32,7 @@ def run_helmholtz_mixed_sphere(MeshClass, r):
     if isinstance(m, SimplexMesh):
         V = FunctionSpace(m, 'RT', 1)
     elif isinstance(m, QuadrilateralMesh):
-        C_elt = FiniteElement("CG", 'interval', 1)
-        D_elt = FiniteElement("DG", 'interval', 0)
-        V_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-        V = FunctionSpace(m, V_elt)
+        V = FunctionSpace(m, 'RTCF', 1)
     Q = FunctionSpace(m, 'DG', 0)
     W = V*Q
 

--- a/tests/regression/test_manifolds.py
+++ b/tests/regression/test_manifolds.py
@@ -100,13 +100,7 @@ def test_contravariant_piola_facet_integral(space):
         mesh = UnitIcosahedralSphereMesh(refinement_level=2)
     global_normal = Expression(("x[0]", "x[1]", "x[2]"))
     mesh.init_cell_orientations(global_normal)
-    if space == "RTCF":
-        C_elt = FiniteElement("CG", "interval", 1)
-        D_elt = FiniteElement("DG", "interval", 0)
-        V_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-        V = FunctionSpace(mesh, V_elt)
-    else:
-        V = FunctionSpace(mesh, space, 1)
+    V = FunctionSpace(mesh, space, 1)
     # Some non-zero function
     u = project(Expression(('x[0]', '-x[1]', '0')), V)
     n = FacetNormal(mesh)
@@ -126,13 +120,7 @@ def test_covariant_piola_facet_integral(space):
         mesh = UnitIcosahedralSphereMesh(refinement_level=2)
     global_normal = Expression(("x[0]", "x[1]", "x[2]"))
     mesh.init_cell_orientations(global_normal)
-    if space == "RTCE":
-        C_elt = FiniteElement("CG", "interval", 1)
-        D_elt = FiniteElement("DG", "interval", 0)
-        V_elt = HCurl(OuterProductElement(C_elt, D_elt)) + HCurl(OuterProductElement(D_elt, C_elt))
-        V = FunctionSpace(mesh, V_elt)
-    else:
-        V = FunctionSpace(mesh, space, 1)
+    V = FunctionSpace(mesh, space, 1)
     # Some non-zero function
     u = project(Expression(('x[0]', '-x[1]', '0')), V)
     n = FacetNormal(mesh)

--- a/tests/regression/test_poisson_mixed_no_bcs.py
+++ b/tests/regression/test_poisson_mixed_no_bcs.py
@@ -34,23 +34,10 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
 
     # Define function spaces and mixed (product) space
     if quadrilateral:
-        S0 = FiniteElement("CG", "interval", 1)
-        S1 = FiniteElement("DG", "interval", 0)
-
-        T0 = FiniteElement("CG", "interval", 1)
-        T1 = FiniteElement("DG", "interval", 0)
-
-        DG_elt = OuterProductElement(S1, T1)
-        BDM_elt_h = HDiv(OuterProductElement(S1, T0))
-        BDM_elt_v = HDiv(OuterProductElement(S0, T1))
-        BDM_elt = BDM_elt_h + BDM_elt_v
-
-        # spaces for calculation
-        DG = FunctionSpace(mesh, DG_elt)
-        BDM = FunctionSpace(mesh, BDM_elt)
+        BDM = FunctionSpace(mesh, "RTCF", 1)
     else:
         BDM = FunctionSpace(mesh, "BDM", 1)
-        DG = FunctionSpace(mesh, "DG", 0)
+    DG = FunctionSpace(mesh, "DG", 0)
     W = BDM * DG
 
     # Define trial and test functions
@@ -96,7 +83,7 @@ def test_poisson_mixed(parameters):
                          [((3, 6), 1.9)])
 def test_hdiv_convergence(testcase, convrate):
     """Test second-order convergence of the mixed poisson formulation
-    on quadrilaterals with HDiv elements."""
+    on quadrilaterals with H(div) elements."""
     start, end = testcase
     l2err = np.zeros(end - start)
     for ii in [i + start for i in range(len(l2err))]:

--- a/tests/regression/test_poisson_mixed_strong_bcs.py
+++ b/tests/regression/test_poisson_mixed_strong_bcs.py
@@ -32,18 +32,7 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
     mesh = UnitSquareMesh(2 ** size, 2 ** size, quadrilateral=quadrilateral)
 
     # Define function spaces and mixed (product) space
-    if quadrilateral:
-        C_elt = FiniteElement("CG", "interval", 1)
-        D_elt = FiniteElement("DG", "interval", 1)
-
-        BDM_elt_h = HDiv(OuterProductElement(D_elt, C_elt))
-        BDM_elt_v = HDiv(OuterProductElement(C_elt, D_elt))
-        BDM_elt = BDM_elt_h + BDM_elt_v
-
-        # spaces for calculation
-        BDM = FunctionSpace(mesh, BDM_elt)
-    else:
-        BDM = FunctionSpace(mesh, "BDM", 1)
+    BDM = FunctionSpace(mesh, "BDM" if not quadrilateral else "RTCF", 1)
     DG = FunctionSpace(mesh, "DG", 0)
     W = BDM * DG
 

--- a/tests/regression/test_poisson_sphere.py
+++ b/tests/regression/test_poisson_sphere.py
@@ -10,13 +10,7 @@ def run_hdiv_l2(MeshClass, refinement, hdiv_space, degree):
     mesh.init_cell_orientations(Expression(('x[0]', 'x[1]', 'x[2]')))
     Ve = FunctionSpace(mesh, "DG", max(3, degree + 1))
 
-    if hdiv_space == "RTCF":
-        C_elt = FiniteElement("CG", 'interval', degree)
-        D_elt = FiniteElement("DG", 'interval', degree - 1)
-        V_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-        V = FunctionSpace(mesh, V_elt)
-    else:
-        V = FunctionSpace(mesh, hdiv_space, degree)
+    V = FunctionSpace(mesh, hdiv_space, degree)
     Q = FunctionSpace(mesh, "DG", degree - 1)
 
     W = V*Q

--- a/tests/regression/test_steady_advection_2D.py
+++ b/tests/regression/test_steady_advection_2D.py
@@ -64,19 +64,13 @@ def test_left_to_right_parallel():
 
 def test_left_to_right_on_quadrilaterals():
     m = UnitSquareMesh(5, 5, quadrilateral=True)
-    C_elt = FiniteElement("CG", "interval", 1)
-    D_elt = FiniteElement("DG", "interval", 0)
-    W_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-    run_left_to_right(m, DG0(m), FunctionSpace(m, W_elt))
+    run_left_to_right(m, DG0(m), FunctionSpace(m, "RTCF", 1))
 
 
 @pytest.mark.parallel
 def test_left_to_right_on_quadrilaterals_parallel():
     m = UnitSquareMesh(5, 5, quadrilateral=True)
-    C_elt = FiniteElement("CG", "interval", 1)
-    D_elt = FiniteElement("DG", "interval", 0)
-    W_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-    run_left_to_right(m, DG0(m), FunctionSpace(m, W_elt))
+    run_left_to_right(m, DG0(m), FunctionSpace(m, "RTCF", 1))
 
 
 def run_up_to_down(mesh, DG1, W):
@@ -119,19 +113,13 @@ def test_up_to_down_parallel():
 
 def test_up_to_down_on_quadrilaterals():
     m = UnitSquareMesh(5, 5, quadrilateral=True)
-    C_elt = FiniteElement("CG", "interval", 1)
-    D_elt = FiniteElement("DG", "interval", 0)
-    W_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-    run_up_to_down(m, DG0(m), FunctionSpace(m, W_elt))
+    run_up_to_down(m, DG0(m), FunctionSpace(m, "RTCF", 1))
 
 
 @pytest.mark.parallel
 def test_up_to_down_on_quadrilaterals_parallel():
     m = UnitSquareMesh(5, 5, quadrilateral=True)
-    C_elt = FiniteElement("CG", "interval", 1)
-    D_elt = FiniteElement("DG", "interval", 0)
-    W_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
-    run_up_to_down(m, DG0(m), FunctionSpace(m, W_elt))
+    run_up_to_down(m, DG0(m), FunctionSpace(m, "RTCF", 1))
 
 
 if __name__ == '__main__':

--- a/tests/regression/test_upwind_flux.py
+++ b/tests/regression/test_upwind_flux.py
@@ -29,13 +29,9 @@ import pytest
 def run_test(quadrilateral):
     if quadrilateral:
         mesh = UnitCubedSphereMesh(refinement_level=2)
-
-        C_elt = FiniteElement("CG", "interval", 1)
-        D_elt = FiniteElement("DG", "interval", 0)
-        RT_elt = HDiv(OuterProductElement(C_elt, D_elt)) + HDiv(OuterProductElement(D_elt, C_elt))
+        RT_elt = FiniteElement("RTCF", "quadrilateral", 1)
     else:
         mesh = UnitIcosahedralSphereMesh(refinement_level=2)
-
         RT_elt = FiniteElement("RT", "triangle", 1)
 
     global_normal = Expression(("x[0]/sqrt(x[0]*x[0]+x[1]*x[1]+x[2]*x[2])",

--- a/tests/regression/test_vector_laplace_on_quadrilaterals.py
+++ b/tests/regression/test_vector_laplace_on_quadrilaterals.py
@@ -7,20 +7,9 @@ from firedrake import *
 def vector_laplace(n, degree):
     mesh = UnitSquareMesh(n, n, quadrilateral=True)
 
-    S0 = FiniteElement("CG", interval, degree)
-    S1 = FiniteElement("DG", interval, degree - 1)
-
-    T0 = FiniteElement("CG", interval, degree)
-    T1 = FiniteElement("DG", interval, degree - 1)
-
-    V0_elt = OuterProductElement(S0, T0)
-    V1_elt_h = HCurl(OuterProductElement(S1, T0))
-    V1_elt_v = HCurl(OuterProductElement(S0, T1))
-    V1_elt = V1_elt_h + V1_elt_v
-
     # spaces for calculation
-    V0 = FunctionSpace(mesh, V0_elt)
-    V1 = FunctionSpace(mesh, V1_elt)
+    V0 = FunctionSpace(mesh, "CG", degree)
+    V1 = FunctionSpace(mesh, "RTCE", degree)
     V = V0*V1
 
     # spaces to store 'analytic' functions


### PR DESCRIPTION
This removes the ugly `_ufl_finite_element` and `_ufl_vector_element` wrappers from Firedrake. FFC pull request 67 replaces their functionality and adds a convenient syntax for creating H(div) and H(curl) conforming finite elements, mostly solving Firedrake issue #447. These changes also update the test cases to use the new, easier syntax.