### PR TITLE
Fix expression kernel generation

### DIFF
--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -569,9 +569,9 @@ _to_aug_assign = lambda op, o: op(_ast(o[0]), _ast(o[1]))
 
 _ast_map = {
     MathFunction: (lambda e: ast.FunCall(e._name, _ast(e._argument)), None),
-    ufl.algebra.Sum: (lambda e: _to_sum(e.ufl_operands)),
-    ufl.algebra.Product: (lambda e: _to_prod(e.ufl_operands)),
-    ufl.algebra.Division: (lambda e: ast.Div(*[_ast(o) for o in e.ufl_operands])),
+    ufl.algebra.Sum: (lambda e: ast.Par(_to_sum(e.ufl_operands))),
+    ufl.algebra.Product: (lambda e: ast.Par(_to_prod(e.ufl_operands))),
+    ufl.algebra.Division: (lambda e: ast.Par(ast.Div(*[_ast(o) for o in e.ufl_operands]))),
     ufl.algebra.Abs: (lambda e: ast.FunCall("abs", _ast(e.ufl_operands[0]))),
     AugmentedAssignment: (lambda e: _to_aug_assign(e._ast, e.ufl_operands)),
     ufl.constantvalue.ScalarValue: (lambda e: ast.Symbol(e._value)),

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -121,6 +121,7 @@ idivtest = partial(ioptest, op=idiv)
 
 common_tests = [
     'assigntest(f, 1, 1)',
+    'assigntest(f, 2.0*(one + one), 4)',
     'exprtest(one + one, 2)',
     'exprtest(3 * one, 3)',
     'exprtest(one + two, 3)',


### PR DESCRIPTION
Enforce the presence of parentheses for binary operations

This is a temporary fix till after Easter, when I'll try to get rid of parentheses everywhere (other solutions at the COFFEE layer don't work straight away, like:
1) putting parentheses everyhwhere - I don't like this since it hinders redability of C code with complex expressions, 
2) putting parentheses only when flipping operation would require changing the code generation system by pre-inspecting parents/children to understand when/where to put parentheses. The strength of the current code generation system is that it's super simple. So instead of changing it, I'll deal directly with the real problem (soon enough)