### PR TITLE
Massively simplify install page

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ help:
 
 TARGETS = html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
-GENERATED_FILES = source/teamgrid.rst source/obtaining_pyop2.rst source/demos
+GENERATED_FILES = source/teamgrid.rst source/demos
 
 publish: html
 # Note that godaddy don't currently do rsync, unfortunately.
@@ -74,11 +74,6 @@ copy_demos:
 
 source/teamgrid.rst: source/team.py
 	cd source; python team.py
-
-.PHONY: source/obtaining_pyop2.rst
-
-source/obtaining_pyop2.rst:
-	wget https://raw.github.com/OP2/PyOP2/master/README.rst -O $@
 
 apidoc: $(GENERATED_FILES) copy_demos
 	sphinx-apidoc ../firedrake -o source/ -f -T

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -29,6 +29,18 @@ may stop to ask you to install some dependency packages. Installation
 on other Unix platforms may work but is untested. Installation on
 Windows is very unlikely to work.
 
+Supported python distributions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On Ubuntu, the system installed python 2.7 is supported and tested.
+On Mac OS, the homebrew_ installed python 2.7 is supported and tested.
+
+.. warning::
+
+   The installation script *does not work* with anaconda_ based python
+   installations, because it uses virtualenvs which anaconda does not
+   support.
+
 Upgrade
 -------
 
@@ -68,69 +80,93 @@ which you wish the rebuilt script to apply (for example `--user` or
 `--disable-ssh`). You should now be able to run `firedrake-update`.
 
 
+Visualisation software
+----------------------
+
+Firedrake can output data in VTK format, suitable for viewing in
+Paraview_.  On Ubuntu and similar systems, you can obtain Paraview by
+installing the ``paraview`` package.  On Mac OS, the easiest approach
+is to download a binary from the `paraview website <Paraview_>`_.
+
 Installing from individual components
 =====================================
 
-Firedrake depends on PyOP2_, FFC_, FIAT_, UFL_ and h5py_. It is easiest to obtain
-all of these components on Ubuntu Linux and related distributions such as Mint
-or Debian. Installation on other Unix-like operating systems is likely to be
-possible, although harder. Installation on a Mac is straightforward using the
-commands below.
+.. warning::
 
-PyOP2
------
+  Installation from individual components is an unsupported route.  If
+  you tried the installation script and it failed, please let us know
+  by filing a `bug report
+  <https://github.com/firedrakeproject/firedrake/issues>`__, we
+  *absolutely* want to fix it.  This section of the documentation
+  provides a bare-bones description of the required dependencies.
 
-Instructions for obtaining PyOP2_ and its dependencies are at
-:doc:`obtaining_pyop2`. Note that PyOP2_ is updated frequently and Firedrake
-requires an up-to-date version.
+Firedrake itself is a Python package available on `github
+<https://github.com/firedrakeproject/firedrake>`__, however, you will
+need a number of additional libraries to use it.
 
-FFC, FIAT and UFL
------------------
+Mac OS
+------
 
-Firedrake currently requires a fork of FFC_, UFL_ and FIAT_.  Note that FFC_
-requires a version of Instant_.
+We list here the required homebrew_ packages:
 
-FFC_ currently depends on Swig_, which you can install from
-package. On Ubuntu and relatives type::
+- openmpi (or mpich)
+- python
+- swig
+- cmake
+- spatialindex
 
-  sudo apt-get install swig
+Ubuntu
+------
 
-while on Mac OS it's::
+On Ubuntu, the following apt packages are required:
 
-  brew install swig
+- build-essential
+- cmake
+- gfortran
+- git-core
+- libblas-dev
+- liblapack-dev
+- libopenmpi-dev
+- libspatialindex-dev
+- mercurial
+- openmpi-bin
+- python-dev
+- python-pip
+- swig
 
-Install FFC_ and all dependencies via pip::
+Common dependencies
+-------------------
 
-  sudo pip install \
-    six \
-    sympy \
-    git+https://bitbucket.org/mapdes/ffc.git#egg=ffc \
-    git+https://bitbucket.org/mapdes/ufl.git#egg=ufl \
-    git+https://bitbucket.org/mapdes/fiat.git#egg=fiat \
-    git+https://bitbucket.org/fenics-project/instant.git#egg=instant
+PETSc
+~~~~~
 
-These dependencies are regularly updated. If you already have the packages
-installed and want to upgrade to the latest versions, do the following::
+We maintain branches of PETSc_ and petsc4py_ that are known to work
+with Firedrake.  Use the ``firedrake`` branch for both:
 
-  sudo pip install -U --no-deps ...
+- https://bitbucket.org/mapdes/petsc
+- https://bitbucket.org/mapdes/petsc4py
 
-To install for your user only, which does not require sudo permissions,
-modify the pip invocation for either case above as follows::
+PETSc must be built with (at least) support for:
 
-  pip install --user ...
+- HDF5
+- CHACO
+- Triangle
+- Ctetgen
+
+We also recommend that you build PETSc with shared libraries.
 
 h5py
-----
+~~~~
 
-It is critical that h5py_ is linked against the same version of the
-HDF5 library that PETSc was built with.  This is unfortunately not
-possible to specify when using ``pip``.  Instead, please follow the
-instructions for a `custom installation`_.  If PETSc was linked
-against a system HDF5 library, use that library when building h5py.
-If the PETSc installation was used to build HDF5 (via
-``--download-hdf5``) then the appropriate HDF5 library is in the PETSc
-install directory.  If installed with ``pip``, this can be obtained
-using::
+Firedrake uses h5py_ to write checkpoint files.  It is critical that
+h5py_ is linked against the same version of the HDF5 library that
+PETSc was built with.  This is unfortunately not possible to specify
+when using ``pip``.  Instead, please follow the instructions for a
+`custom installation`_.  If PETSc was linked against a system HDF5
+library, use that library when building h5py.  If the PETSc
+installation was used to build HDF5 (via ``--download-hdf5``) then the
+appropriate HDF5 library is in the PETSc install directory.  If
+installed with ``pip``, this can be obtained using::
 
   python -c "import petsc; print petsc.get_petsc_dir()"
 
@@ -141,177 +177,42 @@ Otherwise, use the appropriate values of ``PETSC_DIR`` and ``PETSC_ARCH``.
    It is not necessary that h5py be built with MPI support, although
    Firedrake supports both options.
 
+Further dependencies
+~~~~~~~~~~~~~~~~~~~~
 
-Potential installation errors on Mac OS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Firedrake depends on the Python packages PyOP2_, FFC_, FIAT_ and UFL_.
 
-The installation of FFC_ requires a C++11 compatible compiler and
-standard library, some Mac OS systems (for example OS X "Lion")
-supply the former, but not the latter.  Should you obtain errors
-installing FFC_ of the following form:
-
-.. code-block:: c
-
-   ufc/ufc_wrap.cpp:3841:8: error: no member named 'shared_ptr' in namespace 'std'
-   std::shared_ptr< ufc::function > tempshared1 ;
-
-It's possible that you just need to tell the compiler to pick the
-correct standard library.  To do so, try running with
-``CXXFLAGS='-stdlib=libc++'`` when installing::
-
-  sudo CXXFLAGS='-stdlib=libc++' pip install -U --no-deps ...
-
-Visualisation software
-----------------------
-
-Firedrake can output data in VTK format, suitable for viewing in
-Paraview_.  On Ubuntu and similar systems, you can obtain Paraview by
-installing the ``paraview`` package.  On Mac OS, the easiest approach
-is to download a binary from the `paraview website <Paraview_>`_.
-
-Firedrake
----------
-
-In addition to PyOP2, Firedrake also depends on libspatialindex_.  On
-Ubuntu and relatives type::
-
-  sudo apt-get install libspatialindex-dev
-
-while on Mac OS it's::
-
-  brew install spatialindex
-
-Now you need to install Firedrake.  There are two routes, depending on
-whether you intend to contribute to Firedrake development.
+Optional dependencies
+~~~~~~~~~~~~~~~~~~~~~
 
 For performance reasons, there are various levels of caching with
-eviction policies.  To support these, you will need to install
-cachetools::
+eviction policies.  To support these, you will need to install the
+python packages::
 
-   sudo pip install cachetools
-
-or (for your user only)::
-
-   pip install --user cachetools
-
-Firedrake will perform entirely correctly without this package, but
-will be less efficient for tight time-stepping loops.
-
-In order to have the form assembly cache operate in the most automatic
-fashion possible, you are also advised to install psutil (version 2.0.0
-or newer is required)::
-
-  sudo pip install psutil
-
-or (to install for your user only)::
-
-  pip install --user psutil
-
-Pip instructions for users
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you only wish to use Firedrake, and will not be contributing to
-development at all, you can install Firedrake using pip::
-
-  sudo pip install git+https://github.com/firedrakeproject/firedrake.git
-
-or (to install for your user only)::
-
-  pip install --user git+https://github.com/firedrakeproject/firedrake.git
-
-You're now ready to go. You might like to start with the tutorial
-examples on the :doc:`documentation page <documentation>`.
-
-Git instructions for developers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Cython >= 0.22 is required to build Firedrake. Install it using pip ::
-
- pip install "Cython>=0.22"
-
-Next, obtain the Firedrake source from GitHub_ ::
-
- git clone https://github.com/firedrakeproject/firedrake.git
-
-You will also need to point Python at the right directories. You might
-want to consider setting this permanently in your
-``.bashrc`` or similar::
-
-  cd firedrake
-  export PYTHONPATH=$PWD:$PYTHONPATH
-
-From the Firedrake directory build the relevant modules::
-
- make
-
-Cleaning disk caches after upgrade
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-After upgrading, you may need to clear any disk caches that Firedrake
-maintains to ensure that your problem does not pick up any out of date
-compiled modules.  This can be carried out by executing the
-``firedrake-clean`` script.  If you carried out a sudo install of
-Firedrake using pip, ``firedrake-clean`` should be in your ``PATH``
-and so you should just be able to execute it.  If you carried out a
-user install using pip, you will need to add ``$HOME/.local/bin`` to
-your ``PATH`` ::
-
-  export PATH=$HOME/.local/bin:$PATH
-
-If you are using a checkout of Firedrake, ``firedrake-clean`` lives in
-the ``scripts`` subdirectory.
-
-Additional dependencies for developers
---------------------------------------
-
-If you plan to develop Firedrake then you will require a few more
-packages. 
+- cachetools
+- psutil
 
 Documentation dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Building the documention requires Sphinx_
-(including the Youtube and Bibtex plugins) and wget_. For example on Ubuntu-like
-Linux systems::
+Building the documention requires Sphinx_ (including the Youtube and
+Bibtex plugins) and wget_.  In addition the Sphinx Youtube and bibtex
+plugins are required.  The former is available from the
+`sphinx-contrib repository
+<https://bitbucket.org/birkenfeld/sphinx-contrib>`__, the latter is
+the python package ``sphinxcontrib-bibtex``.
 
-  sudo apt-get install wget
-  sudo pip install sphinx
-
-and on Mac OS::
-
-  brew install wget
-  sudo pip install sphinx 
-
-note that the Sphinx in Homebrew is not the python documentation tool!
-
-The Sphinx Youtube plugin is obtained by cloning the sphinx-contrib
-repository::
-
-  hg clone https://bitbucket.org/birkenfeld/sphinx-contrib
-
-Then install the Youtube plugin::
-
-  cd sphinx-contrib/youtube
-  sudo python setup.py install
-
-Note that the ``sphinxcontrib.youtube`` Ubuntu package does not work
-for our purposes.
-
-Finally install the Bibtex plugin::
-
-  sudo pip install sphinxcontrib-bibtex
-
+.. _petsc4py: https://bitbucket.org/mapdes/petsc4py
+.. _PETSc: http://www.mcs.anl.gov/petsc/
 .. _PyOP2: http://op2.github.io/PyOP2
 .. _FFC: https://bitbucket.org/mapdes/ffc
 .. _FIAT: https://bitbucket.org/mapdes/fiat
 .. _UFL: https://bitbucket.org/mapdes/ufl
-.. _Instant: https://bitbucket.org/fenics-project/instant
-.. _GitHub: https://github.com/firedrakeproject/firedrake
 .. _Paraview: http://www.paraview.org
 .. _Sphinx: http://www.sphinx-doc.org
 .. _wget: http://www.gnu.org/software/wget/
-.. _Swig: http://www.swig.org/
 .. _virtualenv: https://virtualenv.pypa.io/
-.. _libspatialindex: https://libspatialindex.github.io/
 .. _h5py: http://www.h5py.org/
-.. _custom installation: http://docs.h5py.org/en/latest/build.html#custom-installation
+.. _custom installation: http://docs.h5py.org/en/latest/build.html#via-setup-py
+.. _homebrew: http://brew.sh
+.. _anaconda: https://www.continuum.io/downloads

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -111,7 +111,6 @@ We list here the required homebrew_ packages:
 
 - openmpi (or mpich)
 - python
-- swig
 - cmake
 - spatialindex
 
@@ -132,7 +131,6 @@ On Ubuntu, the following apt packages are required:
 - openmpi-bin
 - python-dev
 - python-pip
-- swig
 
 Common dependencies
 -------------------


### PR DESCRIPTION
Build from components is now an "unsupported" route.  We just list the
things you need.