### PR TITLE
Citations

### DIFF
--- a/docs/source/_static/bibliography.bib
+++ b/docs/source/_static/bibliography.bib
@@ -1,3 +1,16 @@
+
+@InProceedings{Bokhove2016,
+  author =       {Onno Bokhove and Anna Kalogirou},
+  title =        {Variational water wave modelling: from continuum to experiment},
+  booktitle = {Lectures on the theory of water waves},
+  year =      2016,
+  editor =    {Thomas J. Bridges and Mark D. Groves and David P. Nicholls},
+  volume =    426,
+  series =    {LMS Lecture Note Series},
+  pages =     {226--260},
+  publisher = {Cambridge University Press},
+  url = {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf}}
+
 @article{Cotter2015,
   title={On the shallow atmosphere approximation in finite element dynamical cores},
   author={Cotter, CJ and Ham, DA and McRae, ATT and Mitchell, L and Natale, A},

--- a/docs/source/_static/bibliography.bib
+++ b/docs/source/_static/bibliography.bib
@@ -1,175 +1,195 @@
-
 @InProceedings{Bokhove2016,
   author =       {Onno Bokhove and Anna Kalogirou},
-  title =        {Variational water wave modelling: from continuum to experiment},
-  booktitle = {Lectures on the theory of water waves},
-  year =      2016,
-  editor =    {Thomas J. Bridges and Mark D. Groves and David P. Nicholls},
-  volume =    426,
-  series =    {LMS Lecture Note Series},
-  pages =     {226--260},
-  publisher = {Cambridge University Press},
-  url = {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf}}
-
-@article{Cotter2015,
-  title={On the shallow atmosphere approximation in finite element dynamical cores},
-  author={Cotter, CJ and Ham, DA and McRae, ATT and Mitchell, L and Natale, A},
-  url={http://arxiv.org/abs/1410.3069},
-  archivePrefix ="arXiv",
-  eprint =       {1410.3069},
-  year =         {2015}
-}
-
-@article{Cotter2015a,
-  title =        {Embedded discontinuous Galerkin transport schemes
-                  with localised limiters},
-  author =       {Cotter, CJ and Kuzmin, D},
-  archivePrefix ="arXiv",
-  eprint =       {1509.04431},
-  url =          {http://arxiv.org/abs/1509.04431},
-  year =         {2015}
-}
-
-@Article{Homolya2015,
-  author = 	 {Mikl\`os Homolya and David A. Ham},
-  title = 	 {A parallel edge orientation algorithm for quadrilateral meshes},
-  journal = 	 {Submitted to SIAM Journal on Scientific Computing},
-  year = 	 2015,
-  archivePrefix ="arXiv",
-  eprint={1505.03357},
-  url = {http://arxiv.org/abs/1505.03357}
-}
-
-@article{Lange2015,
-  title =        {Efficient mesh management in {Firedrake} using
-                  {PETSc-DMPlex}},
-  author =       {Lange, Michael and Mitchell, Lawrence and Knepley,
-                  Matthew G and Gorman, Gerard J},
-  journal =      {To appear in SIAM Journal on Scientific Computing},
-  archivePrefix ={arXiv},
-  eprint =       {1506.07749},
-  url =          {http://arxiv.org/abs/1506.07749},
-  year =         {2015}
-}
-
-@article{Rathgeber2015,
-  title={Firedrake: automating the finite element method by composing abstractions},
-  author={Rathgeber, Florian and Ham, David A and Mitchell, Lawrence and Lange, Michael and Luporini, Fabio and McRae, Andrew TT and Bercea, Gheorghe-Teodor and Markall, Graham R and Kelly, Paul HJ},
-  archivePrefix = "arXiv",
-  journal={Submitted to ACM TOMS},
-  eprint={1501.01809},
-  year={2015},
-  url = {http://arxiv.org/abs/1501.01809}
-}
-
-@article{McRae2015,
-  title =        {Automated generation and symbolic manipulation of
-                  tensor product finite elements},
-  author =       {McRae, Andrew TT and Bercea, Gheorge-Teodor and
-                  Mitchell, Lawrence and Ham, David A and Cotter,
-                  Colin J},
-  archivePrefix ="arXiv",
-  journal =      {Submitted to SIAM Journal on Scientific Computing},
-  eprint =       {1411.2940},
-  year =         {2015},
-  url =          {http://arxiv.org/abs/1411.2940}
-}
-
-
-
-@Article{Jacobs2015,
-AUTHOR = {Jacobs, C. T. and Piggott, M. D.},
-TITLE = {Firedrake-Fluids v0.1: numerical modelling of shallow water flows using an automated solution framework},
-JOURNAL = {Geoscientific Model Development},
-VOLUME = 8,
-YEAR = 2015,
-NUMBER = 3,
-PAGES = {533--547},
-URL = {http://www.geosci-model-dev.net/8/533/2015/},
-DOI = {10.5194/gmd-8-533-2015}
+  title =        {Variational water wave modelling: from continuum to
+                  experiment},
+  booktitle =    {Lectures on the theory of water waves},
+  year =         2016,
+  editor =       {Thomas J. Bridges and Mark D. Groves and David
+                  P. Nicholls},
+  volume =       426,
+  series =       {LMS Lecture Note Series},
+  pages =        {226--260},
+  publisher =    {Cambridge University Press},
+  url =
+                  {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf}
 }
 
 @Article{Cotter2014,
   author =       {Colin J. Cotter and Robert C. Kirby},
   title =        {Mixed finite elements for global tide models},
   journal =      {Numerische Mathematik},
-  pages =        {1--23},
   year =         2015,
+  pages =        {1--23},
   doi =          {10.1007/s00211-015-0748-z},
   url =          {http://arxiv.org/abs/1410.0045}
 }
 
-@article{Luporini2015,
- author = {Luporini, Fabio and Varbanescu, Ana Lucia and Rathgeber, Florian and Bercea, Gheorghe-Teodor and Ramanujam, J. and Ham, David A. and Kelly, Paul H. J.},
- title = {Cross-Loop Optimization of Arithmetic Intensity for Finite Element Local Assembly},
- journal = {ACM Trans. Archit. Code Optim.},
- issue_date = {January 2015},
- volume = {11},
- number = {4},
- month = jan,
- year = {2015},
- issn = {1544-3566},
- pages = {57:1--57:25},
- articleno = {57},
- numpages = {25},
- url = {http://doi.acm.org/10.1145/2687415},
- doi = {10.1145/2687415},
- acmid = {2687415},
- publisher = {ACM},
- address = {New York, NY, USA},
- keywords = {Finite element integration, SIMD vectorization, compilers, local assembly, optimizations},
-} 
+@Article{Cotter2015,
+  author =       {Colin J. Cotter and David A. Ham and Andrew
+                  T. T. McRae and Lawrence Mitchell and Andrea Natale},
+  title =        {On the shallow atmosphere approximation in finite
+                  element dynamical cores},
+  year =         2015,
+  url =          {http://arxiv.org/abs/1410.3069},
+  archiveprefix ={arXiv},
+  eprint =       {1410.3069}
+}
 
-@article{Markall2010,
-  title =        "Towards generating optimised finite element solvers
-                  for GPUs from high-level specifications",
-  journal =      "Procedia Computer Science",
-  volume =       "1",
-  number =       "1",
-  pages =        "1815 - 1823",
+@Article{Cotter2015a,
+  author =       {Colin J. Cotter and Dmitri Kuzmin},
+  title =        {Embedded discontinuous Galerkin transport schemes
+                  with localised limiters},
+  year =         2015,
+  archiveprefix ={arXiv},
+  eprint =       {1509.04431},
+  url =          {http://arxiv.org/abs/1509.04431}
+}
+
+@Article{Homolya2016,
+  author =       {Mikl\`os Homolya and David A. Ham},
+  title =        {A parallel edge orientation algorithm for
+                  quadrilateral meshes},
+  journal =      {To appear in SIAM Journal on Scientific Computing},
+  year =         2016,
+  archiveprefix ={arXiv},
+  eprint =       {1505.03357},
+  url =          {http://arxiv.org/abs/1505.03357}
+}
+
+@Article{Jacobs2015,
+  author =       {Christian T. Jacobs and Matthew D. Piggott},
+  title =        {{Firedrake-Fluids} v0.1: numerical modelling of
+                  shallow water flows using an automated solution
+                  framework},
+  journal =      {Geoscientific Model Development},
+  year =         2015,
+  volume =       8,
+  number =       3,
+  pages =        {533--547},
+  url =          {http://www.geosci-model-dev.net/8/533/2015/},
+  doi =          {10.5194/gmd-8-533-2015}
+}
+
+@Article{Lange2015,
+  author =       {Michael Lange and Lawrence Mitchell and Matthew
+                  G. Knepley and Gerard J. Gorman},
+  title =        {Efficient mesh management in {Firedrake} using
+                  {PETSc-DMPlex}},
+  journal =      {To appear in SIAM Journal on Scientific Computing},
+  year =         2015,
+  archiveprefix ={arXiv},
+  eprint =       {1506.07749},
+  url =          {http://arxiv.org/abs/1506.07749}
+}
+
+@Article{Luporini2015,
+  author =       {Fabio Luporini and Ana Lucia Varbanescu and Florian
+                  Rathgeber and Gheorghe-Teodor Bercea and
+                  J. Ramanujam and David A. Ham and Paul H. J. Kelly},
+  title =        {Cross-Loop Optimization of Arithmetic Intensity for
+                  Finite Element Local Assembly},
+  journal =      {ACM Transactions on Architecture and Code
+                  Optimization},
+  year =         2015,
+  volume =       11,
+  number =       4,
+  pages =        {57:1--57:25},
+  url =          {http://doi.acm.org/10.1145/2687415},
+  doi =          {10.1145/2687415},
+}
+
+@Article{Markall2010,
+  author =       {Graham R. Markall and David A. Ham and Paul
+                  H. J. Kelly},
+  title =        {Towards generating optimised finite element solvers
+                  for GPUs from high-level specifications},
+  journal =      {Procedia Computer Science},
   year =         2010,
-  note =         "{ICCS} 2010",
-  doi =          "10.1016/j.procs.2010.04.203",
-  url =          "http://dx.doi.org/10.1016/j.procs.2010.04.203",
-  author =       "Graham R. Markall and David A. Ham and Paul
-                  H. J. Kelly",
-  keywords =     "Finite element method",
-  keywords =     "GPU"
+  volume =       1,
+  number =       1,
+  pages =        {1815 - 1823},
+  note =         {{ICCS} 2010},
+  doi =          {10.1016/j.procs.2010.04.203},
+  url =          {http://dx.doi.org/10.1016/j.procs.2010.04.203},
+  keywords =     {Finite element method},
+  keywords =     {GPU}
 }
 
 @Article{Markall2012,
-  author =       {Markall, G. R. and Slemmer, A. and Ham, D. A. and Kelly, P. H. J. and Cantwell, C. D. and Sherwin, S. J.},
-  title =        {Finite element assembly strategies on multi- and many-core architectures},
-  journal =      {International Journal for Numerical Methods in Fluids},
+  author =       {Graham R. Markall and A. Slemmer and David A. Ham
+                  and Paul H. J. Kelly and Chris D. Cantwell and
+                  Spencer J. Sherwin},
+  title =        {Finite element assembly strategies on multi- and
+                  many-core architectures},
+  journal =      {International Journal for Numerical Methods in
+                  Fluids},
   year =         2013,
-  volume = 71,
-  pages = {80--97},
-  doi = {10.1002/fld.3648},
-  url =          "http://dx.doi.org/10.1002/fld.3648"}
+  volume =       71,
+  pages =        {80--97},
+  doi =          {10.1002/fld.3648},
+  url =          {http://dx.doi.org/10.1002/fld.3648}
+}
 
 @InProceedings{Markall2013,
-  author={Markall, Graham R. and Rathgeber, Florian and Mitchell, Lawrence and Loriant, Nicolas and Bertolli, Carlo and Ham, David A. and Kelly, Paul H.J.},
-  title =        {Performance-Portable Finite Element Assembly Using PyOP2 and FEniCS},
-  booktitle = {28th International Supercomputing Conference, ISC, Proceedings},
-  pages =     {279-289},
-  year =      2013,
-  editor={Kunkel, Julian Martin and Ludwig, Thomas and Meuer, Hans Werner},
-  volume =    7905,
-  series =    {Lecture Notes in Computer Science},
-  publisher = {Springer},
-  doi = {10.1007/978-3-642-38750-0_21},
-  url =          "http://dx.doi.org/10.1007/978-3-642-38750-0_21"
+  author =       {Graham R. Markall and Florian Rathgeber and Lawrence
+                  Mitchell and Nicolas Loriant and Carlo Bertolli and
+                  David A. Ham and Paul H. J. Kelly},
+  title =        {Performance-Portable Finite Element Assembly Using
+                  PyOP2 and FEniCS},
+  booktitle =    {28th International Supercomputing Conference, ISC,
+                  Proceedings},
+  year =         2013,
+  editor =       {Kunkel, Julian Martin and Ludwig, Thomas and Meuer,
+                  Hans Werner},
+  volume =       7905,
+  series =       {Lecture Notes in Computer Science},
+  pages =        {279-289},
+  publisher =    {Springer},
+  doi =          {10.1007/978-3-642-38750-0_21},
+  url =          {http://dx.doi.org/10.1007/978-3-642-38750-0_21}
+}
+
+@Article{McRae2014,
+  author =       {Andrew T. T. McRae and Gheorghe-Teodor Bercea and
+                  Lawrence Mitchell and David A. Ham and Colin
+                  J. Cotter},
+  title =        {Automated generation and symbolic manipulation of
+                  tensor product finite elements},
+  journal =      {Submitted to SIAM Journal on Scientific Computing},
+  year =         2014,
+  archiveprefix ={arXiv},
+  eprint =       {1411.2940},
+  url =          {http://arxiv.org/abs/1411.2940}
 }
 
 @InProceedings{Rathgeber2012,
-author = {Florian Rathgeber and Graham R. Markall and Lawrence Mitchell and Nicolas Loriant and David A. Ham and Carlo Bertolli and Paul H.J. Kelly},
-title = {PyOP2: A High-Level Framework for Performance-Portable Simulations on Unstructured Meshes},
-booktitle ={High Performance Computing, Networking Storage and Analysis, SC Companion:},
-isbn = {978-1-4673-3049-7},
-year = {2012},
-pages = {1116-1123},
-doi = {10.1109/SC.Companion.2012.134},
-publisher = {IEEE Computer Society},
-address = {Los Alamitos, CA, USA},
-  url =          "http://dx.doi.org/10.1109/SC.Companion.2012.134"
+  author =       {Florian Rathgeber and Graham R. Markall and Lawrence
+                  Mitchell and Nicolas Loriant and David A. Ham and
+                  Carlo Bertolli and Paul H. J. Kelly},
+  title =        {PyOP2: A High-Level Framework for
+                  Performance-Portable Simulations on Unstructured
+                  Meshes},
+  booktitle =    {High Performance Computing, Networking Storage and
+                  Analysis, SC Companion:},
+  year =         2012,
+  pages =        {1116-1123},
+  address =      {Los Alamitos, CA, USA},
+  publisher =    {IEEE Computer Society},
+  isbn =         {978-1-4673-3049-7},
+  doi =          {10.1109/SC.Companion.2012.134},
+  url =          {http://dx.doi.org/10.1109/SC.Companion.2012.134}
+}
+
+@Article{Rathgeber2015,
+  author =       {Florian Rathgeber and David A. Ham and Lawrence
+                  Mitchell and Michael Lange and Fabio Luporini and
+                  Andrew T. T. McRae and Gheorghe-Teodor Bercea and
+                  Graham R. Markall and Paul H. J. Kelly},
+  title =        {Firedrake: automating the finite element method by
+                  composing abstractions},
+  journal =      {Submitted to ACM TOMS},
+  year =         2015,
+  archiveprefix ={arXiv},
+  eprint =       {1501.01809},
+  url =          {http://arxiv.org/abs/1501.01809}
 }

--- a/docs/source/_themes/firedrake/static/fenics.css_t
+++ b/docs/source/_themes/firedrake/static/fenics.css_t
@@ -109,6 +109,17 @@ div.related ul {
 	padding-left: 240px;
 }
 
+/* Formatting for sphinx-bibtex generated tables */
+table.citation {
+    border: none;
+}
+
+/* Override some bibbase styles that make things look ugly. */
+td.label {
+    background: inherit;
+    font-weight: normal;
+    text-shadow: none;
+}
 /* -- sidebars -------------------------------------------------------------- */
 
 div.sidebar {

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -2,11 +2,56 @@
 Firedrake and PyOP2 publications
 ================================
 
-Some useful slides from a talk on PyOP2 and Firedrake at Compilers for Parallel Computers are 
-`here <http://florianrathgeber.me/CPC2013/>`_.
+Citing Firedrake
+----------------
+
+If you publish results using Firedrake, we would be grateful if you
+would cite the relevant papers.  The simplest way to determine what
+these are is by asking Firedrake itself.  You can ask that a list of
+citations relevant to your computation be printed when exiting by calling
+:meth:`.Citations.print_at_exit` after importing Firedrake::
+
+  from firedrake import *
+
+  Citations.print_at_exit()
+
+Alternatively, you can select that this should occur by passing the
+command-line option ``-citations``.  In both cases, you will also
+obtain the correct `citations for PETSc
+<http://www.mcs.anl.gov/petsc/documentation/referencing.html>`_.
+
+If you cannot use this approach, there are a number of papers.  Those
+which are relevant depend a little on which functionality you used.
+
+For Firedrake itself, please cite :cite:`Rathgeber2015`.  If you use
+the :doc:`extruded mesh </extruded-meshes>` functionality, or
+quadrilateral meshes, please cite :cite:`McRae2014`.  Additionally,
+when using quadrilateral meshes, please also cite :cite:`Homolya2016`.
+
+If your work relies on the kernel-level performance optimisations that
+Firedrake performs using `COFFEE
+<http://github.com/coneoproject/COFFEE>`_, please cite the
+COFFEE paper :cite:`Luporini2015`.
+
+.. bibliography:: _static/bibliography.bib
+
+Citing other packages
+~~~~~~~~~~~~~~~~~~~~~
+
+Firedrake relies heavily on PETSc, which you should cite
+`appropriately
+<http://www.mcs.anl.gov/petsc/documentation/referencing.html>`_.
+Additionally, if you talk about UFL in your work, please cite the `UFL
+paper <http://fenicsproject.org/citing/#ufl>`_.
+
 
 Journal papers and conference proceedings about or using Firedrake
 ------------------------------------------------------------------
+
+.. rst-class:: emphasis
+
+   If you have published work using Firedrake that does not appear
+   below, we would :doc:`love to hear about it </contact>`.
 
 .. raw:: html
 

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -31,6 +31,7 @@ from pyop2 import op2                                           # noqa
 from firedrake.assemble import *
 from firedrake.bcs import *
 from firedrake.checkpointing import *
+from firedrake.citations import *
 from firedrake.constant import *
 from firedrake.expression import *
 from firedrake.function import *

--- a/firedrake/citations.py
+++ b/firedrake/citations.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+from firedrake.petsc import PETSc
+
+
+__all__ = ["Citations"]
+
+
+class Citations(dict):
+
+    """Entry point to citations management.
+
+    This singleton object may be used to record Bibtex citation
+    information and then register that a particular citation is
+    relevant for a particular computation.  It hooks up with PETSc's
+    citation registration mechanism, so that running with
+    ``-citations`` does the right thing.
+
+    Example usage::
+
+        Citations().add("key", "bibtex-entry-for-my-funky-method")
+
+        ...
+
+        if using_funky_method:
+            Citations().register("key")
+    """
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(Citations, cls).__new__(cls)
+
+        return cls._instance
+
+    def add(self, key, entry):
+        """Add a paper to the database of possible citations.
+
+        :arg key: The key to use.
+        :arg entry: The bibtex entry.
+        """
+        self[key] = entry
+
+    def register(self, key):
+        """Register a paper to be cited so that PETSc knows about it.
+
+        :arg key: The key of the relevant citation.
+
+        :raises: :exc:`~.exceptions.KeyError` if no such citation is
+            found in the database.
+
+        Papers to be cited can be added using :meth:`add`.
+
+        .. note::
+
+           The intended use is that :meth:`register` should be called
+           only when the referenced functionality is actually being
+           used.
+        """
+        cite = self.get(key, None)
+        if cite is None:
+            raise KeyError("Did not find a citation for '%s', did you forget to add it?" % key)
+        PETSc.Sys.registerCitation(cite)
+
+    @classmethod
+    def print_at_exit(cls):
+        """Print citations when exiting."""
+        # We devolve to PETSc for actually printing citations.
+        PETSc.Options()["citations"] = None
+
+
+Citations().add("Rathgeber2015", """
+@Article{Rathgeber2015,
+  author =       {Florian Rathgeber and David A. Ham and Lawrence
+                  Mitchell and Michael Lange and Fabio Luporini and
+                  Andrew T. T. McRae and Gheorghe-Teodor Bercea and
+                  Graham R. Markall and Paul H. J. Kelly},
+  title =        {Firedrake: automating the finite element method by
+                  composing abstractions},
+  journal =      {Submitted to ACM TOMS},
+  year =         2015,
+  archiveprefix ={arXiv},
+  eprint =       {1501.01809},
+  url =          {http://arxiv.org/abs/1501.01809}
+}
+""")
+
+# Register the firedrake paper for citations
+Citations().register("Rathgeber2015")
+
+# The rest are all registered only when using appropriate functionality.
+Citations().add("McRae2014", """
+@Article{McRae2014,
+  author =       {Andrew T. T. McRae and Gheorghe-Teodor Bercea and
+                  Lawrence Mitchell and David A. Ham and Colin
+                  J. Cotter},
+  title =        {Automated generation and symbolic manipulation of
+                  tensor product finite elements},
+  journal =      {Submitted to SIAM Journal on Scientific Computing},
+  year =         2014,
+  archiveprefix ={arXiv},
+  eprint =       {1411.2940},
+  url =          {http://arxiv.org/abs/1411.2940}
+}
+""")
+
+Citations().add("Homolya2016", """
+@Article{Homolya2016,
+  author =       {Mikl\`os Homolya and David A. Ham},
+  title =        {A parallel edge orientation algorithm for
+                  quadrilateral meshes},
+  journal =      {To appear in SIAM Journal on Scientific Computing},
+  year =         2016,
+  archiveprefix ={arXiv},
+  eprint =       {1505.03357},
+  url =          {http://arxiv.org/abs/1505.03357}
+}
+""")
+
+Citations().add("Luporini2015", """
+@Article{Luporini2015,
+  author =       {Fabio Luporini and Ana Lucia Varbanescu and Florian
+                  Rathgeber and Gheorghe-Teodor Bercea and
+                  J. Ramanujam and David A. Ham and Paul H. J. Kelly},
+  title =        {Cross-Loop Optimization of Arithmetic Intensity for
+                  Finite Element Local Assembly},
+  journal =      {ACM Transactions on Architecture and Code
+                  Optimization},
+  year =         2015,
+  volume =       11,
+  number =       4,
+  pages =        {57:1--57:25},
+  url =          {http://doi.acm.org/10.1145/2687415},
+  doi =          {10.1145/2687415},
+}
+""")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -423,6 +423,9 @@ class MeshTopology(object):
                                            cell_numbering, entity_per_cell)
 
         elif cell.cellname() == "quadrilateral":
+            from firedrake.citations import Citations
+            Citations().register("Homolya2016")
+            Citations().register("McRae2014")
             # Quadrilateral mesh
             cell_ranks = dmplex.get_cell_remote_ranks(plex)
 
@@ -585,6 +588,8 @@ class ExtrudedMeshTopology(MeshTopology):
         :arg layers:         number of extruded cell layers in the "vertical"
                              direction.
         """
+        from firedrake.citations import Citations
+        Citations().register("McRae2014")
         # A cache of function spaces that have been built on this mesh
         self._cache = {}
 

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 
 from ffc import default_parameters
 from pyop2.configuration import configuration
+from firedrake.citations import Citations
+
 
 __all__ = ['Parameters', 'parameters', 'disable_performance_optimisations']
 
@@ -32,6 +34,12 @@ class Parameters(dict):
     def rename(self, name):
         self._name = name
 
+    def __getstate__(self):
+        # Remove non-picklable update function slot
+        d = self.__dict__.copy()
+        del d["_update_function"]
+        return d
+
     def set_update_function(self, callable):
         """Set a function to be called whenever a dictionary entry is changed.
 
@@ -54,6 +62,9 @@ parameters.add(Parameters("assembly_cache",
 
 parameters.add(Parameters("coffee",
                           O2=True))
+
+# Spew citation for coffee paper if user modifies coffee options.
+parameters["coffee"].set_update_function(lambda k, v: Citations().register("Luporini2015"))
 
 # Default to the values of PyOP2 configuration dictionary
 pyop2_opts = Parameters("pyop2_options",


### PR DESCRIPTION
Plug in to PETSc's automagic citations mechanism so that Firedrake can report at exit the correct set of papers to cite.  Also mention citing firedrake on the webpage.  Additionally, rationalise bibliography (fix some formatting and name errors).

Needs https://bitbucket.org/petsc/petsc4py/pull-requests/65/expose-petsccitationsregister-as/diff first.