### PR TITLE
Split mixed coefficients

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -341,7 +341,8 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
                 args.append(o.dat(op2.READ, get_map(o), flatten=True))
             for n in coeff_map:
                 c = coefficients[n]
-                args.append(c.dat(op2.READ, get_map(c), flatten=True))
+                for c_ in c.split():
+                    args.append(c_.dat(op2.READ, get_map(c_), flatten=True))
 
             args.extend(extra_args)
             try:

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -90,6 +90,9 @@ class Constant(ufl.Coefficient):
         """Return a null function space."""
         return None
 
+    def split(self):
+        return (self,)
+
     def cell_node_map(self, bcs=None):
         """Return a null cell to node map."""
         if bcs is not None:


### PR DESCRIPTION
Feed in mixed functions by parts to the kernel, corresponding to firedrakeproject/tsfc#37.

This only split mixed functions for forms, interpolation is still done "the old way".