### PR TITLE
need dim keyword for that argument in Mesh

### DIFF
--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -97,7 +97,7 @@ use:
 
 .. code-block:: python
    
-   sphere_mesh = Mesh('sphere_mesh.node', 3)
+   sphere_mesh = Mesh('sphere_mesh.node', dim=3)
 
 Firedrake provides utility meshes for the surfaces of spheres immersed
 in 3D that are approximated using an `icosahedral mesh`_.  You can


### PR DESCRIPTION
``Mesh(meshfile, 3)`` generates a ``TypeError`` since ``Mesh`` only takes ``**kwargs`` after *meshfile*; thus, it should be ``Mesh(meshfile, dim=3)``