### PR TITLE
DMPlex: Performance bug fix for facet loop iteration space

### DIFF
--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -795,20 +795,43 @@ def get_entity_classes(PETSc.DM plex):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_facets_by_class(PETSc.DM plex, label):
+def get_facet_ordering(PETSc.DM plex, PETSc.Section facet_numbering):
+    """Builds a list of all facets ordered according to the given numbering.
+
+    :arg plex: The DMPlex object encapsulating the mesh topology
+    :arg facet_numbering: A Section describing the global facet numbering
+    """
+    cdef:
+        PetscInt fi, fStart, fEnd, offset
+        np.ndarray[np.int32_t, ndim=1, mode="c"] facets
+
+    size = facet_numbering.getStorageSize()
+    facets = np.empty(size, dtype=np.int32)
+    fStart, fEnd = plex.getHeightStratum(1)
+    for fi in range(fStart, fEnd):
+        CHKERR(PetscSectionGetOffset(facet_numbering.sec, fi, &offset))
+        facets[offset] = fi
+    return facets
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_facets_by_class(PETSc.DM plex, label,
+                        np.ndarray[np.int32_t, mode="c"] ordering):
     """Builds a list of all facets ordered according to OP2 entity
     classes and computes the respective class offsets.
 
     :arg plex: The DMPlex object encapsulating the mesh topology
+    :arg ordering: An array giving the global traversal order of facets
     :arg label: Label string that marks the facets to order
     """
     cdef:
-        PetscInt dim, fi, ci, nfacets, nclass, lbl_val, fStart, fEnd
+        PetscInt dim, fi, ci, nfacets, nclass, lbl_val, f, fStart, fEnd
         PetscInt *indices = NULL
         PETSc.IS class_is = None
         char *class_chr = NULL
-        PetscBool has_point
-        DMLabel lbl_facets
+        PetscBool has_point, is_class
+        DMLabel lbl_facets, lbl_class
         np.ndarray[np.int32_t, ndim=1, mode="c"] facets
 
     label_chr = <char*>label
@@ -825,18 +848,15 @@ def get_facets_by_class(PETSc.DM plex, label):
                                   "op2_non_core",
                                   "op2_exec_halo",
                                   "op2_non_exec_halo"]):
+        CHKERR(DMPlexGetLabel(plex.dm, op2class, &lbl_class))
         nclass = plex.getStratumSize(op2class, 1)
         if nclass > 0:
-            class_is = plex.getStratumIS(op2class, 1)
-            CHKERR(ISGetIndices(class_is.iset, &indices))
-            for ci in range(nclass):
-                if fStart <= indices[ci] < fEnd:
-                    CHKERR(DMLabelHasPoint(lbl_facets, indices[ci],
-                                           &has_point))
-                    if has_point:
-                        facets[fi] = indices[ci]
-                        fi += 1
-            CHKERR(ISRestoreIndices(class_is.iset, &indices))
+            for f in ordering:
+                CHKERR(DMLabelHasPoint(lbl_facets, f, &has_point))
+                CHKERR(DMLabelHasPoint(lbl_class, f, &is_class))
+                if has_point and is_class:
+                    facets[fi] = f
+                    fi += 1
         facet_classes[i] = fi
 
     return facets, facet_classes

--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -817,7 +817,7 @@ def get_facet_ordering(PETSc.DM plex, PETSc.Section facet_numbering):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def get_facets_by_class(PETSc.DM plex, label,
-                        np.ndarray[np.int32_t, mode="c"] ordering):
+                        np.ndarray[np.int32_t, ndim=1, mode="c"] ordering):
     """Builds a list of all facets ordered according to OP2 entity
     classes and computes the respective class offsets.
 
@@ -826,7 +826,7 @@ def get_facets_by_class(PETSc.DM plex, label,
     :arg label: Label string that marks the facets to order
     """
     cdef:
-        PetscInt dim, fi, ci, nfacets, nclass, lbl_val, f, fStart, fEnd
+        PetscInt dim, fi, ci, nfacets, nclass, lbl_val, o, f, fStart, fEnd
         PetscInt *indices = NULL
         PETSc.IS class_is = None
         char *class_chr = NULL
@@ -851,7 +851,8 @@ def get_facets_by_class(PETSc.DM plex, label,
         CHKERR(DMPlexGetLabel(plex.dm, op2class, &lbl_class))
         nclass = plex.getStratumSize(op2class, 1)
         if nclass > 0:
-            for f in ordering:
+            for o in range(ordering.shape[0]):
+                f = ordering[o]
                 CHKERR(DMLabelHasPoint(lbl_facets, f, &has_point))
                 CHKERR(DMLabelHasPoint(lbl_class, f, &is_class))
                 if has_point and is_class:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -367,6 +367,11 @@ class MeshTopology(object):
                 self._vertex_numbering = self._plex.createSection([1], entity_dofs,
                                                                   perm=self._plex_renumbering)
 
+                entity_dofs[:] = 0
+                entity_dofs[-2] = 1
+                facet_numbering = self._plex.createSection([1], entity_dofs,
+                                                           perm=self._plex_renumbering)
+                self._facet_ordering = dmplex.get_facet_ordering(self._plex, facet_numbering)
         self._callback = callback
 
     def init(self):
@@ -453,7 +458,8 @@ class MeshTopology(object):
 
             # Order exterior facets by OP2 entity class
             exterior_facets, exterior_facet_classes = \
-                dmplex.get_facets_by_class(self._plex, "exterior_facets")
+                dmplex.get_facets_by_class(self._plex, "exterior_facets",
+                                           self._facet_ordering)
 
             # Derive attached boundary IDs
             if self._plex.hasLabel("boundary_ids"):
@@ -490,7 +496,8 @@ class MeshTopology(object):
 
             # Order interior facets by OP2 entity class
             interior_facets, interior_facet_classes = \
-                dmplex.get_facets_by_class(self._plex, "interior_facets")
+                dmplex.get_facets_by_class(self._plex, "interior_facets",
+                                           self._facet_ordering)
 
             interior_local_facet_number, interior_facet_cell = \
                 dmplex.facet_numbering(self._plex, "interior",


### PR DESCRIPTION
This merge fixes a performance bug whereby the iteration order of facet loops did not agree with the data layout in the generated Dats. The reason for this was that we used to generate the facet-to-dof maps from DMLabels that do not implicitly honour the permutation we attach to the DMPlex. Instead we now generate a global facet numbering through petsc sections that do honour the permutation and derive the ordering for facet sets accordingly. 