### PR TITLE
mac: Stop building openmpi from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
     - os: osx
       # Only test a few things on OSX until we can cache some of the
       # build dependencies, otherwise we often get timeouts.
-      env: PYOP2_BACKEND=sequential PYOP2_TESTS="extrusion/test_2d_cohomology.py extrusion/test_point_eval_cells_extrusion.py extrusion/test_steady_advection_2D_extr.py regression/test_change_coordinates.py regression/test_2dcohomology.py regression/test_upwind_flux.py regression/test_point_eval_fs.py"
+      env: PYOP2_BACKEND=sequential PYOP2_TESTS="extrusion"
     - os: linux
       env: PYOP2_BACKEND=sequential PYOP2_TESTS=regression
     - os: linux

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -595,8 +595,7 @@ if osname == "Darwin":
         stdout.write("Installing required packages via homebrew. You can safely ignore warnings that packages are already installed\n")
         # Ensure a fortran compiler is available
         brew_install("gcc")
-        # Temporary workaround for homebrew bug #46461
-        brew_install("openmpi", options=["--with-fortran", "--build-from-source"])
+        brew_install("openmpi")
         brew_install("python")
         brew_install("cmake")
         brew_install("spatialindex")


### PR DESCRIPTION
Now that Homebrew/homebrew#46461 is fixed, we can revert back to
installing the bottled version of openmpi.