### PR TITLE
Install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - pip install -U pytest
   - pip install -U Cython
   - pip install pytest-benchmark
-  - export BRANCH = $(git symbolic-ref --short -q HEAD)
+  - export BRANCH=$(git symbolic-ref --short -q HEAD)
   - mkdir tmp
   - cd tmp
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,9 @@ before_install:
   - mkdir tmp
   - cd tmp
 install:
-  - ../scripts/firedrake-install --disable_ssh
+  - ../scripts/firedrake-install --disable_ssh --global
 # command to run tests
 script:
-  - . firedrake/bin/activate
   - cd firedrake/src/firedrake
   - make lint
   - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ virtualenv:
   system_site_packages: true
 # command to install dependencies
 before_install:
+  - pip install -U pip
   - pip install -U pytest
   - pip install pytest-benchmark
   - mkdir tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,9 @@ before_install:
   - cd tmp
 install:
   - ../scripts/firedrake-install --disable_ssh --global
+  - cd firedrake/src/firedrake
+  - python setup.py build_ext --inplace
 # command to run tests
 script:
-  - cd firedrake/src/firedrake
   - make lint
   - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ virtualenv:
 before_install:
   - pip install -U pip
   - pip install -U pytest
+  - pip install -U Cython
   - pip install pytest-benchmark
   - mkdir tmp
   - cd tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,21 +42,15 @@ virtualenv:
   system_site_packages: true
 # command to install dependencies
 before_install:
-  - wget https://raw.github.com/OP2/PyOP2/master/requirements-minimal.txt
   - pip install -U pytest
-  - pip install psutil
-  - pip install cachetools
   - pip install pytest-benchmark
-  - "xargs -l1 pip install --allow-external mpi4py --allow-unverified mpi4py \
-       --allow-external petsc --allow-unverified petsc \
-       --allow-external petsc4py  --allow-unverified petsc4py \
-       < requirements-minimal.txt"
-  - pip install -r requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install argparse ordereddict; fi
+  - mkdir tmp
+  - cd tmp
 install:
-  - make
+  - ../scripts/firedrake-install
 # command to run tests
 script:
-  - export PYTHONPATH=`pwd`:$PYTHONPATH
+  - . firedrake/bin/activate
+  - cd firedrake/src/firedrake
   - make lint
   - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   - mkdir tmp
   - cd tmp
 install:
-  - ../scripts/firedrake-install
+  - ../scripts/firedrake-install --disable_ssh
 # command to run tests
 script:
   - . firedrake/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,13 @@ before_install:
   - pip install -U pytest
   - pip install -U Cython
   - pip install pytest-benchmark
+  - export BRANCH = $(git symbolic-ref --short -q HEAD)
   - mkdir tmp
   - cd tmp
 install:
   - ../scripts/firedrake-install --disable_ssh --global
   - cd firedrake/src/firedrake
+  - git checkout $BRANCH
   - python setup.py build_ext --inplace
 # command to run tests
 script:

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -1,6 +1,57 @@
 Obtaining Firedrake
 ===================
 
+The simplest way to install Firedrake is to use our install script::
+
+  curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
+  python firedrake-install
+
+Running `firedrake-install` with no arguments will install firedrake in
+a python virtualenv_ created in a `firedrake` subdirectory of the
+current directory. Run::
+
+  python firedrake-install --help
+
+for a full list of install options including user- or system-wide
+installs and installation in developer mode. If you install in
+virtualenv_ mode, you will need to activate the virtualenv in each
+shell from which you use Firedrake::
+
+  source firedrake/bin/activate
+
+
+System requirements
+-------------------
+
+The installation script is tested on Ubuntu and MacOS X. Installation
+is likely to work well on other Linux platforms, although the script
+may stop to ask you to install some dependency packages. Installation
+on other Unix platforms may work but is untested. Installation on
+Windows is very unlikely work.
+
+Upgrade
+-------
+
+The install script will install an upgrade script in
+`firedrake/bin/firedrake-update`. Running this script will update
+Firedrake and all its dependencies.
+
+Cleaning disk caches after upgrade
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After upgrading, you may need to clear any disk caches that Firedrake
+maintains to ensure that your problem does not pick up any out of date
+compiled modules. To do this run::
+
+  firedrake-clean
+
+If you installed to a virtualenv, you will need to activate the
+virtualenv first.
+
+
+Installing from individual components
+=====================================
+
 Firedrake depends on PyOP2_, FFC_, FIAT_, and UFL_. It is easiest to obtain
 all of these components on Ubuntu Linux and related distributions such as Mint
 or Debian. Installation on other Unix-like operating systems is likely to be
@@ -209,3 +260,4 @@ Finally install the Bibtex plugin::
 .. _Sphinx: http://www.sphinx-doc.org
 .. _wget: http://www.gnu.org/software/wget/
 .. _Swig: http://www.swig.org/
+.. _virtualenv: https://virtualenv.pypa.io/

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,3 +1,4 @@
 six
 sympy
+psutil
 cachetools

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,0 +1,3 @@
+six
+sympy
+cachetools

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://bitbucket.org/fenics-project/instant.git#egg=instant
 git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
 git+https://bitbucket.org/mapdes/fiat.git#egg=fiat
 git+https://bitbucket.org/mapdes/ffc.git#egg=ffc
-git+https://github.com/OP2/PyOP2.git@install_script#egg=pyop2
+git+https://github.com/OP2/PyOP2.git#egg=pyop2

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -2,4 +2,4 @@ git+https://bitbucket.org/fenics-project/instant.git#egg=instant
 git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
 git+https://bitbucket.org/mapdes/fiat.git#egg=fiat
 git+https://bitbucket.org/mapdes/ffc.git#egg=ffc
-git+https://github.com/OP2/PyOP2#egg=pyop2
+git+https://github.com/OP2/PyOP2.git@install_script#egg=pyop2

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,0 +1,5 @@
+git+https://bitbucket.org/fenics-project/instant.git#egg=instant
+git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
+git+https://bitbucket.org/mapdes/fiat.git#egg=fiat
+git+https://bitbucket.org/mapdes/ffc.git#egg=ffc
+git+https://github.com/OP2/PyOP2#egg=pyop2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-six
-sympy
-cachetools
-git+https://bitbucket.org/fenics-project/instant.git#egg=instant
-git+https://bitbucket.org/mapdes/ufl.git#egg=ufl
-git+https://bitbucket.org/mapdes/fiat.git#egg=fiat
-git+https://bitbucket.org/mapdes/ffc.git#egg=ffc
-git+https://github.com/OP2/PyOP2
+-r requirements-ext.txt
+-r requirements-git.txt

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -40,8 +40,8 @@ options. If none of these options are provided, a local installation into
     #                   help="Install to subdirectories of the specified directory.")
     group.add_argument("--user", action='store_true',
                        help="Install using the current user's home directory as the prefix.")
-    parser.add_argument("--developer", action='store_true',
-                        help="Install in developer mode where the core packages are run from their source directories. Due to an upstream bug, petsc4py will not be installed in developer mode.")
+    group.add_argument("--developer", action='store_true',
+                       help="Install in developer mode where the core packages are run from their source directories. Due to an upstream bug, petsc4py will not be installed in developer mode.")
     parser.add_argument("--sudo", action='store_true',
                         help="Use sudo when installing system dependencies and python packages. Regardless of the presence of this flag, sudo will never be used to install packages into $HOME or ./firedrake but sudo will always be used when installing system dependencies using apt.")
 
@@ -369,7 +369,8 @@ else:
         install(p)
 
 stdout.write("Creating firedrake-update script.\n")
-update_script = open("firedrake/scripts/firedrake-install", "r").read()
+with open("firedrake/scripts/firedrake-install", "r") as f:
+    update_script = f.read()
 
 for switch in ["developer", "user", "system", "sudo", "prefix"]:
     update_script = update_script.replace("args.%s = False" % switch,
@@ -378,8 +379,9 @@ try:
     os.mkdir("../bin")
 except:
     pass
-open("../bin/firedrake-update", "w").write(update_script)
-check_call(["chmod", "a+x", "../bin/firedrake-update"])
+with open("../bin/firedrake-update", "w") as f:
+    f.write(update_script)
+os.chmod("../bin/firedrake-update", "a+x")
 
 os.chdir("../..")
 
@@ -392,4 +394,3 @@ if not (args.system or args.user or args.prefix):
     stdout.write("  . firedrake/bin/activate\n\n")
     stdout.write("The virtualenv can be deactivated by running:\n\n")
     stdout.write("  deactivate\n")
-

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -140,7 +140,7 @@ def piprequirements(package):
 def install(package):
     stdout.write("Installing %s\n" % package)
     # The following outrageous hack works around the fact that petsc4py cannot be installed in developer mode.
-    if args.developer or package == "petsc4py":
+    if args.developer and package != "petsc4py/":
         check_call(sudopip + ["-e", package])
     else:
         check_call(sudopip + ["--ignore-installed", package])

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -207,7 +207,7 @@ def pip_requirements(package):
     elif os.path.isfile("%s/requirements.txt"):
         run_pip(["-r", "%s/requirements.txt" % package])
     else:
-        stdout.write("No dependencies found. Skipping.\n" % package)
+        stdout.write("No dependencies found. Skipping.\n")
 
 
 def install(package):

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -381,7 +381,7 @@ except:
     pass
 with open("../bin/firedrake-update", "w") as f:
     f.write(update_script)
-os.chmod("../bin/firedrake-update", "a+x")
+check_call(["chmod", "a+x", "../bin/firedrake-update"])
 
 os.chdir("../..")
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -202,9 +202,9 @@ def run_pip(args):
 
 def pip_requirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
-    if os.path.isfile("%s/requirements-ext.txt"):
+    if os.path.isfile("%s/requirements-ext.txt" % package):
         run_pip(["-r", "%s/requirements-ext.txt" % package])
-    elif os.path.isfile("%s/requirements.txt"):
+    elif os.path.isfile("%s/requirements.txt" % package):
         run_pip(["-r", "%s/requirements.txt" % package])
     else:
         stdout.write("No dependencies found. Skipping.\n")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -9,7 +9,7 @@ if os.path.basename(__file__) == "firedrake-install":
     mode = "install"
 elif os.path.basename(__file__) == "firedrake-update":
     mode = "update"
-    os.chdir(os.path.dirname(__file__) + "../")
+    os.chdir(os.path.dirname(__file__) + "/../..")
 else:
     sys.exit("Script must be invoked either as firedrake-install or firedrake-update")
 
@@ -183,9 +183,9 @@ def git_update(name):
     # Update the named git repo and return true if the current branch actually changed.
     stdout.write("Updating the git repository for %s\n" % name)
     os.chdir(name)
-    git_sha = check_output(["git", "rev-parse", "head"])
+    git_sha = check_output(["git", "rev-parse", "HEAD"])
     check_call(["git", "pull"])
-    git_sha_new = check_output(["git", "rev-parse", "head"])
+    git_sha_new = check_output(["git", "rev-parse", "HEAD"])
     os.chdir("..")
     return git_sha != git_sha_new
 
@@ -277,7 +277,8 @@ if (args.system or args.user or args.prefix) and mode == "install":
         stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
         raise
 
-elif not (args.system or args.user or args.prefix):
+# sys.real_prefix exists if we are already in the virtualenv
+elif not (args.system or args.user or args.prefix) and not hasattr(sys, "real_prefix"):
     try:
         import virtualenv
     except:
@@ -374,3 +375,4 @@ if not (args.system or args.user or args.prefix):
     stdout.write("  . firedrake/bin/activate\n\n")
     stdout.write("The virtualenv can be deactivated by running:\n\n")
     stdout.write("  deactivate\n")
+

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1,0 +1,11 @@
+#! /usr/bin/env python
+import platform
+
+# Check operating system.
+osname = platform.uname()[0]
+if osname == "Linux":
+    # Check for apt.
+    
+# Install minimal OS packages.
+
+# Install python packages.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -32,6 +32,8 @@ group.add_argument("--prefix", type=str, nargs=1,
                     help="Install to subdirectories of the specified directory.")
 group.add_argument("--user", action='store_true',
                    help="Install using the current user's home directory as the prefix.")
+parser.add_argument("--developer", action='store_true',
+                    help="Install in developer mode where the core packages are run from their source directories. Due to an upstream bug, petsc4py will not be installed in developer mode.")
 parser.add_argument("--sudo", action='store_true',
                     help="Use sudo when installing system dependencies and python packages. Regardless of the presence of this flag, sudo will never be used to install packages into $HOME or ./firedrake but sudo will always be used when installing system dependencies using apt.")
 
@@ -40,19 +42,31 @@ parser.add_argument("--log", action='store_true',
 
 args = parser.parse_args()
 print args
+#in Where are packages installed relative to --root?
+# This is a bit of a hack.
+v = sys.version_info
+sitepackages="/usr/local/lib/python%d.%d/site-packages/" % (v.major, v.minor)
+path_extension = ""
 
 if args.sudo and (args.system or args.prefix):
     sudopip = ["sudo", "pip", "install"]
 else:
     sudopip = ["pip", "install"]
 if args.user:
-    sudopip.append("--user")
+    sudopip += ["--user"]
 elif args.prefix:
+    path_extension = args.prefix + sitepackages + os.pathsep
     sudopip += ["--root", args.prefix]
 elif args.system:
     pass
 else:
+    path_extension = os.getcwd() + "/firedrake" + sitepackages + os.pathsep
     sudopip += ["--root", os.getcwd() + "/firedrake"]
+
+if args.developer:
+    path_extension += os.getcwd() + "/firedrake/src"
+
+os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH","")
 
 class Log(object):
     """Class to enable logging to screen and logfile at once."""
@@ -77,6 +91,7 @@ def check_call(args):
         stdout.write(e.output)
         raise
 
+    
 def brewinstall(name):
     check_call(["brew", "install", name])
 
@@ -85,36 +100,49 @@ def aptinstall(name):
     check_call(["sudo", "apt-get", "install", name])
 
     
-def gitclone(name, url):
+def gitclone(url):
+    name = url.split(".git")[0].split("#")[0].split("/")[-1]
     stdout.write("Cloning %s\n" % name)
-    plainurl = url.split("://")[1]
+    spliturl = url.split("://")[1].split("#")[0].split("@")
     try:
-        check_call(["git", "clone", "git@%s:%s" % tuple(plainurl.split("/", 1))])
+        plainurl, branch = spliturl
+    except ValueError:
+        plainurl = spliturl[0]
+        branch = "master"
+    try:
+        check_call(["git", "clone", "-b", branch, "git@%s:%s" % tuple(plainurl.split("/", 1))])
+        stdout.write("Successfully cloned %s.\n" % name)
     except subprocess.CalledProcessError:
         stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
         try:
-            check_call(["git", "clone", "https://%s" % plainurl])
-            stdout.write("Successfully cloded %s" % name)
+            check_call(["git", "clone",  "-b", branch, "https://%s" % plainurl])
+            stdout.write("Successfully cloned %s.\n" % name)
         except subprocess.CalledProcessError:
-            stderr.write("Failed to clone %s\n" % name)
+            stderr.write("Failed to clone %s.\n" % name)
             raise
+    return name
 
-    
+
 def clone_dependencies(name):
     stdout.write("Cloning the dependencies of %s\n" % name)
+    deps = []
     for dep in open(name + "/requirements-git.txt", "r"):
-        gitclone(dep.strip())
+        deps.append(gitclone(dep.strip()))
+    return deps
 
 
-def piprequirements(package, filename):
+def piprequirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
-    check_call(sudopip + ["install", "-r", filename])
+    check_call(sudopip + ["-r", "%s/requirements-ext.txt" % package])
 
 
 def install(package):
     stdout.write("Installing %s\n" % package)
-    #check_call(["pip", "install", ...])
-    raise NotImplementedError
+    # The following outrageous hack works around the fact that petsc4py cannot be installed in developer mode.
+    if args.developer or package == "petsc4py":
+        check_call(sudopip + ["-e", package])        
+    else:
+        check_call(sudopip + ["--ignore-installed", package])
 
 
 def quit(message):
@@ -169,16 +197,17 @@ os.chdir("firedrake")
 os.mkdir("src")
 os.chdir("src")
 
-gitclone("firedrake", "git+https://github.com/firedrakeproject/firedrake.git@install_script")
+gitclone("git+https://github.com/firedrakeproject/firedrake.git@install_script")
 packages = clone_dependencies("firedrake")
 packages += clone_dependencies("PyOP2")
 packages += ["PyOP2", "firedrake"]
 
 print "Installing required Python packages."
-piprequirements("PyOP2/requirements-ext.txt")
-piprequirements("firedrake/requirements-ext.txt")
+piprequirements("PyOP2")
+piprequirements("firedrake")
 
+sudopip.append("--no-deps")
 for p in packages:
-    install(p)
+    install(p+"/")
 
 # Build environment script and update script.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -41,7 +41,6 @@ parser.add_argument("--log", action='store_true',
                     help="Produce a verbose log of the installation process in firedrake-install.log. If you have problem running this script, please include this log in any bug report you file.")
 
 args = parser.parse_args()
-print args
 # Where are packages installed relative to --root?
 # This is a bit of a hack.
 v = sys.version_info
@@ -60,13 +59,16 @@ elif args.prefix:
 elif args.system:
     pass
 else:
-    path_extension = os.getcwd() + "/firedrake" + sitepackages + os.pathsep
-    sudopip += ["--root", os.getcwd() + "/firedrake"]
+    # Use the pip from the virtualenv
+    sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
 
 if args.developer:
     path_extension += os.getcwd() + "/firedrake/src"
 
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
+
+if os.environ["PETSC_DIR"]:
+    sys.stdout("WARNING: The PETSC_DIR environment variable is set. This is probably an error.\n")
 
 
 class Log(object):
@@ -93,15 +95,28 @@ def check_call(args):
         raise
 
 
-def brewinstall(name):
+def brew_install(name):
     check_call(["brew", "install", name])
 
 
-def aptinstall(name):
-    check_call(["sudo", "apt-get", "install", name])
+def apt_check(name):
+    stdout.write("Checking for presence of package %s..." % name)
+    # Note that subprocess return codes have the opposite logical
+    # meanings to those of Python variables.
+    if not subprocess.call(["dpkg", "-l", name]):
+        stdout.write("installed.\n")
+        return True
+    else:
+        stdout.write("missing.\n")
+        return False
 
 
-def gitclone(url):
+def apt_install(names):
+    stdout.write("Installing missing packages: %s.\n" % ", ".join(names))
+    check_call(["sudo", "apt-get", "install"] + names)
+
+
+def git_clone(url):
     name = url.split(".git")[0].split("#")[0].split("/")[-1]
     stdout.write("Cloning %s\n" % name)
     spliturl = url.split("://")[1].split("#")[0].split("@")
@@ -128,22 +143,26 @@ def clone_dependencies(name):
     stdout.write("Cloning the dependencies of %s\n" % name)
     deps = []
     for dep in open(name + "/requirements-git.txt", "r"):
-        deps.append(gitclone(dep.strip()))
+        deps.append(git_clone(dep.strip()))
     return deps
 
 
-def piprequirements(package):
+def run_pip(args):
+    check_call(sudopip + args)
+
+
+def pip_requirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
-    check_call(sudopip + ["-r", "%s/requirements-ext.txt" % package])
+    run_pip(["-r", "%s/requirements-ext.txt" % package])
 
 
 def install(package):
     stdout.write("Installing %s\n" % package)
     # The following outrageous hack works around the fact that petsc4py cannot be installed in developer mode.
     if args.developer and package != "petsc4py/":
-        check_call(sudopip + ["-e", package])
+        run_pip(["-e", package])
     else:
-        check_call(sudopip + ["--ignore-installed", package])
+        run_pip(["--ignore-installed", package])
 
 
 def quit(message):
@@ -153,18 +172,6 @@ def quit(message):
 
 # Check operating system.
 osname = platform.uname()[0]
-if osname == "Linux":
-    # Check for apt.
-    try:
-        check_call(["apt-get", "--version"])
-        have_apt = True
-    except subprocess.CalledProcessError:
-        have_apt = False
-
-# Install minimal OS packages.
-if osname not in ["Linux", "Darwin"]:
-    stdout.write("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
-
 if osname == "Darwin":
     try:
         check_call(["xcodebuild", "-version"])
@@ -178,34 +185,66 @@ if osname == "Darwin":
         quit("Homebrew not found. Please install it using the instructions at http://brew.sh and then try again.")
 
     stdout.write("Installing required packages via homebrew. You can safely ignore warnings that packages are already installed\n")
-    brewinstall("openmpi")
-    brewinstall("python")
+    brew_install("openmpi")
+    brew_install("python")
     check_call(["brew", "tap", "homebrew/python"])
-    brewinstall("numpy")
+    brew_install("numpy")
+
+elif osname == "Linux":
+    # Check for apt.
+    try:
+        check_call(["apt-get", "--version"])
+
+        apt_packages = ["build-essential", "python-dev", "git-core",
+                        "mercurial", "python-pip", "libopenmpi-dev", "openmpi-bin",
+                        "libblas-dev", "liblapack-dev", "gfortran", "libhdf5-mpi-dev"]
+
+        missing_packages = [p for p in apt_packages if not apt_check(p)]
+        if missing_packages:
+            apt_install(missing_packages)
+
+    except subprocess.CalledProcessError:
+        stdout.write("apt-get not found. Proceeding on the rash assumption that your compiled dependencies are in place.\n")
+        stdout.write("If this is not the case, please install the following and try again:\n")
+        stdout.write("A C compiler (for example gcc or clang), make.\n")
+        stdout.write("A Fortran compiler (for PETSc).\n")
+        stdout.write("MPI.\n")
+        stdout.write("Blas and Lapack.\n")
+        stdout.write("Git, Mercurial.\n")
+        stdout.write("Python version 2.7.\n")
+        stdout.write("pip and the Python headers.\n")
 
 else:
-    # If not MacOS then try the Linux options.
-    raise Exception("NotAMac")
+    stdout.write("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.\n")
 
-print "Creating firedrake directory structure"
-try:
-    os.mkdir("firedrake")
-except OSError:
-    stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
-    raise
+
+if args.system or args.user or args.prefix:
+    stdout.write("Creating firedrake directory structure.\n")
+    try:
+        os.mkdir("firedrake")
+    except OSError:
+        stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
+        raise
+
+else:
+    stdout.write("Installing virtualenv.\n")
+    check_call(["pip", "install", "--user", "virtualenv"])
+    import virtualenv
+    stdout.write("Creating firedrake virtualenv.\n")
+    virtualenv.create_environment("firedrake")
+    execfile("firedrake/bin/activate_this.py", dict(__file__='path/to/activate_this.py'))
 
 os.chdir("firedrake")
 os.mkdir("src")
 os.chdir("src")
 
-gitclone("git+https://github.com/firedrakeproject/firedrake.git@install_script")
+git_clone("git+https://github.com/firedrakeproject/firedrake.git@install_script")
 packages = clone_dependencies("firedrake")
-packages += clone_dependencies("PyOP2")
-packages += ["PyOP2", "firedrake"]
+packages = clone_dependencies("PyOP2") + packages
+packages += ["firedrake"]
 
-print "Installing required Python packages."
-piprequirements("PyOP2")
-piprequirements("firedrake")
+pip_requirements("PyOP2")
+pip_requirements("firedrake")
 
 sudopip.append("--no-deps")
 for p in packages:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -295,7 +295,7 @@ elif not (args.system or args.user or args.prefix):
         quit("Virtual env installed. Please run firedrake-install again.\n")
     if mode == "install":
         stdout.write("Creating firedrake virtualenv.\n")
-        virtualenv.create_environment("firedrake")
+        virtualenv.create_environment("firedrake", site_packages=True)
     execfile("firedrake/bin/activate_this.py", dict(__file__='path/to/activate_this.py'))
 
 os.chdir("firedrake")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -165,7 +165,8 @@ def git_clone(url):
         check_call(["git", "clone", "-q", "-b", branch, "git@%s:%s" % tuple(plainurl.split("/", 1))])
         stdout.write("Successfully cloned %s.\n" % name)
     except:
-        stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
+        if not args.disable_ssh:
+            stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
         try:
             check_call(["git", "clone", "-b", branch, "https://%s" % plainurl])
             stdout.write("Successfully cloned %s.\n" % name)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -314,7 +314,7 @@ if mode == "install":
     packages += ["firedrake"]
 
     for p in packages:
-        pip_requirements("p")
+        pip_requirements(p)
 
     sudopip.append("--no-deps")
     for p in packages:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -277,13 +277,16 @@ if (args.system or args.user or args.prefix) and mode == "install":
         stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
         raise
 
-# sys.real_prefix exists if we are already in the virtualenv
-elif not (args.system or args.user or args.prefix) and not hasattr(sys, "real_prefix"):
+elif not (args.system or args.user or args.prefix):
     try:
         import virtualenv
     except:
         stdout.write("Installing virtualenv.\n")
-        check_call(["pip", "install", "--user", "virtualenv"])
+        # sys.real_prefix exists if we are already in the virtualenv
+        if hasattr(sys, "real_prefix"):
+            check_call(["pip", "install", "virtualenv"])
+        else:
+            check_call(["pip", "install", "--user", "virtualenv"])
         quit("Virtual env installed. Please run firedrake-install again.\n")
     if mode == "install":
         stdout.write("Creating firedrake virtualenv.\n")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -158,7 +158,7 @@ def git_clone(url):
         plainurl = spliturl[0]
         branch = "master"
     try:
-        check_call(["git", "clone", "-b", branch, "git@%s:%s" % tuple(plainurl.split("/", 1))])
+        check_call(["git", "clone", "-q", "-b", branch, "git@%s:%s" % tuple(plainurl.split("/", 1))])
         stdout.write("Successfully cloned %s.\n" % name)
     except subprocess.CalledProcessError:
         stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -63,8 +63,9 @@ else:
     sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
 
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
+os.environ["PETSC_CONFIGURE_OPTIONS"] = "--download-ctetgen --download-triangle --download-chaco"
 
-if os.environ.has_key("PETSC_DIR"):
+if "PETSC_DIR" in os.environ:
     sys.stdout("WARNING: The PETSC_DIR environment variable is set. This is probably an error.\n")
 
 
@@ -225,9 +226,12 @@ if args.system or args.user or args.prefix:
         raise
 
 else:
-    stdout.write("Installing virtualenv.\n")
-    check_call(["pip", "install", "--user", "virtualenv"])
-    import virtualenv
+    try:
+        import virtualenv
+    except:
+        stdout.write("Installing virtualenv.\n")
+        check_call(["pip", "install", "--user", "virtualenv"])
+        quit("Virtual env installed. Please run firedrake-install again.\n")
     stdout.write("Creating firedrake virtualenv.\n")
     virtualenv.create_environment("firedrake")
     execfile("firedrake/bin/activate_this.py", dict(__file__='path/to/activate_this.py'))

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -202,7 +202,12 @@ def run_pip(args):
 
 def pip_requirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
-    run_pip(["-r", "%s/requirements-ext.txt" % package])
+    if os.path.isfile("%s/requirements-ext.txt"):
+        run_pip(["-r", "%s/requirements-ext.txt" % package])
+    elif os.path.isfile("%s/requirements.txt"):
+        run_pip(["-r", "%s/requirements.txt" % package])
+    else:
+        stdout.write("No dependencies found. Skipping.\n" % package)
 
 
 def install(package):
@@ -308,8 +313,8 @@ if mode == "install":
     packages = clone_dependencies("PyOP2") + packages
     packages += ["firedrake"]
 
-    pip_requirements("PyOP2")
-    pip_requirements("firedrake")
+    for p in packages:
+        pip_requirements("p")
 
     sudopip.append("--no-deps")
     for p in packages:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -369,6 +369,10 @@ update_script = open("firedrake/scripts/firedrake-install", "r").read()
 for switch in ["developer", "user", "system", "sudo", "prefix"]:
     update_script = update_script.replace("args.%s = False" % switch,
                                           "args.%s = %s" % (switch, args.__getattribute__(switch)))
+try:
+    os.mkdir("../bin")
+except:
+    pass
 open("../bin/firedrake-update", "w").write(update_script)
 check_call(["chmod", "a+x", "../bin/firedrake-update"])
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -62,12 +62,9 @@ else:
     # Use the pip from the virtualenv
     sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
 
-if args.developer:
-    path_extension += os.getcwd() + "/firedrake/src"
-
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
 
-if os.environ["PETSC_DIR"]:
+if os.environ.has_key("PETSC_DIR"):
     sys.stdout("WARNING: The PETSC_DIR environment variable is set. This is probably an error.\n")
 
 
@@ -148,6 +145,7 @@ def clone_dependencies(name):
 
 
 def run_pip(args):
+    stdout.write(" ".join(sudopip + args) + "\n")
     check_call(sudopip + args)
 
 
@@ -158,8 +156,8 @@ def pip_requirements(package):
 
 def install(package):
     stdout.write("Installing %s\n" % package)
-    # The following outrageous hack works around the fact that petsc4py cannot be installed in developer mode.
-    if args.developer and package != "petsc4py/":
+    # The following outrageous hack works around the fact that petsc cannot be installed in developer mode.
+    if args.developer and package not in ["petsc/", "petsc4py/"]:
         run_pip(["-e", package])
     else:
         run_pip(["--ignore-installed", package])
@@ -249,5 +247,13 @@ pip_requirements("firedrake")
 sudopip.append("--no-deps")
 for p in packages:
     install(p+"/")
+    if args.developer:
+        pdir = os.getcwd() + "/" + p + os.pathsep
+        os.environ["PYTHONPATH"] = pdir + os.environ.get("PYTHONPATH", "")
+        path_extension = pdir + path_extension
+
+#if args.developer:
+#    # Append the source directories to the pythonpath.
+#    open("../bin/activate", "a").write(
 
 # Build environment script and update script.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1,11 +1,184 @@
 #! /usr/bin/env python
 import platform
+import subprocess
+import sys
+import os
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+
+# Handle command line arguments.
+parser = ArgumentParser(description="""Install firedrake and its dependencies.""",
+                        epilog="""The install process has three steps.
+
+1. Any required system packages are installed using brew (MacOS) or apt (Ubuntu
+   and similar Linux systems). On a Linux system without apt, the installation
+   will fail if a dependency is not found.
+
+2. A set of standard and/or third party Python packages is installed to the
+   specified install location.
+
+3. The core set of Python packages is downloaded to ./firedrake/src/ and
+   installed to the specified location.
+
+The install location may be specified using the --global, --prefix, or --user
+options. If none of these options are provided, a local installation into
+./firedrake will be performed.""",
+                        formatter_class=RawDescriptionHelpFormatter)
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--global", action='store_true', dest="system",
+                   help="Install to the default global location on the current platform.")
+group.add_argument("--prefix", type=str, nargs=1,
+                    help="Install to subdirectories of the specified directory.")
+group.add_argument("--user", action='store_true',
+                   help="Install using the current user's home directory as the prefix.")
+parser.add_argument("--sudo", action='store_true',
+                    help="Use sudo when installing system dependencies and python packages. Regardless of the presence of this flag, sudo will never be used to install packages into $HOME or ./firedrake but sudo will always be used when installing system dependencies using apt.")
+
+parser.add_argument("--log", action='store_true',
+                    help="Produce a verbose log of the installation process in firedrake-install.log. If you have problem running this script, please include this log in any bug report you file.")
+
+args = parser.parse_args()
+print args
+
+if args.sudo and (args.system or args.prefix):
+    sudopip = ["sudo", "pip", "install"]
+else:
+    sudopip = ["pip", "install"]
+if args.user:
+    sudopip.append("--user")
+elif args.prefix:
+    sudopip += ["--root", args.prefix]
+elif args.system:
+    pass
+else:
+    sudopip += ["--root", os.getcwd() + "/firedrake"]
+
+class Log(object):
+    """Class to enable logging to screen and logfile at once."""
+    def __init__(self, screen, log):
+        self.files = [screen]
+        if log:
+            self.files.append(log)
+
+    def write(self, string):
+        for f in self.files:
+            f.write(string)
+
+log = file("firedrake-install.log", "w") if args.log else None
+stdout = Log(sys.stdout, log)
+stderr = Log(sys.stderr, log)
+
+
+def check_call(args):
+    try:
+        stdout.write(subprocess.check_output(args, stderr=subprocess.STDOUT))
+    except subprocess.CalledProcessError as e:
+        stdout.write(e.output)
+        raise
+
+def brewinstall(name):
+    check_call(["brew", "install", name])
+
+    
+def aptinstall(name):
+    check_call(["sudo", "apt-get", "install", name])
+
+    
+def gitclone(name, url):
+    stdout.write("Cloning %s\n" % name)
+    plainurl = url.split("://")[1]
+    try:
+        check_call(["git", "clone", "git@%s:%s" % tuple(plainurl.split("/", 1))])
+    except subprocess.CalledProcessError:
+        stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
+        try:
+            check_call(["git", "clone", "https://%s" % plainurl])
+            stdout.write("Successfully cloded %s" % name)
+        except subprocess.CalledProcessError:
+            stderr.write("Failed to clone %s\n" % name)
+            raise
+
+    
+def clone_dependencies(name):
+    stdout.write("Cloning the dependencies of %s\n" % name)
+    for dep in open(name + "/requirements-git.txt", "r"):
+        gitclone(dep.strip())
+
+
+def piprequirements(package, filename):
+    stdout.write("Installing pip dependencies for %s\n" % package)
+    check_call(sudopip + ["install", "-r", filename])
+
+
+def install(package):
+    stdout.write("Installing %s\n" % package)
+    #check_call(["pip", "install", ...])
+    raise NotImplementedError
+
+
+def quit(message):
+    log.write(message)
+    sys.exit(message)
+
 
 # Check operating system.
 osname = platform.uname()[0]
 if osname == "Linux":
     # Check for apt.
-    
-# Install minimal OS packages.
+    try:
+        check_call(["apt-get", "--version"])
+        have_apt = True
+    except subprocess.CalledProcessError:
+        have_apt = False
 
-# Install python packages.
+# Install minimal OS packages.
+if osname not in ["Linux", "Darwin"]:
+    stdout.write("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
+
+if osname == "Darwin":
+    try:
+        check_call(["xcodebuild", "-version"])
+    except:
+        raise
+        quit("Xcode not found. Please install xcode from the App Store and try again.")
+
+    try:
+        check_call(["brew", "--version"])
+    except:
+        quit("Homebrew not found. Please install it using the instructions at http://brew.sh and then try again.")
+
+    stdout.write("Installing required packages via homebrew. You can safely ignore warnings that packages are already installed\n")
+    brewinstall("openmpi")
+    brewinstall("python")
+    check_call(["brew", "tap", "homebrew/python"])
+    brewinstall("numpy")
+    
+else:
+    # If not MacOS then try the Linux options.
+    raise Exception("NotAMac")
+
+print "Creating firedrake directory structure"
+try:
+    os.mkdir("firedrake")
+except OSError:
+    stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
+    raise
+
+os.chdir("firedrake")
+os.mkdir("src")
+os.chdir("src")
+
+gitclone("firedrake", "git+https://github.com/firedrakeproject/firedrake.git@install_script")
+packages = clone_dependencies("firedrake")
+packages += clone_dependencies("PyOP2")
+packages += ["PyOP2", "firedrake"]
+
+print "Installing required Python packages."
+piprequirements("PyOP2/requirements-ext.txt")
+piprequirements("firedrake/requirements-ext.txt")
+
+for p in packages:
+    install(p)
+
+# Build environment script and update script.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -29,7 +29,7 @@ group = parser.add_mutually_exclusive_group()
 group.add_argument("--global", action='store_true', dest="system",
                    help="Install to the default global location on the current platform.")
 group.add_argument("--prefix", type=str, nargs=1,
-                    help="Install to subdirectories of the specified directory.")
+                   help="Install to subdirectories of the specified directory.")
 group.add_argument("--user", action='store_true',
                    help="Install using the current user's home directory as the prefix.")
 parser.add_argument("--developer", action='store_true',
@@ -42,10 +42,10 @@ parser.add_argument("--log", action='store_true',
 
 args = parser.parse_args()
 print args
-#in Where are packages installed relative to --root?
+# Where are packages installed relative to --root?
 # This is a bit of a hack.
 v = sys.version_info
-sitepackages="/usr/local/lib/python%d.%d/site-packages/" % (v.major, v.minor)
+sitepackages = "/usr/local/lib/python%d.%d/site-packages/" % (v.major, v.minor)
 path_extension = ""
 
 if args.sudo and (args.system or args.prefix):
@@ -66,7 +66,8 @@ else:
 if args.developer:
     path_extension += os.getcwd() + "/firedrake/src"
 
-os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH","")
+os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
+
 
 class Log(object):
     """Class to enable logging to screen and logfile at once."""
@@ -91,15 +92,15 @@ def check_call(args):
         stdout.write(e.output)
         raise
 
-    
+
 def brewinstall(name):
     check_call(["brew", "install", name])
 
-    
+
 def aptinstall(name):
     check_call(["sudo", "apt-get", "install", name])
 
-    
+
 def gitclone(url):
     name = url.split(".git")[0].split("#")[0].split("/")[-1]
     stdout.write("Cloning %s\n" % name)
@@ -115,7 +116,7 @@ def gitclone(url):
     except subprocess.CalledProcessError:
         stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
         try:
-            check_call(["git", "clone",  "-b", branch, "https://%s" % plainurl])
+            check_call(["git", "clone", "-b", branch, "https://%s" % plainurl])
             stdout.write("Successfully cloned %s.\n" % name)
         except subprocess.CalledProcessError:
             stderr.write("Failed to clone %s.\n" % name)
@@ -140,7 +141,7 @@ def install(package):
     stdout.write("Installing %s\n" % package)
     # The following outrageous hack works around the fact that petsc4py cannot be installed in developer mode.
     if args.developer or package == "petsc4py":
-        check_call(sudopip + ["-e", package])        
+        check_call(sudopip + ["-e", package])
     else:
         check_call(sudopip + ["--ignore-installed", package])
 
@@ -181,7 +182,7 @@ if osname == "Darwin":
     brewinstall("python")
     check_call(["brew", "tap", "homebrew/python"])
     brewinstall("numpy")
-    
+
 else:
     # If not MacOS then try the Linux options.
     raise Exception("NotAMac")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -47,6 +47,8 @@ options. If none of these options are provided, a local installation into
 
     parser.add_argument("--log", action='store_true',
                         help="Produce a verbose log of the installation process in firedrake-install.log. If you have problem running this script, please include this log in any bug report you file.")
+    parser.add_argument("--disable_ssh", action="store_true",
+                        help="Do not attempt to use ssh to clone git repositories: fall immediately back to https.")
 
     args = parser.parse_args()
     args.prefix = False  # Disabled as untested
@@ -158,9 +160,11 @@ def git_clone(url):
         plainurl = spliturl[0]
         branch = "master"
     try:
+        if args.disable_ssh:
+            raise Exception
         check_call(["git", "clone", "-q", "-b", branch, "git@%s:%s" % tuple(plainurl.split("/", 1))])
         stdout.write("Successfully cloned %s.\n" % name)
-    except subprocess.CalledProcessError:
+    except:
         stderr.write("Failed to clone %s using ssh, falling back to https.\n" % name)
         try:
             check_call(["git", "clone", "-b", branch, "https://%s" % plainurl])

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -5,10 +5,18 @@ import sys
 import os
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
+if os.path.basename(__file__) == "firedrake-install":
+    mode = "install"
+elif os.path.basename(__file__) == "firedrake-update":
+    mode = "update"
+    os.chdir(os.path.dirname(__file__) + "../")
+else:
+    sys.exit("Script must be invoked either as firedrake-install or firedrake-update")
 
+if mode == "install":
 # Handle command line arguments.
-parser = ArgumentParser(description="""Install firedrake and its dependencies.""",
-                        epilog="""The install process has three steps.
+    parser = ArgumentParser(description="""Install firedrake and its dependencies.""",
+                            epilog="""The install process has three steps.
 
 1. Any required system packages are installed using brew (MacOS) or apt (Ubuntu
    and similar Linux systems). On a Linux system without apt, the installation
@@ -23,24 +31,41 @@ parser = ArgumentParser(description="""Install firedrake and its dependencies.""
 The install location may be specified using the --global, --prefix, or --user
 options. If none of these options are provided, a local installation into
 ./firedrake will be performed.""",
-                        formatter_class=RawDescriptionHelpFormatter)
+                            formatter_class=RawDescriptionHelpFormatter)
 
-group = parser.add_mutually_exclusive_group()
-group.add_argument("--global", action='store_true', dest="system",
-                   help="Install to the default global location on the current platform.")
-group.add_argument("--prefix", type=str, nargs=1,
-                   help="Install to subdirectories of the specified directory.")
-group.add_argument("--user", action='store_true',
-                   help="Install using the current user's home directory as the prefix.")
-parser.add_argument("--developer", action='store_true',
-                    help="Install in developer mode where the core packages are run from their source directories. Due to an upstream bug, petsc4py will not be installed in developer mode.")
-parser.add_argument("--sudo", action='store_true',
-                    help="Use sudo when installing system dependencies and python packages. Regardless of the presence of this flag, sudo will never be used to install packages into $HOME or ./firedrake but sudo will always be used when installing system dependencies using apt.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--global", action='store_true', dest="system",
+                       help="Install to the default global location on the current platform.")
+    # group.add_argument("--prefix", type=str, nargs=1,
+    #                   help="Install to subdirectories of the specified directory.")
+    group.add_argument("--user", action='store_true',
+                       help="Install using the current user's home directory as the prefix.")
+    parser.add_argument("--developer", action='store_true',
+                        help="Install in developer mode where the core packages are run from their source directories. Due to an upstream bug, petsc4py will not be installed in developer mode.")
+    parser.add_argument("--sudo", action='store_true',
+                        help="Use sudo when installing system dependencies and python packages. Regardless of the presence of this flag, sudo will never be used to install packages into $HOME or ./firedrake but sudo will always be used when installing system dependencies using apt.")
 
-parser.add_argument("--log", action='store_true',
-                    help="Produce a verbose log of the installation process in firedrake-install.log. If you have problem running this script, please include this log in any bug report you file.")
+    parser.add_argument("--log", action='store_true',
+                        help="Produce a verbose log of the installation process in firedrake-install.log. If you have problem running this script, please include this log in any bug report you file.")
 
-args = parser.parse_args()
+    args = parser.parse_args()
+    args.prefix = False  # Disabled as untested
+else:
+    parser = ArgumentParser(description="""Update this firedrake install to the latest versions of all packages.""",
+                            formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument("--rebuild", action="store_true",
+                        help="Rebuild all packages even if no new version is available. Usually petsc and petsc4py are only rebuilt if they change. All other packages are always rebuilt.")
+    parser.add_argument("--log", action='store_true',
+                        help="Produce a verbose log of the update process in firedrake-update.log. If you have problem running this script, please include this log in any bug report you file.")
+
+    args = parser.parse_args()
+    args.system = False
+    args.prefix = False
+    args.user = False
+    args.developer = False
+    args.sudo = False
+
+
 # Where are packages installed relative to --root?
 # This is a bit of a hack.
 v = sys.version_info
@@ -63,7 +88,8 @@ else:
     sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
 
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
-os.environ["PETSC_CONFIGURE_OPTIONS"] = "--download-ctetgen --download-triangle --download-chaco"
+if "PETSC_CONFIGURE_OPTIONS" not in os.environ:
+    os.environ["PETSC_CONFIGURE_OPTIONS"] = "--download-ctetgen --download-triangle --download-chaco"
 
 if "PETSC_DIR" in os.environ:
     sys.stdout("WARNING: The PETSC_DIR environment variable is set. This is probably an error.\n")
@@ -80,7 +106,7 @@ class Log(object):
         for f in self.files:
             f.write(string)
 
-log = file("firedrake-install.log", "w") if args.log else None
+log = file("firedrake-%s.log" % mode, "w") if args.log else None
 stdout = Log(sys.stdout, log)
 stderr = Log(sys.stderr, log)
 
@@ -88,6 +114,14 @@ stderr = Log(sys.stderr, log)
 def check_call(args):
     try:
         stdout.write(subprocess.check_output(args, stderr=subprocess.STDOUT))
+    except subprocess.CalledProcessError as e:
+        stdout.write(e.output)
+        raise
+
+
+def check_output(args):
+    try:
+        return subprocess.check_output(args, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         stdout.write(e.output)
         raise
@@ -145,6 +179,17 @@ def clone_dependencies(name):
     return deps
 
 
+def git_update(name):
+    # Update the named git repo and return true if the current branch actually changed.
+    stdout.write("Updating the git repository for %s\n" % name)
+    os.chdir(name)
+    git_sha = check_output(["git", "rev-parse", "head"])
+    check_call(["git", "pull"])
+    git_sha_new = check_output(["git", "rev-parse", "head"])
+    os.chdir("..")
+    return git_sha != git_sha_new
+
+
 def run_pip(args):
     stdout.write(" ".join(sudopip + args) + "\n")
     check_call(sudopip + args)
@@ -162,6 +207,13 @@ def install(package):
         run_pip(["-e", package])
     else:
         run_pip(["--ignore-installed", package])
+
+
+def clean(package):
+    stdout.write("Cleaning %s\n" % package)
+    os.chdir(package)
+    check_call(["python", "setup.py", "clean"])
+    os.chdir("..")
 
 
 def quit(message):
@@ -217,7 +269,7 @@ else:
     stdout.write("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.\n")
 
 
-if args.system or args.user or args.prefix:
+if (args.system or args.user or args.prefix) and mode == "install":
     stdout.write("Creating firedrake directory structure.\n")
     try:
         os.mkdir("firedrake")
@@ -225,50 +277,100 @@ if args.system or args.user or args.prefix:
         stderr.write("Failed to create firedrake directory. If there is a stale firedrake directory in the current directory, please remove it and try again.\n")
         raise
 
-else:
+elif not (args.system or args.user or args.prefix):
     try:
         import virtualenv
     except:
         stdout.write("Installing virtualenv.\n")
         check_call(["pip", "install", "--user", "virtualenv"])
         quit("Virtual env installed. Please run firedrake-install again.\n")
-    stdout.write("Creating firedrake virtualenv.\n")
-    virtualenv.create_environment("firedrake")
+    if mode == "install":
+        stdout.write("Creating firedrake virtualenv.\n")
+        virtualenv.create_environment("firedrake")
     execfile("firedrake/bin/activate_this.py", dict(__file__='path/to/activate_this.py'))
 
 os.chdir("firedrake")
-os.mkdir("src")
-os.chdir("src")
+if mode == "install":
+    os.mkdir("src")
+    os.chdir("src")
 
-git_clone("git+https://github.com/firedrakeproject/firedrake.git@install_script")
-packages = clone_dependencies("firedrake")
-packages = clone_dependencies("PyOP2") + packages
-packages += ["firedrake"]
+    git_clone("git+https://github.com/firedrakeproject/firedrake.git@install_script")
+    packages = clone_dependencies("firedrake")
+    packages = clone_dependencies("PyOP2") + packages
+    packages += ["firedrake"]
 
-pip_requirements("PyOP2")
-pip_requirements("firedrake")
+    pip_requirements("PyOP2")
+    pip_requirements("firedrake")
 
-sudopip.append("--no-deps")
-for p in packages:
-    install(p+"/")
+    sudopip.append("--no-deps")
+    for p in packages:
+        install(p+"/")
+        if args.developer:
+            pdir = os.getcwd() + "/" + p + os.pathsep
+            os.environ["PYTHONPATH"] = pdir + os.environ.get("PYTHONPATH", "")
+            path_extension = pdir + path_extension
+
+    # Work around easy-install.pth bug.
     if args.developer:
-        pdir = os.getcwd() + "/" + p + os.pathsep
-        os.environ["PYTHONPATH"] = pdir + os.environ.get("PYTHONPATH", "")
-        path_extension = pdir + path_extension
+        packages.remove("petsc")
+        packages.remove("petsc4py")
+        packages.remove("firedrake")
+        v = sys.version_info
+        easyinstall = file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "r").readlines()
+        new_packages = [os.getcwd() + "/" + p + "\n" for p in packages]
+        file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "w").writelines(
+            easyinstall[:1] + new_packages + easyinstall[1:])
 
-# Work around easy-install.pth bug.
-if args.developer:
+else:
+    # Update mode
+    os.chdir("src")
+    packages = os.listdir(".")
+    # update packages.
+    petsc_changed = git_update("petsc")
+    petsc4py_changed = git_update("petsc4py")
+
     packages.remove("petsc")
     packages.remove("petsc4py")
+
+    for p in packages:
+        git_update(p)
+
+    # update dependencies.
+    pip_requirements("PyOP2")
+    pip_requirements("firedrake")
+    sudopip.append("--no-deps")
+
+    # Only rebuild petsc if it has changed.
+    if args.rebuild or petsc_changed:
+        clean("petsc/")
+        install("petsc/")
+    if args.rebuild or petsc_changed or petsc4py_changed:
+        clean("petsc4py/")
+        install("petsc4py/")
+    packages.remove("PyOP2")
     packages.remove("firedrake")
-    v = sys.version_info
-    easyinstall = file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "r").readlines()
-    new_packages = [os.getcwd() + "/" + p + "\n" for p in packages]
-    file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "w").writelines(
-        easyinstall[:1] + new_packages + easyinstall[1:])
+    packages += ("PyOP2", "firedrake")
+    for p in packages:
+        clean(p)
+        install(p)
 
-#if args.developer:
-#    # Append the source directories to the pythonpath.
-#    open("../bin/activate", "a").write(
+stdout.write("Creating firedrake-update script.\n")
+update_script = open("firedrake/scripts/firedrake-install", "r").read()
 
-# Build environment script and update script.
+for switch in ["developer", "user", "system", "sudo", "prefix"]:
+    update_script = update_script.replace("args.%s = False" % switch,
+                                          "args.%s = %s" % (switch, args.__getattribute__(switch)))
+open("../bin/firedrake-update", "w").write(update_script)
+check_call(["chmod", "a+x", "../bin/firedrake-update"])
+
+os.chdir("../..")
+
+stdout.write("Successfully installed Firedrake.\n\n")
+
+stdout.write("To upgrade firedrake, run firedrake/bin/firedrake-update\n")
+
+if not (args.system or args.user or args.prefix):
+    stdout.write("\nFiredrake has been installed in a python virtualenv. You activate it with:\n\n")
+    stdout.write("  . firedrake/bin/activate\n\n")
+    stdout.write("The virtualenv can be deactivated by running:\n\n")
+    stdout.write("  deactivate\n")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -256,6 +256,17 @@ for p in packages:
         os.environ["PYTHONPATH"] = pdir + os.environ.get("PYTHONPATH", "")
         path_extension = pdir + path_extension
 
+# Work around easy-install.pth bug.
+if args.developer:
+    packages.remove("petsc")
+    packages.remove("petsc4py")
+    packages.remove("firedrake")
+    v = sys.version_info
+    easyinstall = file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "r").readlines()
+    new_packages = [os.getcwd() + "/" + p + "\n" for p in packages]
+    file("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "w").writelines(
+        easyinstall[:1] + new_packages + easyinstall[1:])
+
 #if args.developer:
 #    # Append the source directories to the pythonpath.
 #    open("../bin/activate", "a").write(


### PR DESCRIPTION
This creates an install script for Firedrake. The install script is intended to be *the* install mechanism for all workstation installs (supercomputers are another story). The script supports system-wide installation, installation as a user, and installation into a virtualenv (the default). It also supports a "developer mode" install in which the parts of Firedrake we maintain are run from the git clones.

* Installing to a virtualenv should be safe with respect to an existing Dolfin install. 
* The install script also creates an automated update script. The script is smart enough to only rebuild petsc when this is needed, so updates are quite fast.
* Travis will now use the install script, so the script remains tested.
