### PR TITLE
Dumb checkpointing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /evtk/cevtk.c
 /firedrake/dmplex.c
 /firedrake/spatialindex.cpp
+/firedrake/hdf5interface.c
 /docs/build/
 /docs/source/firedrake.mg.rst
 /docs/source/firedrake.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,11 @@ addons:
         - libblas-dev
         - liblapack-dev
         - gfortran
-        - libhdf5-mpi-dev
         - libspatialindex-dev
         - swig
 env:
   global:
-    - C_INCLUDE_PATH=/usr/lib/openmpi/include
-    - PETSC_CONFIGURE_OPTIONS="--download-ctetgen --download-triangle --download-chaco"
+    - CC=mpicc
   matrix:
     - PYOP2_BACKEND=sequential PYOP2_TESTS=regression
     - OMP_NUM_THREADS=1 PYOP2_BACKEND=openmp PYOP2_TESTS=regression

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ install:
 # command to run tests
 script:
   - make lint
-  - for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t}; done
+  - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ env:
     - PYOP2_BACKEND=sequential PYOP2_TESTS=regression
     - OMP_NUM_THREADS=1 PYOP2_BACKEND=openmp PYOP2_TESTS=regression
     - OMP_NUM_THREADS=2 PYOP2_BACKEND=openmp PYOP2_TESTS=regression
-    - PYOP2_BACKEND=sequential PYOP2_TESTS="multigrid benchmarks"
-    - OMP_NUM_THREADS=1 PYOP2_BACKEND=openmp PYOP2_TESTS="benchmarks multigrid"
-    - OMP_NUM_THREADS=2 PYOP2_BACKEND=openmp PYOP2_TESTS="benchmarks multigrid"
+    - PYOP2_BACKEND=sequential PYOP2_TESTS="checkpoints multigrid benchmarks"
+    - OMP_NUM_THREADS=1 PYOP2_BACKEND=openmp PYOP2_TESTS="checkpoints benchmarks multigrid"
+    - OMP_NUM_THREADS=2 PYOP2_BACKEND=openmp PYOP2_TESTS="checkpoints benchmarks multigrid"
     - PYOP2_BACKEND=sequential PYOP2_TESTS=extrusion
     - OMP_NUM_THREADS=1 PYOP2_BACKEND=openmp PYOP2_TESTS=extrusion
     - OMP_NUM_THREADS=2 PYOP2_BACKEND=openmp PYOP2_TESTS=extrusion

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ clean:
 	-@rm -f firedrake/dmplex.so > /dev/null 2>&1
 	@echo "    RM firedrake/dmplex.c"
 	-@rm -f firedrake/dmplex.c > /dev/null 2>&1
+	@echo "    RM firedrake/hdf5interface.so"
+	-@rm -f firedrake/hdf5interface.so > /dev/null 2>&1
+	@echo "    RM firedrake/hdf5interface.c"
+	-@rm -f firedrake/hdf5interface.c > /dev/null 2>&1
 	@echo "    RM firedrake/spatialindex.so"
 	-@rm -f firedrake/spatialindex.so > /dev/null 2>&1
 	@echo "    RM firedrake/spatialindex.cpp"

--- a/docs/source/checkpointing.rst
+++ b/docs/source/checkpointing.rst
@@ -155,18 +155,42 @@ the object goes out of scope.  To use this approach, we use the python
    # Checkpoint file closed, continue with normal code
 
 
+Writing attributes
+------------------
+
+In addition to storing :class:`~.Function` data, it is also possible
+to store metadata in :class:`~.DumbCheckpoint` files using HDF5
+attributes.  This is carried out using h5py_ to manipulate the file.
+The interface allows setting attribute values, reading them, and
+checking if a file has a particular attribute:
+
+:meth:`~.DumbCheckpoint.write_attribute`
+
+      Write an attribute, specifying the object path the attribute
+      should be set on, the name of the attribute and its value.
+
+:meth:`~.DumbCheckpoint.read_attribute`
+
+      Read an attribute with specified name from at a given object
+      path.
+
+:meth:`~.DumbCheckpoint.has_attribute`
+
+      Check if a particular attribute exists.  Does not raise an error
+      if the object also does not exist.
+
+
 Implementation details
 ======================
 
 The on-disk representation of checkpoints is as HDF5_ files.
 Firedrake uses the PETSc_ HDF5 Viewer_ object to write and read state.
-As such, writing data is collective across processes.  Checkpoint
-files can be inspected using the Python h5py_ package.  If h5py_ is
-installed and was linked against the same version of the HDF5 library
-that PETSc was built with, it is possible to obtain a h5py
-:py:class:`h5py:File` object corresponding to an open checkpoint file
-by using :meth:`~.DumbCheckpoint.as_h5py`.  An error is raised if this
-conversion fails.
+As such, writing data is collective across processes.  h5py_ is used
+for attribute manipulation.  To this end, h5py_ *must* be linked
+against the same version of the HDF5 library that PETSc was built
+with.  The ``firedrake-install`` script automates this, however, if
+you build PETSc manually, you will need to ensure that h5py_ is linked
+correctly following the instructions for custom installation here_.
 
 .. warning::
 
@@ -185,3 +209,5 @@ conversion fails.
 
 .. _Viewer: http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Viewer/index.html
 .. _h5py: http://www.h5py.org
+
+.. _here: http://docs.h5py.org/en/latest/build.html#custom-installation

--- a/docs/source/checkpointing.rst
+++ b/docs/source/checkpointing.rst
@@ -1,0 +1,187 @@
+.. only:: html
+
+   .. contents::
+
+=====================
+ Checkpointing state
+=====================
+
+In addition to the ability to write field data to vtu files, suitable
+for visualisation in Paraview_, Firedrake has some support for
+checkpointing state to disk.  This enables pausing, and subsequently
+resuming, a simulation at a later time.
+
+Restrictions on checkpointing
+=============================
+
+The current support for checkpointing is somewhat limited.  One may
+only store :class:`~.Function`\s in the checkpoint object.  Moreover,
+no remapping of data is performed.  This means that resuming the
+checkpoint is only possible on the same number of processes as used to
+create the checkpoint file.  Additionally, the *same* :class:`~.Mesh`
+must be used: that is a :class:`~.Mesh` constructed identically to the
+mesh used to generate the saved checkpoint state.
+
+.. note::
+
+   In the future, this restriction will be lifted and Firedrake will
+   be able to store and resume checkpoints on different number of
+   processes, as long as the mesh topology remains unchanged.
+
+
+Creating and using checkpoint files
+===================================
+
+Opening a checkpoint
+--------------------
+
+A checkpoint file is created using the :class:`~.DumbCheckpoint`
+constructor.  We pass a filename argument, and an access mode.
+Available modes are:
+
+:data:`~.FILE_READ`
+
+     Open the checkpoint file for reading.  Raises :exc:`OSError` if
+     the file does not already exist.
+
+:data:`~.FILE_CREATE`
+
+     Open the checkpoint file for reading and writing, creating the
+     file if it does not exist, and *erasing* any existing contents if
+     it does.
+
+:data:`~.FILE_UPDATE`
+
+     Open the checkpoint file for reading and writing, creating it if
+     it does not exist, without erasing any existing contents.
+
+
+For example, to open a checkpoint file for writing solution state,
+truncating any existing contents we use:
+
+.. code-block:: python
+
+   chk = DumbCheckpoint("dump.h5", mode=FILE_WRITE)
+
+
+Storing data
+------------
+
+Once a checkpoint file is opened, :class:`~.Function` data can be
+stored in the checkpoint using :meth:`~.DumbCheckpoint.store`.
+A :class:`~.Function` is referenced in the checkpoint file by its
+:meth:`~.Function.name`, but this may be overridden by explicitly
+passing an optional `name` argument.  For example, to store a
+:class:`~.Function` using its default name use:
+
+.. code-block:: python
+
+   f = Function(V, name="foo")
+   chk.store(f)
+
+If instead we want to override the name we use:
+
+.. code-block:: python
+
+   chk.store(f, name="bar")
+
+.. warning::
+
+   No warning is provided when storing multiple :class:`~.Function`\s
+   with the same name, existing values are overwritten.
+
+   Moreover, attempting to store a :class:`~.Function` with a
+   different number of degrees of freedom into an existing name will
+   cause an error.
+
+Loading data
+------------
+
+Once a checkpoint is created, we can use it to load saved state into
+:class:`~.Function`\s to resume a simulation.  To load data into a
+:class:`~.Function` from a checkpoint, we pass it to
+:meth:`~.DumbCheckpoint.load`.  As before, the data is looked up by
+its :meth:`~.Function.name`, although once again this may be
+overridden by optionally specifying the ``name`` as an argument.
+
+For example, assume we had previously saved a checkpoint containing
+two different :class:`~.Function`\s with names ``"A"`` and
+``"B"``.  We can load these as follows:
+
+.. code-block:: python
+
+   chk = DumbCheckpoint("dump.h5", mode=FILE_READ)
+
+   a = Function(V, name="A")
+
+   b = Function(V)
+
+   # Use a.name() to look up value
+   chk.load(a)
+
+   # Look up value by explicitly specifying name="B"
+   chk.load(b, name="B")
+
+.. note::
+
+   Since Firedrake does not currently support reading data from a
+   checkpoint file on a different number of processes from that it was
+   written with, whenever a :class:`~.Function` is stored, an
+   attribute is set recording the number of processes used.  When
+   loading data from the checkpoint, this value is validated against
+   the current number of processes and an error is raised if they do
+   not match.
+
+Closing a checkpoint
+--------------------
+
+The on-disk file inside a checkpoint object is automatically closed
+when the checkpoint object is garbage-collected.  However, since this
+may not happen at a predictable time, it is possible to manually close
+a checkpoint file using :meth:`~.DumbCheckpoint.close`.  To facilitate
+this latter usage, checkpoint objects can be used as `context
+managers`_ which ensure that the checkpoint file is closed as soon as
+the object goes out of scope.  To use this approach, we use the python
+``with`` statement:
+
+.. code-block:: python
+
+   # Normal code here
+   with DumbCheckpoint("dump.h5", mode=FILE_UPDATE) as chk:
+       # Checkpoint file open for reading and writing
+       chk.store(...)
+       chk.load(...)
+
+   # Checkpoint file closed, continue with normal code
+
+
+Implementation details
+======================
+
+The on-disk representation of checkpoints is as HDF5_ files.
+Firedrake uses the PETSc_ HDF5 Viewer_ object to write and read state.
+As such, writing data is collective across processes.  Checkpoint
+files can be inspected using the Python h5py_ package.  If h5py_ is
+installed and was linked against the same version of the HDF5 library
+that PETSc was built with, it is possible to obtain a h5py
+:py:class:`h5py:File` object corresponding to an open checkpoint file
+by using :meth:`~.DumbCheckpoint.as_h5py`.  An error is raised if this
+conversion fails.
+
+.. warning::
+
+   Calling :py:meth:`h5py:File.close` on the h5py representation will
+   likely result in errors inside PETSc (since it is not aware that
+   the file has been closed).  So don't do that!
+
+
+.. _Paraview: http://www.paraview.org
+
+.. _context managers: https://www.python.org/dev/peps/pep-0343/
+
+.. _HDF5: https://www.hdfgroup.org/HDF5/
+
+.. _PETSc: http://www.mcs.anl.gov/petsc/
+
+.. _Viewer: http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Viewer/index.html
+.. _h5py: http://www.h5py.org

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -255,5 +255,6 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     'pyop2': ('http://op2.github.io/PyOP2', None),
-    'ufl': ('http://fenicsproject.org/documentation/ufl/dev/', None)
+    'ufl': ('http://fenicsproject.org/documentation/ufl/dev/', None),
+    'h5py': ('http://docs.h5py.org/en/latest/', None),
 }

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -62,6 +62,7 @@ finite element problems in Firedrake.
    boundary_conditions
    extruded-meshes
    point-evaluation
+   checkpointing
 
 .. only:: html
 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -71,7 +71,7 @@ which you wish the rebuilt script to apply (for example `--user` or
 Installing from individual components
 =====================================
 
-Firedrake depends on PyOP2_, FFC_, FIAT_, and UFL_. It is easiest to obtain
+Firedrake depends on PyOP2_, FFC_, FIAT_, UFL_ and h5py_. It is easiest to obtain
 all of these components on Ubuntu Linux and related distributions such as Mint
 or Debian. Installation on other Unix-like operating systems is likely to be
 possible, although harder. Installation on a Mac is straightforward using the
@@ -118,6 +118,29 @@ To install for your user only, which does not require sudo permissions,
 modify the pip invocation for either case above as follows::
 
   pip install --user ...
+
+h5py
+----
+
+It is critical that h5py_ is linked against the same version of the
+HDF5 library that PETSc was built with.  This is unfortunately not
+possible to specify when using ``pip``.  Instead, please follow the
+instructions for a `custom installation`_.  If PETSc was linked
+against a system HDF5 library, use that library when building h5py.
+If the PETSc installation was used to build HDF5 (via
+``--download-hdf5``) then the appropriate HDF5 library is in the PETSc
+install directory.  If installed with ``pip``, this can be obtained
+using::
+
+  python -c "import petsc; print petsc.get_petsc_dir()"
+
+Otherwise, use the appropriate values of ``PETSC_DIR`` and ``PETSC_ARCH``.
+
+.. note::
+
+   It is not necessary that h5py be built with MPI support, although
+   Firedrake supports both options.
+
 
 Potential installation errors on Mac OS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,3 +313,5 @@ Finally install the Bibtex plugin::
 .. _Swig: http://www.swig.org/
 .. _virtualenv: https://virtualenv.pypa.io/
 .. _libspatialindex: https://libspatialindex.github.io/
+.. _h5py: http://www.h5py.org/
+.. _custom installation: http://docs.h5py.org/en/latest/build.html#custom-installation

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -30,6 +30,7 @@ from pyop2 import op2                                           # noqa
 
 from firedrake.assemble import *
 from firedrake.bcs import *
+from firedrake.checkpointing import *
 from firedrake.constant import *
 from firedrake.expression import *
 from firedrake.function import *

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import
+from firedrake.petsc import PETSc
+from firedrake import op2
+import h5py
+
+
+__all__ = ["DumbCheckpoint", "FILE_READ", "FILE_CREATE", "FILE_UPDATE"]
+
+
+class _Mode(object):
+    """Mode used for opening files
+
+    :arg mode: The mode to use (see the h5py documentation for
+         possible modes)."""
+    def __init__(self, mode):
+        self.hmode = mode
+        # Translate to PETSc viewer file mode.
+        self.pmode = {"r": PETSc.Viewer.Mode.READ,
+                      "w": PETSc.Viewer.Mode.WRITE,
+                      "a": PETSc.Viewer.Mode.APPEND}[mode]
+
+"""Open a checkpoint file for reading.  Raises an error if file does not exist."""
+FILE_READ = _Mode("r")
+
+"""Create a checkpoint file.  Truncates the file if it exists."""
+FILE_CREATE = _Mode("w")
+
+"""Open a checkpoint file for updating.  Creates the file if it does
+not exist, providing FILE_READ and FILE_WRITE access."""
+FILE_UPDATE = _Mode("a")
+
+del _Mode
+
+
+class DumbCheckpoint(object):
+
+    """A very dumb checkpoint object.
+
+    This checkpoint object is capable of writing :class:`~.Function`\s
+    to disk in parallel (using HDF5) and reloading them on the same
+    number of processes and a :class:`~.Mesh` constructed identically.
+
+    :arg name: the name of the checkpoint file.
+    :arg mode: the access mode (one of :data:`~.FILE_READ`,
+         :data:`~.FILE_CREATE`, or :data:`~.FILE_UPDATE`)
+    :arg comm: (optional) communicator the writes should be collective
+         over.
+
+    This object can be used in a context manager (in which case it
+    closes the file when the scope is exited).
+
+    """
+    def __init__(self, name, mode=FILE_UPDATE, comm=None):
+        self.comm = comm or op2.MPI.comm
+        # Read (or write) metadata on rank 0.
+        if self.comm.rank == 0:
+            with h5py.File(name, mode=mode.hmode) as f:
+                group = f.require_group("/metadata")
+                dset = group.get("numprocs", None)
+                if dset is None:
+                    group["numprocs"] = self.comm.size
+                nprocs = self.comm.bcast(group["numprocs"].value, root=0)
+        else:
+            nprocs = self.comm.bcast(None, root=0)
+
+        # Verify
+        if nprocs != self.comm.size:
+            raise ValueError("Process mismatch: written on %d, have %d" %
+                             (nprocs, self.comm.size))
+        # Now switch to UPDATE if we were asked to CREATE the file
+        # (we've already created it above, and CREATE truncates)
+        if mode is FILE_CREATE:
+            mode = FILE_UPDATE
+        self.vwr = PETSc.ViewerHDF5().create(name, mode=mode.pmode, comm=self.comm)
+
+    def close(self):
+        """Close the checkpoint file (flushing any pending writes)"""
+        if hasattr(self, "vwr"):
+            self.vwr.destroy()
+
+    def store(self, function, name=None):
+        """Store a function in the checkpoint file.
+
+        :arg function: The function to store.
+        :arg name: an (optional) name to store the function under.  If
+             not provided, uses :data:`function.name()`.
+        """
+        with function.dat.vec_ro as v:
+            self.vwr.pushGroup("/fields")
+            oname = v.getName()
+            v.setName(name or function.name())
+            v.view(self.vwr)
+            v.setName(oname)
+            self.vwr.popGroup()
+
+    def load(self, function, name=None):
+        """Store a function from the checkpoint file.
+
+        :arg function: The function to load values into.
+        :arg name: an (optional) name used to find the function values.  If
+             not provided, uses :data:`function.name()`.
+        """
+        with function.dat.vec as v:
+            self.vwr.pushGroup("/fields")
+            oname = v.getName()
+            v.setName(name or function.name())
+            v.load(self.vwr)
+            v.setName(oname)
+            self.vwr.popGroup()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from firedrake.petsc import PETSc
 from firedrake import op2
+import firedrake
 import h5py
 
 
@@ -85,6 +86,8 @@ class DumbCheckpoint(object):
         :arg name: an (optional) name to store the function under.  If
              not provided, uses :data:`function.name()`.
         """
+        if not isinstance(function, firedrake.Function):
+            raise ValueError("Can only store functions")
         with function.dat.vec_ro as v:
             self.vwr.pushGroup("/fields")
             oname = v.getName()
@@ -100,6 +103,8 @@ class DumbCheckpoint(object):
         :arg name: an (optional) name used to find the function values.  If
              not provided, uses :data:`function.name()`.
         """
+        if not isinstance(function, firedrake.Function):
+            raise ValueError("Can only load functions")
         with function.dat.vec as v:
             self.vwr.pushGroup("/fields")
             oname = v.getName()

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -51,6 +51,7 @@ class DumbCheckpoint(object):
             import os
             if not os.path.exists(name):
                 raise IOError("File '%s' does not exist, cannot be opened for reading" % name)
+        self.mode = mode
         self.vwr = PETSc.ViewerHDF5().create(name, mode=mode, comm=self.comm)
         self.h5file = h5i.get_h5py_file(self.vwr)
 
@@ -68,8 +69,10 @@ class DumbCheckpoint(object):
 
         :arg function: The function to store.
         :arg name: an (optional) name to store the function under.  If
-             not provided, uses :data:`function.name()`.
+             not provided, uses ``function.name()``.
         """
+        if self.mode is FILE_READ:
+            raise IOError("Cannot store to checkpoint opened with mode 'FILE_READ'")
         if not isinstance(function, firedrake.Function):
             raise ValueError("Can only store functions")
         name = name or function.name()

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -3,6 +3,7 @@ from firedrake.petsc import PETSc
 from firedrake import op2
 from firedrake import hdf5interface as h5i
 import firedrake
+import numpy as np
 
 
 __all__ = ["DumbCheckpoint", "FILE_READ", "FILE_CREATE", "FILE_UPDATE"]
@@ -27,7 +28,11 @@ class DumbCheckpoint(object):
     to disk in parallel (using HDF5) and reloading them on the same
     number of processes and a :class:`~.Mesh` constructed identically.
 
-    :arg name: the name of the checkpoint file.
+    :arg basename: the base name of the checkpoint file.
+    :arg single_file: Should the checkpoint object use only a single
+         on-disk file (irrespective of the number of stored
+         timesteps)?  See :meth:`~.DumbCheckpoint.new_file` for more
+         details.
     :arg mode: the access mode (one of :data:`~.FILE_READ`,
          :data:`~.FILE_CREATE`, or :data:`~.FILE_UPDATE`)
     :arg comm: (optional) communicator the writes should be collective
@@ -45,24 +50,141 @@ class DumbCheckpoint(object):
        breakages.
 
     """
-    def __init__(self, name, mode=FILE_UPDATE, comm=None):
+    def __init__(self, basename, single_file=True,
+                 mode=FILE_UPDATE, comm=None):
         self.comm = comm or op2.MPI.comm
-        if mode == FILE_READ:
+        self.mode = mode
+
+        self._single = single_file
+        self._made_file = False
+        self._basename = basename
+        self._time = None
+        self._tidx = -1
+        self._fidx = 0
+        self.new_file()
+
+    def set_timestep(self, t, idx=None):
+        """Set the timestep for output.
+
+        :arg t: The timestep value.
+        :arg idx: An optional timestep index to use, otherwise an
+             internal index is used, incremented by 1 every time
+             :meth:`set_timestep` is called.
+        """
+        if idx is not None:
+            self._tidx = idx
+        else:
+            self._tidx += 1
+        self._time = t
+        if self.mode == FILE_READ:
+            return
+        indices = self.read_attribute("/", "stored_time_indices", [])
+        new_indices = np.concatenate((indices, [self._tidx]))
+        self.write_attribute("/", "stored_time_indices", new_indices)
+        steps = self.read_attribute("/", "stored_time_steps", [])
+        new_steps = np.concatenate((steps, [self._time]))
+        self.write_attribute("/", "stored_time_steps", new_steps)
+
+    def get_timesteps(self):
+        """Return all the time steps (and time indices) in the current
+        checkpoint file.
+
+        This is useful when reloading from a checkpoint file that
+        contains multiple timesteps and one wishes to determine the
+        final available timestep in the file."""
+        indices = self.read_attribute("/", "stored_time_indices", [])
+        steps = self.read_attribute("/", "stored_time_steps", [])
+        return steps, indices
+
+    def new_file(self, name=None):
+        """Open a new on-disk file for writing checkpoint data.
+
+        :arg name: An optional name to use for the file, an extension
+             of ``.h5`` is automatically appended.
+
+        If ``name`` is not provided, a filename is generated from the
+        ``basename`` used when creating the :class:`~.DumbCheckpoint`
+        object.  If ``single_file`` is ``True``, then we write to
+        ``BASENAME.h5`` otherwise, each time
+        :meth:`~.DumbCheckpoint.new_file` is called, we create a new
+        file with an increasing index.  In this case the files created
+        are::
+
+            BASENAME_0.h5
+            BASENAME_1.h5
+            ...
+            BASENAME_n.h5
+
+        with the index incremented on each invocation of
+        :meth:`~.DumbCheckpoint.new_file` (whenever the custom name is
+        not provided).
+        """
+        self.close()
+        if name is None:
+            if self._single:
+                if self._made_file:
+                    raise ValueError("Can't call new_file without name with 'single_file'")
+                name = "%s.h5" % (self._basename)
+                self._made_file = True
+            else:
+                name = "%s_%s.h5" % (self._basename, self._fidx)
+            self._fidx += 1
+        else:
+            name = "%s.h5" % name
+        if self.mode == FILE_READ:
             import os
             if not os.path.exists(name):
                 raise IOError("File '%s' does not exist, cannot be opened for reading" % name)
-        self.mode = mode
-        self.vwr = PETSc.ViewerHDF5().create(name, mode=mode, comm=self.comm)
-        self.h5file = h5i.get_h5py_file(self.vwr)
+        self._vwr = PETSc.ViewerHDF5().create(name, mode=self.mode,
+                                              comm=self.comm)
+        if self.mode == FILE_READ:
+            nprocs = self.read_attribute("/", "nprocs")
+            if nprocs != self.comm.size:
+                raise ValueError("Process mismatch: written on %d, have %d" %
+                                 (nprocs, self.comm.size))
+        else:
+            self.write_attribute("/", "nprocs", self.comm.size)
+
+    @property
+    def vwr(self):
+        """The PETSc Viewer used to store and load function data."""
+        if hasattr(self, '_vwr'):
+            return self._vwr
+        self.new_file()
+        return self._vwr
+
+    @property
+    def h5file(self):
+        """An h5py File object pointing at the open file handle."""
+        if hasattr(self, '_h5file'):
+            return self._h5file
+        self._h5file = h5i.get_h5py_file(self.vwr)
+        return self._h5file
 
     def close(self):
         """Close the checkpoint file (flushing any pending writes)"""
-        if hasattr(self, "h5file"):
-            self.h5file.flush()
-            del self.h5file
-        if hasattr(self, "vwr"):
-            self.vwr.destroy()
-            del self.vwr
+        if hasattr(self, "_vwr"):
+            self._vwr.destroy()
+            del self._vwr
+        if hasattr(self, "_h5file"):
+            self._h5file.flush()
+            del self._h5file
+
+    def _get_data_group(self):
+        """Return the group name for function data.
+
+        If a timestep is set, this incorporates the current timestep
+        index.  See :meth:`.set_timestep`."""
+        if self._time is not None:
+            return "/fields/%d" % self._tidx
+        return "/fields"
+
+    def _write_timestep_attr(self, group):
+        """Write the current timestep value (if it exists) to the
+        specified group."""
+        if self._time is not None:
+            self.h5file.require_group(group)
+            self.write_attribute(group, "timestep", self._time)
 
     def store(self, function, name=None):
         """Store a function in the checkpoint file.
@@ -70,40 +192,41 @@ class DumbCheckpoint(object):
         :arg function: The function to store.
         :arg name: an (optional) name to store the function under.  If
              not provided, uses ``function.name()``.
+
+        This function is timestep-aware and stores to the appropriate
+        place if :meth:`set_timestep` has been called.
         """
         if self.mode is FILE_READ:
             raise IOError("Cannot store to checkpoint opened with mode 'FILE_READ'")
         if not isinstance(function, firedrake.Function):
             raise ValueError("Can only store functions")
         name = name or function.name()
+        group = self._get_data_group()
+        self._write_timestep_attr(group)
         with function.dat.vec_ro as v:
-            self.vwr.pushGroup("/fields")
+            self.vwr.pushGroup(group)
             oname = v.getName()
             v.setName(name)
             v.view(self.vwr)
             v.setName(oname)
             self.vwr.popGroup()
-        # Write metadata
-        obj = "/fields/%s" % name
-        name = "nprocs"
-        self.write_attribute(obj, name, self.comm.size)
 
     def load(self, function, name=None):
         """Store a function from the checkpoint file.
 
         :arg function: The function to load values into.
         :arg name: an (optional) name used to find the function values.  If
-             not provided, uses :data:`function.name()`.
+             not provided, uses ``function.name()``.
+
+        This function is timestep-aware and reads from the appropriate
+        place if :meth:`set_timestep` has been called.
         """
         if not isinstance(function, firedrake.Function):
             raise ValueError("Can only load functions")
         name = name or function.name()
-        nprocs = self.read_attribute("/fields/%s" % name, "nprocs")
-        if nprocs != self.comm.size:
-            raise ValueError("Process mismatch: written on %d, have %d" %
-                             (nprocs, self.comm.size))
+        group = self._get_data_group()
         with function.dat.vec as v:
-            self.vwr.pushGroup("/fields")
+            self.vwr.pushGroup(group)
             oname = v.getName()
             v.setName(name)
             v.load(self.vwr)
@@ -121,22 +244,24 @@ class DumbCheckpoint(object):
         """
         try:
             self.h5file[obj].attrs[name] = val
-        except KeyError as e:
+        except KeyError:
             raise AttributeError("Object '%s' not found" % obj)
 
-    def read_attribute(self, obj, name):
+    def read_attribute(self, obj, name, default=None):
         """Read an HDF5 attribute on a specified data object.
 
         :arg obj: The path to the data object.
         :arg name: The name of the attribute.
-
-        Raises :exec:`AttributeError` if reading the attribute fails.
+        :arg default: Optional default value to return.  If not
+             provided an :exc:`AttributeError` is raised if the
+             attribute does not exist.
         """
         try:
             return self.h5file[obj].attrs[name]
-        except KeyError as e:
+        except KeyError:
+            if default is not None:
+                return default
             raise AttributeError("Attribute '%s' on '%s' not found" % (name, obj))
-
 
     def has_attribute(self, obj, name):
         """Check for existance of an HDF5 attribute on a specified data object.

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -9,15 +9,14 @@ import numpy as np
 __all__ = ["DumbCheckpoint", "FILE_READ", "FILE_CREATE", "FILE_UPDATE"]
 
 
-"""Open a checkpoint file for reading.  Raises an error if file does not exist."""
 FILE_READ = PETSc.Viewer.Mode.READ
+"""Open a checkpoint file for reading.  Raises an error if file does not exist."""
 
-"""Create a checkpoint file.  Truncates the file if it exists."""
 FILE_CREATE = PETSc.Viewer.Mode.WRITE
+"""Create a checkpoint file.  Truncates the file if it exists."""
 
-"""Open a checkpoint file for updating.  Creates the file if it does
-not exist, providing both read and write access."""
 FILE_UPDATE = PETSc.Viewer.Mode.APPEND
+"""Open a checkpoint file for updating.  Creates the file if it does not exist, providing both read and write access."""
 
 
 class DumbCheckpoint(object):

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,36 +1,22 @@
 from __future__ import absolute_import
 from firedrake.petsc import PETSc
 from firedrake import op2
+from firedrake import hdf5interface as h5i
 import firedrake
-import h5py
 
 
 __all__ = ["DumbCheckpoint", "FILE_READ", "FILE_CREATE", "FILE_UPDATE"]
 
 
-class _Mode(object):
-    """Mode used for opening files
-
-    :arg mode: The mode to use (see the h5py documentation for
-         possible modes)."""
-    def __init__(self, mode):
-        self.hmode = mode
-        # Translate to PETSc viewer file mode.
-        self.pmode = {"r": PETSc.Viewer.Mode.READ,
-                      "w": PETSc.Viewer.Mode.WRITE,
-                      "a": PETSc.Viewer.Mode.APPEND}[mode]
-
 """Open a checkpoint file for reading.  Raises an error if file does not exist."""
-FILE_READ = _Mode("r")
+FILE_READ = PETSc.Viewer.Mode.READ
 
 """Create a checkpoint file.  Truncates the file if it exists."""
-FILE_CREATE = _Mode("w")
+FILE_CREATE = PETSc.Viewer.Mode.WRITE
 
 """Open a checkpoint file for updating.  Creates the file if it does
-not exist, providing FILE_READ and FILE_WRITE access."""
-FILE_UPDATE = _Mode("a")
-
-del _Mode
+not exist, providing both read and write access."""
+FILE_UPDATE = PETSc.Viewer.Mode.APPEND
 
 
 class DumbCheckpoint(object):
@@ -50,34 +36,32 @@ class DumbCheckpoint(object):
     This object can be used in a context manager (in which case it
     closes the file when the scope is exited).
 
+    .. note::
+
+       This object contains both a PETSc ``Viewer``, used for storing
+       and loading :class:`~.Function` data, and an :class:`h5py:File`
+       opened on the same file handle.  *DO NOT* call
+       :meth:`h5py:File.close` on the latter, this will cause
+       breakages.
+
     """
     def __init__(self, name, mode=FILE_UPDATE, comm=None):
         self.comm = comm or op2.MPI.comm
-        # Read (or write) metadata on rank 0.
-        if self.comm.rank == 0:
-            with h5py.File(name, mode=mode.hmode) as f:
-                group = f.require_group("/metadata")
-                dset = group.get("numprocs", None)
-                if dset is None:
-                    group["numprocs"] = self.comm.size
-                nprocs = self.comm.bcast(group["numprocs"].value, root=0)
-        else:
-            nprocs = self.comm.bcast(None, root=0)
-
-        # Verify
-        if nprocs != self.comm.size:
-            raise ValueError("Process mismatch: written on %d, have %d" %
-                             (nprocs, self.comm.size))
-        # Now switch to UPDATE if we were asked to CREATE the file
-        # (we've already created it above, and CREATE truncates)
-        if mode is FILE_CREATE:
-            mode = FILE_UPDATE
-        self.vwr = PETSc.ViewerHDF5().create(name, mode=mode.pmode, comm=self.comm)
+        if mode == FILE_READ:
+            import os
+            if not os.path.exists(name):
+                raise IOError("File '%s' does not exist, cannot be opened for reading" % name)
+        self.vwr = PETSc.ViewerHDF5().create(name, mode=mode, comm=self.comm)
+        self.h5file = h5i.get_h5py_file(self.vwr)
 
     def close(self):
         """Close the checkpoint file (flushing any pending writes)"""
+        if hasattr(self, "h5file"):
+            self.h5file.flush()
+            del self.h5file
         if hasattr(self, "vwr"):
             self.vwr.destroy()
+            del self.vwr
 
     def store(self, function, name=None):
         """Store a function in the checkpoint file.
@@ -88,13 +72,18 @@ class DumbCheckpoint(object):
         """
         if not isinstance(function, firedrake.Function):
             raise ValueError("Can only store functions")
+        name = name or function.name()
         with function.dat.vec_ro as v:
             self.vwr.pushGroup("/fields")
             oname = v.getName()
-            v.setName(name or function.name())
+            v.setName(name)
             v.view(self.vwr)
             v.setName(oname)
             self.vwr.popGroup()
+        # Write metadata
+        obj = "/fields/%s" % name
+        name = "nprocs"
+        self.write_attribute(obj, name, self.comm.size)
 
     def load(self, function, name=None):
         """Store a function from the checkpoint file.
@@ -105,16 +94,63 @@ class DumbCheckpoint(object):
         """
         if not isinstance(function, firedrake.Function):
             raise ValueError("Can only load functions")
+        name = name or function.name()
+        nprocs = self.read_attribute("/fields/%s" % name, "nprocs")
+        if nprocs != self.comm.size:
+            raise ValueError("Process mismatch: written on %d, have %d" %
+                             (nprocs, self.comm.size))
         with function.dat.vec as v:
             self.vwr.pushGroup("/fields")
             oname = v.getName()
-            v.setName(name or function.name())
+            v.setName(name)
             v.load(self.vwr)
             v.setName(oname)
             self.vwr.popGroup()
+
+    def write_attribute(self, obj, name, val):
+        """Set an HDF5 attribute on a specified data object.
+
+        :arg obj: The path to the data object.
+        :arg name: The name of the attribute.
+        :arg val: The attribute value.
+
+        Raises :exc:`AttributeError` if writing the attribute fails.
+        """
+        try:
+            self.h5file[obj].attrs[name] = val
+        except KeyError as e:
+            raise AttributeError("Object '%s' not found" % obj)
+
+    def read_attribute(self, obj, name):
+        """Read an HDF5 attribute on a specified data object.
+
+        :arg obj: The path to the data object.
+        :arg name: The name of the attribute.
+
+        Raises :exec:`AttributeError` if reading the attribute fails.
+        """
+        try:
+            return self.h5file[obj].attrs[name]
+        except KeyError as e:
+            raise AttributeError("Attribute '%s' on '%s' not found" % (name, obj))
+
+
+    def has_attribute(self, obj, name):
+        """Check for existance of an HDF5 attribute on a specified data object.
+
+        :arg obj: The path to the data object.
+        :arg name: The name of the attribute.
+        """
+        try:
+            return (name in self.h5file[obj].attrs)
+        except KeyError:
+            return False
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
+        self.close()
+
+    def __del__(self):
         self.close()

--- a/firedrake/hdf5interface.pyx
+++ b/firedrake/hdf5interface.pyx
@@ -1,0 +1,43 @@
+import h5py
+cimport petsc4py.PETSc as PETSc
+
+
+cdef extern from "hdf5.h":
+    ctypedef int hid_t
+
+
+cdef extern from "petscviewerhdf5.h":
+    int PetscViewerHDF5GetFileId(PETSc.PetscViewer,hid_t*)
+
+
+def get_h5py_file(PETSc.Viewer vwr not None):
+    """Attempt to convert PETSc viewer file handle to h5py File.
+
+    :arg vwr: The PETSc Viewer (must have type HDF5).
+
+    .. warning::
+
+       For this to work, h5py and PETSc must both have been compiled
+       against *the same* HDF5 library (otherwise the file handles are
+       not interchangeable).  This is the likeliest reason for failure
+       when attempting the conversion."""
+    cdef hid_t fid = 0
+    cdef int ierr = 0
+
+    if vwr.type != vwr.Type.HDF5:
+        raise TypeError("Viewer is not an HDF5 viewer")
+    ierr = PetscViewerHDF5GetFileId(vwr.vwr, &fid)
+    if ierr != 0:
+        raise RuntimeError("Unable to get file handle")
+
+    try:
+        objid = h5py.h5i.wrap_identifier(fid)
+    except ValueError:
+        raise RuntimeError("Unable to convert handle to h5py object. Likely h5py not linked to same HDF5 as PETSc")
+
+    if type(objid) is not h5py.h5f.FileID:
+        raise TypeError("Provided handle doesn't reference a file")
+    # We got a borrowed reference to the file id from PETSc, need to
+    # inc-ref it so that the file isn't closed behind our backs.
+    h5py.h5i.inc_ref(objid)
+    return h5py.File(objid)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -199,6 +199,9 @@ def apt_install(names):
 
 def git_clone(url):
     name = url.split(".git")[0].split("#")[0].split("/")[-1]
+    if name == "petsc" and args.honour_petsc_dir:
+        stdout.write("Using existing petsc installation\n")
+        return name
     stdout.write("Cloning %s\n" % name)
     spliturl = url.split("://")[1].split("#")[0].split("@")
     try:
@@ -436,10 +439,11 @@ if mode == "install":
     run_pip(["Cython>=0.22"])
 
     # Need to install petsc first in order to resolve hdf5 dependency.
-    sudopip.append("--no-deps")
-    packages.remove("petsc")
-    install("petsc/")
-    sudopip.pop()
+    if not args.honour_petsc_dir:
+        sudopip.append("--no-deps")
+        packages.remove("petsc")
+        install("petsc/")
+        sudopip.pop()
 
     for p in packages:
         pip_requirements(p)
@@ -477,7 +481,8 @@ else:
         petsc_changed = False
     petsc4py_changed = git_update("petsc4py")
 
-    packages.remove("petsc")
+    if args.honour_petsc_dir:
+        packages.remove("petsc")
     packages.remove("petsc4py")
 
     for p in packages:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -112,23 +112,26 @@ path_extension = ""
 
 python = ["python"]
 if args.sudo and (args.system or args.prefix):
-    sudopip = ["sudo", "pip", "install"]
+    sudopip = ["sudo", "pip"]
     pyinstall = ["sudo", "python", "setup.py", "install"]
 else:
-    sudopip = ["pip", "install"]
+    sudopip = ["pip"]
     pyinstall = ["python", "setup.py", "install"]
+
+pipinstall = sudopip + ["install"]
 if args.user:
-    sudopip += ["--user"]
+    pipinstall += ["--user"]
     pyinstall += ["--user"]
 elif args.prefix:
     path_extension = args.prefix + sitepackages + os.pathsep
-    sudopip += ["--root", args.prefix]
+    pipinstall += ["--root", args.prefix]
     pyinstall += ["--root", args.prefix]
 elif args.system:
     pass
 else:
     # Use the pip from the virtualenv
-    sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
+    sudopip = [os.getcwd() + "/firedrake/bin/pip"]
+    pipinstall = sudopip + ["install"]
     python = [os.getcwd() + "/firedrake/bin/python"]
     pyinstall = python + ["setup.py", "install"]
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
@@ -276,6 +279,11 @@ def run_pip(args):
     check_call(sudopip + args)
 
 
+def run_pip_install(args):
+    stdout.write(" ".join(pipinstall + args) + "\n")
+    check_call(pipinstall + args)
+
+
 def run_cmd(args):
     stdout.write(" ".join(args) + "\n")
     check_call(args)
@@ -284,9 +292,9 @@ def run_cmd(args):
 def pip_requirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
     if os.path.isfile("%s/requirements-ext.txt" % package):
-        run_pip(["-r", "%s/requirements-ext.txt" % package])
+        run_pip_install(["-r", "%s/requirements-ext.txt" % package])
     elif os.path.isfile("%s/requirements.txt" % package):
-        run_pip(["-r", "%s/requirements.txt" % package])
+        run_pip_install(["-r", "%s/requirements.txt" % package])
     else:
         stdout.write("No dependencies found. Skipping.\n")
 
@@ -295,9 +303,9 @@ def install(package):
     stdout.write("Installing %s\n" % package)
     # The following outrageous hack works around the fact that petsc cannot be installed in developer mode.
     if args.developer and package not in ["petsc/", "petsc4py/"]:
-        run_pip(["-e", package])
+        run_pip_install(["-e", package])
     else:
-        run_pip(["--ignore-installed", package])
+        run_pip_install(["--ignore-installed", package])
 
 
 def clean(package):
@@ -491,7 +499,7 @@ elif not (args.system or args.user or args.prefix):
         stdout.write("Creating firedrake virtualenv.\n")
         virtualenv.create_environment("firedrake", site_packages=True)
         # For some reason virtualenv does not always install the latest pip.
-        run_pip(["-U", "pip"])
+        run_pip_install(["-U", "pip"])
     execfile("firedrake/bin/activate_this.py", dict(__file__='path/to/activate_this.py'))
 
 os.chdir("firedrake")
@@ -508,20 +516,20 @@ if mode == "install":
         packages.remove("petsc")
 
     # Force Cython to install first to work around pip dependency issues.
-    run_pip(["Cython>=0.22"])
+    run_pip_install(["Cython>=0.22"])
 
     # Need to install petsc first in order to resolve hdf5 dependency.
     if not args.honour_petsc_dir:
-        sudopip.append("--no-deps")
+        pipinstall.append("--no-deps")
         packages.remove("petsc")
         install("petsc/")
-        sudopip.pop()
+        pipinstall.pop()
 
     for p in packages:
         pip_requirements(p)
 
     build_and_install_h5py()
-    sudopip.append("--no-deps")
+    pipinstall.append("--no-deps")
     for p in packages:
         install(p+"/")
         if args.developer:
@@ -565,7 +573,7 @@ else:
     # update dependencies.
     pip_requirements("PyOP2")
     pip_requirements("firedrake")
-    sudopip.append("--no-deps")
+    pipinstall.append("--no-deps")
 
     # Only rebuild petsc if it has changed.
     if not args.honour_petsc_dir and (args.rebuild or petsc_changed):

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -207,13 +207,18 @@ def apt_install(names):
     subprocess.check_call(["sudo", "apt-get", "install"] + names)
 
 
-def git_clone(url):
+def split_requirements_url(url):
     name = url.split(".git")[0].split("#")[0].split("/")[-1]
+    spliturl = url.split("://")[1].split("#")[0].split("@")
+    return name, spliturl
+
+
+def git_clone(url):
+    name, spliturl = split_requirements_url(url)
     if name == "petsc" and args.honour_petsc_dir:
         stdout.write("Using existing petsc installation\n")
         return name
     stdout.write("Cloning %s\n" % name)
-    spliturl = url.split("://")[1].split("#")[0].split("@")
     try:
         plainurl, branch = spliturl
     except ValueError:
@@ -236,6 +241,15 @@ def git_clone(url):
             stderr.write("Failed to clone %s branch %s.\n" % (name, branch))
             raise
     return name
+
+
+def list_cloned_dependencies(name):
+    stdout.write("Finding dependencies of %s\n" % name)
+    deps = []
+    for dep in open(name + "/requirements-git.txt", "r"):
+        name, _ = split_requirements_url(dep.strip())
+        deps.append(name)
+    return deps
 
 
 def clone_dependencies(name):
@@ -532,7 +546,9 @@ if mode == "install":
 else:
     # Update mode
     os.chdir("src")
-    packages = os.listdir(".")
+
+    packages = list_cloned_dependencies("PyOP2") + list_cloned_dependencies("firedrake")
+
     # update packages.
     if not args.honour_petsc_dir:
         petsc_changed = git_update("petsc")
@@ -540,20 +556,9 @@ else:
         petsc_changed = False
     petsc4py_changed = git_update("petsc4py")
 
-    if args.honour_petsc_dir:
-        packages.remove("petsc")
+    packages.remove("petsc")
     packages.remove("petsc4py")
 
-    try:
-        # Not actually a git package
-        packages.remove("h5py-2.5.0")
-    except ValueError:
-        pass
-    try:
-        # This is where it came from
-        packages.remove("h5py.tar.gz")
-    except ValueError:
-        pass
     for p in packages:
         git_update(p)
 
@@ -563,7 +568,7 @@ else:
     sudopip.append("--no-deps")
 
     # Only rebuild petsc if it has changed.
-    if args.rebuild or petsc_changed:
+    if not args.honour_petsc_dir and (args.rebuild or petsc_changed):
         clean("petsc/")
         install("petsc/")
     if args.rebuild or petsc_changed or petsc4py_changed:
@@ -572,8 +577,12 @@ else:
 
     # Always rebuild h5py.
     build_and_install_h5py()
-    packages.remove("PyOP2")
-    packages.remove("firedrake")
+
+    try:
+        packages.remove("PyOP2")
+        packages.remove("firedrake")
+    except ValueError:
+        pass
     packages += ("PyOP2", "firedrake")
     for p in packages:
         clean(p)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -324,6 +324,33 @@ def get_h5py():
 
 
 def build_and_install_h5py():
+    stdout.write("Removing existing h5py installations\n")
+    # Uninstalling something with pip is an absolute disaster.  We
+    # have to use pip freeze to list all available packages "locally"
+    # and keep on removing the one we want until it is gone from this
+    # list!  Yes, pip will happily have two different versions of the
+    # same package co-existing.  Moreover, depending on the phase of
+    # the moon, the order in which they are uninstalled is not the
+    # same as the order in which they appear on sys.path!
+    again = True
+    i = 0
+    while again:
+        # List installed packages, "locally".  In a virtualenv,
+        # this just tells me packages in the virtualenv, otherwise it
+        # gives me everything.
+        lines = check_output(sudopip + ["freeze", "-l"])
+        again = False
+        for line in lines.split("\n"):
+            # Do we have a locally installed h5py?
+            if line.startswith("h5py"):
+                # Uninstall it.
+                run_pip(["uninstall", "-y", line.strip()])
+                # Go round again, because THERE MIGHT BE ANOTHER ONE!
+                again = True
+        i += 1
+        if i > 10:
+            raise InstallError("pip claims it uninstalled h5py more than 10 times.  Something is probably broken.")
+
     stdout.write("Installing h5py\n")
     if os.path.exists("h5py-2.5.0"):
         clean("h5py-2.5.0")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -73,6 +73,9 @@ honoured.""",
     parser.add_argument("--package-branch", "--package_branch", type=str, nargs=2, action="append", metavar=("PACKAGE", "BRANCH"),
                         help="Specify which branch of a package to use. This takes two arguments, the package name and the branch.")
 
+    parser.add_argument("--mpicc", type=str,
+                        action="store", default="mpicc",
+                        help="C compiler to use when building with MPI (default is 'mpicc')")
     args = parser.parse_args()
 
     if args.package_branch:
@@ -98,6 +101,7 @@ else:
     args.package_manager = False
     args.minimal_petsc = False
     args.rebuild_script = False
+    args.mpicc = False
 
 
 # Where are packages installed relative to --root?
@@ -106,24 +110,30 @@ v = sys.version_info
 sitepackages = "/usr/local/lib/python%d.%d/site-packages/" % (v.major, v.minor)
 path_extension = ""
 
+python = ["python"]
 if args.sudo and (args.system or args.prefix):
     sudopip = ["sudo", "pip", "install"]
+    pyinstall = ["sudo", "python", "setup.py", "install"]
 else:
     sudopip = ["pip", "install"]
+    pyinstall = ["python", "setup.py", "install"]
 if args.user:
     sudopip += ["--user"]
+    pyinstall += ["--user"]
 elif args.prefix:
     path_extension = args.prefix + sitepackages + os.pathsep
     sudopip += ["--root", args.prefix]
+    pyinstall += ["--root", args.prefix]
 elif args.system:
     pass
 else:
     # Use the pip from the virtualenv
     sudopip = [os.getcwd() + "/firedrake/bin/pip", "install"]
-
+    python = [os.getcwd() + "/firedrake/bin/python"]
+    pyinstall = python + ["setup.py", "install"]
 os.environ["PYTHONPATH"] = path_extension + os.environ.get("PYTHONPATH", "")
 if args.minimal_petsc:
-    petsc_opts = """--download-ctetgen --download-triangle --download-chaco"""
+    petsc_opts = """--download-ctetgen --download-triangle --download-chaco --download-hdf5"""
 else:
     petsc_opts = """--download-ctetgen --download-triangle --download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre --download-mumps --download-netcdf --download-hdf5 --download-exodusii"""
 
@@ -252,6 +262,11 @@ def run_pip(args):
     check_call(sudopip + args)
 
 
+def run_cmd(args):
+    stdout.write(" ".join(args) + "\n")
+    check_call(args)
+
+
 def pip_requirements(package):
     stdout.write("Installing pip dependencies for %s\n" % package)
     if os.path.isfile("%s/requirements-ext.txt" % package):
@@ -278,6 +293,49 @@ def clean(package):
     os.chdir("..")
 
 
+def get_h5py():
+    stdout.write("Downloading h5py\n")
+    import urllib
+    urllib.urlretrieve("https://github.com/h5py/h5py/archive/2.5.0.tar.gz",
+                       "h5py.tar.gz")
+    run_cmd(["tar", "-zxvf", "h5py.tar.gz"])
+
+
+def build_and_install_h5py():
+    stdout.write("Installing h5py\n")
+    if os.path.exists("h5py-2.5.0"):
+        clean("h5py-2.5.0")
+    else:
+        get_h5py()
+
+    os.chdir("h5py-2.5.0")
+
+    if args.honour_petsc_dir:
+        petsc_dir = os.environ["PETSC_DIR"]
+        petsc_arch = os.environ.get("PETSC_ARCH", "")
+    else:
+        try:
+            petsc_dir = check_output(python +
+                                     ["-c", "import petsc; print petsc.get_petsc_dir()"]).strip()
+
+            petsc_arch = ""
+        except subprocess.CalledProcessError:
+            raise InstallError("Unable to find installed PETSc when building h5py")
+
+    hdf5_dir = "%s/%s" % (petsc_dir, petsc_arch)
+    stdout.write("Linking h5py against PETSc found in %s\n" % hdf5_dir)
+    oldcc = os.environ.get("CC", None)
+    os.environ["CC"] = args.mpicc
+    run_cmd(python + ["setup.py", "configure", "--hdf5=%s" % hdf5_dir])
+    run_cmd(python + ["setup.py", "build"])
+    run_cmd(pyinstall)
+    if oldcc is None:
+        del os.environ["CC"]
+    else:
+        os.environ["CC"] = oldcc
+    os.chdir("..")
+
+
 def quit(message):
     stderr.write(message)
     sys.exit(1)
@@ -288,7 +346,8 @@ def build_update_script():
     with open("firedrake/scripts/firedrake-install", "r") as f:
         update_script = f.read()
 
-    for switch in ["developer", "user", "system", "sudo", "prefix", "package_manager", "minimal_petsc"]:
+    for switch in ["developer", "user", "system", "sudo", "prefix", "package_manager", "minimal_petsc",
+                   "mpicc"]:
         update_script = update_script.replace("args.%s = False" % switch,
                                               "args.%s = %r" % (switch, args.__getattribute__(switch)))
     try:
@@ -347,7 +406,6 @@ if osname == "Darwin":
         brew_install("swig")
         brew_install("cmake")
         check_call(["brew", "tap", "homebrew/science"])
-        brew_install("hdf5")
         brew_install("spatialindex")
 
     else:
@@ -448,6 +506,7 @@ if mode == "install":
     for p in packages:
         pip_requirements(p)
 
+    build_and_install_h5py()
     sudopip.append("--no-deps")
     for p in packages:
         install(p+"/")
@@ -485,6 +544,16 @@ else:
         packages.remove("petsc")
     packages.remove("petsc4py")
 
+    try:
+        # Not actually a git package
+        packages.remove("h5py-2.5.0")
+    except ValueError:
+        pass
+    try:
+        # This is where it came from
+        packages.remove("h5py.tar.gz")
+    except ValueError:
+        pass
     for p in packages:
         git_update(p)
 
@@ -500,6 +569,9 @@ else:
     if args.rebuild or petsc_changed or petsc4py_changed:
         clean("petsc4py/")
         install("petsc4py/")
+
+    # Always rebuild h5py.
+    build_and_install_h5py()
     packages.remove("PyOP2")
     packages.remove("firedrake")
     packages += ("PyOP2", "firedrake")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -287,7 +287,7 @@ def build_update_script():
 
     for switch in ["developer", "user", "system", "sudo", "prefix", "package_manager", "minimal_petsc"]:
         update_script = update_script.replace("args.%s = False" % switch,
-                                              "args.%s = %s" % (switch, args.__getattribute__(switch)))
+                                              "args.%s = %r" % (switch, args.__getattribute__(switch)))
     try:
         os.mkdir("../bin")
     except:

--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,14 @@ try:
     cmdclass['build_ext'] = build_ext
     dmplex_sources = ["firedrake/dmplex.pyx"]
     spatialindex_sources = ["firedrake/spatialindex.pyx"]
+    h5iface_sources = ["firedrake/hdf5interface.pyx"]
     mg_sources = ["firedrake/mg/impl.pyx"]
     evtk_sources = ['evtk/cevtk.pyx']
 except ImportError:
     # No cython, dmplex.c must be generated in distributions.
     dmplex_sources = ["firedrake/dmplex.c"]
     spatialindex_sources = ["firedrake/spatialindex.cpp"]
+    h5iface_sources = ["firedrake/hdf5interface.c"]
     mg_sources = ["firedrake/mg/impl.c"]
     evtk_sources = ['evtk/cevtk.c']
 
@@ -74,6 +76,13 @@ setup(name='firedrake',
       scripts=glob('scripts/*'),
       ext_modules=[Extension('firedrake.dmplex',
                              sources=dmplex_sources,
+                             include_dirs=include_dirs,
+                             libraries=["petsc"],
+                             extra_link_args=["-L%s/lib" % d for d in petsc_dirs] +
+                             ["-Wl,-rpath,%s/lib" % d for d in petsc_dirs] +
+                             ["-Wl,-rpath,%s/lib" % sys.prefix]),
+                   Extension('firedrake.hdf5interface',
+                             sources=h5iface_sources,
                              include_dirs=include_dirs,
                              libraries=["petsc"],
                              extra_link_args=["-L%s/lib" % d for d in petsc_dirs] +

--- a/tests/checkpoints/test_dumb_checkpoint.py
+++ b/tests/checkpoints/test_dumb_checkpoint.py
@@ -77,6 +77,21 @@ def test_serial_checkpoint_parallel_load_fails(serial_checkpoint):
             pass
 
 
+@pytest.mark.parametrize("obj",
+                         [lambda: Constant(1),
+                          lambda: np.arange(10)])
+def test_checkpoint_fails_for_non_function(obj, dumpfile):
+    with DumbCheckpoint(dumpfile, mode=FILE_CREATE) as chk:
+        with pytest.raises(ValueError):
+            chk.store(obj)
+
+
+def test_checkpoint_read_not_exist_ioerror(dumpfile):
+    with pytest.raises(IOError):
+        with DumbCheckpoint(dumpfile, mode=FILE_READ):
+            pass
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/checkpoints/test_dumb_checkpoint.py
+++ b/tests/checkpoints/test_dumb_checkpoint.py
@@ -1,0 +1,82 @@
+import pytest
+from firedrake import *
+import numpy as np
+
+
+@pytest.fixture(scope="module",
+                params=[False, True],
+                ids=["simplex", "quad"])
+def mesh(request):
+    return UnitSquareMesh(2, 2, quadrilateral=request.param)
+
+
+@pytest.fixture(params=range(1, 4))
+def degree(request):
+    return request.param
+
+
+@pytest.fixture(params=["CG"])
+def fs(request):
+    return request.param
+
+
+@pytest.fixture
+def dumpfile(tmpdir):
+    return str(tmpdir.join("dump.h5"))
+
+
+def run_store_load(mesh, fs, degree, dumpfile):
+
+    V = FunctionSpace(mesh, fs, degree)
+
+    f = Function(V, name="f")
+
+    expr = Expression("x[0]*x[1]")
+
+    f.interpolate(expr)
+
+    f2 = Function(V, name="f")
+
+    dumpfile = op2.MPI.comm.bcast(dumpfile, root=0)
+    chk = DumbCheckpoint(dumpfile, mode=FILE_CREATE)
+
+    chk.store(f)
+
+    chk.load(f2)
+
+    assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
+
+
+def test_store_load(mesh, fs, degree, dumpfile):
+    run_store_load(mesh, fs, degree, dumpfile)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_store_load_parallel(mesh, fs, degree, dumpfile):
+    run_store_load(mesh, fs, degree, dumpfile)
+
+
+@pytest.fixture
+def serial_checkpoint(dumpfile):
+    # Make the checkpoint file on rank zero, writing the COMM_SELF (size 1)
+    if op2.MPI.comm.rank == 0:
+        from mpi4py import MPI
+        chk = DumbCheckpoint(dumpfile, mode=FILE_CREATE, comm=MPI.COMM_SELF)
+        chk.close()
+    # Make sure it's written
+    return op2.MPI.comm.bcast(dumpfile, root=0)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_serial_checkpoint_parallel_load_fails(serial_checkpoint):
+    # serial_checkpoint fixture makes the checkpoint file (on one
+    # process), which we now try and read on two, and therefore expect
+    # an error.
+    with pytest.raises(ValueError):
+        with DumbCheckpoint(serial_checkpoint, mode=FILE_READ):
+            pass
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/checkpoints/test_dumb_checkpoint.py
+++ b/tests/checkpoints/test_dumb_checkpoint.py
@@ -25,6 +25,13 @@ def dumpfile(tmpdir):
     return str(tmpdir.join("dump.h5"))
 
 
+@pytest.fixture(scope="module")
+def f():
+    m = UnitSquareMesh(2, 2)
+    V = FunctionSpace(m, 'CG', 1)
+    return Function(V, name="f")
+
+
 def run_store_load(mesh, fs, degree, dumpfile):
 
     V = FunctionSpace(mesh, fs, degree)
@@ -57,11 +64,8 @@ def test_store_load_parallel(mesh, fs, degree, dumpfile):
 
 
 @pytest.mark.parallel(nprocs=2)
-def test_serial_checkpoint_parallel_load_fails(dumpfile):
+def test_serial_checkpoint_parallel_load_fails(f, dumpfile):
     from firedrake.petsc import PETSc
-    m = UnitSquareMesh(2, 2)
-    V = FunctionSpace(m, 'CG', 1)
-    f = Function(V, name="f")
     # Write on COMM_SELF (size == 1)
     chk = DumbCheckpoint("%s.%d" % (dumpfile, op2.MPI.comm.rank),
                          mode=FILE_CREATE, comm=PETSc.COMM_SELF)
@@ -87,21 +91,32 @@ def test_checkpoint_read_not_exist_ioerror(dumpfile):
             pass
 
 
-def test_attributes(dumpfile):
-    m = UnitSquareMesh(1, 1)
+def test_attributes(f, dumpfile):
+    mesh = f.function_space().mesh()
     with DumbCheckpoint(dumpfile, mode=FILE_CREATE) as chk:
         with pytest.raises(AttributeError):
             chk.write_attribute("/foo", "nprocs", 1)
         with pytest.raises(AttributeError):
             chk.read_attribute("/bar", "nprocs")
 
-        chk.store(m.coordinates, name="coords")
+        chk.store(mesh.coordinates, name="coords")
 
         assert chk.read_attribute("/", "nprocs") == 1
 
-        chk.write_attribute("/fields/coords", "dimension", m.coordinates.dat.cdim)
+        chk.write_attribute("/fields/coords", "dimension",
+                            mesh.coordinates.dat.cdim)
 
-        assert chk.read_attribute("/fields/coords", "dimension") == m.coordinates.dat.cdim
+        assert chk.read_attribute("/fields/coords", "dimension") == \
+            mesh.coordinates.dat.cdim
+
+
+def test_store_read_only_ioerror(f, dumpfile):
+    # Make file
+    with DumbCheckpoint(dumpfile, mode=FILE_CREATE) as chk:
+        pass
+    with DumbCheckpoint(dumpfile, mode=FILE_READ) as chk:
+        with pytest.raises(IOError):
+            chk.store(f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It looks like I am not going to be able to get "proper" checkpointing done by the end of the week.  So here's the dumb version.  Make a checkpoint file with:

```python
chk = DumbCheckpoint("filename.h5", mode=FILE_CREATE)

```

Then store some function in it

```python
chk.store(function)
```

`function.name()` is used as the path to the data in the hdf5 file.

To later load data do:

```python

chk.load(function2)
```

The data is looked up by name.

For both `load` and `store` you can optionally specify a name, overriding what the function provides.

```python
chk.store(function, name="foo")
chk.load(function2, name="foo")
```

Three modes are available, `FILE_READ`, `FILE_CREATE`, and `FILE_UPDATE`.  The first is read-only, the second creates (if not existing) and truncates otherwise, the last is for read-write access.

Because I only store data (not topology).  It is the user's responsibility to ensure that the mesh/functionspace are the same.  In particular, I raise an error if you try and read in data on a different number of processes from what you dumped on, but the following is also not likely to succeed:

```python

m1 = Mesh(..., reorder=False)

...

f = Function(FS(m1, ...))

chk.store(f)

...

m2 = Mesh(..., reorder=True)

f2 = Function(FS(m2, ...))
chk.load(f2)
```

IOW, you can use this to restart on the same number of processes if you have the same mesh lying around, but otherwise not.