### PR TITLE
Sf halos

### DIFF
--- a/firedrake/dmplex.pxi
+++ b/firedrake/dmplex.pxi
@@ -55,6 +55,7 @@ cdef extern from "petscsf.h":
     ctypedef PetscSFNode PetscSFNode "PetscSFNode"
 
     int PetscSFGetGraph(PETSc.PetscSF,PetscInt*,PetscInt*,PetscInt**,PetscSFNode**)
+    int PetscSFSetGraph(PETSc.PetscSF,PetscInt,PetscInt,PetscInt*,PetscCopyMode,PetscSFNode*,PetscCopyMode)
     int PetscSFBcastBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,)
     int PetscSFBcastEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*)
     int PetscSFReduceBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)

--- a/firedrake/dmplex.pxi
+++ b/firedrake/dmplex.pxi
@@ -1,10 +1,5 @@
 cimport petsc4py.PETSc as PETSc
-
-cdef extern from "mpi.h" nogil:
-    ctypedef struct _mpi_datatype_t
-    ctypedef _mpi_datatype_t* MPI_Datatype
-
-    MPI_Datatype MPI_INT
+cimport mpi4py.MPI as MPI
 
 cdef extern from "petsc.h":
    ctypedef long PetscInt
@@ -44,7 +39,7 @@ cdef extern from "petscdmplex.h":
     int DMLabelSetValue(DMLabel, PetscInt, PetscInt)
     int DMLabelClearValue(DMLabel, PetscInt, PetscInt)
 
-    int DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI_Datatype,void*,PETSc.PetscSection,void**)
+    int DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI.MPI_Datatype,void*,PETSc.PetscSection,void**)
 
 cdef extern from "petscis.h":
     int PetscSectionGetOffset(PETSc.PetscSection,PetscInt,PetscInt*)
@@ -60,6 +55,10 @@ cdef extern from "petscsf.h":
     ctypedef PetscSFNode PetscSFNode "PetscSFNode"
 
     int PetscSFGetGraph(PETSc.PetscSF,PetscInt*,PetscInt*,PetscInt**,PetscSFNode**)
+    int PetscSFBcastBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,)
+    int PetscSFBcastEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*)
+    int PetscSFReduceBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
+    int PetscSFReduceEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
 
 cdef extern from "petscbt.h":
     ctypedef char * PetscBT

--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -5,6 +5,7 @@ import numpy as np
 cimport numpy as np
 import cython
 cimport petsc4py.PETSc as PETSc
+
 cimport mpi4py.MPI as MPI
 from mpi4py import MPI
 
@@ -12,6 +13,9 @@ from libc.string cimport memset
 from libc.stdlib cimport qsort
 
 np.import_array()
+
+cdef extern from "mpi-compat.h":
+    pass
 
 include "dmplex.pxi"
 

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -106,17 +106,9 @@ class FunctionSpaceBase(ObjectCached):
                                        perm=mesh._plex_renumbering)
         dm.setDefaultSection(sec)
         self._global_numbering = sec
-        self._universal_numbering = dm.getDefaultGlobalSection()
-
-        # Initialise the DefaultSF with the numbering for this FS
-        dm.createDefaultSF(self._global_numbering,
-                           self._universal_numbering)
-        # Derive the Halo from the DefaultSF
-        self._halo = halo.Halo(dm.getDefaultSF(),
-                               self._global_numbering,
-                               self._universal_numbering)
         self._dm = dm
         self._ises = None
+        self._halo = halo.Halo(dm)
 
         # Compute entity class offsets
         self.dof_classes = [0, 0, 0, 0]
@@ -192,7 +184,7 @@ class FunctionSpaceBase(ObjectCached):
         name = "%s_nodes" % self.name
         if self._halo:
             s = op2.Set(self.dof_classes, name,
-                        halo=self._halo.op2_halo)
+                        halo=self._halo)
             if self.extruded:
                 return op2.ExtrudedSet(s, layers=self._mesh.layers)
             return s

--- a/firedrake/halo.py
+++ b/firedrake/halo.py
@@ -1,121 +1,100 @@
-import numpy as np
-from collections import defaultdict
+from pyop2 import op2
+from pyop2.utils import maybe_setflags
 from mpi4py import MPI
 
-from pyop2 import op2
+import dmplex
 
-import utils
+
+_MPI_types = {}
+
+
+def _get_mtype(dat):
+    """Get an MPI datatype corresponding to a Dat.
+
+    This builds (if necessary a contiguous derived datatype of the
+    correct size)."""
+    key = (dat.dtype, dat.cdim)
+    try:
+        return _MPI_types[key]
+    except KeyError:
+        try:
+            tdict = MPI.__TypeDict__
+        except AttributeError:
+            tdict = MPI._typedict
+        try:
+            btype = tdict[dat.dtype.char]
+        except KeyError:
+            raise RuntimeError("Unknown base type %r", dat.dtype)
+        if dat.cdim == 1:
+            typ = btype
+        else:
+            typ = btype.Create_contiguous(dat.cdim)
+            typ.Commit()
+        _MPI_types[key] = typ
+        return typ
 
 
 class Halo(object):
-    """Build a Halo associated with the appropriate FunctionSpace.
+    """Build a Halo for a function space.
 
-    The Halo is derived from a PetscSF object and builds the global
-    to universal numbering map from the respective PetscSections."""
+    :arg fs:  The :class:`.FunctionSpace` to build a :class:`Halo` for.
 
-    def __init__(self, petscsf, global_numbering, universal_numbering):
-        self._tag = utils._new_uid()
-        self._comm = op2.MPI.comm
-        self._nprocs = self.comm.size
-        self._sends = defaultdict(list)
-        self._receives = defaultdict(list)
-        self._gnn2unn = None
-        remote_sends = defaultdict(list)
+    The halo is implemented using a PETSc SF (star forest) object and
+    is usable as a PyOP2 :class:`pyop2.Halo`."""
 
-        if op2.MPI.comm.size <= 1:
-            return
-
-        # Sort the SF by local indices
-        nroots, nleaves, local, remote = petscsf.getGraph()
-        local_new, remote_new = (list(x) for x in zip(*sorted(zip(local, remote), key=lambda x: x[0])))
-        petscsf.setGraph(nroots, nleaves, local_new, remote_new)
-
-        # Derive local receives and according remote sends
-        nroots, nleaves, local, remote = petscsf.getGraph()
-        for local, (rank, index) in zip(local, remote):
-            if rank != self.comm.rank:
-                self._receives[rank].append(local)
-                remote_sends[rank].append(index)
-
-        # Propagate remote send lists to the actual sender
-        send_reqs = []
-        for p in range(self._nprocs):
-            # send sizes
-            if p != self._comm.rank:
-                s = np.array(len(remote_sends[p]), dtype=np.int32)
-                send_reqs.append(self.comm.Isend(s, dest=p, tag=self.tag))
-
-        recv_reqs = []
-        sizes = [np.zeros(1, dtype=np.int32) for _ in range(self._nprocs)]
-        for p in range(self._nprocs):
-            # receive sizes
-            if p != self._comm.rank:
-                recv_reqs.append(self.comm.Irecv(sizes[p], source=p, tag=self.tag))
-
-        MPI.Request.Waitall(recv_reqs)
-        MPI.Request.Waitall(send_reqs)
-
-        for p in range(self._nprocs):
-            # allocate buffers
-            if p != self._comm.rank:
-                if sizes[p][0] > 0:
-                    self._sends[p] = np.empty(sizes[p][0], dtype=np.int32)
-
-        send_reqs = []
-        for p in range(self._nprocs):
-            if p != self._comm.rank:
-                if len(remote_sends[p]) > 0:
-                    send_buf = np.array(remote_sends[p], dtype=np.int32)
-                    send_reqs.append(self.comm.Isend(send_buf, dest=p, tag=self.tag))
-
-        recv_reqs = []
-        for p in range(self._nprocs):
-            if p != self._comm.rank:
-                if sizes[p][0] > 0:
-                    recv_reqs.append(self.comm.Irecv(self._sends[p], source=p, tag=self.tag))
-
-        MPI.Request.Waitall(send_reqs)
-        MPI.Request.Waitall(recv_reqs)
-
-        # Build Global-To-Universal mapping
-        pStart, pEnd = global_numbering.getChart()
-        self._gnn2unn = np.zeros(global_numbering.getStorageSize(), dtype=np.int32)
-        for p in range(pStart, pEnd):
-            dof = global_numbering.getDof(p)
-            goff = global_numbering.getOffset(p)
-            uoff = universal_numbering.getOffset(p)
-            if uoff < 0:
-                uoff = (-1*uoff)-1
-            for c in range(dof):
-                self._gnn2unn[goff+c] = uoff+c
-
-    @utils.cached_property
-    def op2_halo(self):
-        if not self.sends and not self.receives:
-            return None
-        return op2.Halo(self.sends, self.receives,
-                        comm=self.comm, gnn2unn=self.gnn2unn)
+    def __init__(self, dm):
+        lsec = dm.getDefaultSection()
+        gsec = dm.getDefaultGlobalSection()
+        dm.createDefaultSF(lsec, gsec)
+        self.sf = dm.getDefaultSF()
+        self.sf.setFromOptions()
+        if self.sf.getType() != self.sf.Type.BASIC:
+            raise RuntimeError("Windowed SFs expose bugs in OpenMPI (use -sf_type basic)")
+        if op2.MPI.comm.size == 1:
+            self._gnn2unn = None
+        self._gnn2unn = dmplex.make_global_numbering(lsec,
+                                                     gsec)
 
     @property
     def comm(self):
-        return self._comm
+        """The communicator for this halo."""
+        return self.sf.comm
+
+    def begin(self, dat, reverse=False):
+        """Begin a halo exchange.
+
+        :arg dat: The :class:`pyop2.Dat` to start a halo exchange on.
+        :arg reverse: (optional) perform a reverse halo exchange.
+
+        .. note::
+
+           If :data:`reverse` is :data:`True` then the input buffer
+           may not be touched before calling :meth:`.end`."""
+        if self.comm.size == 1:
+            return
+        mtype = _get_mtype(dat)
+        dmplex.halo_begin(self.sf, dat, mtype, reverse)
+
+    def end(self, dat, reverse=False):
+        """End a halo exchange.
+
+        :arg dat: The :class:`pyop2.Dat` to end a halo exchange on.
+        :arg reverse: (optional) perform a reverse halo exchange.
+
+        See also :meth:`.begin`."""
+        if self.comm.size == 1:
+            return
+        mtype = _get_mtype(dat)
+        maybe_setflags(dat._data, write=True)
+        dmplex.halo_end(self.sf, dat, mtype, reverse)
+        maybe_setflags(dat._data, write=False)
+
+    def verify(self, *args):
+        """No-op"""
+        pass
 
     @property
-    def tag(self):
-        return self._tag
-
-    @property
-    def nprocs(self):
-        return self._nprocs
-
-    @property
-    def sends(self):
-        return self._sends
-
-    @property
-    def receives(self):
-        return self._receives
-
-    @property
-    def gnn2unn(self):
+    def global_to_petsc_numbering(self):
+        """Return a mapping from global (process-local) to universal
+    (process-global) numbers"""
         return self._gnn2unn

--- a/firedrake/mg/firedrakeimpl.pxi
+++ b/firedrake/mg/firedrakeimpl.pxi
@@ -1,3 +1,6 @@
+cdef extern from "../mpi-compat.h":
+    pass
+
 cdef extern from * nogil:
     int DMPlexCreatePointNumbering(PETSc.PetscDM,PETSc.PetscIS*)
     int ISLocalToGlobalMappingCreateIS(PETSc.PetscIS,PETSc.PetscLGMap*)

--- a/firedrake/mpi-compat.h
+++ b/firedrake/mpi-compat.h
@@ -1,0 +1,14 @@
+/* Author:  Lisandro Dalcin   */
+/* Contact: dalcinl@gmail.com */
+
+#ifndef MPI_COMPAT_H
+#define MPI_COMPAT_H
+
+#include <mpi.h>
+
+#if (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
+typedef void *PyMPI_MPI_Message;
+#define MPI_Message PyMPI_MPI_Message
+#endif
+
+#endif/*MPI_COMPAT_H*/


### PR DESCRIPTION
This change switches to using PETSc SFs for halo exchanges rather than the PyOP2 machinery.

Requires OP2/PyOP2#424, along with https://bitbucket.org/petsc/petsc/pull-request/255/sf-fix-multiple-in-flight-comm-rounds-for in PETSc.  So not safe to run yet.

SFs have two implementation modes: "basic" (the default) which uses non-blocking point to point and "window" which uses MPI one-sided.  The latter works now with MPICH, but DOES NOT WORK with OpenMPI, because they have long-standing bugs in their MPI one-sided implementation (see thread here http://lists.mcs.anl.gov/pipermail/petsc-users/2015-February/024260.html).

Implementation changes:

Firedrake now just provides a halo object directly to PyOP2 which implements the necessary methods.  The PETSc SF implementation is such that you can have multiple rounds of communication in flight on the same SF simultaneously.  BUT, between the XXXBegin and XXXEnd calls you're not allowed to touch the input buffer (the Dat in our case) or look at the output buffer (which holds undefined values).

To work around this (since we have a slightly different computational model), I introduce a temporary buffer and perform some copies.  If this is considered bad we'll have to do some rethinking.  (See implementation at the end of dmplex.pyx).