### PR TITLE
Use correct key when summing integrands in form splitter

### DIFF
--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -53,7 +53,13 @@ def sum_integrands(form):
     """Produce a form with the integrands on the same measure summed."""
     integrals = defaultdict(list)
     for integral in form.integrals():
-        integrals[(integral.integral_type(), integral.subdomain_id())].append(integral)
+        md = integral.metadata()
+        mdkey = tuple((k, md[k]) for k in sorted(md.keys()))
+        integrals[(integral.integral_type(),
+                   integral.domain(),
+                   integral.subdomain_id(),
+                   integral.subdomain_data(),
+                   mdkey)].append(integral)
     return Form([it[0].reconstruct(reduce(add, [i.integrand() for i in it]))
                  for it in integrals.values()])
 


### PR DESCRIPTION
We can't just use the integral type and subdomain, but also need to
respect the metadata and so forth.  In particular, prior to this change
integrals over the same measure but with different quadrature degrees
would be treated the same if they appeared in a sum.