### PR TITLE
Work functions

### DIFF
--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -207,6 +207,56 @@ def get_bt_masks(mesh, key, fiat_element):
     return bt_masks
 
 
+@cached
+def get_work_function_cache(mesh, ufl_element):
+    """Get the cache for work functions.
+
+    :arg mesh: The mesh to use.
+    :arg ufl_element: The ufl element, used as a key.
+    :returns: A dict.
+
+    :class:`.FunctionSpace` objects sharing the same UFL element (and
+    therefore comparing equal) share a work function cache.
+    """
+    return {}
+
+
+def get_max_work_functions(V):
+    """Get the maximum number of work functions.
+
+    :arg V: The function space to get the number of work functions for.
+    :returns: The maximum number of work functions.
+
+    This number is shared between all function spaces with the same
+    :meth:`~.FunctionSpace.ufl_element` and
+    :meth:`~FunctionSpace.mesh`.
+
+    The default is 25 work functions per function space.  This can be
+    set using :func:`set_max_work_functions`.
+    """
+    mesh = V.mesh()
+    assert hasattr(mesh, "_shared_data_cache")
+    cache = mesh._shared_data_cache["max_work_functions"]
+    return cache.get(V.ufl_element(), 25)
+
+
+def set_max_work_functions(V, val):
+    """Set the maximum number of work functions.
+
+    :arg V: The function space to set the number of work functions
+        for.
+    :arg val: The new maximum number of work functions.
+
+    This number is shared between all function spaces with the same
+    :meth:`~.FunctionSpace.ufl_element` and
+    :meth:`~FunctionSpace.mesh`.
+    """
+    mesh = V.mesh()
+    assert hasattr(mesh, "_shared_data_cache")
+    cache = mesh._shared_data_cache["max_work_functions"]
+    cache[V.ufl_element()] = val
+
+
 def entity_dofs_key(entity_dofs):
     """Provide a canonical key for an entity_dofs dict.
 

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -67,6 +67,99 @@ class WithGeometry(ufl.FunctionSpace):
     def sub(self, i):
         return WithGeometry(self.topological.sub(i), self.mesh())
 
+    @property
+    def num_work_functions(self):
+        """The number of checked out work functions."""
+        return sum(self._work_functions.values())
+
+    @property
+    def max_work_functions(self):
+        """The maximum number of work functions this :class:`FunctionSpace` supports.
+
+        See :meth:`get_work_function` for obtaining work functions."""
+        return getattr(self.topological, '_max_work_functions', 25)
+
+    @max_work_functions.setter
+    def max_work_functions(self, val):
+        """Set the number of work functions this :class:`FunctionSpace` supports.
+
+        :arg val: The new maximum number of work functions.
+        :raises ValueError: if the provided value is smaller than the
+            number of currently checked out work functions.
+            """
+        # Clear cache
+        cache = self._work_functions
+        if val < len(cache):
+            for k in cache.keys():
+                if not cache[k]:
+                    del cache[k]
+            if val < len(cache):
+                raise ValueError("Can't set work function cache smaller (%d) than current checked out functions (%d)" %
+                                 (val, len(cache)))
+        setattr(self.topological, '_max_work_functions', val)
+
+    def get_work_function(self, zero=True):
+        """Get a temporary work :class:`~.Function` on this :class:`FunctionSpace`.
+
+        :arg zero: Should the :class:`~.Function` be guaranteed zero?
+            If ``zero`` is ``False`` the returned function may or may
+            not be zeroed, and the user is responsible for appropriate
+            zeroing.
+
+        :raises ValueError: if :attr:`max_work_functions` are already
+            checked out.
+
+        .. note ::
+
+            This method is intended to be used for short-lived work
+            functions, if you actually need a function for general
+            usage use the :class:`~.Function` constructor.
+
+            When you are finished with the work function, you should
+            restore it to the pool of available functions with
+            :meth:`restore_work_function`.
+
+        """
+        cache = self._work_functions
+        for function in cache.keys():
+            # Check if we've got a free work function available
+            out = cache[function]
+            if not out:
+                cache[function] = True
+                if zero:
+                    function.dat.zero()
+                return function
+        if len(cache) == self.max_work_functions:
+            raise ValueError("Can't check out more than %d work functions." %
+                             self.max_work_functions)
+        from firedrake import Function
+        function = Function(self)
+        cache[function] = True
+        return function
+
+    def restore_work_function(self, function):
+        """Restore a work function obtained with :meth:`get_work_function`.
+
+        :arg function: The work function to restore
+        :raises ValueError: if the provided function was not obtained
+            with :meth:`get_work_function` or it has already been restored.
+
+        .. warning::
+
+           This does *not* invalidate the name in the calling scope,
+           it is the user's responsibility not to use a work function
+           after restoring it.
+        """
+        cache = self._work_functions
+        try:
+            out = cache[function]
+        except KeyError:
+            raise ValueError("Function %s is not a work function" % function)
+
+        if not out:
+            raise ValueError("Function %s is not checked out, cannot restore" % function)
+        cache[function] = False
+
     def __eq__(self, other):
         try:
             return self.topological == other.topological and \
@@ -156,6 +249,11 @@ class FunctionSpace(object):
         self._ufl_element = element
         self._shared_data = sdata
         self._mesh = mesh
+        # Cache for "work functions", temporary Functions built on
+        # this function space that are used and then restored.
+        # TODO: This is not shared between function space instances
+        # that compare the same.
+        self._work_functions = {}
 
         self.rank = len(self.shape)
         """The rank of this :class:`FunctionSpace`.  Spaces where the

--- a/tests/regression/test_work_functions.py
+++ b/tests/regression/test_work_functions.py
@@ -1,0 +1,121 @@
+import pytest
+from firedrake import *
+
+
+@pytest.fixture
+def mesh():
+    return UnitSquareMesh(1, 1)
+
+
+@pytest.fixture
+def V(mesh):
+    return FunctionSpace(mesh, "CG", 1)
+
+
+@pytest.fixture
+def Q(mesh):
+    return FunctionSpace(mesh, "CG", 2)
+
+
+def test_max_work_functions(V):
+    # Default is 25
+    assert V.max_work_functions == 25
+
+    # Can set number
+    V.max_work_functions = 2
+    assert V.max_work_functions == 2
+
+
+def test_get_work_function(V):
+    f = V.get_work_function()
+    assert V.num_work_functions == 1
+    assert f.function_space() is V
+
+    V.restore_work_function(f)
+    assert V.num_work_functions == 0
+
+
+def test_get_work_function_valueerror(V):
+    V.max_work_functions = 2
+
+    f = V.get_work_function()
+    g = V.get_work_function()
+    assert V.num_work_functions == 2
+
+    with pytest.raises(ValueError):
+        V.get_work_function()
+
+    V.restore_work_function(f)
+    V.restore_work_function(g)
+    assert V.num_work_functions == 0
+
+
+def test_restore_work_function_valueerror(V):
+    V.max_work_functions = 2
+
+    f = V.get_work_function()
+    g = Function(V)
+    assert V.num_work_functions == 1
+
+    with pytest.raises(ValueError):
+        V.restore_work_function(g)
+
+    V.restore_work_function(f)
+    assert V.num_work_functions == 0
+
+    with pytest.raises(ValueError):
+        V.restore_work_function(f)
+
+
+def test_set_max_work_functions_valueerror(V):
+    fns = []
+    for _ in range(4):
+        fns.append(V.get_work_function())
+
+    assert V.num_work_functions == 4
+    # Can't resize when have more checked out than new size.
+    with pytest.raises(ValueError):
+        V.max_work_functions = 3
+
+    V.restore_work_function(fns.pop())
+    assert V.num_work_functions == 3
+
+    # Can resize
+    V.max_work_functions = 3
+
+    assert V.max_work_functions == 3
+
+
+def test_get_restore_get(V):
+    f = V.get_work_function()
+    V.restore_work_function(f)
+    g = V.get_work_function()
+
+    assert f is g
+
+    assert V.num_work_functions == 1
+
+
+def test_get_get(V):
+    f = V.get_work_function()
+    g = V.get_work_function()
+
+    assert f is not g
+    assert V.num_work_functions == 2
+
+
+def test_different_spaces(V, Q):
+    f = V.get_work_function()
+    g = Q.get_work_function()
+
+    assert f is not g
+
+    assert f.function_space() is not g.function_space()
+
+    assert V.num_work_functions == 1
+    assert Q.num_work_functions == 1
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_work_functions.py
+++ b/tests/regression/test_work_functions.py
@@ -116,6 +116,33 @@ def test_different_spaces(V, Q):
     assert Q.num_work_functions == 1
 
 
+def test_max_work_functions_shared_across_instances(V, Q):
+    V2 = FunctionSpace(V.mesh(), V.ufl_element())
+
+    assert V.max_work_functions == V2.max_work_functions
+
+    V.max_work_functions = 1
+
+    assert V.max_work_functions == 1
+    assert V2.max_work_functions == 1
+
+    f = V.get_work_function()
+    g = Q.get_work_function()
+    assert f is not g
+    Q.restore_work_function(g)
+    with pytest.raises(ValueError):
+        V2.get_work_function()
+
+    with pytest.raises(ValueError):
+        V.get_work_function()
+
+    V.restore_work_function(f)
+
+    g = V2.get_work_function()
+
+    assert f is g
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
This addition adds methods to function space instances to provide "work functions".  These are temporary functions that you need to do some work on that you will then restore for reuse elsewhere.  The idea is that rather than the user creating all the temporary functions they need up front, they can use a `V.get_work_function()`, `V.restore_work_function()` pair.  The number of work functions you can create in this manner is limited.

Currently, the cache is not shared between functionspace instances that compare the same.  It could be if we want that.