### PR TITLE
ffc_interface: better catching of empty integrals

### DIFF
--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -199,8 +199,13 @@ class FFCKernel(DiskCached):
                 kernels.append((Kernel(Root([incl, kernel]), '%s_%s_integral_0_%s' %
                                        (name, it.integral_type(), it.subdomain_id()), opts, inc),
                                 needs_orientations))
-            self.kernels = tuple(kernels)
-            self._empty = False
+            # Sometimes FFC returns an empty list without raising
+            # EmptyIntegrandError, catch that here.
+            if len(kernels) == 0:
+                self._empty = True
+            else:
+                self.kernels = tuple(kernels)
+                self._empty = False
         except EmptyIntegrandError:
             # FFC noticed that the integrand was zero and simplified
             # it, catch this here and set a flag telling us to ignore

--- a/tests/extrusion/test_extrusion_zero_integrand.py
+++ b/tests/extrusion/test_extrusion_zero_integrand.py
@@ -1,0 +1,34 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+
+def test_empty_integrand():
+    m = UnitSquareMesh(5, 5)
+    mesh = ExtrudedMesh(m, layers=5)
+
+    P1 = FunctionSpace(mesh, 'CG', 1)
+
+    u = TrialFunction(P1)
+    v = TestFunction(P1)
+    sol = Function(P1)
+    f = Function(P1)
+    f.interpolate(Expression("4.5"))
+
+    A = inner(u, v)*dx
+    L = inner(f, v)*dx + inner(f, v)*ds_v
+
+    u = Function(P1)
+    solve(A == L, u)
+
+    # Derivative of ds_v term wrt sol is zero, but FFC generates
+    # "empty" code, which we must catch.
+    F = inner(sol, v)*dx - inner(f, v)*dx - inner(f, v)*ds_v
+    solve(F == 0, sol)
+
+    assert np.allclose(u.dat.data_ro, sol.dat.data_ro)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
In some circumstances, FFC will return an empty list of kernels.  We
should treat these as empty.