### PR TITLE
Functionspace cleanup

### DIFF
--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -167,19 +167,6 @@ def get_map_caches(mesh, entity_dofs):
 
 
 @cached
-def get_dof_layout_vec(mesh, dof_dset, V):
-    """Get the PETSc Vec describing the dof layout.
-
-    :arg mesh: The mesh to use.
-    :arg dof_dset: The :class:`pyop2.DataSet` describing the data
-        layout.
-    :arg V: The :class:`~.FunctionSpace` that can create a :class:`pyop2.Dat`
-    """
-    with V.make_dat().vec_ro as v:
-        return v.duplicate()
-
-
-@cached
 def get_dof_offset(mesh, key, entity_dofs, ndof):
     """Get the dof offsets.
 

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -211,8 +211,7 @@ class FunctionSpace(object):
         dm.setAttr('__fs__', weakref.ref(self))
         dm.setPointSF(self.mesh()._plex.getPointSF())
         dm.setDefaultSection(self._shared_data.global_numbering)
-        from firedrake.functionspacedata import get_dof_layout_vec
-        dm.setGlobalVector(get_dof_layout_vec(self.mesh(), self.dof_dset, self))
+        dm.setGlobalVector(self.dof_dset.layout_vec)
         return dm
 
     @utils.cached_property
@@ -595,8 +594,7 @@ class MixedFunctionSpace(object):
         dm.setAttr('__fs__', weakref.ref(self))
         dm.setCreateFieldDecomposition(self.create_field_decomp)
         dm.setCreateSubDM(self.create_subdm)
-        from firedrake.functionspacedata import get_dof_layout_vec
-        dm.setGlobalVector(get_dof_layout_vec(self.mesh(), self.dof_dset, self))
+        dm.setGlobalVector(self.dof_dset.layout_vec)
         return dm
 
     @utils.cached_property

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -4,28 +4,6 @@ from decorator import decorator
 from pyop2.utils import cached_property  # noqa: imported from here elsewhere
 
 
-# after https://micheles.googlecode.com/hg/decorator/documentation.html and
-# http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
-def _memoize(func, obj, *args, **kw):
-    try:
-        cache = obj.__cache
-    except AttributeError:
-        cache = obj.__cache = {}
-    if kw:
-        key = func, args, tuple(kw.iteritems())
-    else:
-        key = func, args
-    if key in cache:
-        return cache[key]
-    else:
-        cache[key] = result = func(obj, *args, **kw)
-        return result
-
-
-def memoize(f):
-    return decorator(_memoize, f)
-
-
 _current_uid = 0
 
 

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -69,3 +69,31 @@ def test_indexed_function_space_index(fs):
 
 def test_mixed_function_space_split(fs):
     assert fs.split() == tuple(fs)
+
+
+@pytest.mark.parametrize("modifier",
+                         [BrokenElement, FacetElement,
+                          InteriorElement, TraceElement, HDivElement,
+                          HCurlElement])
+@pytest.mark.parametrize("element",
+                         [FiniteElement("CG", triangle, 1),
+                          EnrichedElement(FiniteElement("CG", triangle, 1),
+                                          FiniteElement("B", triangle, 3)),
+                          TensorProductElement(FiniteElement("CG", triangle, 1),
+                                               FiniteElement("CG", interval, 3)),
+                          MixedElement(FiniteElement("CG", triangle, 1),
+                                       FiniteElement("DG", triangle, 2))],
+                         ids=["FE", "Enriched", "TPE", "Mixed"])
+def test_validation(modifier, element):
+    with pytest.raises(ValueError):
+        FunctionSpace(UnitSquareMesh(1, 1), modifier(VectorElement(element)))
+    if type(element) is MixedElement:
+        with pytest.raises(ValueError):
+            FunctionSpace(UnitSquareMesh(1, 1), VectorElement(element))
+        with pytest.raises(ValueError):
+            FunctionSpace(UnitSquareMesh(1, 1), modifier(element))
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Adds a little more error checking and removes some now dead code.  In particular, I ensure that vector/tensor-element modifiers live on the outside of the provided element.