### PR TITLE
Fix install dependencies

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -268,7 +268,6 @@ if osname == "Darwin":
         try:
             check_call(["xcodebuild", "-version"])
         except:
-            raise
             quit("Xcode not found. Please install xcode from the App Store and try again.")
 
         try:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -358,9 +358,9 @@ if mode == "install":
     run_pip(["Cython>=0.22"])
 
     # Need to install petsc first in order to resolve hdf5 dependency.
-    sudopip.append("--no_deps")
+    sudopip.append("--no-deps")
     packages.remove("petsc")
-    install("petsc")
+    install("petsc/")
     sudopip.pop()
 
     for p in packages:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -358,6 +358,12 @@ if mode == "install":
     # Force Cython to install first to work around pip dependency issues.
     run_pip(["Cython>=0.22"])
 
+    # Need to install petsc first in order to resolve hdf5 dependency.
+    sudopip.append("--no_deps")
+    packages.remove("petsc")
+    install("petsc")
+    sudopip.pop()
+
     for p in packages:
         pip_requirements(p)
 
@@ -371,7 +377,6 @@ if mode == "install":
 
     # Work around easy-install.pth bug.
     if args.developer:
-        packages.remove("petsc")
         packages.remove("petsc4py")
         packages.remove("firedrake")
         v = sys.version_info


### PR DESCRIPTION
Now that we're getting PETSc to download HDF5 for us, we need to make sure PETSc is built before h5py.