### PR TITLE
Collectable meshes

### DIFF
--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -55,10 +55,14 @@ def sum_integrands(form):
     for integral in form.integrals():
         md = integral.metadata()
         mdkey = tuple((k, md[k]) for k in sorted(md.keys()))
+        sd = integral.subdomain_data()
+        # subdomain data is a weakref
+        sd = sd()
+        assert sd is not None, "Lost reference to subdomain data, argh!"
         integrals[(integral.integral_type(),
                    integral.domain(),
                    integral.subdomain_id(),
-                   integral.subdomain_data(),
+                   sd,
                    mdkey)].append(integral)
     return Form([it[0].reconstruct(reduce(add, [i.integrand() for i in it]))
                  for it in integrals.values()])

--- a/firedrake/parloops.py
+++ b/firedrake/parloops.py
@@ -223,7 +223,11 @@ def par_loop(kernel, measure, args, **kwargs):
         if not mesh:
             raise TypeError("No Functions passed to direct par_loop")
     else:
-        mesh = measure.subdomain_data().function_space().mesh()
+        sd = measure.subdomain_data()
+        # subdomain data is a weakref
+        sd = sd()
+        assert sd is not None, "Lost reference to subdomain data, argh!"
+        mesh = sd.function_space().mesh()
 
     op2args = [_form_kernel(kernel, measure, args, **kwargs)]
 

--- a/tests/regression/test_fs_caching.py
+++ b/tests/regression/test_fs_caching.py
@@ -7,6 +7,30 @@ def howmany(cls):
     return len([x for x in gc.get_objects() if isinstance(x, cls)])
 
 
+def test_meshes_collected():
+    before = howmany(Mesh)
+
+    def foo():
+        old_val = parameters['assembly_cache']['enabled']
+        parameters['assembly_cache']['enabled'] = False
+        for i in range(10):
+            m = UnitSquareMesh(1, 1)
+            V = FunctionSpace(m, 'CG', 1)
+            u = TrialFunction(V)
+            v = TestFunction(V)
+            f = Function(V)
+            solve((i+1)*u*v*dx == v*dx, f)
+        parameters['assembly_cache']['enabled'] = old_val
+
+    foo()
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    after = howmany(Mesh)
+
+    assert before >= after
+
+
 def test_same_fs_hits_cache():
     m = UnitSquareMesh(1, 1)
 

--- a/tests/regression/test_poisson_strong_bcs.py
+++ b/tests/regression/test_poisson_strong_bcs.py
@@ -50,7 +50,7 @@ def run_test_linear(x, degree, parameters={}, quadrilateral=False):
     u = TrialFunction(V)
     v = TestFunction(V)
     a = dot(grad(v), grad(u)) * dx
-    L = v*0*dx
+    L = v*Constant(0)*dx
 
     bcs = [DirichletBC(V, 0, 3),
            DirichletBC(V, 42, 4)]


### PR DESCRIPTION
Removes references from the (global) Measure objects to the mesh they were built on.  This means that if we remove the mesh and all "visible" references thereto that it will be collected.