### PR TITLE
Nascent support for subdomains

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -233,8 +233,8 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
     # assemble it.
     def thunk(bcs):
         zero_tensor()
-        for (i, j), integral_type, subdomain_id, coords, coefficients, needs_orientations, kernel in kernels:
-            m = coords.function_space().mesh()
+        for (i, j), integral_type, m, subdomain_data, subdomain_id, coefficients, needs_orientations, kernel in kernels:
+            coords = m.coordinates
             if needs_orientations:
                 cell_orientations = m.cell_orientations()
             # Extract block from tensor and test/trial spaces
@@ -265,7 +265,7 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
                     else:
                         tensor_arg = tensor(op2.INC)
 
-                    itspace = m.cell_set
+                    itspace = subdomain_data or m.cell_set
                     args = [kernel, itspace, tensor_arg,
                             coords.dat(op2.READ, coords.cell_node_map(),
                                        flatten=True)]

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -235,6 +235,8 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
         zero_tensor()
         for (i, j), integral_type, m, subdomain_data, subdomain_id, coefficients, needs_orientations, kernel in kernels:
             coords = m.coordinates
+            if integral_type != 'cell' and subdomain_data is not None:
+                raise NotImplementedError("subdomain_data only supported with cell integrals.")
             if needs_orientations:
                 cell_orientations = m.cell_orientations()
             # Extract block from tensor and test/trial spaces

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -19,7 +19,7 @@ from firedrake.parameters import parameters
 from firedrake.petsc import PETSc
 
 
-__all__ = ['Mesh', 'ExtrudedMesh', 'make_subdomain_data']
+__all__ = ['Mesh', 'ExtrudedMesh', 'SubDomainData']
 
 
 _cells = {
@@ -1153,7 +1153,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
     return self
 
 
-def make_subdomain_data(geometric_expr):
+def SubDomainData(geometric_expr):
     import firedrake.functionspace as functionspace
     import firedrake.projection as projection
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1165,5 +1165,5 @@ def SubDomainData(geometric_expr):
     f = projection.project(ufl.conditional(geometric_expr, 1, 0), fs)
 
     # Create cell subset
-    indices, = np.nonzero(f.dat.data > 0.5)
+    indices, = np.nonzero(f.dat.data_ro_with_halos > 0.5)
     return op2.Subset(m.cell_set, indices)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1154,6 +1154,16 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
 
 
 def SubDomainData(geometric_expr):
+    """Creates a subdomain data object from a boolean-valued UFL expression.
+
+    The result can be attached as the subdomain_data field of a
+    :class:`ufl.Measure`. For example:
+
+        x = mesh.coordinates
+        sd = SubDomainData(x[0] < 0.5)
+        assemble(f*dx(subdomain_data=sd))
+
+    """
     import firedrake.functionspace as functionspace
     import firedrake.projection as projection
 

--- a/tests/extrusion/test_subdomain_extruded.py
+++ b/tests/extrusion/test_subdomain_extruded.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from firedrake import *
+
+
+def test_base_box_3d():
+    m = UnitSquareMesh(10, 10, quadrilateral=True)
+    mesh = ExtrudedMesh(m, layers=8)
+    f = Function(FunctionSpace(mesh, 'CG', 1))
+    f.interpolate(Expression("x[0] + 2*x[1] + 4*x[2]"))
+
+    # A caching bug might cause to recall the following value at a later
+    # assembly.  We keep this line to have that case tested.
+    assert np.allclose(3.5, assemble(f*dx))
+
+    x = m.coordinates
+    sd = make_subdomain_data(And(And(0.2 <= x[0], x[0] <= 0.5),
+                                 And(0.3 <= x[1], x[1] <= 0.7)))
+
+    # TEMPORARY HACK:
+    # Retarget base subdomain into columns of the extruded mesh.
+    sd = op2.Subset(mesh.cell_set, sd.indices)
+    assert np.allclose(0.402, assemble(f*dx(subdomain_data=sd)))
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/extrusion/test_subdomain_extruded.py
+++ b/tests/extrusion/test_subdomain_extruded.py
@@ -15,8 +15,8 @@ def test_base_box_3d():
     assert np.allclose(3.5, assemble(f*dx))
 
     x = m.coordinates
-    sd = make_subdomain_data(And(And(0.2 <= x[0], x[0] <= 0.5),
-                                 And(0.3 <= x[1], x[1] <= 0.7)))
+    sd = SubDomainData(And(And(0.2 <= x[0], x[0] <= 0.5),
+                           And(0.3 <= x[1], x[1] <= 0.7)))
 
     # TEMPORARY HACK:
     # Retarget base subdomain into columns of the extruded mesh.

--- a/tests/extrusion/test_subdomain_extruded.py
+++ b/tests/extrusion/test_subdomain_extruded.py
@@ -4,7 +4,7 @@ import pytest
 from firedrake import *
 
 
-def test_base_box_3d():
+def run_base_box_3d():
     m = UnitSquareMesh(10, 10, quadrilateral=True)
     mesh = ExtrudedMesh(m, layers=8)
     f = Function(FunctionSpace(mesh, 'CG', 1))
@@ -22,6 +22,15 @@ def test_base_box_3d():
     # Retarget base subdomain into columns of the extruded mesh.
     sd = op2.Subset(mesh.cell_set, sd.indices)
     assert np.allclose(0.402, assemble(f*dx(subdomain_data=sd)))
+
+
+def test_base_box_3d():
+    run_base_box_3d()
+
+
+@pytest.mark.parallel(nprocs=3)
+def test_base_box_3d_parallel():
+    run_base_box_3d()
 
 
 if __name__ == '__main__':

--- a/tests/regression/test_subdomain.py
+++ b/tests/regression/test_subdomain.py
@@ -4,7 +4,7 @@ import pytest
 from firedrake import *
 
 
-def test_box_1d():
+def test_box_1d_0form():
     mesh = UnitIntervalMesh(4)
     x = mesh.coordinates
     f = Function(FunctionSpace(mesh, 'CG', 1))
@@ -19,6 +19,40 @@ def test_box_1d():
 
     sd = make_subdomain_data(x[0] > 0.5)
     assert np.allclose(0.375, assemble(f*dx(subdomain_data=sd)))
+
+
+def test_box_1d_1form():
+    mesh = UnitIntervalMesh(4)
+    x = mesh.coordinates
+    v = TestFunction(FunctionSpace(mesh, 'CG', 1))
+
+    whole = assemble(v*dx).dat.data
+
+    sd = make_subdomain_data(x[0] < 0.5)
+    half_1 = assemble(v*dx(subdomain_data=sd)).dat.data
+
+    sd = make_subdomain_data(x[0] > 0.5)
+    half_2 = assemble(v*dx(subdomain_data=sd)).dat.data
+
+    assert np.allclose(whole, half_1 + half_2)
+
+
+def test_box_1d_2form():
+    mesh = UnitIntervalMesh(4)
+    x = mesh.coordinates
+    V = FunctionSpace(mesh, 'CG', 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    whole = assemble(u*v*dx).M.values
+
+    sd = make_subdomain_data(x[0] < 0.5)
+    half_1 = assemble(u*v*dx(subdomain_data=sd)).M.values
+
+    sd = make_subdomain_data(x[0] > 0.5)
+    half_2 = assemble(u*v*dx(subdomain_data=sd)).M.values
+
+    assert np.allclose(whole, half_1 + half_2)
 
 
 if __name__ == '__main__':

--- a/tests/regression/test_subdomain.py
+++ b/tests/regression/test_subdomain.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from firedrake import *
+
+
+def test_box_1d():
+    mesh = UnitIntervalMesh(4)
+    x = mesh.coordinates
+    f = Function(FunctionSpace(mesh, 'CG', 1))
+    f.interpolate(Expression("x[0]"))
+
+    # A caching bug might cause to recall the following value at a later
+    # assembly.  We keep this line to have that case tested.
+    assert np.allclose(0.5, assemble(f*dx))
+
+    sd = make_subdomain_data(x[0] < 0.5)
+    assert np.allclose(0.125, assemble(f*dx(subdomain_data=sd)))
+
+    sd = make_subdomain_data(x[0] > 0.5)
+    assert np.allclose(0.375, assemble(f*dx(subdomain_data=sd)))
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_subdomain.py
+++ b/tests/regression/test_subdomain.py
@@ -4,7 +4,7 @@ import pytest
 from firedrake import *
 
 
-def test_box_1d_0form():
+def run_box_1d_0form():
     mesh = UnitIntervalMesh(4)
     x = mesh.coordinates
     f = Function(FunctionSpace(mesh, 'CG', 1))
@@ -21,7 +21,7 @@ def test_box_1d_0form():
     assert np.allclose(0.375, assemble(f*dx(subdomain_data=sd)))
 
 
-def test_box_1d_1form():
+def run_box_1d_1form():
     mesh = UnitIntervalMesh(4)
     x = mesh.coordinates
     v = TestFunction(FunctionSpace(mesh, 'CG', 1))
@@ -29,30 +29,57 @@ def test_box_1d_1form():
     whole = assemble(v*dx).dat.data
 
     sd = SubDomainData(x[0] < 0.5)
-    half_1 = assemble(v*dx(subdomain_data=sd)).dat.data
+    half_1 = assemble(v*dx(subdomain_data=sd)).dat.data_ro
 
     sd = SubDomainData(x[0] > 0.5)
-    half_2 = assemble(v*dx(subdomain_data=sd)).dat.data
+    half_2 = assemble(v*dx(subdomain_data=sd)).dat.data_ro
 
     assert np.allclose(whole, half_1 + half_2)
 
 
-def test_box_1d_2form():
+def run_box_1d_2form():
     mesh = UnitIntervalMesh(4)
     x = mesh.coordinates
     V = FunctionSpace(mesh, 'CG', 1)
     u = TrialFunction(V)
     v = TestFunction(V)
 
-    whole = assemble(u*v*dx).M.values
+    whole = assemble(u*v*dx).M.handle
 
     sd = SubDomainData(x[0] < 0.5)
-    half_1 = assemble(u*v*dx(subdomain_data=sd)).M.values
+    half_1 = assemble(u*v*dx(subdomain_data=sd)).M.handle
 
     sd = SubDomainData(x[0] > 0.5)
-    half_2 = assemble(u*v*dx(subdomain_data=sd)).M.values
+    half_2 = assemble(u*v*dx(subdomain_data=sd)).M.handle
 
-    assert np.allclose(whole, half_1 + half_2)
+    assert whole.equal(half_1 + half_2)
+
+
+def test_box_1d_0form():
+    run_box_1d_0form()
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_box_1d_0form_parallel():
+    run_box_1d_0form()
+
+
+def test_box_1d_1form():
+    run_box_1d_1form()
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_box_1d_1form_parallel():
+    run_box_1d_1form()
+
+
+def test_box_1d_2form():
+    run_box_1d_2form()
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_box_1d_2form_parallel():
+    run_box_1d_2form()
 
 
 if __name__ == '__main__':

--- a/tests/regression/test_subdomain.py
+++ b/tests/regression/test_subdomain.py
@@ -14,10 +14,10 @@ def test_box_1d_0form():
     # assembly.  We keep this line to have that case tested.
     assert np.allclose(0.5, assemble(f*dx))
 
-    sd = make_subdomain_data(x[0] < 0.5)
+    sd = SubDomainData(x[0] < 0.5)
     assert np.allclose(0.125, assemble(f*dx(subdomain_data=sd)))
 
-    sd = make_subdomain_data(x[0] > 0.5)
+    sd = SubDomainData(x[0] > 0.5)
     assert np.allclose(0.375, assemble(f*dx(subdomain_data=sd)))
 
 
@@ -28,10 +28,10 @@ def test_box_1d_1form():
 
     whole = assemble(v*dx).dat.data
 
-    sd = make_subdomain_data(x[0] < 0.5)
+    sd = SubDomainData(x[0] < 0.5)
     half_1 = assemble(v*dx(subdomain_data=sd)).dat.data
 
-    sd = make_subdomain_data(x[0] > 0.5)
+    sd = SubDomainData(x[0] > 0.5)
     half_2 = assemble(v*dx(subdomain_data=sd)).dat.data
 
     assert np.allclose(whole, half_1 + half_2)
@@ -46,10 +46,10 @@ def test_box_1d_2form():
 
     whole = assemble(u*v*dx).M.values
 
-    sd = make_subdomain_data(x[0] < 0.5)
+    sd = SubDomainData(x[0] < 0.5)
     half_1 = assemble(u*v*dx(subdomain_data=sd)).M.values
 
-    sd = make_subdomain_data(x[0] > 0.5)
+    sd = SubDomainData(x[0] > 0.5)
     half_2 = assemble(u*v*dx(subdomain_data=sd)).M.values
 
     assert np.allclose(whole, half_1 + half_2)


### PR DESCRIPTION
##### Limitations:
 * Cell integrals only (`dx`)
 * Whole cells only (not cutting of cells at this stage)
 * For an extruded mesh:
   * Columns are monolithic (either all or none of the cells in a column are in the subdomain)
   * API not stable yet

##### Features:
 * Subdomain defined as geometric expression (UFL-based)
 * Works on 0-forms, 1-forms and 2-forms

##### Usage:
    ...
    x = mesh.coordinates
    sd = SubDomainData(x[0] < 0.5)
    assemble(f*dx(subdomain_data=sd))