### PR TITLE
solvers: Break ref cycles in _SNESContext

### DIFF
--- a/firedrake/mg/solver_hierarchy.py
+++ b/firedrake/mg/solver_hierarchy.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import weakref
 
 import firedrake
 from firedrake.petsc import PETSc
@@ -226,12 +227,12 @@ class NLVSHierarchy(object):
         dm = self.snes.getDM()
 
         nlevel = len(self.ctx._problems)
-        dm.setAppCtx(self.ctx)
+        dm.setAppCtx(weakref.proxy(self.ctx))
         dm.setCreateMatrix(self.ctx.create_matrix)
         # FIXME: Need to set this up on the subDMs
         for i in range(nlevel - 1, 0, -1):
             dm = dm.coarsen()
-            dm.setAppCtx(self.ctx)
+            dm.setAppCtx(weakref.proxy(self.ctx))
 
         for i in range(nlevel - 1):
             dm.setCreateInterpolation(create_interpolation)

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -1,3 +1,4 @@
+import weakref
 import ufl
 
 from pyop2.profiling import timed_function, profile
@@ -144,7 +145,7 @@ class NonlinearVariationalSolver(object):
     @profile
     def solve(self):
         dm = self.snes.getDM()
-        dm.setAppCtx(self._ctx)
+        dm.setAppCtx(weakref.proxy(self._ctx))
         dm.setCreateMatrix(self._ctx.create_matrix)
 
         # Apply the boundary conditions to the initial guess.


### PR DESCRIPTION
This fixes a memory leak whereby Meshes were never being collected, and
hence nothing else either.