### PR TITLE
travis: Install requirements one by one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,11 @@ before_install:
     libopenmpi-dev openmpi-bin libblas-dev liblapack-dev gfortran triangle-bin \
     libvtk5-dev python-vtk libparmetis-dev python-vtk cython"
   - wget https://raw.github.com/OP2/PyOP2/master/requirements-minimal.txt
-  - pip install psutil -r requirements-minimal.txt
+  - pip install psutil
+  - "xargs -l1 pip install --allow-external mpi4py --allow-unverified mpi4py \
+       --allow-external petsc --allow-unverified petsc \
+       --allow-external petsc4py  --allow-unverified petsc4py \
+       < requirements-minimal.txt"
   - pip install -r requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install argparse ordereddict; fi
 install:


### PR DESCRIPTION
Recent pip updates no longer install packages in requirements.txt in the
order they're specified.  But some of the packages we use depend on
previously having installed other requirements.  Fudge around this
particular Python packaging disaster by passing each line of the
requirements file individually to pip via xargs.  This does mean the
only things we can put in requirements files are package requirements,
oh well.