### PR TITLE
Rework overhead reduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_install:
     libvtk5-dev python-vtk libparmetis-dev python-vtk cython"
   - wget https://raw.github.com/OP2/PyOP2/master/requirements-minimal.txt
   - pip install psutil
+  - pip install cachetools
+  - pip install pytest-benchmark
   - "xargs -l1 pip install --allow-external mpi4py --allow-unverified mpi4py \
        --allow-external petsc --allow-unverified petsc \
        --allow-external petsc4py  --allow-unverified petsc4py \

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -83,6 +83,19 @@ In addition to PyOP2, you will need to install Firedrake. There are two
 routes, depending on whether you intend to contribute to Firedrake
 development.
 
+For performance reasons, there are various levels of caching with
+eviction policies.  To support these, you will need to install
+cachetools::
+
+   sudo pip install cachetools
+
+or (for your user only)::
+
+   pip install --user cachetools
+
+Firedrake will perform entirely correctly without this package, but
+will be less efficient for tight time-stepping loops.
+
 In order to have the form assembly cache operate in the most automatic
 fashion possible, you are also advised to install psutil::
 

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -125,49 +125,49 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
         cell_domains = []
         exterior_facet_domains = []
         interior_facet_domains = []
-        # For horizontal facets of extrded meshes, the corresponding domain
-        # in the base mesh is the cell domain. Hence all the maps used for top
-        # bottom and interior horizontal facets will use the cell to dofs map
-        # coming from the base mesh as a starting point for the actual dynamic map
-        # computation.
-        for integral in integrals:
-            integral_type = integral.integral_type()
-            if integral_type == "cell":
-                cell_domains.append(op2.ALL)
-            elif integral_type == "exterior_facet":
-                exterior_facet_domains.append(op2.ALL)
-            elif integral_type == "interior_facet":
-                interior_facet_domains.append(op2.ALL)
-            elif integral_type == "exterior_facet_bottom":
-                cell_domains.append(op2.ON_BOTTOM)
-            elif integral_type == "exterior_facet_top":
-                cell_domains.append(op2.ON_TOP)
-            elif integral_type == "exterior_facet_vert":
-                exterior_facet_domains.append(op2.ALL)
-            elif integral_type == "interior_facet_horiz":
-                cell_domains.append(op2.ON_INTERIOR_FACETS)
-            elif integral_type == "interior_facet_vert":
-                interior_facet_domains.append(op2.ALL)
-            else:
-                raise RuntimeError('Unknown integral type "%s"' % integral_type)
-
-        # To avoid an extra check for extruded domains, the maps that are being passed in
-        # are DecoratedMaps. For the non-extruded case the DecoratedMaps don't restrict the
-        # space over which we iterate as the domains are dropped at Sparsity construction
-        # time. In the extruded case the cell domains are used to identify the regions of the
-        # mesh which require allocation in the sparsity.
-        if cell_domains:
-            map_pairs.append((op2.DecoratedMap(test.cell_node_map(), cell_domains),
-                              op2.DecoratedMap(trial.cell_node_map(), cell_domains)))
-        if exterior_facet_domains:
-            map_pairs.append((op2.DecoratedMap(test.exterior_facet_node_map(), exterior_facet_domains),
-                              op2.DecoratedMap(trial.exterior_facet_node_map(), exterior_facet_domains)))
-        if interior_facet_domains:
-            map_pairs.append((op2.DecoratedMap(test.interior_facet_node_map(), interior_facet_domains),
-                              op2.DecoratedMap(trial.interior_facet_node_map(), interior_facet_domains)))
-
-        map_pairs = tuple(map_pairs)
         if tensor is None:
+            # For horizontal facets of extrded meshes, the corresponding domain
+            # in the base mesh is the cell domain. Hence all the maps used for top
+            # bottom and interior horizontal facets will use the cell to dofs map
+            # coming from the base mesh as a starting point for the actual dynamic map
+            # computation.
+            for integral in integrals:
+                integral_type = integral.integral_type()
+                if integral_type == "cell":
+                    cell_domains.append(op2.ALL)
+                elif integral_type == "exterior_facet":
+                    exterior_facet_domains.append(op2.ALL)
+                elif integral_type == "interior_facet":
+                    interior_facet_domains.append(op2.ALL)
+                elif integral_type == "exterior_facet_bottom":
+                    cell_domains.append(op2.ON_BOTTOM)
+                elif integral_type == "exterior_facet_top":
+                    cell_domains.append(op2.ON_TOP)
+                elif integral_type == "exterior_facet_vert":
+                    exterior_facet_domains.append(op2.ALL)
+                elif integral_type == "interior_facet_horiz":
+                    cell_domains.append(op2.ON_INTERIOR_FACETS)
+                elif integral_type == "interior_facet_vert":
+                    interior_facet_domains.append(op2.ALL)
+                else:
+                    raise RuntimeError('Unknown integral type "%s"' % integral_type)
+
+            # To avoid an extra check for extruded domains, the maps that are being passed in
+            # are DecoratedMaps. For the non-extruded case the DecoratedMaps don't restrict the
+            # space over which we iterate as the domains are dropped at Sparsity construction
+            # time. In the extruded case the cell domains are used to identify the regions of the
+            # mesh which require allocation in the sparsity.
+            if cell_domains:
+                map_pairs.append((op2.DecoratedMap(test.cell_node_map(), cell_domains),
+                                  op2.DecoratedMap(trial.cell_node_map(), cell_domains)))
+            if exterior_facet_domains:
+                map_pairs.append((op2.DecoratedMap(test.exterior_facet_node_map(), exterior_facet_domains),
+                                  op2.DecoratedMap(trial.exterior_facet_node_map(), exterior_facet_domains)))
+            if interior_facet_domains:
+                map_pairs.append((op2.DecoratedMap(test.interior_facet_node_map(), interior_facet_domains),
+                                  op2.DecoratedMap(trial.interior_facet_node_map(), interior_facet_domains)))
+
+            map_pairs = tuple(map_pairs)
             # Construct OP2 Mat to assemble into
             fs_names = (
                 test.function_space().name, trial.function_space().name)

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -568,11 +568,12 @@ _to_prod = lambda o: ast.Prod(_ast(o[0]), _to_sum(o[1:])) if len(o) > 1 else _as
 _to_aug_assign = lambda op, o: op(_ast(o[0]), _ast(o[1]))
 
 _ast_map = {
-    MathFunction: (lambda e: ast.FunCall(e._name, _ast(e._argument)), None),
+    MathFunction: (lambda e: ast.FunCall(e._name, *[_ast(o) for o in e.ufl_operands])),
     ufl.algebra.Sum: (lambda e: ast.Par(_to_sum(e.ufl_operands))),
     ufl.algebra.Product: (lambda e: ast.Par(_to_prod(e.ufl_operands))),
     ufl.algebra.Division: (lambda e: ast.Par(ast.Div(*[_ast(o) for o in e.ufl_operands]))),
     ufl.algebra.Abs: (lambda e: ast.FunCall("abs", _ast(e.ufl_operands[0]))),
+    Assign: (lambda e: _to_aug_assign(e._ast, e.ufl_operands)),
     AugmentedAssignment: (lambda e: _to_aug_assign(e._ast, e.ufl_operands)),
     ufl.constantvalue.ScalarValue: (lambda e: ast.Symbol(e._value)),
     ufl.constantvalue.Zero: (lambda e: ast.Symbol(0)),

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -67,7 +67,7 @@ class Constant(ufl.Coefficient):
             e = ufl.TensorElement("Real", domain, 0, shape=shape)
         super(Constant, self).__init__(e)
         self._ufl_element = self.element()
-        self._repr = 'Constant(%r)' % self._ufl_element
+        self._repr = 'Constant(%r, %r)' % (self._ufl_element, self.count())
 
     def evaluate(self, x, mapping, component, index_values):
         """Return the evaluation of this :class:`Constant`.

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -5,6 +5,7 @@ import ufl
 import coffee.base as ast
 
 from pyop2 import op2
+from pyop2.logger import warning
 
 import assemble_expressions
 import expression as expression_t
@@ -12,6 +13,11 @@ import functionspace
 import projection
 import utils
 import vector
+try:
+    import cachetools
+except ImportError:
+    warning("cachetools not available, expression assembly will be slowed down")
+    cachetools = None
 
 
 __all__ = ['Function', 'interpolate']
@@ -84,6 +90,11 @@ class Function(ufl.Coefficient):
         self._repr = None
         self._split = None
 
+        if cachetools:
+            # LRU cache for expressions assembled onto this function
+            self._expression_cache = cachetools.LRUCache(maxsize=50)
+        else:
+            self._expression_cache = None
         if isinstance(function_space, Function):
             self.assign(function_space)
 

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -42,9 +42,7 @@ def _init():
     from pyop2 import op2
     from parameters import parameters
     if not op2.initialised():
-        op2.init(log_level='INFO',
-                 compiler=parameters["coffee"]["compiler"],
-                 simd_isa=parameters["coffee"]["simd_isa"])
+        op2.init(**parameters["pyop2_options"])
 
 
 def unique_name(name, nameset):

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -1,5 +1,6 @@
 # Some generic python utilities not really specific to our work.
 from decorator import decorator
+from pyop2.utils import cached_property
 
 
 # after https://micheles.googlecode.com/hg/decorator/documentation.html and
@@ -22,26 +23,6 @@ def _memoize(func, obj, *args, **kw):
 
 def memoize(f):
     return decorator(_memoize, f)
-
-
-# from http://www.toofishes.net/blog/python-cached-property-decorator/
-class cached_property(object):
-
-    '''A read-only @property that is only evaluated once. The value is cached
-    on the object itself rather than the function or class; this should prevent
-    memory leakage.'''
-
-    def __init__(self, fget, doc=None):
-        self.fget = fget
-        self.__doc__ = doc or fget.__doc__
-        self.__name__ = fget.__name__
-        self.__module__ = fget.__module__
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return self
-        obj.__dict__[self.__name__] = result = self.fget(obj)
-        return result
 
 
 _current_uid = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 six
 sympy
+cachetools
 git+https://bitbucket.org/fenics-project/instant.git#egg=instant
 git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
 git+https://bitbucket.org/mapdes/fiat.git#egg=fiat

--- a/tests/benchmarks/test_overheads.py
+++ b/tests/benchmarks/test_overheads.py
@@ -1,0 +1,189 @@
+from firedrake import *
+import pytest
+from decorator import decorator
+
+try:
+    import pytest_benchmark     # noqa: Checking for availability of plugin
+except ImportError:
+    @pytest.fixture(scope='module')
+    def benchmark():
+        return lambda c: pytest.skip("pytest-benchmark plugin not installed")
+
+
+@decorator
+def disable_cache_lazy(func, *args, **kwargs):
+    val = parameters["assembly_cache"]["enabled"]
+    parameters["assembly_cache"]["enabled"] = False
+    lazy_val = parameters["pyop2_options"]["lazy_evaluation"]
+    parameters["pyop2_options"]["lazy_evaluation"] = False
+    try:
+        func(*args, **kwargs)
+    finally:
+        parameters["assembly_cache"]["enabled"] = val
+        parameters["pyop2_options"]["lazy_evaluation"] = lazy_val
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("fresh_form",
+                         [False, True],
+                         ids=["reuse_form", "fresh_form"])
+@pytest.mark.parametrize("fresh_tensor",
+                         [False, True],
+                         ids=["reuse_tensor", "fresh_tensor"])
+def test_assemble_residual(fresh_tensor, fresh_form, benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+
+    v = TestFunction(V)
+    f = Function(V)
+    g = Function(V)
+    if fresh_form:
+        L = lambda: inner(f, v)*dx
+    else:
+        L_ = inner(f, v)*dx
+        L = lambda: L_
+
+    if fresh_tensor:
+        call = lambda: assemble(L())
+    else:
+        call = lambda: assemble(L(), tensor=g)
+    benchmark(lambda: call())
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("fresh_form",
+                         [False, True],
+                         ids=["reuse_form", "fresh_form"])
+@pytest.mark.parametrize("fresh_tensor",
+                         [False, True],
+                         ids=["reuse_tensor", "fresh_tensor"])
+def test_assemble_mass(fresh_tensor, fresh_form, benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    if fresh_form:
+        L = lambda: inner(u, v)*dx
+    else:
+        L_ = inner(u, v)*dx
+        L = lambda: L_
+
+    if fresh_tensor:
+        call = lambda: assemble(L()).M
+    else:
+        g = assemble(L())
+        call = lambda: assemble(L(), tensor=g).M
+    benchmark(lambda: call())
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("fresh_tensor",
+                         [False, True],
+                         ids=["reuse_tensor", "fresh_tensor"])
+def test_assemble_mass_with_bcs(fresh_tensor, benchmark):
+    m = UnitSquareMesh(1, 1)
+    V = FunctionSpace(m, 'CG', 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    bcs = DirichletBC(V, 0, (1, 2, 3, 4))
+    L = inner(u, v)*dx
+
+    if fresh_tensor:
+        call = lambda: assemble(L, bcs=bcs).M
+    else:
+        g = assemble(L)
+        call = lambda: assemble(L, tensor=g, bcs=bcs).M
+    benchmark(lambda: call())
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("nspaces", range(2, 6))
+@pytest.mark.parametrize("fresh_tensor",
+                         [False, True],
+                         ids=["reuse_tensor", "fresh_tensor"])
+def test_assemble_mixed_mass(fresh_tensor, nspaces, benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+    W = MixedFunctionSpace([V]*nspaces)
+    u = TrialFunction(W)
+    v = TestFunction(W)
+    L = inner(u, v)*dx
+
+    if fresh_tensor:
+        call = lambda: assemble(L, nest=False).M
+    else:
+        g = assemble(L)
+        call = lambda: assemble(L, nest=False, tensor=g).M
+    benchmark(lambda: call())
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+def test_dat_zero(benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+    f = Function(V)
+    benchmark(lambda: f.dat.zero())
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+def test_assign_zero(benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+    f = Function(V)
+    benchmark(lambda: f.assign(0))
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+def test_assign_function(benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+    f = Function(V)
+    g = Function(V)
+    benchmark(lambda: f.assign(g))
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("fresh_expr",
+                         [False, True],
+                         ids=["reuse_expr", "fresh_expr"])
+def test_assign_complicated(fresh_expr, benchmark):
+    m = UnitTriangleMesh()
+    V = FunctionSpace(m, 'DG', 0)
+    f = Function(V)
+    g = Function(V)
+    if fresh_expr:
+        expr = lambda: g*sqrt(Constant(10) + Constant(11)) + Constant(2)**Constant(4)
+    else:
+        expr_ = g*sqrt(Constant(10) + Constant(11)) + Constant(2)**Constant(4)
+        expr = lambda: expr_
+    benchmark(lambda: f.assign(expr()))
+
+
+@disable_cache_lazy
+@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@pytest.mark.parametrize("val",
+                         [lambda V: Constant(0),
+                          lambda V: Expression("0"),
+                          lambda V: Function(V)],
+                         ids=["Constant", "Expression", "Function"])
+def test_apply_bc(val, benchmark):
+    m = UnitSquareMesh(1, 1)
+    V = FunctionSpace(m, 'CG', 1)
+    bc = DirichletBC(V, val(V), (1, 2, 3, 4))
+    f = Function(V)
+    benchmark(lambda: bc.apply(f))
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,3 +67,10 @@ def pytest_cmdline_preparse(config, args):
         args.insert(0, '--tb=native')
     if 'PYTEST_WATCH' in os.environ and '-f' not in args:
         args.insert(0, '-f')
+    try:
+        import pytest_benchmark   # noqa: Checking for availability of plugin
+        # Set number of warmup iteration to 1
+        if "--benchmark-warmup-iterations" not in args:
+            args.insert(0, "--benchmark-warmup-iterations=1")
+    except ImportError:
+        pass

--- a/tests/regression/test_constant.py
+++ b/tests/regression/test_constant.py
@@ -162,6 +162,14 @@ def test_constant_multiplies_function():
     assert np.allclose(f.dat.data_ro, 110)
 
 
+@pytest.mark.xfail
+def test_fresh_constant_hashes_different():
+    c = Constant(1)
+    d = Constant(1)
+
+    assert hash(c) != hash(d)
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_constant.py
+++ b/tests/regression/test_constant.py
@@ -162,7 +162,6 @@ def test_constant_multiplies_function():
     assert np.allclose(f.dat.data_ro, 110)
 
 
-@pytest.mark.xfail
 def test_fresh_constant_hashes_different():
     c = Constant(1)
     d = Constant(1)

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -141,6 +141,7 @@ common_tests = [
 scalar_tests = common_tests + [
     'interpolatetest(f, 0.0, 0)',
     'interpolatetest(f, "sin(pi/2)", 1)',
+    pytest.mark.xfail(reason='Mathfunctions not dealt with properly')('assigntest(f, sqrt(one), 1)'),
     'exprtest(ufl.ln(one), 0)',
     'exprtest(two ** minusthree, 0.125)',
     'exprtest(ufl.sign(minusthree), -1)',

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -141,7 +141,7 @@ common_tests = [
 scalar_tests = common_tests + [
     'interpolatetest(f, 0.0, 0)',
     'interpolatetest(f, "sin(pi/2)", 1)',
-    pytest.mark.xfail(reason='Mathfunctions not dealt with properly')('assigntest(f, sqrt(one), 1)'),
+    'assigntest(f, sqrt(one), 1)',
     'exprtest(ufl.ln(one), 0)',
     'exprtest(two ** minusthree, 0.125)',
     'exprtest(ufl.sign(minusthree), -1)',


### PR DESCRIPTION
Here's the firedrake side of OP2/PyOP2#435, to reduce the overhead of doing nothing.  It comes with some minimal performance benchmarks in tests/benchmarks/test_overheads.py.  Before the PyOP2 side of the changes:

```
-------- benchmark: 12 tests, min 5 rounds (of min 25.00us), 1.00s max time, timer: time.time -------
Name (time in us)                             Min        Max       Mean    StdDev  Rounds  Iterations
-----------------------------------------------------------------------------------------------------
test_assemble_residual[False-False]     1312.9711  2273.0827  1469.8625  197.4718     379           1
test_assemble_residual[False-True]      3825.9029  4155.8743  3871.4068   44.2845     252           1
test_assemble_residual[True-False]      1478.9104  2487.8979  1520.0290   63.8244     658           1
test_assemble_residual[True-True]       3987.0739  4503.0117  4036.9730   62.2400     243           1
test_dat_zero                            339.9849  1441.9556   353.9915   24.6601    2800           1
test_assign_zero                         575.0656   807.0469   679.1022   36.5976    1593           1
test_assign_function                     490.9039  1728.0579   517.3772   30.2120    1829           1
test_assign_complicated[False]          1317.9779  3493.0706  1394.8652  139.8864     661           1
test_assign_complicated[True]           1725.1968  2152.2045  1861.3576   97.6922     482           1
test_apply_bc[val0]                      786.7813   938.8924   811.6583   21.2202    1165           1
test_apply_bc[val1]                      460.8631   657.0816   522.4380   17.0296    1845           1
test_apply_bc[val2]                      455.8563  1648.9029   471.6958   29.2202    2046           1
```

With the PyOP2 changes:

```
-------- benchmark: 12 tests, min 5 rounds (of min 25.00us), 1.00s max time, timer: time.time -------
Name (time in us)                             Min        Max       Mean    StdDev  Rounds  Iterations
-----------------------------------------------------------------------------------------------------
test_assemble_residual[False-False]      215.0536  2052.0687   243.3649   48.4345    2428           1
test_assemble_residual[False-True]      2696.9910  5686.0447  2854.6614  269.8075     359           1
test_assemble_residual[True-False]       399.8280  2219.9154   423.5837   40.3317    2417           1
test_assemble_residual[True-True]       2883.9111  3525.0187  2999.1161  125.6397     337           1
test_dat_zero                             15.1992   471.5323    16.3731    4.2646   12337           4
test_assign_zero                         279.9034   399.1127   294.0679   10.3682    2599           1
test_assign_function                      72.9561   164.9857    80.9015    4.7848    8613           1
test_assign_complicated[False]           607.0137  2192.9741   670.7917   51.3886    1356           1
test_assign_complicated[True]            964.8800  2975.9407  1166.1976  198.8277     914           1
test_apply_bc[val0]                      324.0108   465.1546   339.0325   12.4257    2599           1
test_apply_bc[val1]                       82.9697  1044.0350    85.7248   10.9076    8406           1
test_apply_bc[val2]                       80.8239   128.9845    82.9472    2.4247    9533           1
```

With the firedrake side, the expression assembly gets faster.

```
------- benchmark: 12 tests, min 5 rounds (of min 25.00us), 1.00s max time, timer: time.time -------
Name (time in us)                             Min        Max       Mean   StdDev  Rounds  Iterations
----------------------------------------------------------------------------------------------------
test_assemble_residual[False-False]      218.8683  1530.1704   234.3449  39.5995    3984           1
test_assemble_residual[False-True]      2707.0045  3077.0302  2767.4773  73.8890     315           1
test_assemble_residual[True-False]       257.0152  1450.0618   276.3456  24.1058    3367           1
test_assemble_residual[True-True]       2892.9710  3937.9597  2953.7530  91.9805     339           1
test_dat_zero                             16.9873   496.9835    17.7706   4.1617   13487           4
test_assign_zero                          82.0160   577.9266    86.9320   7.9157    7464           1
test_assign_function                      74.8634   144.9585    77.3128   2.8869    8775           1
test_assign_complicated[False]           162.8399   218.8683   167.7646   4.9185    4833           1
test_assign_complicated[True]           1005.8880  2546.7873  1123.2240  61.9693     917           1
test_apply_bc[val0]                      114.9178   167.1314   120.8434   4.8934    6251           1
test_apply_bc[val1]                       83.9233   129.9381    87.0042   2.3952    8339           1
test_apply_bc[val2]                       82.9697  1120.8057    85.1386  11.0119    9342           1
```

These are all the "safe" changes I'm willing to make.  We can squeeze more out by saving ParLoop objects on forms, but I think that's likely to result in even more difficult than already to debug caching issues.