### PR TITLE
Travis & install script fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
         - liblapack-dev
         - gfortran
         - libspatialindex-dev
-        - swig
         - gmsh
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,9 @@ install:
   # Having activated the virtualenv, attempt to save cached dependencies
   # This saves PETSc and petsc4py to speed up building
   - (cd firedrake; ../../scripts/firedrake-install --write-cache)
-  - cd firedrake/src/firedrake
-  - if git fetch origin pull/$TRAVIS_PULL_REQUEST/merge; then git checkout FETCH_HEAD; else git checkout $TRAVIS_COMMIT; fi
-  - python setup.py build_ext --inplace
 # command to run tests
 script:
+  - cd firedrake/src/firedrake
+  - python setup.py build_ext --inplace
   - make lint
   - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -676,6 +676,17 @@ if mode == "install":
     os.chdir("src")
 
     git_clone("git+https://github.com/firedrakeproject/firedrake.git")
+    if travis:
+        travis_pull_request = os.environ["TRAVIS_PULL_REQUEST"]
+        travis_commit = os.environ["TRAVIS_COMMIT"]
+        os.chdir("firedrake")
+        if travis_pull_request != "false":
+            check_call(["git", "fetch", "origin", "pull/" + travis_pull_request + "/merge"])
+            check_call(["git", "checkout", "FETCH_HEAD"])
+        else:
+            check_call(["git", "checkout", travis_commit])
+        os.chdir("..")
+
     packages = clone_dependencies("firedrake")
     packages = clone_dependencies("PyOP2") + packages
     packages += ["firedrake"]


### PR DESCRIPTION
The install script always installs the dependencies of master on Travis.

We don't need SWIG anymore.

@dham: please review.