### PR TITLE
Warn rather than fail for a missing component sha

### DIFF
--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -167,7 +167,7 @@ if args.release or not args.input_file:
     shas = collect_repo_shas()
 else:
     # Read hashes from file.
-    infile = file(cwd+"/"+args.input_file[0], "r")
+    infile = file(os.path.abspath(args.input_file[0]), "r")
     shas = json.loads(infile.read())
 
 if args.message:
@@ -246,7 +246,7 @@ for component in components:
         log.warn("No commit specified for %s. No release will be created for this component." % component)
 
 # Now create releases.
-for component in shas:
+for component in (set(shas) and set(components)):
     log.info("Releasing %s" % component)
     repo = gh.repository(projects[component], component)
 

--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -235,13 +235,18 @@ tag += "." + str(index + 1)
 for component in components:
     repo = gh.repository(projects[component], component)
 
-    commit = repo.commit(shas[component])
-    if not commit:
-        log.error("Failed to find specified commit for %s" % component)
-    shas[component] = commit.sha
+    try:
+        commit = repo.commit(shas[component])
+        if not commit:
+            log.error("Failed to find specified commit for %s" % component)
+
+        shas[component] = commit.sha
+
+    except KeyError:
+        log.warn("No commit specified for %s. No release will be created for this component.")
 
 # Now create releases.
-for component in components:
+for component in shas:
     log.info("Releasing %s" % component)
     repo = gh.repository(projects[component], component)
 

--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -246,7 +246,7 @@ for component in components:
         log.warn("No commit specified for %s. No release will be created for this component." % component)
 
 # Now create releases.
-for component in (set(shas) and set(components)):
+for component in (set(shas) & set(components)):
     log.info("Releasing %s" % component)
     repo = gh.repository(projects[component], component)
 

--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -243,7 +243,7 @@ for component in components:
         shas[component] = commit.sha
 
     except KeyError:
-        log.warn("No commit specified for %s. No release will be created for this component.")
+        log.warn("No commit specified for %s. No release will be created for this component." % component)
 
 # Now create releases.
 for component in shas:


### PR DESCRIPTION
If someone has some odd setup which does not include one or more components, we should still create a release for them.