### PR TITLE
solvers: Add more extensive error checking of arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,4 +80,4 @@ script:
   - cd firedrake
   - make lint
   - (rc=0; for t in ${PYOP2_TESTS}; do py.test --short -v tests/${t} || rc=$?; done; exit $rc)
-  - if [ -n $TEST_ADJOINT ]; then python ../dolfin-adjoint/tests_firedrake/test.py; fi
+  - if [ "x$TEST_ADJOINT" != "x" ]; then python ../dolfin-adjoint/tests_firedrake/test.py; fi

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import ufl
 import firedrake.function as function
+import firedrake.matrix as matrix
 import firedrake.solving_utils as solving_utils
 from firedrake.petsc import PETSc
 from firedrake.utils import cached_property
@@ -45,6 +46,11 @@ class LinearSolver(object):
             self._opt_prefix = "firedrake_ksp_%d_" % LinearSolver._id
             self._auto_prefix = True
             LinearSolver._id += 1
+
+        if not isinstance(A, matrix.Matrix):
+            raise TypeError("Provided operator is a '%s', not a Matrix" % type(A).__name__)
+        if P is not None and not isinstance(P, matrix.Matrix):
+            raise TypeError("Provided preconditioner is a '%s', not a Matrix" % type(P).__name__)
 
         self.A = A
         self.P = P if P is not None else A
@@ -120,6 +126,11 @@ class LinearSolver(object):
             delattr(self, '_opt_prefix')
 
     def solve(self, x, b):
+        if not isinstance(x, function.Function):
+            raise TypeError("Provided solution is a '%s', not a Function" % type(x).__name__)
+        if not isinstance(b, function.Function):
+            raise TypeError("Provided RHS is a '%s', not a Function" % type(b).__name__)
+
         if len(self._W) > 1 and self.nullspace is not None:
             self.nullspace._apply(self._W.dof_dset.field_ises)
         # User may have updated parameters

--- a/tests/regression/test_solver_error_checking.py
+++ b/tests/regression/test_solver_error_checking.py
@@ -1,0 +1,87 @@
+import pytest
+from firedrake import *
+
+
+@pytest.fixture
+def V():
+    return FunctionSpace(UnitSquareMesh(1, 1), "CG", 1)
+
+
+@pytest.fixture
+def a(V):
+    return TrialFunction(V)*TestFunction(V)*dx
+
+
+@pytest.fixture
+def f(V):
+    return Function(V)
+
+
+@pytest.fixture
+def L(V, f):
+    return f*TestFunction(V)*dx
+
+
+@pytest.fixture
+def c(V):
+    return Constant(1, domain=V.mesh())
+
+
+def test_too_few_arguments(a, L):
+    with pytest.raises(TypeError):
+        solve(a == L)
+
+
+def test_invalid_solution_type(a, L, c):
+    with pytest.raises(TypeError):
+        solve(a == L, c)
+
+
+def test_invalid_lhs_type(L, f):
+    with pytest.raises(TypeError):
+        solve(f == L, f)
+
+
+def test_invalid_rhs_type(a, L, f):
+    with pytest.raises(TypeError):
+        solve(a == f, f)
+
+
+def test_invalid_lhs_arity(L, f):
+    with pytest.raises(ValueError):
+        solve(L == L, f)
+
+
+def test_invalid_rhs_arity(a, L, f):
+    with pytest.raises(ValueError):
+        solve(a == a, f)
+
+
+def test_invalid_bc_type(a, L, f, c):
+    with pytest.raises(TypeError):
+        solve(a == L, f, bcs=(c, ))
+
+
+def test_la_invalid_matrix_type(a, L, f):
+    with pytest.raises(TypeError):
+        solve(a, f, assemble(L))
+
+
+def test_la_invalid_function_type(a, L, f):
+    with pytest.raises(TypeError):
+        solve(assemble(a), f, L)
+
+
+def test_la_invalid_solution_type(a, L, c):
+    with pytest.raises(TypeError):
+        solve(assemble(a), c, assemble(L))
+
+
+def test_la_too_few_arguments(a, f):
+    with pytest.raises(TypeError):
+        solve(a, f)
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Validate not only that arguments to solve calls have the correct type,
but also the correct value (e.g. the LHS of a linear variational solve
must be a bilinear form).  This results in much easier to understand
error messages if the user does the wrong thing and accidentally
provides (say) a residual on the LHS of a linear variational solve, or
similar.