### PR TITLE
Work around homebrew openmpi build bug

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -184,13 +184,16 @@ def check_output(args):
         raise
 
 
-def brew_install(name):
+def brew_install(name, options=None):
     try:
         # Check if it's already installed
         check_call(["brew", "list", name])
     except subprocess.CalledProcessError:
         # If not found, go ahead and install
-        check_call(["brew", "install", name])
+        args = [name]
+        if options:
+            args = options + args
+        check_call(["brew", "install"] + args)
 
 
 def apt_check(name):
@@ -448,7 +451,10 @@ if osname == "Darwin":
             quit("Homebrew not found. Please install it using the instructions at http://brew.sh and then try again.")
 
         stdout.write("Installing required packages via homebrew. You can safely ignore warnings that packages are already installed\n")
-        brew_install("openmpi")
+        # Ensure a fortran compiler is available
+        brew_install("gcc")
+        # Temporary workaround for homebrew bug #46461
+        brew_install("openmpi", options=["--with-fortran", "--build-from-source"])
         brew_install("python")
         check_call(["brew", "tap", "homebrew/python"])
         brew_install("numpy")


### PR DESCRIPTION
This updates the install script to build openmpi from source after installing the gcc package (so that mpif90 is available).

Maybe merge this into the osx-travis branch so that it gets tested properly though in a clean environment.