### PR TITLE
Multigrid extrusion

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -668,6 +668,10 @@ class SimplexMesh(MeshBase):
         # Facets have co-dimension 1
         return [self.ufl_cell().topological_dimension() - 1]
 
+    def cell_dimension(self):
+        """Return the cell dimension"""
+        return self.ufl_cell().topological_dimension()
+
 
 class QuadrilateralMesh(MeshBase):
     """A mesh class providing functionality specific to quadrilateral meshes.
@@ -707,6 +711,10 @@ class QuadrilateralMesh(MeshBase):
     def facet_dimensions(self):
         """Returns a list containing the facet dimensions."""
         return [(0, 1), (1, 0)]
+
+    def cell_dimension(self):
+        """Return the cell dimension"""
+        return (1, 1)
 
 
 class ExtrudedMesh(MeshBase):
@@ -913,6 +921,16 @@ class ExtrudedMesh(MeshBase):
     @property
     def geometric_dimension(self):
         return self.ufl_cell().geometric_dimension()
+
+    def cell_dimension(self):
+        """Return the cell dimension"""
+        if self.geometric_dimension == 3:
+            return (2, 1)
+        elif self.geometric_dimension == 2:
+            return (1, 1)
+        else:
+            raise RuntimeError("Dimension computation not supported for gdim %d",
+                               self.geometric_dimension)
 
     def facet_dimensions(self):
         """Returns a singleton list containing the facet dimension.

--- a/firedrake/mg/functionspace.py
+++ b/firedrake/mg/functionspace.py
@@ -125,14 +125,7 @@ class BaseHierarchy(object):
                 restriction_fs = self
             self._restriction_weights = firedrake.mg.function.FunctionHierarchy(restriction_fs)
 
-            k = """
-            static inline void weights(double weight[%(d)d])
-            {
-                for ( int i = 0; i < %(d)d; i++ ) {
-                    weight[i] += 1.0;
-                }
-            }""" % {'d': self.cell_node_map(0).arity}
-            k = op2.Kernel(k, "weights")
+            k = utils.get_count_kernel(self.cell_node_map(0).arity)
             weights = self._restriction_weights
             # Count number of times each fine dof is hit
             for lvl in range(1, len(weights)):

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -20,8 +20,8 @@ class MeshHierarchy(object):
         :arg reorder: optional flag indicating whether to reorder the
              refined meshes.
         """
-        if m.ufl_cell().cellname() != "triangle":
-            raise NotImplementedError("Only supported on triangles")
+        if m.ufl_cell().cellname() not in ["triangle", "interval"]:
+            raise NotImplementedError("Only supported on intervals and triangles")
         m._plex.setRefinementUniform(True)
         dm_hierarchy = []
 

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -223,15 +223,7 @@ def get_injection_weights(fiat_element):
         keys = tabulation.keys()
         if len(keys) != 1:
             raise RuntimeError("Expected 1 key, found %d", len(keys))
-        vals = tabulation[keys[0]]
-        for i, pt in enumerate(pts):
-            found = False
-            for opt in points:
-                if np.allclose(opt, pt):
-                    found = True
-                    break
-            if not found:
-                vals[:, i] = 0.0
+        vals = np.where(np.isclose(tabulation[keys[0]], 1.0), 1.0, 0.0)
         values.append(np.round(vals.T, decimals=14))
 
     return np.concatenate(values)

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -242,18 +242,31 @@ def get_injection_kernel(fiat_element, unique_indices, dim=1):
     # rowsum.
     weights = weights / np.sum(weights, axis=1).reshape(-1, 1)
 
+    all_same = np.allclose(weights, weights[0, 0])
+
     arglist = [ast.Decl("double", ast.Symbol("coarse", (ncdof*dim, ))),
                ast.Decl("double", ast.Symbol("**fine", ()))]
-    w_sym = ast.Symbol("weights", (ncdof, nfdof))
-    w = ast.Decl("double", w_sym, ast.ArrayInit(format_array_literal(weights)),
-                 qualifiers=["static", "const"])
+    if all_same:
+        w_sym = ast.Symbol("weights", ())
+        w = [ast.Decl("double", w_sym, weights[0, 0],
+                      qualifiers=["static", "const"])]
+    else:
+        init = ast.ArrayInit(format_array_literal(weights))
+        w_sym = ast.Symbol("weights", (ncdof, nfdof))
+        w = [ast.Decl("double", w_sym, init,
+                      qualifiers=["static", "const"])]
 
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
     k = ast.Symbol("k", ())
+    if all_same:
+        assign = ast.Prod(ast.Symbol("fine", (j, k)),
+                          w_sym)
+    else:
+        assign = ast.Prod(ast.Symbol("fine", (j, k)),
+                          ast.Symbol("weights", (i, j)))
     assignment = ast.Incr(ast.Symbol("coarse", (ast.Sum(k, ast.Prod(i, ast.c_sym(dim))),)),
-                          ast.Prod(ast.Symbol("fine", (j, k)),
-                                   ast.Symbol("weights", (i, j))))
+                          assign)
     k_loop = ast.For(ast.Decl("int", k, ast.c_sym(0)),
                      ast.Less(k, ast.c_sym(dim)),
                      ast.Incr(k, ast.c_sym(1)),
@@ -266,7 +279,7 @@ def get_injection_kernel(fiat_element, unique_indices, dim=1):
                      ast.Less(i, ast.c_sym(ncdof)),
                      ast.Incr(i, ast.c_sym(1)),
                      ast.Block([j_loop], open_scope=True))
-    k = ast.FunDecl("void", "injection", arglist, ast.Block([w, i_loop]),
+    k = ast.FunDecl("void", "injection", arglist, ast.Block(w + [i_loop]),
                     pred=["static", "inline"])
 
     return op2.Kernel(k, "injection", opts=parameters["coffee"])
@@ -277,16 +290,31 @@ def get_prolongation_kernel(fiat_element, unique_indices, dim=1):
     nfdof = weights.shape[0]
     ncdof = weights.shape[1]
     arglist = [ast.Decl("double", ast.Symbol("fine", (nfdof*dim, ))),
-               ast.Decl("double", ast.Symbol("**coarse", ()))]
-    w_sym = ast.Symbol("weights", (nfdof, ncdof))
-    w = ast.Decl("double", w_sym, ast.ArrayInit(format_array_literal(weights)),
-                 qualifiers=["static", "const"])
+               ast.Decl("double", ast.Symbol("*restrict *restrict coarse", ()),
+                        qualifiers=["const"])]
+    all_same = np.allclose(weights, weights[0, 0])
+
+    if all_same:
+        w_sym = ast.Symbol("weights", ())
+        w = [ast.Decl("double", w_sym, weights[0, 0],
+                      qualifiers=["const"])]
+    else:
+        w_sym = ast.Symbol("weights", (nfdof, ncdof))
+        init = ast.ArrayInit(format_array_literal(weights))
+        w = [ast.Decl("double", w_sym, init,
+                      qualifiers=["static", "const"])]
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
     k = ast.Symbol("k", ())
+    if all_same:
+        assign = ast.Prod(ast.Symbol("coarse", (j, k)),
+                          w_sym)
+    else:
+        assign = ast.Prod(ast.Symbol("coarse", (j, k)),
+                          ast.Symbol("weights", (i, j)))
+
     assignment = ast.Incr(ast.Symbol("fine", (ast.Sum(k, ast.Prod(i, ast.c_sym(dim))),)),
-                          ast.Prod(ast.Symbol("coarse", (j, k)),
-                                   ast.Symbol("weights", (i, j))))
+                          assign)
     k_loop = ast.For(ast.Decl("int", k, ast.c_sym(0)),
                      ast.Less(k, ast.c_sym(dim)),
                      ast.Incr(k, ast.c_sym(1)),
@@ -299,7 +327,7 @@ def get_prolongation_kernel(fiat_element, unique_indices, dim=1):
                      ast.Less(i, ast.c_sym(nfdof)),
                      ast.Incr(i, ast.c_sym(1)),
                      ast.Block([j_loop], open_scope=True))
-    k = ast.FunDecl("void", "prolongation", arglist, ast.Block([w, i_loop]),
+    k = ast.FunDecl("void", "prolongation", arglist, ast.Block(w + [i_loop]),
                     pred=["static", "inline"])
 
     return op2.Kernel(k, "prolongation", opts=parameters["coffee"])
@@ -313,20 +341,35 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1, no_weights=False
                ast.Decl("double", ast.Symbol("**fine", ()))]
     if not no_weights:
         arglist.append(ast.Decl("double", ast.Symbol("**count_weights", ())))
-    w_sym = ast.Symbol("weights", (ncdof, nfdof))
-    w = ast.Decl("double", w_sym, ast.ArrayInit(format_array_literal(weights)),
-                 qualifiers=["static", "const"])
+
+    all_ones = np.allclose(weights, 1.0)
+
+    if all_ones:
+        w = []
+    else:
+        w_sym = ast.Symbol("weights", (ncdof, nfdof))
+        init = ast.ArrayInit(format_array_literal(weights))
+        w = [ast.Decl("double", w_sym, init,
+                      qualifiers=["static", "const"])]
 
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
     k = ast.Symbol("k", ())
+    fine = ast.Symbol("fine", (j, k))
     if no_weights:
-        prod = ast.Symbol("weights", (i, j))
+        if all_ones:
+            assign = fine
+        else:
+            assign = ast.Prod(fine, ast.Symbol("weights", (i, j)))
     else:
-        prod = ast.Prod(ast.Symbol("weights", (i, j)),
-                        ast.Symbol("count_weights", (j, 0)))
+        if all_ones:
+            assign = ast.Prod(fine, ast.Symbol("count_weights", (j, 0)))
+        else:
+            assign = ast.Prod(fine,
+                              ast.Prod(ast.Symbol("weights", (i, j)),
+                                       ast.Symbol("count_weights", (j, 0))))
     assignment = ast.Incr(ast.Symbol("coarse", (ast.Sum(k, ast.Prod(i, ast.c_sym(dim))),)),
-                          ast.Prod(ast.Symbol("fine", (j, k)), prod))
+                          assign)
     k_loop = ast.For(ast.Decl("int", k, ast.c_sym(0)),
                      ast.Less(k, ast.c_sym(dim)),
                      ast.Incr(k, ast.c_sym(1)),
@@ -339,7 +382,7 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1, no_weights=False
                      ast.Less(i, ast.c_sym(ncdof)),
                      ast.Incr(i, ast.c_sym(1)),
                      ast.Block([j_loop], open_scope=True))
-    k = ast.FunDecl("void", "restriction", arglist, ast.Block([w, i_loop]),
+    k = ast.FunDecl("void", "restriction", arglist, ast.Block(w + [i_loop]),
                     pred=["static", "inline"])
 
     return op2.Kernel(k, "restriction", opts=parameters["coffee"])

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -250,12 +250,12 @@ def get_injection_kernel(fiat_element, unique_indices, dim=1):
     if all_same:
         w_sym = ast.Symbol("weights", ())
         w = [ast.Decl("double", w_sym, weights[0, 0],
-                      qualifiers=["static", "const"])]
+                      qualifiers=["const"])]
     else:
         init = ast.ArrayInit(format_array_literal(weights))
         w_sym = ast.Symbol("weights", (ncdof, nfdof))
         w = [ast.Decl("double", w_sym, init,
-                      qualifiers=["static", "const"])]
+                      qualifiers=["const"])]
 
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
@@ -303,7 +303,7 @@ def get_prolongation_kernel(fiat_element, unique_indices, dim=1):
         w_sym = ast.Symbol("weights", (nfdof, ncdof))
         init = ast.ArrayInit(format_array_literal(weights))
         w = [ast.Decl("double", w_sym, init,
-                      qualifiers=["static", "const"])]
+                      qualifiers=["const"])]
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
     k = ast.Symbol("k", ())
@@ -353,7 +353,7 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1, no_weights=False
         w_sym = ast.Symbol("weights", (ncdof, nfdof))
         init = ast.ArrayInit(format_array_literal(weights))
         w = [ast.Decl("double", w_sym, init,
-                      qualifiers=["static", "const"])]
+                      qualifiers=["const"])]
 
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -320,10 +320,13 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1, no_weights=False
     i = ast.Symbol("i", ())
     j = ast.Symbol("j", ())
     k = ast.Symbol("k", ())
+    if no_weights:
+        prod = ast.Symbol("weights", (i, j))
+    else:
+        prod = ast.Prod(ast.Symbol("weights", (i, j)),
+                        ast.Symbol("count_weights", (j, 0)))
     assignment = ast.Incr(ast.Symbol("coarse", (ast.Sum(k, ast.Prod(i, ast.c_sym(dim))),)),
-                          ast.Prod(ast.Symbol("fine", (j, k)),
-                                   ast.Prod(ast.Symbol("weights", (i, j)),
-                                            ast.Symbol("count_weights", (j, 0)))))
+                          ast.Prod(ast.Symbol("fine", (j, k)), prod))
     k_loop = ast.For(ast.Decl("int", k, ast.c_sym(0)),
                      ast.Less(k, ast.c_sym(dim)),
                      ast.Incr(k, ast.c_sym(1)),

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -338,3 +338,17 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1):
                     pred=["static", "inline"])
 
     return op2.Kernel(k, "restriction")
+
+
+def get_count_kernel(arity):
+    arglist = [ast.Decl("double", ast.Symbol("weight", (arity, )))]
+    i = ast.Symbol("i", ())
+    assignment = ast.Incr(ast.Symbol("weight", (i, )), ast.c_sym(1.0))
+    loop = ast.For(ast.Decl("int", i, ast.c_sym(0)),
+                   ast.Less(i, ast.c_sym(arity)),
+                   ast.Incr(i, ast.c_sym(1)),
+                   ast.Block([assignment], open_scope=True))
+    k = ast.FunDecl("void", "count_weights", arglist,
+                    ast.Block([loop]),
+                    pred=["static", "inline"])
+    return op2.Kernel(k, "count_weights")

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -245,7 +245,8 @@ def get_injection_kernel(fiat_element, unique_indices, dim=1):
     all_same = np.allclose(weights, weights[0, 0])
 
     arglist = [ast.Decl("double", ast.Symbol("coarse", (ncdof*dim, ))),
-               ast.Decl("double", ast.Symbol("**fine", ()))]
+               ast.Decl("double", ast.Symbol("*restrict *restrict fine", ()),
+                        qualifiers=["const"])]
     if all_same:
         w_sym = ast.Symbol("weights", ())
         w = [ast.Decl("double", w_sym, weights[0, 0],
@@ -338,9 +339,11 @@ def get_restriction_kernel(fiat_element, unique_indices, dim=1, no_weights=False
     ncdof = weights.shape[0]
     nfdof = weights.shape[1]
     arglist = [ast.Decl("double", ast.Symbol("coarse", (ncdof*dim, ))),
-               ast.Decl("double", ast.Symbol("**fine", ()))]
+               ast.Decl("double", ast.Symbol("*restrict *restrict fine", ()),
+                        qualifiers=["const"])]
     if not no_weights:
-        arglist.append(ast.Decl("double", ast.Symbol("**count_weights", ())))
+        arglist.append(ast.Decl("double", ast.Symbol("*restrict *restrict count_weights", ()),
+                                qualifiers=["const"]))
 
     all_ones = np.allclose(weights, 1.0)
 

--- a/tests/multigrid/test_basics.py
+++ b/tests/multigrid/test_basics.py
@@ -2,11 +2,21 @@ from firedrake import *
 import pytest
 
 
-@pytest.mark.xfail(reason="Not yet implemented")
 def test_refine_interval():
-    m = UnitIntervalMesh(1)
+    m = UnitIntervalMesh(10)
 
-    mh = MeshHierarchy(m, 1)    # noqa
+    mh = MeshHierarchy(m, 1)
+
+    assert mh[1].num_cells() == 2 * mh[0].num_cells()
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_refine_interval_parallel():
+    m = UnitIntervalMesh(10)
+
+    mh = MeshHierarchy(m, 1)
+
+    assert mh[1].num_cells() < 2 * mh[0].num_cells()
 
 
 @pytest.mark.xfail(reason="Not yet implemented")


### PR DESCRIPTION
This adds support for grid transfer on hierarchies of intervals, as well as extruded hierarchies.  Needs up to the minute petsc and petsc4py combo, but everything seems to work locally.