### PR TITLE
BC components

### DIFF
--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -480,6 +480,51 @@ details of how Firedrake applies strong boundary conditions are
 slightly involved and therefore have :doc:`their own section
 <boundary_conditions>` in the manual.
 
+Specifying conditions on components of a space
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When solving a problem defined on either a
+:class:`~.MixedFunctionSpace` or a :class:`~.VectorFunctionSpace`, it is
+common to want to specify boundary values for only some of the
+components.  In the former case, this is the only supported method of
+setting boundary values, the latter also supports setting the value
+for all components.  In both cases, the syntax is the same.  When
+defining the :py:class:`~.DirichletBC` we must index the FunctionSpace
+used.  For example, to specify that the third component of a
+:py:class:`~.VectorFunctionSpace` should take the boundary value 0, we write:
+
+.. code-block:: python
+
+   V = VectorFunctionSpace(mesh, ...)
+   bc = DirichletBC(V.sub(2), Constant(0), boundary_ids)
+
+Note that when indexing a :py:class:`~.MixedFunctionSpace` in this
+manner, one pulls out the indexed sub-space, rather than a component.
+For example, to specify the velocity values in a Taylor-Hood
+discretisation we write:
+
+.. code-block:: python
+
+   V = VectorFunctionSpace(mesh, "CG", 2)
+   P = FunctionSpace(mesh, "CG", 1)
+   W = V*P
+
+   bcv = DirichletBC(W.sub(0), Constant((0, 0)), boundary_ids)
+
+If we only wanted to specify a single component, we would have to
+index twice.  For example, specifying that the x-component of the
+velocity is zero, using the same function space definitions:
+
+.. code-block:: python
+
+   bcv_x = DirichletBC(W.sub(0).sub(0), Constant(0), boundary_ids)
+
+.. note::
+
+   Extruded meshes have full support for indexing
+   :py:class:`~.MixedFunctionSpace`\s, but currently do not support
+   indexing on :py:class:`~.VectorFunctionSpace`\s.
+
 Boundary conditions in discontinuous spaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -604,7 +604,7 @@ problems.
 .. _CGNS: http://www.cgns.org/
 .. _Exodus: http://sourceforge.net/projects/exodusii/
 .. _UFL: http://arxiv.org/abs/1211.4047
-.. _UFL_package: http://fenicsproject.org/documentation/ufl/1.2.0/ufl.html
+.. _UFL_package: http://fenicsproject.org/documentation/ufl/dev/ufl.html
 .. _FIAT: https://bitbucket.org/mapdes/fiat
 .. _FFC: https://bitbucket.org/mapdes/ffc
 .. _submanifold: http://en.wikipedia.org/wiki/Submanifold

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -7,6 +7,7 @@ from pyop2.profiling import timed_function
 
 import expression
 import function
+import functionspace
 import matrix
 import projection
 import utils
@@ -63,6 +64,8 @@ class DirichletBC(object):
 
         if V.extruded and method == "geometric":
             raise ValueError("Geometric boundary conditions are not yet supported on extruded meshes")
+        if V.extruded and isinstance(V, functionspace.IndexedVFS):
+            raise NotImplementedError("Indexed VFS bcs not implemented on extruded meshes")
 
     @property
     def function_arg(self):

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -81,7 +81,7 @@ class Function(ufl.Coefficient):
         self.uid = utils._new_uid()
         self._name = name or 'function_%d' % self.uid
 
-        if isinstance(val, op2.Dat):
+        if isinstance(val, (op2.Dat, op2.DatView)):
             self.dat = val
         else:
             self.dat = self._function_space.make_dat(val, dtype,
@@ -112,7 +112,16 @@ class Function(ufl.Coefficient):
 
         :arg i: the index to extract
 
-        See also :meth:`split`"""
+        See also :meth:`split`.
+
+        If the :class:`Function` is defined on a
+        :class:`.~VectorFunctionSpace`, this returns a proxy object
+        indexing the ith component of the space, suitable for use in
+        boundary condition application."""
+        if isinstance(self.function_space(), functionspace.VectorFunctionSpace):
+            fs = self.function_space().sub(i)
+            return Function(fs, val=op2.DatView(self.dat, i),
+                            name="view[%d](%s)" % (i, self.name()))
         return self.split()[i]
 
     @property

--- a/tests/extrusion/test_vfs_components.py
+++ b/tests/extrusion/test_vfs_components.py
@@ -1,0 +1,19 @@
+import pytest
+from firedrake import *
+
+
+@pytest.fixture
+def V():
+    m = UnitSquareMesh(1, 1)
+    e = ExtrudedMesh(m, layers=1)
+    return VectorFunctionSpace(e, 'CG', 1)
+
+
+def test_cant_subscript_extruded_VFS(V):
+    with pytest.raises(NotImplementedError):
+        DirichletBC(V.sub(0), 0, 1)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_vfs_component_bcs.py
+++ b/tests/regression/test_vfs_component_bcs.py
@@ -1,0 +1,108 @@
+import pytest
+from firedrake import *
+import numpy as np
+
+
+@pytest.fixture
+def m():
+    return UnitSquareMesh(4, 4)
+
+
+@pytest.fixture
+def V(m):
+    return VectorFunctionSpace(m, 'CG', 1)
+
+
+@pytest.fixture(params=[0, 1])
+def idx(request):
+    return request.param
+
+
+def test_assign_component(V):
+    f = Function(V)
+
+    f.assign(Constant((1, 2)))
+
+    assert np.allclose(f.dat.data, [1, 2])
+
+    g = f.sub(0)
+
+    g.assign(10)
+
+    assert np.allclose(g.dat.data, 10)
+
+    assert np.allclose(f.dat.data, [10, 2])
+
+    g = f.sub(1)
+
+    g.assign(3)
+
+    assert np.allclose(f.dat.data, [10, 3])
+
+    assert np.allclose(g.dat.data, 3)
+
+
+def test_apply_bc_component(V, idx):
+    f = Function(V)
+
+    bc = DirichletBC(V.sub(idx), Constant(10), (1, 3))
+
+    bc.apply(f)
+
+    nodes = bc.nodes
+
+    assert np.allclose(f.dat.data[nodes, idx], 10)
+
+    assert np.allclose(f.dat.data[nodes, 1 - idx], 0)
+
+
+def test_poisson_in_components(V):
+    # Solve vector laplacian with different boundary conditions on the
+    # x and y components, giving effectively two decoupled Poisson
+    # problems in the two components
+    g = Function(V)
+
+    f = Constant((0, 0))
+
+    bcs = [DirichletBC(V.sub(0), 0, 1),
+           DirichletBC(V.sub(0), 42, 2),
+           DirichletBC(V.sub(1), 10, 3),
+           DirichletBC(V.sub(1), 15, 4)]
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = inner(grad(u), grad(v))*dx
+
+    L = dot(f, v)*dx
+
+    solve(a == L, g, bcs=bcs)
+
+    expect = Function(V)
+
+    expect.interpolate(Expression(("42*x[0]", "5*x[1] + 10")))
+    assert np.allclose(g.dat.data, expect.dat.data)
+
+
+def test_cant_integrate_subscripted_VFS(V):
+    f = Function(V)
+    with pytest.raises(NotImplementedError):
+        assemble(f.sub(0)*dx)
+
+
+@pytest.mark.parametrize("cmpt",
+                         [-1, 2])
+def test_cant_subscript_outside_components(V, cmpt):
+    with pytest.raises(AssertionError):
+        return V.sub(cmpt)
+
+
+def test_cant_subscript_3_cmpt(m):
+    V = VectorFunctionSpace(m, 'CG', 1, dim=4)
+    with pytest.raises(NotImplementedError):
+        V.sub(3)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
I think this allows setting (along with OP2/PyOP2#450) boundary conditions on a component of a vector function space.  Some rudimentary tests are added.  

The solves are xfailed because they don't do what I expect, but I'm not sure if this actually right.  Perhaps  I'm just misunderstanding what's going on.  Consider the following:

```python
from firedrake import *

parameters["pyop2_options"]["lazy_evaluation"] = False
parameters["assembly_cache"]["enabled"] = False
parameters["pyop2_options"]["debug"] = True
parameters["coffee"]["O2"] = False

mesh = UnitSquareMesh(1, 1)
V = VectorFunctionSpace(mesh, "CG", 1)

g = Function(V)

f = Constant((1, 2))

bcval = Constant((3, 3))

idx = 0
bc = DirichletBC(V, bcval, 1)

u = TrialFunction(V)
v = TestFunction(V)

a = dot(u, v)*dx
L = dot(f, v)*dx

expect = Function(V)

expect.assign(f)

expect.assign(bcval, subset=bc.node_set)

print expect.dat.data

solve(a == L, g, bcs=bc)

print g.dat.data
```

I expect to see 4 of the dofs set to the boundary condition value (3) and the other four to be the value of the input function.  I.e. I expect

```
3 3
3 3
1 2
1 2
```

Instead I see:

```
[[ 3.          3.        ]
 [ 3.          3.        ]
 [-0.42857143  1.28571429]
 [ 0.71428571  1.85714286]]
```


Dolfin produces what I would similarly call nonsense.  Ideas?