### PR TITLE
Fix hedgehog

### DIFF
--- a/firedrake/extrusion_utils.py
+++ b/firedrake/extrusion_utils.py
@@ -208,8 +208,8 @@ def make_extruded_coords(extruded_mesh, layer_height,
              */
             norm = sqrt(norm);
             norm *= (dot < 0 ? -1 : 1);
-            for (d = 0; d < %(base_coord_dim)d; ++d) {
-                for (c = 0; c < %(base_map_arity)d; ++c ) {
+            for (d = 0; d < %(base_map_arity)d; ++d) {
+                for (c = 0; c < %(base_coord_dim)d; ++c ) {
                     ext_coords[2*d][c] = base_coords[d][c] + n[c] * layer_height[0] * layer[0][0] / norm;
                     ext_coords[2*d+1][c] = base_coords[d][c] + n[c] * layer_height[0] * (layer[0][0] + 1)/ norm;
                 }

--- a/tests/extrusion/test_meshes.py
+++ b/tests/extrusion/test_meshes.py
@@ -1,0 +1,45 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+
+@pytest.fixture(params=["interval", "square", "quad-square"])
+def uniform_mesh(request):
+    if request.param == "interval":
+        base = UnitIntervalMesh(4)
+    elif request.param == "square":
+        base = UnitSquareMesh(5, 4)
+    elif request.param == "quad-square":
+        base = UnitSquareMesh(4, 6, quadrilateral=True)
+    return ExtrudedMesh(base, layers=10, layer_height=0.1,
+                        extrusion_type="uniform")
+
+
+@pytest.fixture(params=["circlemanifold",
+                        "icosahedron",
+                        pytest.mark.xfail(reason="Bad coordinate extrusion code")("cubedsphere")])
+def hedgehog_mesh(request):
+    if request.param == "circlemanifold":
+        # Circumference of 1
+        base = CircleManifoldMesh(ncells=3, radius=1/np.sqrt(27))
+    elif request.param == "icosahedron":
+        # Surface area of 1
+        base = IcosahedralSphereMesh(np.sin(2*np.pi/5) * np.sqrt(1/(5*np.sqrt(3))), refinement_level=0)
+    elif request.param == "cubedsphere":
+        # Surface area of 1
+        base = CubedSphereMesh(radius=1/(2*np.sqrt(2)), refinement_level=0)
+
+    return ExtrudedMesh(base, layers=5, layer_height=0.2, extrusion_type="radial_hedgehog")
+
+
+def test_uniform_extrusion_volume(uniform_mesh):
+    assert np.allclose(assemble(Constant(1, domain=uniform_mesh)*dx), 1.0)
+
+
+def test_hedgehog_extrusion_volume(hedgehog_mesh):
+    assert np.allclose(assemble(Constant(1, domain=hedgehog_mesh)*dx), 1.0)
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/extrusion/test_meshes.py
+++ b/tests/extrusion/test_meshes.py
@@ -17,7 +17,7 @@ def uniform_mesh(request):
 
 @pytest.fixture(params=["circlemanifold",
                         "icosahedron",
-                        pytest.mark.xfail(reason="Bad coordinate extrusion code")("cubedsphere")])
+                        "cubedsphere"])
 def hedgehog_mesh(request):
     if request.param == "circlemanifold":
         # Circumference of 1


### PR DESCRIPTION
We were punning the map arity and coordinate dimension in a way which was safe on simplex meshes, but not quad meshes (or indeed higher-order coordinate representations).