### PR TITLE
Test/partially mixed mat bsize

### DIFF
--- a/tests/regression/test_partially_mixed_mat.py
+++ b/tests/regression/test_partially_mixed_mat.py
@@ -1,0 +1,44 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+
+@pytest.fixture
+def mesh():
+    return UnitSquareMesh(2, 2)
+
+
+@pytest.fixture
+def V(mesh):
+    return FunctionSpace(mesh, "DG", 0)
+
+
+@pytest.fixture
+def Q(mesh):
+    return VectorFunctionSpace(mesh, "DG", 0)
+
+
+@pytest.mark.parametrize("nest", [False, True],
+                         ids=["Monolithic", "Nested"])
+@pytest.mark.parametrize("scalar", [False, True],
+                         ids=["Vector", "Scalar"])
+def test_partially_mixed_mat(V, Q, nest, scalar):
+
+    W = V*Q
+
+    u, p = TrialFunctions(W)
+    if scalar:
+        v = TestFunction(V)
+        a = inner(u, v)*dx
+        idx = 0, 0
+        other = 0, 1
+    else:
+        q = TestFunction(Q)
+        a = inner(p, q)*dx
+        idx = 0, 1
+        other = 0, 0
+
+    A = assemble(a, nest=nest).M
+
+    assert np.allclose(A[idx].values.diagonal(), 0.125)
+    assert np.allclose(A[other].values, 0.0)


### PR DESCRIPTION
Test fixes for assembling `inner(u, v)*dx` where `u` comes from a mixed space and `v` comes from a `VectorFunctionSpace`.  Requires OP2/PyOP2#487.