### PR TITLE
Add swig to firedrake-install apt_packages

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -360,7 +360,7 @@ elif osname == "Linux":
         apt_packages = ["build-essential", "python-dev", "git-core",
                         "mercurial", "python-pip", "libopenmpi-dev", "openmpi-bin",
                         "libblas-dev", "liblapack-dev", "libspatialindex-dev",
-                        "gfortran", "cmake"]
+                        "gfortran", "cmake", "swig"]
 
         missing_packages = [p for p in apt_packages if not apt_check(p)]
         if missing_packages:


### PR DESCRIPTION
With this branch, and Lawrence's removal of h5py from the pyop2 requirements file, I *finally* get the script to work on clean 14.04 and 15.10 machines.

`python firedrake-install --developer --sudo --log --disable_ssh --minimal_petsc`

(otherwise I get a fail in the FFC install)