### PR TITLE
Monolithic matrices

### DIFF
--- a/firedrake/mg/solver_hierarchy.py
+++ b/firedrake/mg/solver_hierarchy.py
@@ -28,7 +28,8 @@ def coarsen_problem(problem):
                                                         bcs=new_bcs,
                                                         J=new_J,
                                                         Jp=new_Jp,
-                                                        form_compiler_parameters=problem.form_compiler_parameters)
+                                                        form_compiler_parameters=problem.form_compiler_parameters,
+                                                        nest=problem._nest)
     return new_problem
 
 

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -47,3 +47,5 @@ ffc_parameters['pyop2-ir'] = True
 parameters.add(Parameters("form_compiler", **ffc_parameters))
 
 parameters["reorder_meshes"] = True
+
+parameters["matnest"] = True

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -127,19 +127,21 @@ def _solve_varproblem(*args, **kwargs):
 
     # Extract arguments
     eq, u, bcs, J, Jp, M, form_compiler_parameters, \
-        solver_parameters, nullspace, options_prefix = _extract_args(*args, **kwargs)
+        solver_parameters, nullspace, options_prefix, \
+        nest = _extract_args(*args, **kwargs)
 
     # Solve linear variational problem
     if isinstance(eq.lhs, ufl.Form) and isinstance(eq.rhs, ufl.Form):
 
         # Create problem
         problem = vs.LinearVariationalProblem(eq.lhs, eq.rhs, u, bcs, Jp,
-                                              form_compiler_parameters=form_compiler_parameters)
+                                              form_compiler_parameters=form_compiler_parameters,
+                                              nest=nest)
 
         # Create solver and call solve
         solver = vs.LinearVariationalSolver(problem, solver_parameters=solver_parameters,
                                             nullspace=nullspace,
-                                            options_preifx=options_prefix)
+                                            options_prefix=options_prefix)
         with progress(INFO, 'Solving linear variational problem'):
             solver.solve()
 

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -150,7 +150,8 @@ def _solve_varproblem(*args, **kwargs):
 
         # Create problem
         problem = vs.NonlinearVariationalProblem(eq.lhs, u, bcs, J, Jp,
-                                                 form_compiler_parameters=form_compiler_parameters)
+                                                 form_compiler_parameters=form_compiler_parameters,
+                                                 nest=nest)
 
         # Create solver and call solve
         solver = vs.NonlinearVariationalSolver(problem, solver_parameters=solver_parameters,
@@ -234,7 +235,8 @@ def _extract_args(*args, **kwargs):
     valid_kwargs = ["bcs", "J", "Jp", "M",
                     "form_compiler_parameters", "solver_parameters",
                     "nullspace",
-                    "options_prefix"]
+                    "options_prefix",
+                    "nest"]
     for kwarg in kwargs.iterkeys():
         if kwarg not in valid_kwargs:
             raise RuntimeError("Illegal keyword argument '%s'; valid keywords \
@@ -277,9 +279,10 @@ def _extract_args(*args, **kwargs):
     form_compiler_parameters = kwargs.get("form_compiler_parameters", {})
     solver_parameters = kwargs.get("solver_parameters", {})
     options_prefix = kwargs.get("options_prefix", None)
+    nest = kwargs.get("nest", None)
 
     return eq, u, bcs, J, Jp, M, form_compiler_parameters, \
-        solver_parameters, nullspace, options_prefix
+        solver_parameters, nullspace, options_prefix, nest
 
 
 def _extract_eq(eq):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -100,11 +100,13 @@ class _SNESContext(object):
         # form_jacobian we call assemble again which drops this
         # computation on the floor.
         self._jacs = tuple(assemble.assemble(problem.J, bcs=problem.bcs,
-                                             form_compiler_parameters=problem.form_compiler_parameters)
+                                             form_compiler_parameters=problem.form_compiler_parameters,
+                                             nest=problem._nest)
                            for problem in problems)
         if problems[-1].Jp is not None:
             self._pjacs = tuple(assemble.assemble(problem.Jp, bcs=problem.bcs,
-                                                  form_compiler_parameters=problem.form_compiler_parameters)
+                                                  form_compiler_parameters=problem.form_compiler_parameters,
+                                                  nest=problem._nest)
                                 for problem in problems)
         else:
             self._pjacs = self._jacs
@@ -178,7 +180,8 @@ class _SNESContext(object):
                 X.copy(v)
 
         assemble.assemble(ctx.Fs[lvl], tensor=ctx._Fs[lvl],
-                          form_compiler_parameters=problem.form_compiler_parameters)
+                          form_compiler_parameters=problem.form_compiler_parameters,
+                          nest=problem._nest)
         for bc in problem.bcs:
             bc.zero(ctx._Fs[lvl])
 
@@ -218,11 +221,13 @@ class _SNESContext(object):
         assemble.assemble(ctx.Js[lvl],
                           tensor=ctx._jacs[lvl],
                           bcs=problem.bcs,
-                          form_compiler_parameters=problem.form_compiler_parameters)
+                          form_compiler_parameters=problem.form_compiler_parameters,
+                          nest=problem._nest)
         ctx._jacs[lvl].M._force_evaluation()
         if ctx.Jps[lvl] is not None:
             assemble.assemble(ctx.Jps[lvl],
                               tensor=ctx._pjacs[lvl],
                               bcs=problem.bcs,
-                              form_compiler_parameters=problem.form_compiler_parameters)
+                              form_compiler_parameters=problem.form_compiler_parameters,
+                              nest=problem._nest)
             ctx._pjacs[lvl].M._force_evaluation()

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -19,7 +19,8 @@ class NonlinearVariationalProblem(object):
 
     def __init__(self, F, u, bcs=None, J=None,
                  Jp=None,
-                 form_compiler_parameters=None):
+                 form_compiler_parameters=None,
+                 nest=None):
         """
         :param F: the nonlinear form
         :param u: the :class:`.Function` to solve for
@@ -30,6 +31,11 @@ class NonlinearVariationalProblem(object):
                  will be used.
         :param dict form_compiler_parameters: parameters to pass to the form
             compiler (optional)
+        :param nest: indicate if matrices on mixed spaces should be
+               built as monolithic operators (suitable for direct
+               solves), or as nested blocks (suitable for fieldsplit
+               preconditioning).  If not provided, uses the default
+               given by :data:`parameters["matnest"]`.
         """
 
         # Extract and check arguments
@@ -45,6 +51,7 @@ class NonlinearVariationalProblem(object):
         self.u = u
         self.bcs = bcs
 
+        self._nest = nest
         # Store form compiler parameters
         self.form_compiler_parameters = form_compiler_parameters
         self._constant_jacobian = False
@@ -74,7 +81,6 @@ class NonlinearVariationalSolver(object):
                created.  Use this option if you want to pass options
                to the solver from the command line in addition to
                through the :data:`solver_parameters` dict.
-
         .. code-block:: python
 
             {'snes_type': 'ksponly'}
@@ -160,6 +166,7 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
 
     def __init__(self, a, L, u, bcs=None, aP=None,
                  form_compiler_parameters=None,
+                 nest=None,
                  constant_jacobian=True):
         """
         :param a: the bilinear form
@@ -171,6 +178,11 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
                  computed from ``a``)
         :param dict form_compiler_parameters: parameters to pass to the form
             compiler (optional)
+        :param nest: indicate if matrices on mixed spaces should be
+               built as monolithic operators (suitable for direct
+               solves), or as nested blocks (suitable for fieldsplit
+               preconditioning).  If not provided, uses the default
+               given by :data:`parameters["matnest"]`.
         :param constant_jacobian: (optional) flag indicating that the
                  Jacobian is constant (i.e. does not depend on
                  varying fields).  If your Jacobian can change, set
@@ -182,7 +194,7 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
         F = ufl.action(J, u) - L
 
         super(LinearVariationalProblem, self).__init__(F, u, bcs, J, aP,
-                                                       form_compiler_parameters=form_compiler_parameters)
+                                                       form_compiler_parameters=form_compiler_parameters, nest=nest)
         self._constant_jacobian = constant_jacobian
 
 

--- a/tests/extrusion/test_mixed_bcs.py
+++ b/tests/extrusion/test_mixed_bcs.py
@@ -95,7 +95,8 @@ def test_multiple_poisson_strong_weak_Pn(quadrilateral, degree):
     assert assemble(inner(w - wexact, w - wexact)*dx) < 1e-8
 
 
-def test_stokes_taylor_hood():
+@pytest.mark.parametrize('nest', [True, False])
+def test_stokes_taylor_hood(nest):
     length = 10
     m = IntervalMesh(40, length)
     mesh = ExtrudedMesh(m, 20)
@@ -138,7 +139,8 @@ def test_stokes_taylor_hood():
                              'fieldsplit_schur_fact_type': 'diag',
                              'fieldsplit_0_pc_type': 'redundant',
                              'fieldsplit_0_redundant_pc_type': 'lu',
-                             'fieldsplit_1_pc_type': 'none'})
+                             'fieldsplit_1_pc_type': 'none'},
+          nest=nest)
 
     # We've set up Poiseuille flow, so we expect a parabolic velocity
     # field and a linearly decreasing pressure.
@@ -151,7 +153,12 @@ def test_stokes_taylor_hood():
 
 @pytest.mark.parallel
 def test_stokes_taylor_hood_parallel():
-    test_stokes_taylor_hood()
+    test_stokes_taylor_hood(nest=True)
+
+
+@pytest.mark.parallel
+def test_stokes_taylor_hood_parallel_monolithic():
+    test_stokes_taylor_hood(nest=False)
 
 
 if __name__ == '__main__':

--- a/tests/extrusion/test_mixed_bcs.py
+++ b/tests/extrusion/test_mixed_bcs.py
@@ -136,7 +136,8 @@ def test_stokes_taylor_hood():
                              'ksp_rtol': 1e-15,
                              'pc_fieldsplit_type': 'schur',
                              'fieldsplit_schur_fact_type': 'diag',
-                             'fieldsplit_0_pc_type': 'lu',
+                             'fieldsplit_0_pc_type': 'redundant',
+                             'fieldsplit_0_redundant_pc_type': 'lu',
                              'fieldsplit_1_pc_type': 'none'})
 
     # We've set up Poiseuille flow, so we expect a parabolic velocity
@@ -146,6 +147,11 @@ def test_stokes_taylor_hood():
 
     assert errornorm(u, uexact, degree_rise=0) < 1e-7
     assert errornorm(p, pexact, degree_rise=0) < 1e-7
+
+
+@pytest.mark.parallel
+def test_stokes_taylor_hood_parallel():
+    test_stokes_taylor_hood()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Along with https://bitbucket.org/petsc/petsc/pull-request/281/unbreak-matcreatelocalref-in-light-of
and OP2/PyOP2#431 this change adds support for assembling AIJ (rather than NEST) matrices on mixed spaces.  IOW, LU for mixed solves.  All the field split machinery is still in place if you want that too.

Globally, the parameter `"matnest"` controls whether nested matrices should be assembled, or not.  Individually, one can assemble an operator monolithically as: `assemble(a, ..., nest=False)`.

This is not yet hooked up to solves (one should probably supply an option to assemble monolithic jacobians to the solver interface).

Ideas on how to test this within the test framework.  I'd like to run the whole test suite with the configuration option set to False.  I wonder if there's a magic pytest way to parametrize all tests over these two options.