### PR TITLE
Interpolate arbitrary UFL expressions

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -66,6 +66,7 @@ finite element problems in Firedrake.
    boundary_conditions
    extruded-meshes
    mesh-coordinates
+   interpolation
    point-evaluation
    checkpointing
    petsc-interface

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -52,13 +52,6 @@ virtualenv_ as above and then run::
   cd firedrake/src/firedrake
   make alltest
 
-.. note::
-
-   At present, ``make alltest`` will return three test failures, see
-   https://github.com/firedrakeproject/firedrake/issues/531 for
-   details.  However, firedrake is nonetheless functional at this
-   point.
-
 
 System requirements
 -------------------

--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -1,0 +1,143 @@
+.. only:: html
+
+  .. contents::
+
+Interpolation
+=============
+
+Firedrake offers various ways to interpolate expressions onto fields
+(:py:class:`~.Function`\s).  Interpolation is often used to set up
+initial conditions and/or boundary conditions. The basic syntax for
+interpolation is:
+
+.. code-block:: python
+
+   # create new function f on function space V
+   f = interpolate(expression, V)
+
+   # alternatively:
+   f = Function(V).interpolate(expression)
+
+   # setting the values of an existing function
+   f.interpolate(expression)
+
+.. warning::
+
+   Interpolation currently only works if all nodes of the target
+   finite element are point evaluation nodes.
+
+Firedrake offers three ways to specify the source expression:
+
+
+C string expressions
+--------------------
+
+The :py:class:`~.Expression` class wraps a C string expression,
+e.g. ``Expression("sin(x[0]*pi)")``, which is then copy-pasted into
+the interpolation kernel.  Consequently, C syntax rules apply inside
+the string, with the following "environment":
+
+* The physical spatial coordinate is available as "vector" ``x``
+  (array in C), i.e. the coordinates `x`, `y`, and `z` are accessed as
+  ``x[0]``, ``x[1]``, and ``x[2]``.
+* The mathematical constant :math:`{\pi}` is available as ``pi``.
+* Mathematical functions from the C header `math.h`_.
+
+It is possible to augment this environment.  For example,
+``Expression('sin(x[0]*t)', t=t)`` takes the value from the Python
+variable ``t``, and uses that value for ``t`` inside the C string.
+
+
+Python expression classes
+-------------------------
+
+One can subclass :py:class:`~.Expression` and define a Python method
+``eval`` on the subclass.  An example usage:
+
+.. code-block:: python
+
+   class MyExpression(Expression):
+       def eval(self, value, x):
+           value[:] = numpy.dot(x, x)
+
+       def value_shape(self):
+           return (1,)
+
+   f.interpolate(MyExpression())
+
+Here the arguments ``value`` and ``x`` of ``eval`` are `numpy` arrays.
+``x`` contains the physical coordinates, and the result of the
+expression must be written into ``value``.  One *must not reassign*
+the local variable ``value``, but *overwrite* its content.
+
+
+UFL expressions
+---------------
+
+Using UFL_ expressions is the most general way that Firedrake offers
+to specify the source expression of an interpolation.  This option
+allows the source expressions to contain:
+
+* other :py:class:`~.Function`\s,
+* derivatives of :py:class:`~.Function`\s,
+* :py:class:`~.Constant`\s,
+* compound expressions involving any of the above.
+
+One can rewrite any of the above examples using UFL_:
+
+.. code-block:: python
+
+   # Expression:
+   f = interpolate(Expression("sin(x[0]*pi)"), V)
+
+   # UFL equivalent:
+   x = SpatialCoordinate(V.mesh())
+   f = interpolate(sin(x[0] * math.pi), V)
+
+   # Expression with a Constant parameter:
+   f = interpolate(Expression('sin(x[0]*t)', t=t), V)
+
+   # UFL equivalent:
+   x = SpatialCoordinate(V.mesh())
+   f = interpolate(sin(x[0] * t), V)
+
+   # Python expression:
+   class MyExpression(Expression):
+       def eval(self, value, x):
+           value[:] = numpy.dot(x, x)
+
+       def value_shape(self):
+           return (1,)
+
+   f.interpolate(MyExpression())
+
+   # UFL equivalent:
+   x = SpatialCoordinate(f.function_space().mesh())
+   f.interpolate(dot(x, x))
+
+As mentioned above, one can have :py:class:`~.Function`\s in UFL
+expressions for interpolation.  Here is an example which has no
+equivalent using C strings or Python expression classes:
+
+.. code-block:: python
+
+   # g is a vector-valued Function, e.g. on an H(div) function space
+   f = interpolate(sqrt(3.2 * div(g)), V)
+
+
+.. note::
+
+   UFL expressions are type checked, and thus safer to use than C
+   strings, which rely on string manipulation to assemble the
+   interpolation kernel.
+
+.. note::
+
+   UFL expressions have good run-time performance (unlike Python
+   expression classes), since they are translated to C interpolation
+   kernels using TSFC_ technology.
+
+
+.. _math.h: http://en.cppreference.com/w/c/numeric/math
+.. _UFL: https://bitbucket.org/mapdes/ufl
+.. _TSFC: https://github.com/firedrakeproject/tsfc

--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -589,7 +589,7 @@ we can write:
 
 .. code-block:: python
 
-   e = Expression('sin(x[0]*t'), t=t)
+   e = Expression('sin(x[0]*t)', t=t)
    bc = DirichletBC(V, e, 1)
    while t < T:
        solve(F == 0, bcs=[bc])

--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -368,7 +368,7 @@ we will populate with the x component of the coordinate field.
 
 For details on how :py:class:`~.Expression`\s and
 :py:meth:`~.Function.interpolate` work, see the
-:doc:`appropriate section in the manual <expressions>`.  The
+:doc:`appropriate section in the manual <interpolation>`.  The
 variational problem is to find :math:`u \in V` such that
 
 .. math::

--- a/firedrake/expression.py
+++ b/firedrake/expression.py
@@ -207,6 +207,10 @@ class Expression(ufl.Coefficient):
         """
         return self._shape
 
+    @property
+    def ufl_shape(self):
+        return self.value_shape()
+
 
 def to_expression(val, **kwargs):
     """Convert val to an :class:`Expression`.

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -26,7 +26,7 @@ def test_function():
 def test_coordinates(cg2):
     f = interpolate(Expression("x[0]*x[0]"), cg2)
 
-    x = cg2.mesh().coordinates
+    x = SpatialCoordinate(cg2.mesh())
     g = interpolate(x[0]*x[0], cg2)
 
     assert np.allclose(f.dat.data, g.dat.data)
@@ -73,7 +73,7 @@ def test_constant_expression():
 
 def test_compound_expression():
     m = UnitTriangleMesh()
-    x = m.coordinates
+    x = SpatialCoordinate(m)
     U = FunctionSpace(m, 'RT', 2)
     V = FunctionSpace(m, 'P', 2)
 
@@ -87,19 +87,19 @@ def test_compound_expression():
 
 
 def test_cell_orientation():
-    m = UnitCubedSphereMesh(1)
+    m = UnitCubedSphereMesh(2)
     m.init_cell_orientations(Expression(('x[0]', 'x[1]', 'x[2]')))
     x = m.coordinates
     U = FunctionSpace(m, 'RTCF', 1)
-    V = VectorFunctionSpace(m, 'Q', 1)
+    V = VectorFunctionSpace(m, 'DQ', 1)
 
     f = project(as_tensor([x[1], -x[0], 0.0]), U)
     g = interpolate(f, V)
 
-    # g shall be equivalent to:
-    h = interpolate(f, V)
+    # g shall be close to:
+    h = project(f, V)
 
-    assert np.allclose(g.dat.data, h.dat.data)
+    assert abs(g.dat.data - h.dat.data).max() < 1e-2
 
 
 def test_mixed():

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -1,0 +1,90 @@
+import pytest
+import numpy as np
+from firedrake import *
+from tests.common import *
+
+
+def test_constant(cg1):
+    f = interpolate(Constant(1.0), cg1)
+    assert np.allclose(1.0, f.dat.data)
+
+
+def test_function():
+    m = UnitTriangleMesh()
+    V1 = FunctionSpace(m, 'P', 1)
+    V2 = FunctionSpace(m, 'P', 2)
+
+    f = interpolate(Expression("x[0]*x[0]"), V1)
+    g = interpolate(f, V2)
+
+    # g shall be equivalent to:
+    h = interpolate(Expression("x[0]"), V2)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_coordinates(cg2):
+    f = interpolate(Expression("x[0]*x[0]"), cg2)
+
+    x = cg2.mesh().coordinates
+    g = interpolate(x[0]*x[0], cg2)
+
+    assert np.allclose(f.dat.data, g.dat.data)
+
+
+def test_piola():
+    m = UnitTriangleMesh()
+    U = FunctionSpace(m, 'RT', 1)
+    V = FunctionSpace(m, 'P', 2)
+
+    f = project(Expression(("x[0]", "0.0")), U)
+    g = interpolate(f[0], V)
+
+    # g shall be equivalent to:
+    h = project(f[0], V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_vector():
+    m = UnitTriangleMesh()
+    U = FunctionSpace(m, 'RT', 1)
+    V = VectorFunctionSpace(m, 'P', 2)
+
+    f = project(Expression(("x[0]", "0.0")), U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = project(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_constant_expression():
+    m = UnitTriangleMesh()
+    U = FunctionSpace(m, 'RT', 1)
+    V = FunctionSpace(m, 'P', 2)
+
+    f = project(Expression(("x[0]", "x[1]")), U)
+    g = interpolate(div(f), V)
+
+    assert np.allclose(2.0, g.dat.data)
+
+
+def test_compound_expression():
+    m = UnitTriangleMesh()
+    x = m.coordinates
+    U = FunctionSpace(m, 'RT', 2)
+    V = FunctionSpace(m, 'P', 2)
+
+    f = project(Expression(("x[0]", "x[1]")), U)
+    g = interpolate(Constant(1.5)*div(f) + sin(x[0] * np.pi), V)
+
+    # g shall be equivalent to:
+    h = interpolate(Expression("3.0 + sin(pi * x[0])"), V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -85,6 +85,22 @@ def test_compound_expression():
 
     assert np.allclose(g.dat.data, h.dat.data)
 
+
+def test_cell_orientation():
+    m = UnitCubedSphereMesh(1)
+    m.init_cell_orientations(Expression(('x[0]', 'x[1]', 'x[2]')))
+    x = m.coordinates
+    U = FunctionSpace(m, 'RTCF', 1)
+    V = VectorFunctionSpace(m, 'Q', 1)
+
+    f = project(as_tensor([x[1], -x[0], 0.0]), U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = interpolate(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -101,6 +101,21 @@ def test_cell_orientation():
 
     assert np.allclose(g.dat.data, h.dat.data)
 
+
+def test_mixed():
+    m = UnitTriangleMesh()
+    x = m.coordinates
+    V1 = FunctionSpace(m, 'BDFM', 2)
+    V2 = VectorFunctionSpace(m, 'P', 2)
+    f = Function(V1 * V2)
+    f.sub(0).project(as_tensor([x[1], -x[0]]))
+    f.sub(1).interpolate(as_tensor([x[0], x[1]]))
+
+    V = FunctionSpace(m, 'P', 1)
+    g = interpolate(dot(grad(f[0]), grad(f[3])), V)
+
+    assert np.allclose(1.0, g.dat.data)
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Implementation of #711. Fixes #526 and #485.

Target space is still limited to finite elements which have point evaluation nodes only. Uses TSFC technology to evaluate arbitrary UFL expressions at those points. ~~Depends on firedrakeproject/tsfc#22.~~

Comes with tests, of course.