### PR TITLE
Update script fix

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -266,8 +266,8 @@ def clean(package):
 
 
 def quit(message):
-    log.write(message)
-    sys.exit(message)
+    stderr.write(message)
+    sys.exit(1)
 
 
 def build_update_script():
@@ -301,7 +301,9 @@ if args.rebuild_script:
 
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
-    If you really want to use your own PETSc build, please run again with the --honour_petsc_dir option.""")
+If you really want to use your own PETSc build, please run again with the
+--honour_petsc_dir option.
+""")
 
 
 # Check operating system.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -290,7 +290,6 @@ def build_update_script():
 if args.rebuild_script:
     os.chdir(os.path.dirname(os.path.realpath(__file__)) + ("/../.."))
 
-    print os.getcwd()
     build_update_script()
 
     stdout.write("Successfully rebuilt firedrake-update.\n\n")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -401,6 +401,9 @@ if mode == "install":
     packages = clone_dependencies("PyOP2") + packages
     packages += ["firedrake"]
 
+    if args.honour_petsc_dir:
+        packages.remove("petsc")
+
     # Force Cython to install first to work around pip dependency issues.
     run_pip(["Cython>=0.22"])
 
@@ -423,6 +426,10 @@ if mode == "install":
 
     # Work around easy-install.pth bug.
     if args.developer:
+        try:
+            packages.remove("petsc")
+        except ValueError:
+            pass
         packages.remove("petsc4py")
         packages.remove("firedrake")
         v = sys.version_info
@@ -436,7 +443,10 @@ else:
     os.chdir("src")
     packages = os.listdir(".")
     # update packages.
-    petsc_changed = git_update("petsc")
+    if not args.honour_petsc_dir:
+        petsc_changed = git_update("petsc")
+    else:
+        petsc_changed = False
     petsc4py_changed = git_update("petsc4py")
 
     packages.remove("petsc")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -300,7 +300,7 @@ if args.rebuild_script:
 
 
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
-    stdout.write("""The PETSC_DIR environment variable is set. This is probably an error.
+    quit("""The PETSC_DIR environment variable is set. This is probably an error.
     If you really want to use your own PETSc build, please run again with the --honour_petsc_dir option.""")
 
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -117,7 +117,7 @@ os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
 if args.minimal_petsc:
     petsc_opts = """--download-ctetgen --download-triangle --download-chaco"""
 else:
-    petsc_opts = """--download-ctetgen --download-triangle --download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre=1 --download-mumps --download-netcdf --download-hdf5 --download-exodusii"""
+    petsc_opts = """--download-ctetgen --download-triangle --download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre --download-mumps --download-netcdf --download-hdf5 --download-exodusii"""
 
 
 if "PETSC_CONFIGURE_OPTIONS" not in os.environ:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -64,6 +64,10 @@ honoured.""",
                         help="Do not attempt to use apt or homebrew to install operating system packages on which we depend.")
     parser.add_argument("--minimal_petsc", action="store_true",
                         help="Minimise the set of petsc dependencies installed. This creates faster build times (useful for build testing).")
+    parser.add_argument("--honour_petsc_dir", action="store_true",
+                        help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
+    parser.add_argument("--rebuild_script", action="store_true",
+                        help="Only rebuild the firedrake-install script. Use this option if your firedrake-install script is broken and a fix has been released in upstream Firedrake. You will need to specify any other options which you wish to be honoured by your new update script (eg. --developer or --sudo).")
 
     args = parser.parse_args()
     args.prefix = False  # Disabled as untested
@@ -72,6 +76,8 @@ else:
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument("--rebuild", action="store_true",
                         help="Rebuild all packages even if no new version is available. Usually petsc and petsc4py are only rebuilt if they change. All other packages are always rebuilt.")
+    parser.add_argument("--honour_petsc_dir", action="store_true",
+                        help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
     parser.add_argument("--log", action='store_true',
                         help="Produce a verbose log of the update process in firedrake-update.log. If you have problem running this script, please include this log in any bug report you file.")
 
@@ -83,6 +89,7 @@ else:
     args.sudo = False
     args.package_manager = False
     args.minimal_petsc = False
+    args.rebuild_script = False
 
 
 # Where are packages installed relative to --root?
@@ -135,9 +142,6 @@ class Log(object):
 log = file("firedrake-%s.log" % mode, "w") if args.log else None
 stdout = Log(sys.stdout, log)
 stderr = Log(sys.stderr, log)
-
-if "PETSC_DIR" in os.environ:
-    stdout.write("WARNING: The PETSC_DIR environment variable is set. This is probably an error.\n")
 
 
 def check_call(arguments):
@@ -264,6 +268,40 @@ def clean(package):
 def quit(message):
     log.write(message)
     sys.exit(message)
+
+
+def build_update_script():
+    stdout.write("Creating firedrake-update script.\n")
+    with open("firedrake/scripts/firedrake-install", "r") as f:
+        update_script = f.read()
+
+    for switch in ["developer", "user", "system", "sudo", "prefix", "package_manager", "minimal_petsc"]:
+        update_script = update_script.replace("args.%s = False" % switch,
+                                              "args.%s = %s" % (switch, args.__getattribute__(switch)))
+    try:
+        os.mkdir("../bin")
+    except:
+        pass
+    with open("../bin/firedrake-update", "w") as f:
+        f.write(update_script)
+    check_call(["chmod", "a+x", "../bin/firedrake-update"])
+
+
+if args.rebuild_script:
+    os.chdir(os.path.dirname(os.path.realpath(__file__)) + ("/../.."))
+
+    print os.getcwd()
+    build_update_script()
+
+    stdout.write("Successfully rebuilt firedrake-update.\n\n")
+
+    stdout.write("To upgrade firedrake, run firedrake-update\n")
+    sys.exit(0)
+
+
+if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
+    stdout.write("""The PETSC_DIR environment variable is set. This is probably an error.
+    If you really want to use your own PETSc build, please run again with the --honour_petsc_dir option.""")
 
 
 # Check operating system.
@@ -422,22 +460,9 @@ else:
     packages += ("PyOP2", "firedrake")
     for p in packages:
         clean(p)
-        install(p)
+        install(p+"/")
 
-stdout.write("Creating firedrake-update script.\n")
-with open("firedrake/scripts/firedrake-install", "r") as f:
-    update_script = f.read()
-
-for switch in ["developer", "user", "system", "sudo", "prefix", "package_manager", "minimal_petsc"]:
-    update_script = update_script.replace("args.%s = False" % switch,
-                                          "args.%s = %s" % (switch, args.__getattribute__(switch)))
-try:
-    os.mkdir("../bin")
-except:
-    pass
-with open("../bin/firedrake-update", "w") as f:
-    f.write(update_script)
-check_call(["chmod", "a+x", "../bin/firedrake-update"])
+build_update_script()
 
 os.chdir("../..")
 


### PR DESCRIPTION
Some critical firedrake-update fixes.
* Install the locally downloaded versions of core packages.
* Enable the firedrake-update script to be rebuilt from firedrake-install.
* Make setting PETSC_DIR fatal by default (with an option to override).