### PR TITLE
Detection of invalid regions.

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -52,7 +52,8 @@ class _Facets(object):
         # assert that markers is a proper subset of unique_markers
         if markers is not None:
             for marker in markers:
-                assert(marker in unique_markers)
+                assert (marker in unique_markers), \
+                    "Every marker has to be contained in unique_markers"
 
         self.markers = markers
         self.unique_markers = [] if unique_markers is None else unique_markers

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -49,6 +49,11 @@ class _Facets(object):
 
         self.local_facet_number = local_facet_number
 
+        # assert that markers is a proper subset of unique_markers
+        if markers is not None:
+            for marker in markers:
+                assert(marker in unique_markers)
+
         self.markers = markers
         self.unique_markers = [] if unique_markers is None else unique_markers
         self._subsets = {}
@@ -106,6 +111,15 @@ class _Facets(object):
         try:
             return self._subsets[markers]
         except KeyError:
+            # check that the given markers are valid
+            for marker in markers:
+                if marker not in self.unique_markers:
+                    raise LookupError(
+                        '{0} is not a valid marker'.
+                        format(marker))
+
+            # build a list of indices corresponding to the subsets selected by
+            # markers
             indices = np.concatenate([np.nonzero(self.markers == i)[0]
                                       for i in markers])
             self._subsets[markers] = op2.Subset(self.set, indices)
@@ -767,7 +781,8 @@ class ExtrudedMesh(Mesh):
                                         "exterior",
                                         exterior_f.facet_cell,
                                         exterior_f.local_facet_number,
-                                        exterior_f.markers)
+                                        exterior_f.markers,
+                                        unique_markers=exterior_f.unique_markers)
 
         self.ufl_cell_element = ufl.FiniteElement("Lagrange",
                                                   domain=mesh.ufl_cell(),

--- a/tests/regression/test_bcs.py
+++ b/tests/regression/test_bcs.py
@@ -356,6 +356,14 @@ def test_empty_exterior_facet_node_list():
     assert V.exterior_facet_node_map([bc])
 
 
+def test_invalid_marker_raises_error(a, V):
+    with pytest.raises(LookupError):
+        # UnitSquareMesh has region IDs from 1 to 4. Thus 100 should raise an
+        # exception.
+        bc1 = DirichletBC(V, 0, 100)
+        assemble(a, bcs=[bc1])
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_matrix.py
+++ b/tests/regression/test_matrix.py
@@ -86,7 +86,7 @@ def test_assemble_with_bcs(a, V):
     assert A.assembled
     assert not A._needs_reassembly
 
-    bc3 = DirichletBC(V, 1, 0)
+    bc3 = DirichletBC(V, 1, 2)
     A.bcs = bc3
     assert A.assembled
     assert A._needs_reassembly
@@ -122,7 +122,7 @@ def test_assemble_with_bcs_then_not(a, V):
 
 
 def test_assemble_with_bcs_multiple_subdomains(a, V):
-    bc1 = DirichletBC(V, 0, [0, 1])
+    bc1 = DirichletBC(V, 0, [1, 2])
     A = assemble(a, bcs=[bc1])
     assert not A.assembled
     assert A._needs_reassembly


### PR DESCRIPTION
When setting Dirichlet boundary conditions invalid region ids were silently
ignored. This will now raise an exception.