### PR TITLE
Make mesh measures public.

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -277,6 +277,14 @@ class Mesh(object):
 
         """
 
+        # The following lines are here to force the generation of documentation.
+        #: The volume measure on this :class:`Mesh`
+        self.dx = None
+        #: The exterior facet measure on this :class:`Mesh`
+        self.ds = None
+        #: The interior facet measure on this :class:`Mesh`
+        self.dS = None
+
         utils._init()
 
         geometric_dim = kwargs.get("dim", None)
@@ -405,9 +413,12 @@ class Mesh(object):
             # Add subdomain_data to the measure objects we store with
             # the mesh.  These are weakrefs for consistency with the
             # "global" measure objects
-            self._dx = ufl.Measure('cell', subdomain_data=weakref.ref(self.coordinates))
-            self._ds = ufl.Measure('exterior_facet', subdomain_data=weakref.ref(self.coordinates))
-            self._dS = ufl.Measure('interior_facet', subdomain_data=weakref.ref(self.coordinates))
+            #: The volume measure on this :class:`Mesh`
+            self.dx = ufl.Measure('cell', subdomain_data=weakref.ref(self.coordinates))
+            #: The exterior facet measure on this :class:`Mesh`
+            self.ds = ufl.Measure('exterior_facet', subdomain_data=weakref.ref(self.coordinates))
+            #: The interior facet measure on this :class:`Mesh`
+            self.dS = ufl.Measure('interior_facet', subdomain_data=weakref.ref(self.coordinates))
             # Set the subdomain_data on all the default measures to this
             # coordinate field.
             # We don't set the domain on the measure since this causes
@@ -847,14 +858,22 @@ class ExtrudedMesh(Mesh):
         # Add subdomain_data to the measure objects we store with
         # the mesh.  These are weakrefs for consistency with the
         # "global" measure objects
-        self._dx = ufl.Measure('cell', subdomain_data=weakref.ref(self.coordinates))
-        self._ds = ufl.Measure('exterior_facet', subdomain_data=weakref.ref(self.coordinates))
-        self._dS = ufl.Measure('interior_facet', subdomain_data=weakref.ref(self.coordinates))
-        self._ds_t = ufl.Measure('exterior_facet_top', subdomain_data=weakref.ref(self.coordinates))
-        self._ds_b = ufl.Measure('exterior_facet_bottom', subdomain_data=weakref.ref(self.coordinates))
-        self._ds_v = ufl.Measure('exterior_facet_vert', subdomain_data=weakref.ref(self.coordinates))
-        self._dS_h = ufl.Measure('interior_facet_horiz', subdomain_data=weakref.ref(self.coordinates))
-        self._dS_v = ufl.Measure('interior_facet_vert', subdomain_data=weakref.ref(self.coordinates))
+        #: The volume measure on this :class:`ExtrudedMesh`
+        self.dx = ufl.Measure('cell', subdomain_data=weakref.ref(self.coordinates))
+        #: The exterior facet measure on this :class:`ExtrudedMesh`
+        self.ds = ufl.Measure('exterior_facet', subdomain_data=weakref.ref(self.coordinates))
+        #: The interior facet measure on this :class:`ExtrudedMesh`
+        self.dS = ufl.Measure('interior_facet', subdomain_data=weakref.ref(self.coordinates))
+        #: The exterior facet measure on the top surface of this :class:`ExtrudedMesh`
+        self.ds_t = ufl.Measure('exterior_facet_top', subdomain_data=weakref.ref(self.coordinates))
+        #: The exterior facet measure on the bottom surface of this :class:`ExtrudedMesh`
+        self.ds_b = ufl.Measure('exterior_facet_bottom', subdomain_data=weakref.ref(self.coordinates))
+        #: The exterior facet measure on the vertical (side) surfaces of this :class:`ExtrudedMesh`
+        self.ds_v = ufl.Measure('exterior_facet_vert', subdomain_data=weakref.ref(self.coordinates))
+        #: The interior facet measure on the horizontal surfaces of this :class:`ExtrudedMesh`
+        self.dS_h = ufl.Measure('interior_facet_horiz', subdomain_data=weakref.ref(self.coordinates))
+        #: The interior facet measure on the vertical surfaces of this :class:`ExtrudedMesh`
+        self.dS_v = ufl.Measure('interior_facet_vert', subdomain_data=weakref.ref(self.coordinates))
         # Set the subdomain_data on all the default measures to this
         # coordinate field.  We don't set the domain on the measure
         # since this causes an uncollectable reference in the global

--- a/firedrake/norms.py
+++ b/firedrake/norms.py
@@ -100,7 +100,7 @@ def norm(v, norm_type="L2", mesh=None):
 
     typ = norm_type.lower()
     mesh = v.function_space().mesh()
-    dx = mesh._dx
+    dx = mesh.dx
     if typ == 'l2':
         form = inner(v, v)*dx
     elif typ == 'h1':

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -80,8 +80,8 @@ def project(v, V, bcs=None, mesh=None,
 
     p = ufl_expr.TestFunction(V)
     q = ufl_expr.TrialFunction(V)
-    a = ufl.inner(p, q) * V.mesh()._dx
-    L = ufl.inner(p, v) * V.mesh()._dx
+    a = ufl.inner(p, q) * V.mesh().dx
+    L = ufl.inner(p, v) * V.mesh().dx
 
     # Default to 1e-8 relative tolerance
     if solver_parameters is None:

--- a/tests/multigrid/test_restriction.py
+++ b/tests/multigrid/test_restriction.py
@@ -25,7 +25,7 @@ def run_restriction(mtype, vector, space, degree):
 
     for e in expected:
         v = TestFunction(e.function_space())
-        e.assign(assemble(dot(c, v)*e.function_space().mesh()._dx))
+        e.assign(assemble(dot(c, v)*e.function_space().mesh().dx))
 
     actual = FunctionHierarchy(V)
 
@@ -122,7 +122,7 @@ def run_extruded_restriction(mtype, vector, space, degree):
 
     for e in expected:
         v = TestFunction(e.function_space())
-        e.assign(assemble(dot(c, v)*e.function_space().mesh()._dx))
+        e.assign(assemble(dot(c, v)*e.function_space().mesh().dx))
 
     actual = FunctionHierarchy(V)
 
@@ -211,7 +211,7 @@ def run_mixed_restriction():
         v, p = TestFunctions(e.function_space())
         c = Constant((1, 1))
 
-        dx = e.function_space().mesh()._dx
+        dx = e.function_space().mesh().dx
         e.assign(assemble(dot(c, v)*dx + p*dx))
 
     actual = FunctionHierarchy(W)

--- a/tests/regression/test_constant.py
+++ b/tests/regression/test_constant.py
@@ -6,15 +6,15 @@ import pytest
 def test_scalar_constant():
     for m in [UnitIntervalMesh(5), UnitSquareMesh(2, 2), UnitCubeMesh(2, 2, 2)]:
         c = Constant(1, domain=m)
-        assert abs(assemble(c*m._dx) - 1.0) < 1e-10
+        assert abs(assemble(c*m.dx) - 1.0) < 1e-10
 
 
 def test_scalar_constant_assign():
     for m in [UnitIntervalMesh(5), UnitSquareMesh(2, 2), UnitCubeMesh(2, 2, 2)]:
         c = Constant(1, domain=m)
-        assert abs(assemble(c*m._dx) - 1.0) < 1e-10
+        assert abs(assemble(c*m.dx) - 1.0) < 1e-10
         c.assign(4)
-        assert abs(assemble(c*m._dx) - 4.0) < 1e-10
+        assert abs(assemble(c*m.dx) - 4.0) < 1e-10
 
 
 @pytest.mark.parametrize(('init', 'new_vals'),


### PR DESCRIPTION
This makes Mesh.dx, Mesh.ds, Mesh.dS, and their extruded equivalents
public.  This is required as users actually need to use these
attributes when they have multiple meshes in use.