### PR TITLE
Optimise mesh renumbering

### DIFF
--- a/firedrake/dmplex.pxi
+++ b/firedrake/dmplex.pxi
@@ -33,9 +33,16 @@ cdef extern from "petscdmplex.h":
     int DMPlexGetTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
     int DMPlexRestoreTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
 
+    struct _n_DMLabel
+    ctypedef _n_DMLabel* DMLabel "DMLabel"
+    int DMPlexGetLabel(PETSc.PetscDM,char[],DMLabel*)
     int DMPlexGetLabelValue(PETSc.PetscDM,char[],PetscInt,PetscInt*)
     int DMPlexSetLabelValue(PETSc.PetscDM,char[],PetscInt,PetscInt)
     int DMPlexClearLabelValue(PETSc.PetscDM,char[],PetscInt,PetscInt)
+    int DMLabelCreateIndex(DMLabel, PetscInt, PetscInt)
+    int DMLabelHasPoint(DMLabel, PetscInt, PetscBool*)
+    int DMLabelSetValue(DMLabel, PetscInt, PetscInt)
+    int DMLabelClearValue(DMLabel, PetscInt, PetscInt)
 
     int DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI_Datatype,void*,PETSc.PetscSection,void**)
 

--- a/firedrake/dmplex.pxi
+++ b/firedrake/dmplex.pxi
@@ -22,6 +22,7 @@ cdef extern from "petscsys.h":
 
 cdef extern from "petscdmplex.h":
     int DMPlexGetHeightStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
+    int DMPlexGetDepthStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
 
     int DMPlexGetConeSize(PETSc.PetscDM,PetscInt,PetscInt*)
     int DMPlexGetCone(PETSc.PetscDM,PetscInt,PetscInt*[])

--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -166,7 +166,7 @@ def closure_ordering(PETSc.DM plex,
                 cell_closure[cell, vi] = vertices[vi]
         offset = v_per_cell
 
-        # Find all faces (dim=1)
+        # Find all edges (dim=1)
         if dim > 2:
             nfaces = 0
             for ci in range(nclosure):
@@ -178,7 +178,7 @@ def closure_ordering(PETSc.DM plex,
                     CHKERR(DMPlexGetCone(plex.dm, closure[2*ci],
                                          &face_vertices))
 
-                    # Faces in 3D are tricky because we need a
+                    # Edges in 3D are tricky because we need a
                     # lexicographical sort with two keys (the local
                     # numbers of the two non-incident vertices).
 

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -109,15 +109,9 @@ class FunctionSpaceBase(ObjectCached):
         # Compute entity class offsets
         self.dof_classes = [0, 0, 0, 0]
         for d in range(mesh._plex.getDimension()+1):
-            ncore = mesh._entity_classes[d, 0]
-            nowned = mesh._entity_classes[d, 1]
-            nhalo = mesh._entity_classes[d, 2]
-            nnonexec = mesh._entity_classes[d, 3]
             ndofs = self._dofs_per_entity[d]
-            self.dof_classes[0] += ndofs * ncore
-            self.dof_classes[1] += ndofs * (ncore + nowned)
-            self.dof_classes[2] += ndofs * (ncore + nowned + nhalo)
-            self.dof_classes[3] += ndofs * (ncore + nowned + nhalo + nnonexec)
+            for i in range(4):
+                self.dof_classes[i] += ndofs * mesh._entity_classes[d, i]
 
         self._node_count = self._global_numbering.getStorageSize()
 

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -109,10 +109,10 @@ class FunctionSpaceBase(ObjectCached):
         # Compute entity class offsets
         self.dof_classes = [0, 0, 0, 0]
         for d in range(mesh._plex.getDimension()+1):
-            ncore = mesh._plex.getStratumSize("op2_core", d)
-            nowned = mesh._plex.getStratumSize("op2_non_core", d)
-            nhalo = mesh._plex.getStratumSize("op2_exec_halo", d)
-            nnonexec = mesh._plex.getStratumSize("op2_non_exec_halo", d)
+            ncore = mesh._entity_classes[d, 0]
+            nowned = mesh._entity_classes[d, 1]
+            nhalo = mesh._entity_classes[d, 2]
+            nnonexec = mesh._entity_classes[d, 3]
             ndofs = self._dofs_per_entity[d]
             self.dof_classes[0] += ndofs * ncore
             self.dof_classes[1] += ndofs * (ncore + nowned)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -351,6 +351,7 @@ class Mesh(object):
             # Mark OP2 entities and derive the resulting Plex renumbering
             with timed_region("Mesh: renumbering"):
                 dmplex.mark_entity_classes(self._plex)
+                self._entity_classes = dmplex.get_entity_classes(self._plex)
                 self._plex_renumbering = dmplex.plex_renumbering(self._plex, reordering)
                 self.cell_classes = dmplex.get_cell_classes(self._plex)
 
@@ -738,6 +739,7 @@ class ExtrudedMesh(Mesh):
         self._plex = mesh._plex
         self._plex_renumbering = mesh._plex_renumbering
         self._cell_numbering = mesh._cell_numbering
+        self._entity_classes = mesh._entity_classes
 
         interior_f = self._old_mesh.interior_facets
         self._interior_facets = _Facets(self, interior_f.classes,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -352,7 +352,9 @@ class Mesh(object):
             with timed_region("Mesh: renumbering"):
                 dmplex.mark_entity_classes(self._plex)
                 self._entity_classes = dmplex.get_entity_classes(self._plex)
-                self._plex_renumbering = dmplex.plex_renumbering(self._plex, reordering)
+                self._plex_renumbering = dmplex.plex_renumbering(self._plex,
+                                                                 self._entity_classes,
+                                                                 reordering)
 
             with timed_region("Mesh: cell numbering"):
                 # Derive a cell numbering from the Plex renumbering

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -353,7 +353,6 @@ class Mesh(object):
                 dmplex.mark_entity_classes(self._plex)
                 self._entity_classes = dmplex.get_entity_classes(self._plex)
                 self._plex_renumbering = dmplex.plex_renumbering(self._plex, reordering)
-                self.cell_classes = dmplex.get_cell_classes(self._plex)
 
             with timed_region("Mesh: cell numbering"):
                 # Derive a cell numbering from the Plex renumbering
@@ -660,9 +659,13 @@ class Mesh(object):
     def size(self, d):
         return self.num_entities(d)
 
+    @property
+    def cell_classes(self):
+        return self._entity_classes[self.cell_dimension(), :]
+
     @utils.cached_property
     def cell_set(self):
-        size = self.cell_classes
+        size = list(self.cell_classes)
         return self.parent.cell_set if self.parent else \
             op2.Set(size, "%s_cells" % self.name)
 


### PR DESCRIPTION
This merge optimises the mesh reordering procedures by flattening and indexing the labels used to mark OP2 entity classes on the DMPlex. This speeds up mesh creation and enables future multi-level `owned`/`halo` regions as required by tiling algorithms. The `plex_renumbering` routine has also been simplified.