### PR TITLE
Projector does not create a solver in trivial projection case

### DIFF
--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -211,6 +211,28 @@ def test_projector():
     assert(np.abs(mass1-mass2) < 1.0e-10)
 
 
+def test_trivial_projector():
+    m = UnitSquareMesh(2, 2)
+    Vc = FunctionSpace(m, "CG", 2)
+    v = Function(Vc).interpolate(Expression("x[0]*x[1] + cos(x[0]+x[1])"))
+    mass1 = assemble(v*dx)
+
+    vo = Function(Vc)
+
+    P = Projector(v, vo)
+    P.project()
+
+    mass2 = assemble(vo*dx)
+    assert(np.abs(mass1-mass2) < 1.0e-10)
+
+    v.interpolate(Expression("x[1] + exp(x[0]+x[1])"))
+    mass1 = assemble(v*dx)
+
+    P.project()
+    mass2 = assemble(vo*dx)
+    assert(np.abs(mass1-mass2) < 1.0e-10)
+
+
 def test_projector_expression():
     mesh = UnitSquareMesh(2, 2)
     V = FunctionSpace(mesh, "CG", 1)


### PR DESCRIPTION
Projector reverts to assign operator if input and output functions belong to the same function space. This is useful in cases when there's a lot of functions and it's difficult to keep track of their function spaces.