### PR TITLE
Formsplitter decision fix

### DIFF
--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -200,13 +200,8 @@ class FFCKernel(DiskCached):
                 kernels.append((Kernel(Root(incl + [_kernel]), '%s_%s_integral_0_%s' %
                                        (name, it.integral_type(), it.subdomain_id()), opts, inc),
                                 needs_orientations))
-            # Sometimes FFC returns an empty list without raising
-            # EmptyIntegrandError, catch that here.
-            if len(kernels) == 0:
-                self._empty = True
-            else:
-                self.kernels = tuple(kernels)
-                self._empty = False
+            self.kernels = tuple(kernels)
+            self._empty = False
         except EmptyIntegrandError:
             # FFC noticed that the integrand was zero and simplified
             # it, catch this here and set a flag telling us to ignore

--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -8,7 +8,7 @@ from os import path, environ, getuid, makedirs
 import tempfile
 
 import ufl
-from ufl import Form, FiniteElement, VectorElement, as_vector
+from ufl import Form, MixedElement, as_vector
 from ufl.measure import Measure
 from ufl.algorithms import compute_form_data, ReuseTransformer
 from ufl.constantvalue import Zero
@@ -265,7 +265,9 @@ def compile_form(form, name, parameters=None, inverse=False):
     fd = compute_form_data(form)
 
     # If there is no mixed element involved, return the kernels FFC produces
-    if all(isinstance(e, (FiniteElement, VectorElement)) for e in fd.unique_sub_elements):
+    # Note: using type rather than isinstance because UFL's VectorElement,
+    # TensorElement and OPVectorElement all inherit from MixedElement
+    if not any(type(e) is MixedElement for e in fd.unique_sub_elements):
         kernels = [((0, 0),
                     it.integral_type(), it.subdomain_id(),
                     it.domain().data().coordinates,

--- a/tests/regression/test_zero_integrand.py
+++ b/tests/regression/test_zero_integrand.py
@@ -1,0 +1,39 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+
+def test_empty_integrand():
+    mesh = UnitSquareMesh(5, 5)
+
+    P1 = FiniteElement("CG", triangle, 1)
+    B = FiniteElement("B", triangle, 3)
+    Mini = FunctionSpace(mesh, P1+B)
+
+    u = TrialFunction(Mini)
+    v = TestFunction(Mini)
+    sol = Function(Mini)
+    f = Function(Mini)
+    f.assign(1)
+
+    a = inner(u, v)*dx
+    L = inner(f, v)*dx + inner(f, v)*ds(3)
+
+    u = Function(Mini)
+    solve(a == L, u)
+
+    # Derivative of ds term wrt sol is zero, but FFC generates
+    # "empty" code, which we must catch.
+
+    # At one point, this test would have failed since we use an EnrichedElement
+    # rather than a FiniteElement or VectorElement.
+    # Note the failure mode is an error during the solve, not a failed assertion.
+    F = inner(sol, v)*dx - inner(f, v)*dx - inner(f, v)*ds(3)
+    solve(F == 0, sol)
+
+    assert np.allclose(u.dat.data_ro, sol.dat.data_ro)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
When deciding whether the form needs splitting, we were deciding based on whether all the elements were `FiniteElement`s or `VectorElement`s.  This misses the multitude of other non-`MixedElement` elements available, including `OuterProductElement`s and `EnrichedElement`s.

It appears that this is related to the occasional bug reports that stemmed from FFC returning empty kernels in certain situations, which always seemed to be on extruded meshes!  (Though using enriched elements on non-extruded meshes would have failed too, see new test)

Reverted the changes from #474 too (but kept the test); I'd rather not have safety checks that might mask deeper problems.  Agree?