### PR TITLE
Make firedrake-install usable on travis outside firedrake repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     - CC=mpicc
     # The install script expects to see this environment variable
     - CACHE_DIRECTORY=$HOME/cached_dependencies_$TRAVIS_OS_NAME
+    - FIREDRAKE_TRAVIS_TESTS=1
   matrix:
     - PYOP2_BACKEND=none
 matrix:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -24,6 +24,7 @@ branches = {}
 
 # Disgusting hack, are we running on travis?
 travis = "TRAVIS" in os.environ
+travis_testing_firedrake = "FIREDRAKE_TRAVIS_TESTS" in os.environ
 travis_cache_dir = os.environ.get("CACHE_DIRECTORY", None)
 
 if mode == "install":
@@ -676,7 +677,7 @@ if mode == "install":
     os.chdir("src")
 
     git_clone("git+https://github.com/firedrakeproject/firedrake.git")
-    if travis:
+    if travis and travis_testing_firedrake:
         travis_pull_request = os.environ["TRAVIS_PULL_REQUEST"]
         travis_commit = os.environ["TRAVIS_COMMIT"]
         os.chdir("firedrake")


### PR DESCRIPTION
Other users may wish to run firedrake-install on travis, in this case,
we shouldn't attempt to checkout a commit specified by travis.