### PR TITLE
Generate proper ASTs for expression kernels

### DIFF
--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -80,7 +80,7 @@ class DummyFunction(ufl.Coefficient):
     @property
     def arg(self):
         argtype = self.function.dat.ctype + "*"
-        name = " fn_%r" % self.argnum
+        name = "fn_%r" % self.argnum
 
         return ast.Decl(argtype, ast.Symbol(name))
 

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -48,7 +48,7 @@ def ufl_type(*args, **kwargs):
 
 
 def _ast(expr):
-    """Convert expr to a PyOP2 ast."""
+    """Convert expr to a COFFEE AST."""
 
     try:
         return expr.ast
@@ -527,10 +527,7 @@ def expression_kernel(expr, args):
     fs = args[0].function.function_space()
 
     d = ast.Symbol("dim")
-    if isinstance(fs, functionspace.VectorFunctionSpace):
-        ast_expr = _ast(expr)
-    else:
-        ast_expr = ast.FlatBlock(str(expr) + ";")
+    ast_expr = _ast(expr)
     body = ast.Block(
         (
             ast.Decl("int", d),


### PR DESCRIPTION
This fixes the generation of COFFEE's ASTs for expression kernels by replacing FlatBlocks with "meaningful" nodes 