### PR TITLE
Support assigning a vector-valued Constant to a mixed Function

### DIFF
--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -231,6 +231,68 @@ def test_assign_mixed_no_zero(mfs):
         assert np.allclose(v.dat.data_ro, 2.0)
 
 
+def test_assign_vector_const_to_mfs_scalar_vector(cg1, vcg1):
+    W = cg1*vcg1
+
+    w = Function(W)
+
+    c = Constant(range(1, w.element().value_shape()[0]+1))
+
+    w.assign(c)
+
+    s, v = w.split()
+
+    assert np.allclose(s.dat.data_ro, c.dat.data_ro[0])
+    assert np.allclose(v.dat.data_ro, c.dat.data_ro[1:])
+
+
+def test_assign_vector_const_to_mfs_scalar_vector_vector(cg1, vcg1):
+    W = cg1*vcg1*vcg1
+
+    w = Function(W)
+
+    c = Constant(range(1, w.element().value_shape()[0]+1))
+
+    w.assign(c)
+
+    s, v, v2 = w.split()
+
+    assert np.allclose(s.dat.data_ro, c.dat.data_ro[0])
+    assert np.allclose(v.dat.data_ro, c.dat.data_ro[1:3])
+    assert np.allclose(v2.dat.data_ro, c.dat.data_ro[3:])
+
+
+def test_assign_vector_const_to_vfs(vcg1):
+    f = Function(vcg1)
+
+    c = Constant(range(1, f.element().value_shape()[0]+1))
+
+    f.assign(c)
+    assert np.allclose(f.dat.data_ro, c.dat.data_ro)
+
+
+def test_assign_scalar_const_to_vfs(vcg1):
+    f = Function(vcg1)
+
+    c = Constant(10.0)
+
+    f.assign(c)
+    assert np.allclose(f.dat.data_ro, c.dat.data_ro)
+
+
+def test_assign_vector_const_to_mfs_scalars(cg1):
+    W = cg1*cg1*cg1
+
+    w = Function(W)
+
+    c = Constant(range(1, w.element().value_shape()[0]+1))
+
+    w.assign(c)
+
+    for i, w_ in enumerate(w.split()):
+        assert np.allclose(w_.dat.data_ro, c.dat.data_ro[i])
+
+
 def test_assign_to_mfs_sub(cg1, vcg1):
     W = cg1*vcg1
 


### PR DESCRIPTION
If the Constant has the same shape as the mixed function's element,
split it into as many pieces as there are spaces in the mixed space and
use each of these in turn to assign to the sub functions.