### PR TITLE
MixedFunctionSpace on different meshes

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -63,7 +63,7 @@ class CoordinatelessFunction(ufl.Coefficient):
         :param dtype: optional data type for this :class:`Function`
                (defaults to ``valuetype``).
         """
-        assert isinstance(function_space, (functionspace.FunctionSpaceBase, functionspace.MixedFunctionSpace)), \
+        assert isinstance(function_space, functionspace.FunctionSpaceBase), \
             "Can't make a CoordinatelessFunction defined on a " + str(type(function_space))
 
         ufl.Coefficient.__init__(self, function_space.ufl_element())
@@ -117,8 +117,6 @@ class CoordinatelessFunction(ufl.Coefficient):
     def cell_set(self):
         """The :class:`pyop2.Set` of cells for the mesh on which this
         :class:`Function` is defined."""
-        # Function space may be mixed, which does not always have a
-        # single mesh.  We extract the single mesh if there is one.
         return self._function_space.mesh().cell_set
 
     @property
@@ -215,23 +213,19 @@ class Function(ufl.Coefficient):
 
         if isinstance(function_space, Function):
             self._function_space = function_space._function_space
-        else:
+        elif isinstance(function_space, functionspace.FunctionSpaceBase):
             self._function_space = function_space
-
-        if isinstance(self._function_space, functionspace.FunctionSpaceBase):
-            make_dat_fs = self._function_space.topological
-        elif isinstance(self._function_space, functionspace.MixedFunctionSpace):
-            make_dat_fs = self._function_space
         else:
             raise NotImplementedError("Can't make a Function defined on a "
                                       + str(type(function_space)))
 
         if isinstance(val, CoordinatelessFunction):
-            if val.function_space() != make_dat_fs:
+            if val.function_space() != self._function_space.topological:
                 raise ValueError("Function values have wrong function space.")
             self._data = val
         else:
-            self._data = CoordinatelessFunction(make_dat_fs, val=val, name=name, dtype=dtype)
+            self._data = CoordinatelessFunction(self._function_space.topological,
+                                                val=val, name=name, dtype=dtype)
 
         ufl.Coefficient.__init__(self, self.function_space().ufl_function_space())
         self._split = None

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -41,7 +41,7 @@ def project(v, V, bcs=None, mesh=None,
     currently ignored."""
     from firedrake import function
 
-    if isinstance(V, functionspace.FunctionSpaceBase):
+    if isinstance(V, (functionspace.FunctionSpaceBase, functionspace.MixedFunctionSpace)):
         ret = function.Function(V, name=name)
     elif isinstance(V, function.Function):
         ret = V

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -41,7 +41,7 @@ def project(v, V, bcs=None, mesh=None,
     currently ignored."""
     from firedrake import function
 
-    if isinstance(V, (functionspace.FunctionSpaceBase, functionspace.MixedFunctionSpace)):
+    if isinstance(V, functionspace.FunctionSpaceBase):
         ret = function.Function(V, name=name)
     elif isinstance(V, function.Function):
         ret = V


### PR DESCRIPTION
This patch allows to build a MixedFunctionSpace on different mesh geometries. This is not enough however to solve *not-actually-mixed* problems, since trying that causes further failures in UFL.