### PR TITLE
Create subdm

### DIFF
--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -468,14 +468,44 @@ inverses of the block system.  These work for any number of blocks,
 whereas the Schur complement approach mentioned above only works for
 two by two blocks.
 
-.. note::
+Recursive fieldsplits
++++++++++++++++++++++
 
-   PETSc offers support for composing fieldsplit preconditioners
-   recursively.  That is, defining a :math:`3\times3` block system as
-   composed of a :math:`2\times2` piece and a :math:`1\times1` piece.
-   However, the Firedrake interface to the solver options does not
-   currently support this.  At present, we cannot tell PETSc that the
-   blocks should be split recursively.
+If your system contains more than two fields, it is possible to
+recursively define block preconditioners by specifying the
+fields which should belong to each split.  Note that at present this
+only works for "monolithically assembled" matrices, so you should
+either specify ``nest=False`` when solving your system or assembling
+your matrix, or else set the global parameter ``parameters["matnest"] = False``.
+
+As an example, consider a three field system which we wish to
+precondition by forming a schur complement of the first two fields
+into the third, and then using a multiplicative fieldsplit with LU on
+each split for the approximation to :math:`A^{-1}` and ILU to
+precondition the schur complement.  The solver parameters we need are
+as follows::
+
+.. code-block::
+
+   parameters = {"pc_type": "fieldsplit",
+                 "pc_fieldsplit_type": "schur",
+                 # first split contains first two fields, second
+                 # contains the third
+                 "pc_fieldsplit_0_fields": "0, 1",
+                 "pc_fieldsplit_1_fields": "2",
+                 # Multiplicative fieldsplit for first field
+                 "fieldsplit_0_pc_type": "fieldsplit",
+                 "fieldsplit_0_pc_fieldsplit_type": "multiplicative",
+                 # LU on each field
+                 "fieldsplit_0_fieldsplit_0_pc_type": "lu",
+                 "fieldsplit_0_fieldsplit_1_pc_type": "lu",
+                 # ILU on the schur complement block
+                 # Note that the fieldsplit number is the that of the
+                 # outer field number
+                 "fieldsplit_2_pc_type": "ilu"}
+
+
+.. note::
 
    Future versions of Firedrake may offer a symbolic language for
    describing the composition of such physics-like preconditioners,

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -669,8 +669,28 @@ class MixedFunctionSpace(FunctionSpaceBase):
             dm.setGlobalVector(v.duplicate())
         dm.setAttr('__fs__', weakref.ref(self))
         dm.setCreateFieldDecomposition(self.create_field_decomp)
+        dm.setCreateSubDM(self.create_subdm)
         self._dm = dm
         self._ises = self.dof_dset.field_ises
+        self._subspaces = []
+
+    @classmethod
+    def create_subdm(cls, dm, fields, *args, **kwargs):
+        W = dm.getAttr('__fs__')()
+        if len(fields) == 1:
+            # Subspace is just a single FunctionSpace.
+            subspace = W[fields[0]]
+        else:
+            # Need to build an MFS for the subspace
+            subspace = MixedFunctionSpace([W[f] for f in fields])
+        # Sub-DM is just the DM belonging to the subspace.
+        subdm = subspace._dm
+        # Keep hold of strong reference, to created subspace (given we
+        # only hold a weakref in the shell DM)
+        W._subspaces.append(subspace)
+        # Index set mapping from W into subspace.
+        iset = PETSc.IS().createGeneral(np.concatenate([W._ises[f].indices for f in fields]))
+        return iset, subdm
 
     @classmethod
     def create_field_decomp(cls, dm, *args, **kwargs):

--- a/tests/regression/test_nested_fieldsplit_solves.py
+++ b/tests/regression/test_nested_fieldsplit_solves.py
@@ -127,6 +127,26 @@ def test_nested_fieldsplit_solve(W, A, b, expect, parameters):
     assert norm(f) < 1e-11
 
 
+@pytest.mark.parallel(nprocs=3)
+def test_nested_fieldsplit_solve_parallel(W, A, b, expect):
+    parameters = {"ksp_type": "preonly",
+                  "pc_type": "fieldsplit",
+                  "pc_fieldsplit_type": "additive",
+                  "pc_fieldsplit_0_fields": "0, 3",
+                  "pc_fieldsplit_1_fields": "1, 2",
+                  "fieldsplit_ksp_type": "cg",
+                  "fieldsplit_ksp_rtol": 1e-12,
+                  "fieldsplit_pc_type": "bjacobi",
+                  "fieldsplit_sub_pc_type": "lu"}
+    solver = LinearSolver(A, solver_parameters=parameters)
+    f = Function(W)
+
+    solver.solve(f, b)
+
+    f -= expect
+    assert norm(f) < 1e-11
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_nested_fieldsplit_solves.py
+++ b/tests/regression/test_nested_fieldsplit_solves.py
@@ -1,0 +1,132 @@
+from firedrake import *
+import pytest
+
+
+@pytest.fixture(scope="module")
+def W():
+    m = UnitSquareMesh(4, 4)
+
+    V = FunctionSpace(m, 'CG', 1, name="V")
+    P = VectorFunctionSpace(m, 'CG', 2, name="P")
+    Q = FunctionSpace(m, 'CG', 2, name="Q")
+    R = VectorFunctionSpace(m, 'CG', 1, name="R")
+
+    return V*P*Q*R
+
+
+@pytest.fixture(scope="module")
+def A(W):
+    u = TrialFunction(W)
+    v = TestFunction(W)
+
+    a = inner(u, v)*dx
+
+    return assemble(a, nest=False)
+
+
+@pytest.fixture(scope="module")
+def expect():
+    return Constant((1, 2, 3, 4, 5, 6))
+
+
+@pytest.fixture(scope="module")
+def b(W, expect):
+    v = TestFunction(W)
+
+    L = inner(expect, v)*dx
+
+    return assemble(L)
+
+
+@pytest.mark.parametrize("parameters",
+                         [{"ksp_type": "preonly",
+                           "pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "fieldsplit_V_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu",
+                           "fieldsplit_Q_pc_type": "lu",
+                           "fieldsplit_R_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 3",
+                           "pc_fieldsplit_1_fields": "1, 2",
+                           "fieldsplit_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 2",
+                           "pc_fieldsplit_1_fields": "1",
+                           "pc_fieldsplit_2_fields": "3",
+                           "fieldsplit_0_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu",
+                           "fieldsplit_R_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 2, 3",
+                           "pc_fieldsplit_1_fields": "1",
+                           "fieldsplit_0_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 2, 3",
+                           "pc_fieldsplit_1_fields": "1",
+                           "fieldsplit_0_pc_type": "fieldsplit",
+                           "fieldsplit_0_pc_fieldsplit_type": "additive",
+                           "fieldsplit_0_fieldsplit_V_pc_type": "lu",
+                           "fieldsplit_0_fieldsplit_Q_pc_type": "lu",
+                           "fieldsplit_0_fieldsplit_R_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 2, 3",
+                           "pc_fieldsplit_1_fields": "1",
+                           "fieldsplit_0_pc_type": "fieldsplit",
+                           "fieldsplit_0_pc_fieldsplit_type": "additive",
+                           "fieldsplit_0_pc_fieldsplit_0_fields": "1",
+                           "fieldsplit_0_pc_fieldsplit_1_fields": "0, 2",
+                           "fieldsplit_0_fieldsplit_Q_pc_type": "lu",
+                           "fieldsplit_0_fieldsplit_1_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu"},
+                          {"ksp_type": "preonly",
+                           "pc_type": "fieldsplit",
+                           "pc_fieldsplit_type": "additive",
+                           "pc_fieldsplit_0_fields": "0, 2, 3",
+                           "pc_fieldsplit_1_fields": "1",
+                           "fieldsplit_0_pc_type": "fieldsplit",
+                           "fieldsplit_0_pc_fieldsplit_type": "additive",
+                           "fieldsplit_0_pc_fieldsplit_0_fields": "1",
+                           "fieldsplit_0_pc_fieldsplit_1_fields": "0, 2",
+                           "fieldsplit_0_fieldsplit_Q_pc_type": "lu",
+                           "fieldsplit_0_fieldsplit_1_pc_type": "fieldsplit",
+                           "fieldsplit_0_fieldsplit_1_pc_fieldsplit_type": "additive",
+                           "fieldsplit_0_fieldsplit_1_fieldsplit_V_pc_type": "lu",
+                           "fieldsplit_0_fieldsplit_1_fieldsplit_R_pc_type": "lu",
+                           "fieldsplit_P_pc_type": "lu"}],
+                         ids=["LU",
+                              "FS 4 blocks + LU",
+                              "FS 2 blocks [(0, 3), (1, 2)] + LU",
+                              "FS 3 blocks [(0, 2), (1, ), (3, )] + LU",
+                              "FS 2 blocks [(0, 2, 3), (1, )] + LU",
+                              "FS 2 blocks [(0, 2, 3), (1, )] + block 1 LU, block 0 FS 3 blocks + LU",
+                              "FS 2 blocks [(0, 2, 3), (1, )] + block 1 LU, block 0 FS 2 blocks [(1, ), (0, 2)] + LU",
+                              "FS 2 blocks [(0, 2, 3), (1, )] + block 1 LU, block 0 FS 2 blocks [(1, ), (0, 2)] + block 0 LU, block 1 FS 2 blocks + LU"])
+def test_nested_fieldsplit_solve(W, A, b, expect, parameters):
+    solver = LinearSolver(A, solver_parameters=parameters)
+
+    f = Function(W)
+
+    solver.solve(f, b)
+
+    f -= expect
+    assert norm(f) < 1e-11
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
This change, which requires matching changes in petsc and petsc4py (https://bitbucket.org/petsc/petsc/pull-request/330/dmshell-support-dmshellsetcreatesubdm/diff and https://bitbucket.org/petsc/petsc4py/pull-request/54/dmshell-add-support-for/diff respectively) enables support for recursive fieldsplits if the assembled operator is monolithic rather than nested.  Some tests demonstrating this functionality are added.

To support the same thing for nested matrices, either petsc support for extracting subblocks from matnests needs to be extended, or we need to support "nested" mixed space definitions and building nested/non-nested operators at various points in the mixed operator.