### PR TITLE
Add new COFFEE dependency GLPK

### DIFF
--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -596,9 +596,9 @@ _to_aug_assign = lambda op, o: op(_ast(o[0]), _ast(o[1]))
 
 _ast_map = {
     MathFunction: (lambda e: ast.FunCall(e._name, *[_ast(o) for o in e.ufl_operands])),
-    ufl.algebra.Sum: (lambda e: ast.Par(_to_sum(e.ufl_operands))),
-    ufl.algebra.Product: (lambda e: ast.Par(_to_prod(e.ufl_operands))),
-    ufl.algebra.Division: (lambda e: ast.Par(ast.Div(*[_ast(o) for o in e.ufl_operands]))),
+    ufl.algebra.Sum: (lambda e: _to_sum(e.ufl_operands)),
+    ufl.algebra.Product: (lambda e: _to_prod(e.ufl_operands)),
+    ufl.algebra.Division: (lambda e: ast.Div(*[_ast(o) for o in e.ufl_operands])),
     ufl.algebra.Abs: (lambda e: ast.FunCall("abs", _ast(e.ufl_operands[0]))),
     Assign: (lambda e: _to_aug_assign(e._ast, e.ufl_operands)),
     AugmentedAssignment: (lambda e: _to_aug_assign(e._ast, e.ufl_operands)),

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -572,6 +572,22 @@ def build_and_install_h5py():
     os.chdir("..")
 
 
+def build_and_install_glpsol():
+    log.info("Installing GLPK\n")
+    if os.path.exists("glpk"):
+        glpk_changed = git_update("glpk")
+    else:
+        git_clone("git+https://github.com/firedrakeproject/glpk.git")
+        glpk_changed = True
+
+    if glpk_changed:
+        os.chdir("glpk")
+        check_call(["./configure", "--disable-shared", "--disable-static"])
+        check_call(["make"])
+        check_call(["cp", "examples/glpsol", os.environ["VIRTUAL_ENV"] + "/bin/"])
+        os.chdir("..")
+
+
 def build_and_install_slepc():
     try:
         petsc_dir = check_output(python + ["-c", "import petsc; print petsc.get_petsc_dir()"]).strip()
@@ -843,6 +859,7 @@ if mode == "install":
         pip_requirements(p)
 
     build_and_install_h5py()
+    build_and_install_glpsol()
     pipinstall.append("--no-deps")
     for p in packages:
         install(p+"/")
@@ -926,6 +943,7 @@ else:
 
     # Always rebuild h5py.
     build_and_install_h5py()
+    build_and_install_glpsol()
 
     try:
         packages.remove("PyOP2")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -912,8 +912,8 @@ else:
                 raise
 
     # update dependencies.
-    pip_requirements("PyOP2")
-    pip_requirements("firedrake")
+    for p in packages:
+        pip_requirements(p)
     pipinstall.append("--no-deps")
 
     # Only rebuild petsc if it has changed.


### PR DESCRIPTION
coneoproject/COFFEE#67 introduces a new dependency on the GNU Linear Programming Kit (GLPK), used via the Python package PuLP.

The safe order of merges:
 * This pull request.
 * coneoproject/COFFEE#67
 * firedrakeproject/tsfc#28