### PR TITLE
Enable FFC optimisations

### DIFF
--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -206,8 +206,13 @@ class FFCKernel(DiskCached):
                 kernels.append((Kernel(Root(incl + [_kernel]), '%s_%s_integral_0_%s' %
                                        (name, it.integral_type(), it.subdomain_id()), opts, inc),
                                 needs_orientations))
-            self.kernels = tuple(kernels)
-            self._empty = False
+            # Sometimes FFC returns an empty list without raising
+            # EmptyIntegrandError, catch that here.
+            if len(kernels) == 0:
+                self._empty = True
+            else:
+                self.kernels = tuple(kernels)
+                self._empty = False
         except EmptyIntegrandError:
             # FFC noticed that the integrand was zero and simplified
             # it, catch this here and set a flag telling us to ignore

--- a/firedrake/ffc_interface.py
+++ b/firedrake/ffc_interface.py
@@ -8,7 +8,7 @@ from os import path, environ, getuid, makedirs
 import tempfile
 
 import ufl
-from ufl import Form, MixedElement, as_vector
+from ufl import Form, as_vector
 from ufl.measure import Measure
 from ufl.algorithms import compute_form_data, ReuseTransformer
 from ufl.constantvalue import Zero
@@ -262,23 +262,6 @@ def compile_form(form, name, parameters=None, inverse=False):
            params == parameters:
             return kernels
 
-    # need compute_form_data since we use preproc. form integrals later
-    fd = compute_form_data(form)
-
-    # If there is no mixed element involved, return the kernels FFC produces
-    # Note: using type rather than isinstance because UFL's VectorElement,
-    # TensorElement and OPVectorElement all inherit from MixedElement
-    if not any(type(e) is MixedElement for e in fd.unique_sub_elements):
-        kernels = [((0, 0),
-                    it.integral_type(), it.subdomain_id(),
-                    it.domain().data().coordinates,
-                    fd.preprocessed_form.coefficients(), needs_orientations, kernel)
-                   for it, (kernel, needs_orientations) in zip(fd.preprocessed_form.integrals(),
-                                                               FFCKernel(form, name,
-                                                                         parameters).kernels)]
-        form._cache["firedrake_kernels"] = (kernels, parameters)
-        return kernels
-    # Otherwise pre-split the form into mixed blocks before calling FFC
     kernels = []
     for forms in FormSplitter().split(form):
         for (i, j), f in forms:

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -69,6 +69,7 @@ ffc_parameters = default_parameters()
 ffc_parameters['write_file'] = False
 ffc_parameters['format'] = 'pyop2'
 ffc_parameters['representation'] = 'quadrature'
+ffc_parameters['optimize'] = True
 ffc_parameters['pyop2-ir'] = True
 parameters.add(Parameters("form_compiler", **ffc_parameters))
 

--- a/tests/extrusion/test_extrusion_0_dg_coords.py
+++ b/tests/extrusion/test_extrusion_0_dg_coords.py
@@ -1,4 +1,5 @@
 from firedrake import *
+import weakref
 import pytest
 import ufl
 
@@ -11,7 +12,7 @@ def test_extruded_interval_area():
     m._coordinate_fs = new_coords.function_space()
     m.coordinates = new_coords
 
-    ufl.dx._subdomain_data = m.coordinates
+    ufl.dx._subdomain_data = weakref.ref(m.coordinates)
     V = FunctionSpace(m, 'CG', 1)
     u = Function(V)
     u.assign(1)


### PR DESCRIPTION
This enables FFC optimisations in our stack. Requires FFC pull request 75 which disables broken optimisations.

The main motivation is bendy performance, since these optimisations allow to optimise all zero tables, which arise as second derivatives on flat elements.

It would be nice if we could verify that this won't cause any performance regressions in our stack, but I'm not sure how to do that.
