### PR TITLE
Add license file (LGPLv3 or later)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Firedrake is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+Firedrake is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with Firedrake. If not, see <http://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -10,3 +10,13 @@ License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with Firedrake. If not, see <http://www.gnu.org/licenses/>.
+
+Included packages:
+
+Firedrake includes two third-party packages:
+
+- evtk (in source directory evtk)
+- pylit (in source directory pylit)
+
+Please see, respectively, evtk/LICENSE and pylit/README.rst for their
+respective licenses.


### PR DESCRIPTION
I have not added in the full GNU COPYING and COPYING.LESSER files.  Should I?  I make no reference to the licenses of the bundled pylit and evtk, (GPLv2 or later, GPLv3 or later respectively).