### PR TITLE
Type checking on

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -14,6 +14,7 @@ from firedrake import functionspace
 from firedrake import matrix
 from firedrake import parameters
 from firedrake import solving
+from firedrake import utils
 
 
 __all__ = ["assemble"]
@@ -72,6 +73,7 @@ def assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
         raise TypeError("Unable to assemble: %r" % f)
 
 
+@utils.known_pyop2_safe
 def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
               inverse=False, nest=None):
     """Assemble the form f and return a Firedrake object representing the

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -16,6 +16,7 @@ from pyop2 import op2
 from firedrake import constant
 from firedrake import function
 from firedrake import functionspace
+from firedrake import utils
 
 
 def ufl_type(*args, **kwargs):
@@ -547,6 +548,7 @@ def evaluate_preprocessed_expression(kernel, args, subset=None):
         op2.par_loop(kernel, itset, *parloop_args)
 
 
+@utils.known_pyop2_safe
 def evaluate_expression(expr, subset=None):
     """Evaluates UFL expressions on :class:`.Function`\s."""
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -327,6 +327,7 @@ class Function(ufl.Coefficient):
                 d += dim
         return self
 
+    @utils.known_pyop2_safe
     def _interpolate(self, fs, dat, expression, subset):
         """Interpolate expression onto a :class:`FunctionSpace`.
 
@@ -377,6 +378,7 @@ class Function(ufl.Coefficient):
 
         for _, arg in expression._user_args:
             args.append(arg(op2.READ))
+
         op2.par_loop(*args)
 
     def _interpolate_python_kernel(self, expression, to_pts, to_element, fs, coords):
@@ -483,6 +485,7 @@ for (unsigned int %(d)s=0; %(d)s < %(dim)d; %(d)s++) {
                                             open_scope=False))
         return op2.Kernel(kernel_code, "expression_kernel")
 
+    @utils.known_pyop2_safe
     def assign(self, expr, subset=None):
         """Set the :class:`Function` value to the pointwise value of
         expr. expr may only contain :class:`Function`\s on the same
@@ -502,16 +505,16 @@ for (unsigned int %(d)s=0; %(d)s < %(dim)d; %(d)s++) {
         """
 
         if isinstance(expr, Function) and \
-                expr._function_space == self._function_space:
+           expr._function_space == self._function_space:
             expr.dat.copy(self.dat, subset=subset)
             return self
 
         from firedrake import assemble_expressions
         assemble_expressions.evaluate_expression(
             assemble_expressions.Assign(self, expr), subset)
-
         return self
 
+    @utils.known_pyop2_safe
     def __iadd__(self, expr):
 
         if np.isscalar(expr):
@@ -528,6 +531,7 @@ for (unsigned int %(d)s=0; %(d)s < %(dim)d; %(d)s++) {
 
         return self
 
+    @utils.known_pyop2_safe
     def __isub__(self, expr):
 
         if np.isscalar(expr):
@@ -544,6 +548,7 @@ for (unsigned int %(d)s=0; %(d)s < %(dim)d; %(d)s++) {
 
         return self
 
+    @utils.known_pyop2_safe
     def __imul__(self, expr):
 
         if np.isscalar(expr):
@@ -560,6 +565,7 @@ for (unsigned int %(d)s=0; %(d)s < %(dim)d; %(d)s++) {
 
         return self
 
+    @utils.known_pyop2_safe
     def __idiv__(self, expr):
 
         if np.isscalar(expr):

--- a/firedrake/matrix.py
+++ b/firedrake/matrix.py
@@ -4,6 +4,7 @@ import ufl
 
 from pyop2 import op2
 from pyop2.utils import as_tuple, flatten
+from firedrake import utils
 
 
 class Matrix(object):
@@ -38,6 +39,7 @@ class Matrix(object):
         self._bcs = [bc for bc in bcs] if bcs is not None else []
         self._bcs_at_point_of_assembly = []
 
+    @utils.known_pyop2_safe
     def assemble(self):
         """Actually assemble this :class:`Matrix`.
 

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -16,6 +16,12 @@ def prolong(coarse, fine):
     hierarchy, lvl = utils.get_level(cfs)
     if hierarchy is None:
         raise RuntimeError("Coarse function not from hierarchy")
+    fhierarchy, flvl = utils.get_level(fine.function_space())
+    if flvl != lvl + 1:
+        raise ValueError("Can only prolong from level %d to level %d, not %d" %
+                         (lvl, lvl + 1, flvl))
+    if hierarchy is not fhierarchy:
+        raise ValueError("Can't prolong between functions from different hierarchies")
     if isinstance(hierarchy, firedrake.MixedFunctionSpaceHierarchy):
         for c, f in zip(coarse.split(), fine.split()):
             prolong(c, f)
@@ -31,6 +37,12 @@ def restrict(fine, coarse):
     hierarchy, lvl = utils.get_level(cfs)
     if hierarchy is None:
         raise RuntimeError("Coarse function not from hierarchy")
+    fhierarchy, flvl = utils.get_level(fine.function_space())
+    if flvl != lvl + 1:
+        raise ValueError("Can only restrict from level %d to level %d, not %d" %
+                         (flvl, flvl - 1, lvl))
+    if hierarchy is not fhierarchy:
+        raise ValueError("Can't restrict between functions from different hierarchies")
     if isinstance(hierarchy, firedrake.MixedFunctionSpaceHierarchy):
         for f, c in zip(fine.split(), coarse.split()):
             restrict(f, c)
@@ -76,6 +88,12 @@ def inject(fine, coarse):
     hierarchy, lvl = utils.get_level(cfs)
     if hierarchy is None:
         raise RuntimeError("Coarse function not from hierarchy")
+    fhierarchy, flvl = utils.get_level(fine.function_space())
+    if flvl != lvl + 1:
+        raise ValueError("Can only inject from level %d to level %d, not %d" %
+                         (flvl, flvl - 1, lvl))
+    if hierarchy is not fhierarchy:
+        raise ValueError("Can't prolong between functions from different hierarchies")
     if isinstance(hierarchy, firedrake.MixedFunctionSpaceHierarchy):
         for f, c in zip(fine.split(), coarse.split()):
             inject(f, c)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -5,12 +5,14 @@ import ufl
 from pyop2 import op2
 
 import firedrake
+import firedrake.utils
 from . import utils
 
 
 __all__ = ["prolong", "restrict", "inject"]
 
 
+@firedrake.utils.known_pyop2_safe
 def prolong(coarse, fine):
     cfs = coarse.function_space()
     hierarchy, lvl = utils.get_level(cfs)
@@ -32,6 +34,7 @@ def prolong(coarse, fine):
                  coarse.dat(op2.READ, coarse.cell_node_map()))
 
 
+@firedrake.utils.known_pyop2_safe
 def restrict(fine, coarse):
     cfs = coarse.function_space()
     hierarchy, lvl = utils.get_level(cfs)
@@ -83,6 +86,7 @@ def restrict(fine, coarse):
                  *args)
 
 
+@firedrake.utils.known_pyop2_safe
 def inject(fine, coarse):
     cfs = coarse.function_space()
     hierarchy, lvl = utils.get_level(cfs)

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -61,7 +61,7 @@ pyop2_opts = Parameters("pyop2_options",
 pyop2_opts.set_update_function(lambda k, v: configuration.reconfigure(**{k: v}))
 
 # Override values
-pyop2_opts["type_check"] = False
+pyop2_opts["type_check"] = True
 pyop2_opts["log_level"] = "INFO"
 
 parameters.add(pyop2_opts)

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -58,7 +58,7 @@ parameters.add(Parameters("coffee",
 pyop2_opts = Parameters("pyop2_options",
                         **configuration)
 
-pyop2_opts.set_update_function(lambda k, v: configuration.reconfigure(**{k: v}))
+pyop2_opts.set_update_function(lambda k, v: configuration.unsafe_reconfigure(**{k: v}))
 
 # Override values
 pyop2_opts["type_check"] = True

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -76,3 +76,5 @@ parameters.add(Parameters("form_compiler", **ffc_parameters))
 parameters["reorder_meshes"] = True
 
 parameters["matnest"] = True
+
+parameters["type_check_safe_par_loops"] = False

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from ffc import default_parameters
 from pyop2.configuration import configuration
 
-__all__ = ['Parameters', 'parameters']
+__all__ = ['Parameters', 'parameters', 'disable_performance_optimisations']
 
 
 class Parameters(dict):
@@ -78,3 +78,41 @@ parameters["reorder_meshes"] = True
 parameters["matnest"] = True
 
 parameters["type_check_safe_par_loops"] = False
+
+
+def disable_performance_optimisations():
+    """Switches off performance optimisations in Firedrake.
+
+    This is mostly useful for debugging purposes.
+
+    This switches off all of COFFEE's kernel compilation optimisations
+    and enables PyOP2's runtime checking of par_loop arguments in all
+    cases (even those where they are claimed safe).  Additionally, it
+    switches to compiling generated code in debug mode.
+
+    Returns a function that can be called with no arguments, to
+    restore the state of the parameters dict."""
+
+    check = parameters["pyop2_options"]["type_check"]
+    debug = parameters["pyop2_options"]["debug"]
+    lazy = parameters["pyop2_options"]["lazy_evaluation"]
+    safe_check = parameters["type_check_safe_par_loops"]
+    coffee = parameters["coffee"]
+    cache = parameters["assembly_cache"]["enabled"]
+
+    def restore():
+        parameters["pyop2_options"]["type_check"] = check
+        parameters["pyop2_options"]["debug"] = debug
+        parameters["pyop2_options"]["lazy_evaluation"] = lazy
+        parameters["type_check_safe_par_loops"] = safe_check
+        parameters["coffee"] = coffee
+        parameters["assembly_cache"]["enabled"] = cache
+
+    parameters["pyop2_options"]["type_check"] = True
+    parameters["pyop2_options"]["debug"] = True
+    parameters["pyop2_options"]["lazy_evaluation"] = False
+    parameters["type_check_safe_par_loops"] = True
+    parameters["coffee"] = {}
+    parameters["assembly_cache"]["enabled"] = False
+
+    return restore

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -63,3 +63,25 @@ def unique_name(name, nameset):
         else:
             nameset.add(name)
             return newname
+
+
+def known_pyop2_safe(f):
+    """Decorator to mark a function as being PyOP2 type-safe.
+
+    This switches the current PyOP2 type checking mode to the value
+    given by the parameter "type_check_safe_par_loops", and restores
+    it after the function completes."""
+    from firedrake.parameters import parameters
+
+    def wrapper(f, *args, **kwargs):
+        opts = parameters["pyop2_options"]
+        check = opts["type_check"]
+        safe = parameters["type_check_safe_par_loops"]
+        if check == safe:
+            return f(*args, **kwargs)
+        opts["type_check"] = safe
+        try:
+            return f(*args, **kwargs)
+        finally:
+            opts["type_check"] = check
+    return decorator(wrapper, f)

--- a/tests/multigrid/test_invalid_transfers.py
+++ b/tests/multigrid/test_invalid_transfers.py
@@ -1,0 +1,57 @@
+from firedrake import *
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mesh_hierarchy():
+    m = UnitIntervalMesh(10)
+    return MeshHierarchy(m, 2)
+
+
+@pytest.fixture(scope="module")
+def f1(mesh_hierarchy):
+    V = FunctionSpaceHierarchy(mesh_hierarchy, "DG", 0)
+    return FunctionHierarchy(V)
+
+
+@pytest.fixture(scope="module")
+def f2(mesh_hierarchy):
+    V = FunctionSpaceHierarchy(mesh_hierarchy, "CG", 1)
+    return FunctionHierarchy(V)
+
+
+@pytest.mark.parametrize("transfer",
+                         ["prolong", "inject", "restrict"])
+def test_transfer_invalid_level_combo(transfer, f1):
+    a = f1[2]
+    b = f1[0]
+    transfer = restrict
+    if transfer == "prolong":
+        a = f1[0]
+        b = f1[2]
+        transfer = prolong
+    elif transfer == "inject":
+        transfer = inject
+    with pytest.raises(ValueError):
+        transfer(a, b)
+
+
+@pytest.mark.parametrize("transfer",
+                         ["prolong", "inject", "restrict"])
+def test_transfer_mismatching_functionspace(transfer, f1, f2):
+    a = f1[2]
+    b = f2[1]
+    transfer = restrict
+    if transfer == "prolong":
+        a = f1[1]
+        b = f2[2]
+        transfer = prolong
+    elif transfer == "inject":
+        transfer = inject
+    with pytest.raises(ValueError):
+        transfer(a, b)
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Mostly addresses #626.  Turns pyop2 type checking on by default, but then switches it off by default for "known safe" par_loops where firedrake already claims to have validated the arguments.  This is not quite as fast as previously, but significantly better than turning type checking off everywhere.  Former performance can be obtained by turning off pyop2 type checking everywhere.

Additionally adds a disable_performance_optimisations call that can be used to turn off EVERYTHING potentially bad.