### PR TITLE
Add support for loop fusion in PyOP2

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -39,6 +39,7 @@ from mesh import *
 from mg import *
 from norms import *
 from nullspace import *
+from optimizer import *
 from parameters import *
 from parloops import *
 from projection import *

--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -195,7 +195,7 @@ class FFCKernel(DiskCached):
             needs_orientations = self._needs_orientations(elements)
             for it, kernel in zip(fd.preprocessed_form.integrals(), ffc_tree):
                 # Set optimization options
-                opts = {} if it.integral_type() not in ['cell'] else default_parameters["coffee"]
+                opts = default_parameters["coffee"]
                 _kernel = kernel if not parameters.get("assemble_inverse", False) else _inverse(kernel)
                 kernels.append((Kernel(Root(incl + [_kernel]), '%s_%s_integral_0_%s' %
                                        (name, it.integral_type(), it.subdomain_id()), opts, inc),

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -241,14 +241,17 @@ class FunctionSpaceBase(ObjectCached):
             parent = None
 
         offset = self.cell_node_map().offset
-        return self._map_cache(self._interior_facet_map_cache,
-                               self._mesh.interior_facets.set,
-                               self.interior_facet_node_list,
-                               2*self.fiat_element.space_dimension(),
-                               bcs,
-                               "interior_facet_node",
-                               offset=np.append(offset, offset),
-                               parent=parent)
+        map = self._map_cache(self._interior_facet_map_cache,
+                              self._mesh.interior_facets.set,
+                              self.interior_facet_node_list,
+                              2*self.fiat_element.space_dimension(),
+                              bcs,
+                              "interior_facet_node",
+                              offset=np.append(offset, offset),
+                              parent=parent)
+        map.factors = (self._mesh.interior_facets.facet_cell_map,
+                       self.cell_node_map())
+        return map
 
     def exterior_facet_node_map(self, bcs=None):
         """Return the :class:`pyop2.Map` from exterior facets to

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -118,6 +118,11 @@ class _Facets(object):
         return op2.Dat(op2.DataSet(self.set, self._rank), self.local_facet_number,
                        np.uintc, "%s_%s_local_facet_number" % (self.mesh.name, self.kind))
 
+    @utils.cached_property
+    def facet_cell_map(self):
+        """Map from facets to cells."""
+        return op2.Map(self.set, self.bottom_set, self._rank, self.facet_cell,
+                       "facet_to_cell_map")
 
 def _from_gmsh(filename):
     """Read a Gmsh .msh file from `filename`"""

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -124,6 +124,7 @@ class _Facets(object):
         return op2.Map(self.set, self.bottom_set, self._rank, self.facet_cell,
                        "facet_to_cell_map")
 
+
 def _from_gmsh(filename):
     """Read a Gmsh .msh file from `filename`"""
 

--- a/firedrake/optimizer.py
+++ b/firedrake/optimizer.py
@@ -7,7 +7,14 @@ def slope(mesh, debug=False):
         * Mesh coordinates
         * All available maps binding sets of mesh components
     """
+    # Add coordinates
     if debug:
         coords = mesh.coordinates.dat
         slope_python.set_debug_mode('VERY_LOW', (coords.dataset.set.name,
-                                                 coords._data, coords.shape[1]))
+                                                 coords._data,
+                                                 coords.shape[1]))
+    # Add any known maps potentially useful for fusion of cell and facet integrals
+    slope_python.HardFusion.add_maps([('cell_to_interior_facet',
+                                       mesh.interior_facets.set.name,
+                                       mesh.cell_set.name,
+                                       mesh.interior_facets.facet_cell)])

--- a/firedrake/optimizer.py
+++ b/firedrake/optimizer.py
@@ -1,5 +1,3 @@
-import slope_python
-
 def slope(mesh, debug=False):
     """Initialize the SLOPE library by providing information about the mesh,
     including:
@@ -7,6 +5,11 @@ def slope(mesh, debug=False):
         * Mesh coordinates
         * All available maps binding sets of mesh components
     """
+    try:
+        import slope_python
+    except ImportError:
+        return
+
     # Add coordinates
     if debug:
         coords = mesh.coordinates.dat

--- a/firedrake/optimizer.py
+++ b/firedrake/optimizer.py
@@ -1,0 +1,13 @@
+import slope_python
+
+def slope(mesh, debug=False):
+    """Initialize the SLOPE library by providing information about the mesh,
+    including:
+
+        * Mesh coordinates
+        * All available maps binding sets of mesh components
+    """
+    if debug:
+        coords = mesh.coordinates.dat
+        slope_python.set_debug_mode('VERY_LOW', (coords.dataset.set.name,
+                                                 coords._data, coords.shape[1]))

--- a/firedrake/optimizer.py
+++ b/firedrake/optimizer.py
@@ -13,8 +13,3 @@ def slope(mesh, debug=False):
         slope_python.set_debug_mode('VERY_LOW', (coords.dataset.set.name,
                                                  coords._data,
                                                  coords.shape[1]))
-    # Add any known maps potentially useful for fusion of cell and facet integrals
-    slope_python.HardFusion.add_maps([('cell_to_interior_facet',
-                                       mesh.interior_facets.set.name,
-                                       mesh.cell_set.name,
-                                       mesh.interior_facets.facet_cell)])

--- a/tests/test_ffc_interface.py
+++ b/tests/test_ffc_interface.py
@@ -101,16 +101,16 @@ class TestFFCCache:
 
     def test_ffc_cell_kernel(self, mass):
         k = ffc_interface.compile_form(mass, 'mass')
-        assert 'cell_integral' in k[0][-1].code and len(k) == 1
+        assert 'cell_integral' in k[0][-1].code() and len(k) == 1
 
     def test_ffc_exterior_facet_kernel(self, rhs):
         k = ffc_interface.compile_form(rhs, 'rhs')
-        assert 'exterior_facet_integral' in k[0][-1].code and len(k) == 1
+        assert 'exterior_facet_integral' in k[0][-1].code() and len(k) == 1
 
     def test_ffc_cell_exterior_facet_kernel(self, rhs2):
         k = ffc_interface.compile_form(rhs2, 'rhs2')
-        assert 'cell_integral' in k[0][-1].code and \
-            'exterior_facet_integral' in k[1][-1].code and len(k) == 2
+        assert 'cell_integral' in k[0][-1].code() and \
+            'exterior_facet_integral' in k[1][-1].code() and len(k) == 2
 
 if __name__ == '__main__':
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
This PR:
- attaches factors composing the facet_to_node map for facet integral. This is required for cell/facet integrals fusion in PyOP2
- enables optimisation of facet integrals

It depends on:
- #39 in coneoproject/COFFEE