### PR TITLE
Fix unassembled operators for QuasiNewton

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -123,8 +123,6 @@ class NonlinearVariationalSolver(object):
             if k.startswith(self._opt_prefix):
                 parameters[k[len(self._opt_prefix):]] = v
 
-        self.parameters = parameters
-
         self._problem = problem
 
         self._ctx = ctx
@@ -133,6 +131,8 @@ class NonlinearVariationalSolver(object):
         ctx.set_function(self.snes)
         ctx.set_jacobian(self.snes)
         ctx.set_nullspace(nullspace, problem.J.arguments()[0].function_space()._ises)
+
+        self.parameters = parameters
 
     def __del__(self):
         # Remove stuff from the options database

--- a/tests/regression/test_solving_interface.py
+++ b/tests/regression/test_solving_interface.py
@@ -202,6 +202,23 @@ def test_constant_jacobian_lvs():
     assert not (norm(assemble(out*5 - f)) < 2e-7)
 
 
+def test_quasinewton_ops_assembled():
+    mesh = UnitSquareMesh(2, 2)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = Function(V)
+    v = TestFunction(V)
+
+    F = inner(u*grad(u), grad(v))*dx
+
+    problem = NonlinearVariationalProblem(F, u)
+    solver_parameters = {'snes_type': 'qn'}
+    solver = NonlinearVariationalSolver(problem, solver_parameters=solver_parameters)
+    solver.snes.setUp()
+
+    assert solver.snes.ksp.pc.getOperators()[0].assembled
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Set parameters after the function and jacobian.
SNESSetJacobian is called from SNESSetFromOptions, so it needs to know how to assemble it.
@parameters.setter calls petsc_obj.setFromOptions() via solving_utils.update_parameters(), and must  be moved to after ctx.set_jacobian

fixes #545 