### PR TITLE
set default to false so that substitution works.

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -81,7 +81,7 @@ else:
     args.user = False
     args.developer = False
     args.sudo = False
-    args.package_manager = True
+    args.package_manager = False
     args.minimal_petsc = False
 
 


### PR DESCRIPTION
This fixes a small bug in the way the install script creates the update script.