### PR TITLE
Communicators

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -80,6 +80,7 @@ finite element problems in Firedrake.
    visualisation
    checkpointing
    petsc-interface
+   parallelism
 
 Advanced tutorials
 ==================

--- a/docs/source/parallelism.rst
+++ b/docs/source/parallelism.rst
@@ -1,0 +1,68 @@
+.. only:: html
+
+   .. contents::
+
+==========================
+ Parallelism in Firedrake
+==========================
+
+Firedrake uses MPI_ for distributed memory parallelism.  This is
+carried out transparently as long as your usage of Firedrake is only
+through the public API.  To run your code in parallel you need you use
+the MPI job launcher available on your system.  Often this program is
+called ``mpiexec``.  For example, to run a simulation in a file named
+``simulation.py`` on 16 processes we might use.
+
+.. code-block:: shell
+
+   mpiexec -n 16 python simulation.py
+
+Expected performance improvements
+=================================
+
+Without detailed analysis, it is difficult to say precisely how much
+performance improvement should be expected from running in parallel.
+As a rule of thumb, it is worthwhile adding more processes as long as
+the number of degrees of freedom per process is more than
+around 50000.  This is explored in some depth in the :doc:`main
+Firedrake paper <publications>`.  Additionally, most of the finite
+element calculations performed by Firedrake are limited by the *memory
+bandwidth* of the machine.  You can measure how the achieved memory
+bandwidth changes depending on the number of processes used on your
+machine using STREAMS_.
+
+Using MPI Communicators
+=======================
+
+By default, Firedrake parallelises across ``MPI_COMM_WORLD``.  If you
+want to perform a simulation in which different subsets of processes
+perform different computations (perhaps solving the same PDE for
+multiple different initial conditions), this can be achieved by using
+sub-communicators.  The mechanism to do so is to provide a
+communicator when building the ``Mesh`` you will perform the
+simulation on, using the optional ``comm`` keyword argument.  All
+subsequent operations using that mesh are then only collective over
+the supplied communicator, rather than ``MPI_COMM_WORLD``.  For
+example, to split the global communicator into two and perform two
+different simulations on the two halves we would write.
+
+.. code-block:: python
+
+   from firedrake import *
+
+   comm = COMM_WORLD.Split(COMM_WORLD.rank % 2)
+
+   if COMM_WORLD.rank % 2 == 0:
+      # Even ranks create a quad mesh
+      mesh = UnitSquareMesh(N, N, quadrilateral=True, comm=comm)
+   else:
+      # Odd ranks create a triangular mesh
+      mesh = UnitSquareMesh(N, N, comm=comm)
+
+   ...
+
+To access the communicator a mesh was created on, we can use the
+``mesh.comm`` property, or the function ``mesh.mpi_comm()``.
+
+.. _MPI: http://www.mpi-forum.org/
+.. _STREAMS: http://www.cs.virginia.edu/stream/

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -27,6 +27,7 @@ from pyop2.logger import set_log_level, info_red, info_green, info_blue, log  # 
 from pyop2.logger import debug, info, warning, error, critical  # noqa
 from pyop2.logger import DEBUG, INFO, WARNING, ERROR, CRITICAL  # noqa
 from pyop2 import op2                                           # noqa
+from pyop2.mpi import COMM_WORLD, COMM_SELF                     # noqa
 
 from firedrake.assemble import *
 from firedrake.bcs import *

--- a/firedrake/assembly_cache.py
+++ b/firedrake/assembly_cache.py
@@ -36,7 +36,7 @@ import weakref
 from collections import defaultdict
 
 from pyop2.logger import debug, warning
-from pyop2.mpi import COMM_WORLD, MPI
+from pyop2.mpi import COMM_WORLD, MPI, dup_comm, free_comm
 
 from firedrake.parameters import parameters
 from firedrake.petsc import PETSc
@@ -46,7 +46,9 @@ try:
     import psutil
     memory = np.array([psutil.virtual_memory().total/psutil.cpu_count()])
     if COMM_WORLD.size > 1:
-        COMM_WORLD.Allreduce(MPI.IN_PLACE, memory, MPI.MIN)
+        comm = dup_comm(COMM_WORLD)
+        comm.Allreduce(MPI.IN_PLACE, memory, MPI.MIN)
+        free_comm(comm)
 except (ImportError, AttributeError):
     memory = None
 

--- a/firedrake/assembly_cache.py
+++ b/firedrake/assembly_cache.py
@@ -36,7 +36,7 @@ import weakref
 from collections import defaultdict
 
 from pyop2.logger import debug, warning
-from pyop2.mpi import MPI, _MPI
+from pyop2.mpi import COMM_WORLD, MPI
 
 from firedrake.parameters import parameters
 from firedrake.petsc import PETSc
@@ -45,8 +45,8 @@ try:
     # Estimate the amount of memory per core may use.
     import psutil
     memory = np.array([psutil.virtual_memory().total/psutil.cpu_count()])
-    if MPI.comm.size > 1:
-        MPI.comm.Allreduce(_MPI.IN_PLACE, memory, _MPI.MIN)
+    if COMM_WORLD.size > 1:
+        COMM_WORLD.Allreduce(MPI.IN_PLACE, memory, MPI.MIN)
 except (ImportError, AttributeError):
     memory = None
 
@@ -141,9 +141,10 @@ class _CacheEntry(object):
         global _assemble_count
         self._assemble_count += 1
         self.value = self._assemble_count
-        if MPI.comm.size > 1:
+        comm = form.ufl_domain().comm
+        if comm.size > 1:
             tmp = np.array([obj.nbytes])
-            MPI.comm.Allreduce(_MPI.IN_PLACE, tmp, _MPI.MAX)
+            comm.Allreduce(MPI.IN_PLACE, tmp, MPI.MAX)
             self.nbytes = tmp[0]
         else:
             self.nbytes = obj.nbytes

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -52,6 +52,7 @@ class DirichletBC(object):
         # function and then throws the expression away.
         self._original_val = g
         self.function_arg = g
+        self.comm = V.comm
         self._original_arg = self.function_arg
         if sub_domain == "on_boundary":
             self.sub_domain = \

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from firedrake.petsc import PETSc
-from pyop2.mpi import COMM_WORLD
+from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
 from firedrake import hdf5interface as h5i
 import firedrake
 import numpy as np
@@ -51,7 +51,7 @@ class DumbCheckpoint(object):
     """
     def __init__(self, basename, single_file=True,
                  mode=FILE_UPDATE, comm=None):
-        self.comm = comm or COMM_WORLD
+        self.comm = dup_comm(comm or COMM_WORLD)
         self.mode = mode
 
         self._single = single_file
@@ -285,3 +285,6 @@ class DumbCheckpoint(object):
 
     def __del__(self):
         self.close()
+        if hasattr(self, "comm"):
+            free_comm(self.comm)
+            del self.comm

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from firedrake.petsc import PETSc
-from firedrake import op2
+from pyop2.mpi import COMM_WORLD
 from firedrake import hdf5interface as h5i
 import firedrake
 import numpy as np
@@ -51,7 +51,7 @@ class DumbCheckpoint(object):
     """
     def __init__(self, basename, single_file=True,
                  mode=FILE_UPDATE, comm=None):
-        self.comm = comm or op2.MPI.comm
+        self.comm = comm or COMM_WORLD
         self.mode = mode
 
         self._single = single_file

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -54,12 +54,12 @@ class Constant(ufl.Coefficient):
     def __init__(self, value, domain=None):
         # Init also called in mesh constructor, but constant can be built without mesh
         utils._init()
-        self.dat, rank, shape = _globalify(value)
 
         cell = None
         if domain is not None:
             domain = ufl.as_domain(domain)
             cell = domain.ufl_cell()
+        self.dat, rank, shape = _globalify(value)
         if rank == 0:
             e = ufl.FiniteElement("Real", cell, 0)
         elif rank == 1:

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -54,12 +54,12 @@ class Constant(ufl.Coefficient):
     def __init__(self, value, domain=None):
         # Init also called in mesh constructor, but constant can be built without mesh
         utils._init()
+        self.dat, rank, shape = _globalify(value)
 
         cell = None
         if domain is not None:
             domain = ufl.as_domain(domain)
             cell = domain.ufl_cell()
-        self.dat, rank, shape = _globalify(value)
         if rank == 0:
             e = ufl.FiniteElement("Real", cell, 0)
         elif rank == 1:

--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -1,6 +1,5 @@
 # Utility functions to derive global and local numbering from DMPlex
 from petsc import PETSc
-from pyop2 import MPI as _MPI
 import numpy as np
 cimport numpy as np
 import cython
@@ -629,7 +628,7 @@ def mark_entity_classes(PETSc.DM plex):
     CHKERR(DMLabelCreateIndex(lbl_exec, pStart, pEnd))
     CHKERR(DMLabelCreateIndex(lbl_non_exec, pStart, pEnd))
 
-    if _MPI.comm.size > 1:
+    if plex.comm.size > 1:
         # Mark exec_halo from point overlap SF
         point_sf = plex.getPointSF()
         CHKERR(PetscSFGetGraph(point_sf.sf, &nroots, &nleaves,
@@ -1053,7 +1052,7 @@ def plex_renumbering(PETSc.DM plex,
         CHKERR(ISRestoreIndices(facet_is.iset, &facets))
 
     CHKERR(PetscBTDestroy(&seen))
-    perm_is = PETSc.IS().create()
+    perm_is = PETSc.IS().create(comm=plex.comm)
     perm_is.setType("general")
     CHKERR(ISGeneralSetIndices(perm_is.iset, pEnd - pStart,
                                perm, PETSC_OWN_POINTER))
@@ -1079,7 +1078,7 @@ def get_cell_remote_ranks(PETSc.DM plex):
     ncells = cEnd - cStart
 
     result = np.full(ncells, -1, dtype=np.int32)
-    if _MPI.comm.size > 1:
+    if plex.comm.size > 1:
         sf = plex.getPointSF()
         CHKERR(PetscSFGetGraph(sf.sf, &nroots, &nleaves, &ilocal, &iremote))
 
@@ -1198,7 +1197,7 @@ cdef inline void get_communication_lists(
                       buffer, inverse of 'facets' (return value)
     """
     cdef:
-        int comm_size = _MPI.comm.size
+        int comm_size = plex.comm.size
         PetscInt cStart, cEnd
         PetscInt nfacets, fStart, fEnd, f
         PetscInt i, k, support_size
@@ -1570,7 +1569,8 @@ cdef locally_orient_quadrilateral_plex(PETSc.DM plex,
 cdef inline void exchange_edge_orientation_data(
     np.int32_t nranks, np.int32_t *ranks, np.int32_t *offsets,
     np.ndarray[np.int32_t, ndim=1, mode="c"] ours,
-    np.ndarray[np.int32_t, ndim=1, mode="c"] theirs):
+    np.ndarray[np.int32_t, ndim=1, mode="c"] theirs,
+    MPI.Comm comm):
 
     """Exchange edge orientation data between neighbouring MPI nodes.
 
@@ -1579,18 +1579,19 @@ cdef inline void exchange_edge_orientation_data(
     :arg offsets: Offset for each neighbour in the data buffer
     :arg ours: Local data, to be sent to neigbours
     :arg theirs: Remote data, to be received from neighbours (return value)
+    :arg comm: MPI Communicator.
     """
     cdef np.int32_t ri
 
     # Initiate receiving
     recv_reqs = []
     for ri in range(nranks):
-        recv_reqs.append(_MPI.comm.Irecv(theirs[offsets[ri] : offsets[ri+1]], ranks[ri]))
+        recv_reqs.append(comm.Irecv(theirs[offsets[ri] : offsets[ri+1]], ranks[ri]))
 
     # Initiate sending
     send_reqs = []
     for ri in range(nranks):
-        send_reqs.append(_MPI.comm.Isend(ours[offsets[ri] : offsets[ri+1]], ranks[ri]))
+        send_reqs.append(comm.Isend(ours[offsets[ri] : offsets[ri+1]], ranks[ri]))
 
     # Wait for completion
     for req in recv_reqs:
@@ -1619,6 +1620,7 @@ def quadrilateral_facet_orientations(
         np.int32_t *facets = NULL
         np.int32_t *facet2index = NULL
 
+        MPI.Comm comm = plex.comm.tompi4py()
         PetscInt nfacets, nfacets_shared, fStart, fEnd
 
         np.ndarray[np.int32_t, ndim=1, mode="c"] affects
@@ -1654,7 +1656,7 @@ def quadrilateral_facet_orientations(
     # the sign tells the edge direction. Positive sign implies that the edge
     # points from the vertex with the smaller global number to the vertex with
     # the greater global number, negative implies otherwise.
-    ours = _MPI.comm.size * np.arange(nfacets_shared, dtype=np.int32) + _MPI.comm.rank
+    ours = comm.size * np.arange(nfacets_shared, dtype=np.int32) + comm.rank
 
     # We update these values based on the local connections
     # before we do any communication.
@@ -1672,10 +1674,10 @@ def quadrilateral_facet_orientations(
     theirs = np.empty_like(ours)
 
     # Synchronise shared edge directions in parallel
-    conflict = int(_MPI.comm.size > 1)
+    conflict = int(comm.size > 1)
     while conflict != 0:
         # Populate 'theirs' by communication from the 'ours' of others.
-        exchange_edge_orientation_data(nranks, ranks, offsets, ours, theirs)
+        exchange_edge_orientation_data(nranks, ranks, offsets, ours, theirs, comm)
 
         conflict = 0
         for i in range(nfacets_shared):
@@ -1712,7 +1714,7 @@ def quadrilateral_facet_orientations(
 
         # If there was a conflict anywhere, do another round
         # of communication everywhere.
-        conflict = _MPI.comm.allreduce(conflict)
+        conflict = comm.allreduce(conflict)
 
     CHKERR(PetscFree(ranks))
     CHKERR(PetscFree(offsets))
@@ -1872,11 +1874,11 @@ def exchange_cell_orientations(
 
     # Halo exchange of cell orientations, i.e. receive orientations
     # from the owners in the halo region.
-    if _MPI.comm.size > 1:
+    if plex.comm.size > 1:
         sf = plex.getPointSF()
         CHKERR(PetscSFGetGraph(sf.sf, &nroots, &nleaves, &ilocal, &iremote))
 
-        new_section = PETSc.Section().create()
+        new_section = PETSc.Section().create(comm=plex.comm)
         CHKERR(DMPlexDistributeData(plex.dm, sf.sf, section.sec,
                                     dtype.ob_mpi, <void *>orientations.data,
                                     new_section.sec, <void **>&new_values))
@@ -1952,7 +1954,7 @@ def prune_sf(PETSc.SF sf):
             new_iremote[j].index = iremote[i].index
             j += 1
 
-    pruned_sf = PETSc.SF().create()
+    pruned_sf = PETSc.SF().create(comm=sf.comm)
     CHKERR(PetscSFSetGraph(pruned_sf.sf, nroots, new_nleaves,
                            new_ilocal, PETSC_OWN_POINTER,
                            new_iremote, PETSC_OWN_POINTER))

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -59,6 +59,7 @@ class CoordinatelessFunction(ufl.Coefficient):
 
         ufl.Coefficient.__init__(self, function_space.ufl_element())
 
+        self.comm = function_space.comm
         self._function_space = function_space
         self.uid = utils._new_uid()
         self._name = name or 'function_%d' % self.uid
@@ -66,6 +67,7 @@ class CoordinatelessFunction(ufl.Coefficient):
         self._split = None
 
         if isinstance(val, (op2.Dat, op2.DatView)):
+            assert val.comm == self.comm
             self.dat = val
         else:
             self.dat = function_space.make_dat(val, dtype, self.name(), uid=self.uid)
@@ -431,11 +433,6 @@ class Function(ufl.Coefficient):
     def at(self, arg, *args, **kwargs):
         """Evaluate function at points."""
         from mpi4py import MPI
-        halo = self.dof_dset.halo
-        if isinstance(halo, tuple):
-            # mixed function space
-            halo = halo[0]
-        comm = halo.comm.tompi4py()
 
         if args:
             arg = (arg,) + args
@@ -462,9 +459,9 @@ class Function(ufl.Coefficient):
             raise ValueError("Point dimension (%d) does not match geometric dimension (%d)." % (arg.shape[-1], gdim))
 
         # Check if we have got the same points on each process
-        root_arg = comm.bcast(arg, root=0)
+        root_arg = self.comm.bcast(arg, root=0)
         same_arg = arg.shape == root_arg.shape and np.allclose(arg, root_arg)
-        diff_arg = comm.allreduce(int(not same_arg), op=MPI.SUM)
+        diff_arg = self.comm.allreduce(int(not same_arg), op=MPI.SUM)
         if diff_arg:
             raise ValueError("Points to evaluate are inconsistent among processes.")
 
@@ -508,7 +505,7 @@ class Function(ufl.Coefficient):
             else:
                 return np.allclose(a, b)
 
-        all_results = comm.allgather(l_result)
+        all_results = self.comm.allgather(l_result)
         g_result = [None] * len(points)
         for results in all_results:
             for i, result in results:
@@ -567,4 +564,5 @@ def make_c_evaluate(function, c_name="evaluate", ldargs=None):
     return compilation.load(src, "cpp", c_name,
                             cppargs=["-I%s" % path.dirname(__file__),
                                      "-I%s/include" % sys.prefix],
-                            ldargs=ldargs)
+                            ldargs=ldargs,
+                            comm=function.comm)

--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -84,11 +84,11 @@ def get_node_set(mesh, nodes_per_entity):
     """
     global_numbering = get_global_numbering(mesh, nodes_per_entity)
     # Use a DM to create the halo SFs
-    dm = PETSc.DMShell().create()
+    dm = PETSc.DMShell().create(mesh.comm)
     dm.setPointSF(mesh._plex.getPointSF())
     dm.setDefaultSection(global_numbering)
     node_classes = tuple(numpy.dot(nodes_per_entity, mesh._entity_classes))
-    node_set = op2.Set(node_classes, halo=halo_mod.Halo(dm))
+    node_set = op2.Set(node_classes, halo=halo_mod.Halo(dm), comm=mesh.comm)
     # Don't need it any more, explicitly destroy.
     dm.destroy()
     extruded = bool(mesh.layers)
@@ -364,7 +364,8 @@ class FunctionSpaceData(object):
         # loop is direct and we already have all the correct
         # information available locally.  So We fake a set of the
         # correct size and carry out a direct loop
-        facet_set = op2.Set(self.mesh.exterior_facets.set.total_size)
+        facet_set = op2.Set(self.mesh.exterior_facets.set.total_size,
+                            comm=self.mesh.comm)
 
         fs_dat = op2.Dat(facet_set**el.space_dimension(),
                          data=V.exterior_facet_node_map().values_with_halo)

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -274,6 +274,8 @@ class FunctionSpace(object):
                                     name="%s_nodes_dset" % self.name)
         """A :class:`pyop2.DataSet` representing the function space
         degrees of freedom."""
+
+        self.comm = self.node_set.comm
         self.fiat_element = fiat_element
         self.extruded = sdata.extruded
         self.offset = sdata.offset
@@ -306,7 +308,7 @@ class FunctionSpace(object):
     @utils.cached_property
     def _dm(self):
         """A PETSc DM describing the data layout for this FunctionSpace."""
-        dm = PETSc.DMShell().create()
+        dm = PETSc.DMShell().create(comm=self.comm)
         dm.setAttr('__fs__', weakref.ref(self))
         dm.setPointSF(self.mesh()._plex.getPointSF())
         dm.setDefaultSection(self._shared_data.global_numbering)
@@ -520,6 +522,7 @@ class MixedFunctionSpace(object):
         self.name = name or "_".join(str(s.name) for s in spaces)
         self._subspaces = {}
         self._mesh = spaces[0].mesh()
+        self.comm = self.node_set.comm
 
     # These properties are so a mixed space can behave like a normal FunctionSpace.
     index = None
@@ -689,7 +692,7 @@ class MixedFunctionSpace(object):
     @utils.cached_property
     def _dm(self):
         """A PETSc DM describing the data layout for fieldsplit solvers."""
-        dm = PETSc.DMShell().create()
+        dm = PETSc.DMShell().create(comm=self.comm)
         dm.setAttr('__fs__', weakref.ref(self))
         dm.setCreateFieldDecomposition(self.create_field_decomp)
         dm.setCreateSubDM(self.create_subdm)
@@ -720,7 +723,8 @@ class MixedFunctionSpace(object):
             subspace = MixedFunctionSpace([W[f] for f in fields])
             # Index set mapping from W into subspace.
             iset = PETSc.IS().createGeneral(numpy.concatenate([W._ises[f].indices
-                                                               for f in fields]))
+                                                               for f in fields]),
+                                            comm=W.comm)
             # Keep hold of strong reference to created subspace (given we
             # only hold a weakref in the shell DM), and so we can
             # reuse it later.

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -57,6 +57,7 @@ class LinearSolver(object):
             raise TypeError("Provided preconditioner is a '%s', not a Matrix" % type(P).__name__)
 
         self.A = A
+        self.comm = A.comm
         self.P = P if P is not None else A
 
         parameters = solver_parameters.copy() if solver_parameters is not None else {}
@@ -65,7 +66,7 @@ class LinearSolver(object):
         if self.P._M.sparsity.shape != (1, 1):
             parameters.setdefault('pc_type', 'jacobi')
 
-        self.ksp = PETSc.KSP().create()
+        self.ksp = PETSc.KSP().create(comm=self.comm)
         self.ksp.setOptionsPrefix(self._opt_prefix)
 
         # Allow command-line arguments to override dict parameters

--- a/firedrake/matrix.py
+++ b/firedrake/matrix.py
@@ -31,6 +31,7 @@ class Matrix(object):
     def __init__(self, a, bcs, *args, **kwargs):
         self._a = a
         self._M = op2.Mat(*args, **kwargs)
+        self.comm = self._M.comm
         self._thunk = None
         self._assembled = False
         # Iteration over bcs must be in a parallel consistent order

--- a/firedrake/mg/impl.pyx
+++ b/firedrake/mg/impl.pyx
@@ -70,7 +70,7 @@ def create_lgmap(PETSc.DM dm):
         PetscInt start, end
 
     # Not necessary on one process
-    if MPI.comm.size == 1:
+    if dm.comm.size == 1:
         return None
     CHKERR(DMPlexCreatePointNumbering(dm.dm, &iset.iset))
     CHKERR(ISLocalToGlobalMappingCreateIS(iset.iset, &lgmap.lgm))
@@ -164,7 +164,7 @@ def coarse_to_fine_cells(mc, mf):
     # Walk owned fine cells:
     fStart, fEnd = 0, nfine
 
-    if MPI.comm.size > 1:
+    if mc.comm.size > 1:
         # Compute global numbers of original cell numbers
         mf._overlapped_lgmap.apply(fn2o, result=fn2o)
         # Compute local numbers of original cells on non-overlapped mesh
@@ -248,7 +248,7 @@ def compute_orientations(P1c, P1f, np.ndarray[PetscInt, ndim=2, mode="c"] c2f):
 
     cvertices = P1c.cell_node_map().values
     fvertices = P1f.cell_node_map().values
-    if MPI.comm.size > 1:
+    if coarse.comm.size > 1:
         # Convert values in indices to points in the overlapped
         # (rather than non-overlapped) mesh.
         # Convert to global numbers

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import numpy as np
-from pyop2.mpi import MPI
 
 from firedrake import functionspace
 from firedrake import mesh
@@ -27,8 +26,9 @@ class MeshHierarchy(object):
         dm_hierarchy = []
 
         cdm = m._plex
+        self.comm = m.comm
         fpoint_ises = []
-        if MPI.comm.size > 1 and m._grown_halos:
+        if m.comm.size > 1 and m._grown_halos:
             raise RuntimeError("Cannot refine parallel overlapped meshes (make sure the MeshHierarchy is built immediately after the Mesh)")
         for i in range(refinement_levels):
             rdm = cdm.refine()
@@ -112,6 +112,7 @@ class ExtrudedMeshHierarchy(MeshHierarchy):
 
         See :func:`~.ExtrudedMesh` for the meaning of the remaining parameters.
         """
+        self.comm = mesh_hierarchy.comm
         self._base_hierarchy = mesh_hierarchy
         hierarchy = [set_level(mesh.ExtrudedMesh(m, layers, kernel=kernel,
                                                  layer_height=layer_height,

--- a/firedrake/mg/solver_hierarchy.py
+++ b/firedrake/mg/solver_hierarchy.py
@@ -103,7 +103,7 @@ def create_interpolation(dmc, dmf):
                 w.axpy(1.0, y)
 
     ctx = Interpolation(cfn, ffn, cbcs, fbcs)
-    mat = PETSc.Mat().create()
+    mat = PETSc.Mat().create(comm=dmc.comm)
     mat.setSizes(((nrow, None), (ncol, None)))
     mat.setType(mat.Type.PYTHON)
     mat.setPythonContext(ctx)
@@ -143,7 +143,7 @@ def create_injection(dmc, dmf):
                 v.copy(y)
 
     ctx = Injection(cfn, ffn, cbcs)
-    mat = PETSc.Mat().create()
+    mat = PETSc.Mat().create(comm=dmc.comm)
     mat.setSizes(((nrow, None), (ncol, None)))
     mat.setType(mat.Type.PYTHON)
     mat.setPythonContext(ctx)
@@ -211,7 +211,7 @@ class NLVSHierarchy(object):
 
         if nullspace is not None or tnullspace is not None:
             raise NotImplementedError("Coarsening nullspaces not yet implemented")
-        snes = PETSc.SNES().create()
+        snes = PETSc.SNES().create(comm=problems[-1].dm.comm)
 
         snes.setDM(problems[-1].dm)
         self.problems = problems

--- a/firedrake/nullspace.py
+++ b/firedrake/nullspace.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from numpy import prod
 
 from pyop2 import op2
+from pyop2.mpi import COMM_WORLD
 
 from firedrake import function
 from firedrake.petsc import PETSc
@@ -30,6 +31,7 @@ class VectorSpaceBasis(object):
     def __init__(self, vecs=None, constant=False):
         if vecs is None and not constant:
             raise RuntimeError("Must either provide a list of null space vectors, or constant keyword (or both)")
+
         self._vecs = vecs or []
         self._petsc_vecs = []
         for v in self._vecs:
@@ -37,13 +39,18 @@ class VectorSpaceBasis(object):
                 self._petsc_vecs.append(v_)
         if not self.is_orthonormal():
             raise RuntimeError("Provided vectors must be orthonormal")
-        self._nullspace = PETSc.NullSpace().create(constant=constant,
-                                                   vectors=self._petsc_vecs)
         self._constant = constant
 
-    @property
-    def nullspace(self):
-        """The PETSc NullSpace object for this :class:`.VectorSpaceBasis`"""
+    def nullspace(self, comm=None):
+        """The PETSc NullSpace object for this :class:`.VectorSpaceBasis`.
+
+        :kwarg comm: Communicator to create the nullspace on."""
+        if hasattr(self, "_nullspace"):
+            return self._nullspace
+        comm = comm or COMM_WORLD
+        self._nullspace = PETSc.NullSpace().create(constant=self._constant,
+                                                   vectors=self._petsc_vecs,
+                                                   comm=comm)
         return self._nullspace
 
     def orthogonalize(self, b):
@@ -94,9 +101,9 @@ class VectorSpaceBasis(object):
         if not isinstance(matrix, op2.Mat):
             return
         if transpose:
-            matrix.handle.setTransposeNullSpace(self.nullspace)
+            matrix.handle.setTransposeNullSpace(self.nullspace(comm=matrix.comm))
         else:
-            matrix.handle.setNullSpace(self.nullspace)
+            matrix.handle.setNullSpace(self.nullspace(comm=matrix.comm))
 
     def __iter__(self):
         """Yield self when iterated over"""
@@ -142,6 +149,7 @@ class MixedVectorSpaceBasis(object):
     """
     def __init__(self, function_space, bases):
         self._function_space = function_space
+        self.comm = function_space.comm
         for basis in bases:
             if isinstance(basis, VectorSpaceBasis):
                 continue
@@ -196,7 +204,8 @@ class MixedVectorSpaceBasis(object):
             with v.dat.vec_ro as v_:
                 self._petsc_vecs.append(v_)
         self._nullspace = PETSc.NullSpace().create(constant=False,
-                                                   vectors=self._petsc_vecs)
+                                                   vectors=self._petsc_vecs,
+                                                   comm=self.comm)
 
     def _apply_monolithic(self, matrix, transpose=False):
         """Set this class:`MixedVectorSpaceBasis` as a nullspace for a
@@ -260,7 +269,7 @@ class MixedVectorSpaceBasis(object):
             # Compose appropriate nullspace with IS for schur complement
             if ises is not None:
                 is_ = ises[i]
-                is_.compose("nullspace", basis.nullspace)
+                is_.compose("nullspace", basis.nullspace(comm=self.comm))
 
     def __iter__(self):
         """Yield the individual bases making up this MixedVectorSpaceBasis"""

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -6,6 +6,7 @@ import numpy
 import os
 import ufl
 import weakref
+from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
 
 
 __all__ = ("File", )
@@ -256,9 +257,7 @@ class File(object):
         if ext not in (".pvd", ):
             raise ValueError("Only output to PVD is supported")
 
-        if comm is None:
-            from pyop2.mpi import COMM_WORLD
-            comm = COMM_WORLD
+        comm = dup_comm(comm or COMM_WORLD)
 
         if comm.rank == 0:
             outdir = os.path.dirname(os.path.abspath(filename))

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -257,8 +257,8 @@ class File(object):
             raise ValueError("Only output to PVD is supported")
 
         if comm is None:
-            from pyop2.mpi import MPI
-            comm = MPI.comm
+            from pyop2.mpi import COMM_WORLD
+            comm = COMM_WORLD
 
         if comm.rank == 0:
             outdir = os.path.dirname(os.path.abspath(filename))

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -4,6 +4,10 @@ from __future__ import absolute_import
 
 from hashlib import md5
 from os import path, environ, getuid, makedirs
+import cPickle
+import gzip
+import os
+import zlib
 import tempfile
 import numpy
 import collections
@@ -16,7 +20,7 @@ from firedrake.ufl_expr import Argument
 
 from tsfc import compile_form as tsfc_compile_form
 
-from pyop2.caching import DiskCached
+from pyop2.caching import Cached
 from pyop2.op2 import Kernel
 from pyop2.mpi import MPI
 
@@ -131,15 +135,56 @@ KernelInfo = collections.namedtuple("KernelInfo",
                                      "coefficient_map"])
 
 
-class TSFCKernel(DiskCached):
+class TSFCKernel(Cached):
 
     _cache = {}
-    if MPI.comm.rank == 0:
-        _cachedir = environ.get('FIREDRAKE_TSFC_KERNEL_CACHE_DIR',
-                                path.join(tempfile.gettempdir(),
-                                          'firedrake-tsfc-kernel-cache-uid%d' % getuid()))
-    else:
-        _cachedir = None
+
+    _cachedir = environ.get('FIREDRAKE_TSFC_KERNEL_CACHE_DIR',
+                            path.join(tempfile.gettempdir(),
+                                      'firedrake-tsfc-kernel-cache-uid%d' % getuid()))
+
+    @classmethod
+    def _cache_lookup(cls, key):
+        key, comm = key
+        return cls._cache.get(key) or cls._read_from_disk(key, comm)
+
+    @classmethod
+    def _read_from_disk(cls, key, comm):
+        if comm.rank == 0:
+            cache = cls._cachedir
+            filepath = os.path.join(cache, key)
+            val = None
+            if os.path.exists(filepath):
+                try:
+                    with gzip.open(filepath, 'rb') as f:
+                        val = f.read()
+                except zlib.error:
+                    pass
+
+            comm.bcast(val, root=0)
+        else:
+            val = comm.bcast(None, root=0)
+
+        if val is None:
+            raise KeyError("Object with key %s not found" % key)
+        val = cPickle.loads(val)
+        cls._cache[key] = val
+        return val
+
+    @classmethod
+    def _cache_store(cls, key, val):
+        key, comm = key
+        _ensure_cachedir(comm=comm)
+        if comm.rank == 0:
+            val._key = key
+            filepath = os.path.join(cls._cachedir, key)
+            tempfile = os.path.join(cls._cachedir, "%s_p%d.tmp" % (key, os.getpid()))
+            # No need for a barrier after this, since non root
+            # processes will never race on this file.
+            with gzip.open(tempfile, 'wb') as f:
+                cPickle.dump(val, f)
+            os.rename(tempfile, filepath)
+        comm.barrier()
 
     @classmethod
     def _cache_key(cls, form, name, parameters, number_map):
@@ -149,7 +194,7 @@ class TSFCKernel(DiskCached):
         return md5(form.signature() + name + Kernel._backend.__name__
                    + str(default_parameters["coffee"])
                    + str(parameters)
-                   + str(number_map)).hexdigest()
+                   + str(number_map)).hexdigest(), form.ufl_domain().comm
 
     def __init__(self, form, name, parameters, number_map):
         """A wrapper object for one or more TSFC kernels compiled from a given :class:`~ufl.classes.Form`.
@@ -249,19 +294,21 @@ def compile_form(form, name, parameters=None, inverse=False):
     return kernels
 
 
-def clear_cache():
+def clear_cache(comm=None):
     """Clear the Firedrake TSFC kernel cache."""
-    if MPI.comm.rank != 0:
+    comm = comm or MPI.COMM_WORLD
+    if comm.rank != 0:
         return
     if path.exists(TSFCKernel._cachedir):
         import shutil
         shutil.rmtree(TSFCKernel._cachedir, ignore_errors=True)
-        _ensure_cachedir()
+        _ensure_cachedir(comm=comm)
 
 
-def _ensure_cachedir():
+def _ensure_cachedir(comm=None):
     """Ensure that the TSFC kernel cache directory exists."""
-    if MPI.comm.rank != 0:
+    comm = comm or MPI.COMM_WORLD
+    if comm.rank != 0:
         return
     if not path.exists(TSFCKernel._cachedir):
         makedirs(TSFCKernel._cachedir)
@@ -281,6 +328,3 @@ def _inverse(kernel):
     kernel.children[0].children.append(Invert(name, size))
 
     return kernel
-
-
-_ensure_cachedir()

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -29,7 +29,7 @@ __all__ = ['IntervalMesh', 'UnitIntervalMesh',
            'TorusMesh', 'CylinderMesh']
 
 
-def IntervalMesh(ncells, length_or_left, right=None, comm=None):
+def IntervalMesh(ncells, length_or_left, right=None, comm=COMM_WORLD):
     """
     Generate a uniform mesh of an interval.
 
@@ -59,7 +59,7 @@ def IntervalMesh(ncells, length_or_left, right=None, comm=None):
     coords = np.arange(left, right + 0.01 * dx, dx).reshape(-1, 1)
     cells = np.dstack((np.arange(0, len(coords) - 1, dtype=np.int32),
                        np.arange(1, len(coords), dtype=np.int32))).reshape(-1, 2)
-    plex = mesh._from_cell_list(1, cells, coords, comm=comm)
+    plex = mesh._from_cell_list(1, cells, coords, comm)
     # Apply boundary IDs
     plex.createLabel("boundary_ids")
     coordinates = plex.getCoordinates()
@@ -75,7 +75,7 @@ def IntervalMesh(ncells, length_or_left, right=None, comm=None):
     return mesh.Mesh(plex, reorder=False)
 
 
-def UnitIntervalMesh(ncells, comm=None):
+def UnitIntervalMesh(ncells, comm=COMM_WORLD):
     """
     Generate a uniform mesh of the interval [0,1].
 
@@ -90,7 +90,7 @@ def UnitIntervalMesh(ncells, comm=None):
     return IntervalMesh(ncells, length_or_left=1.0, comm=comm)
 
 
-def PeriodicIntervalMesh(ncells, length, comm=None):
+def PeriodicIntervalMesh(ncells, length, comm=COMM_WORLD):
     """Generate a periodic mesh of an interval.
 
     :arg ncells: The number of cells over the interval.
@@ -128,7 +128,7 @@ cells are not currently supported")
     return mesh.Mesh(new_coordinates)
 
 
-def PeriodicUnitIntervalMesh(ncells, comm=None):
+def PeriodicUnitIntervalMesh(ncells, comm=COMM_WORLD):
     """Generate a periodic mesh of the unit interval
 
     :arg ncells: The number of cells in the interval.
@@ -138,7 +138,7 @@ def PeriodicUnitIntervalMesh(ncells, comm=None):
     return PeriodicIntervalMesh(ncells, length=1.0, comm=comm)
 
 
-def UnitTriangleMesh(comm=None):
+def UnitTriangleMesh(comm=COMM_WORLD):
     """Generate a mesh of the reference triangle
 
     :kwarg comm: Optional communicator to build the mesh on (defaults to
@@ -146,11 +146,11 @@ def UnitTriangleMesh(comm=None):
     """
     coords = [[0., 0.], [1., 0.], [0., 1.]]
     cells = [[0, 1, 2]]
-    plex = mesh._from_cell_list(2, cells, coords, comm=comm)
+    plex = mesh._from_cell_list(2, cells, coords, comm)
     return mesh.Mesh(plex, reorder=False)
 
 
-def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None, comm=None):
+def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None, comm=COMM_WORLD):
     """Generate a rectangular mesh
 
     :arg nx: The number of cells in the x direction
@@ -181,7 +181,7 @@ def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None, comm=None):
         cells = [i*(ny+1) + j, i*(ny+1) + j+1, (i+1)*(ny+1) + j+1, (i+1)*(ny+1) + j]
         cells = np.asarray(cells).swapaxes(0, 2).reshape(-1, 4)
 
-        plex = mesh._from_cell_list(2, cells, coords, comm=comm)
+        plex = mesh._from_cell_list(2, cells, coords, comm)
     else:
         boundary = PETSc.DMPlex().create(comm)
         boundary.setDimension(1)
@@ -213,7 +213,7 @@ def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None, comm=None):
     return mesh.Mesh(plex, reorder=reorder)
 
 
-def SquareMesh(nx, ny, L, reorder=None, quadrilateral=False, comm=None):
+def SquareMesh(nx, ny, L, reorder=None, quadrilateral=False, comm=COMM_WORLD):
     """Generate a square mesh
 
     :arg nx: The number of cells in the x direction
@@ -236,7 +236,7 @@ def SquareMesh(nx, ny, L, reorder=None, quadrilateral=False, comm=None):
                          comm=comm)
 
 
-def UnitSquareMesh(nx, ny, reorder=None, quadrilateral=False, comm=None):
+def UnitSquareMesh(nx, ny, reorder=None, quadrilateral=False, comm=COMM_WORLD):
     """Generate a unit square mesh
 
     :arg nx: The number of cells in the x direction
@@ -259,7 +259,7 @@ def UnitSquareMesh(nx, ny, reorder=None, quadrilateral=False, comm=None):
 
 
 def PeriodicRectangleMesh(nx, ny, Lx, Ly, direction="both",
-                          quadrilateral=False, reorder=None, comm=None):
+                          quadrilateral=False, reorder=None, comm=COMM_WORLD):
     """Generate a periodic rectangular mesh
 
     :arg nx: The number of cells in the x direction
@@ -355,7 +355,7 @@ for(int i=0; i<new_coords.dofs; i++) {
 
 
 def PeriodicSquareMesh(nx, ny, L, direction="both", quadrilateral=False, reorder=None,
-                       comm=None):
+                       comm=COMM_WORLD):
     """Generate a periodic square mesh
 
     :arg nx: The number of cells in the x direction
@@ -384,7 +384,7 @@ def PeriodicSquareMesh(nx, ny, L, direction="both", quadrilateral=False, reorder
 
 
 def PeriodicUnitSquareMesh(nx, ny, direction="both", reorder=None,
-                           quadrilateral=False, comm=None):
+                           quadrilateral=False, comm=COMM_WORLD):
     """Generate a periodic unit square mesh
 
     :arg nx: The number of cells in the x direction
@@ -411,7 +411,7 @@ def PeriodicUnitSquareMesh(nx, ny, direction="both", reorder=None,
                               comm=comm)
 
 
-def CircleManifoldMesh(ncells, radius=1, comm=None):
+def CircleManifoldMesh(ncells, radius=1, comm=COMM_WORLD):
     """Generated a 1D mesh of the circle, immersed in 2D.
 
     :arg ncells: number of cells the circle should be
@@ -430,13 +430,13 @@ def CircleManifoldMesh(ncells, radius=1, comm=None):
     cells = np.column_stack((np.arange(0, ncells, dtype=np.int32),
                              np.roll(np.arange(0, ncells, dtype=np.int32), -1)))
 
-    plex = mesh._from_cell_list(1, cells, vertices, comm=comm)
+    plex = mesh._from_cell_list(1, cells, vertices, comm)
     m = mesh.Mesh(plex, dim=2, reorder=False)
     m._circle_manifold = radius
     return m
 
 
-def UnitTetrahedronMesh(comm=None):
+def UnitTetrahedronMesh(comm=COMM_WORLD):
     """Generate a mesh of the reference tetrahedron.
 
     :kwarg comm: Optional communicator to build the mesh on (defaults to
@@ -444,11 +444,11 @@ def UnitTetrahedronMesh(comm=None):
     """
     coords = [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]
     cells = [[0, 1, 2, 3]]
-    plex = mesh._from_cell_list(3, cells, coords, comm=comm)
+    plex = mesh._from_cell_list(3, cells, coords, comm)
     return mesh.Mesh(plex, reorder=False)
 
 
-def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, comm=None):
+def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, comm=COMM_WORLD):
     """Generate a mesh of a 3D box.
 
     :arg nx: The number of cells in the x direction
@@ -504,7 +504,7 @@ def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, comm=None):
     return mesh.Mesh(plex, reorder=reorder)
 
 
-def CubeMesh(nx, ny, nz, L, reorder=None, comm=None):
+def CubeMesh(nx, ny, nz, L, reorder=None, comm=COMM_WORLD):
     """Generate a mesh of a cube
 
     :arg nx: The number of cells in the x direction
@@ -527,7 +527,7 @@ def CubeMesh(nx, ny, nz, L, reorder=None, comm=None):
     return BoxMesh(nx, ny, nz, L, L, L, reorder=reorder, comm=comm)
 
 
-def UnitCubeMesh(nx, ny, nz, reorder=None, comm=None):
+def UnitCubeMesh(nx, ny, nz, reorder=None, comm=COMM_WORLD):
     """Generate a mesh of a unit cube
 
     :arg nx: The number of cells in the x direction
@@ -550,7 +550,7 @@ def UnitCubeMesh(nx, ny, nz, reorder=None, comm=None):
 
 
 def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
-                          comm=None):
+                          comm=COMM_WORLD):
     """Generate an icosahedral approximation to the surface of the
     sphere.
 
@@ -609,7 +609,7 @@ def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
                       [8, 6, 7],
                       [9, 8, 1]], dtype=np.int32)
 
-    plex = mesh._from_cell_list(2, faces, vertices, comm=comm)
+    plex = mesh._from_cell_list(2, faces, vertices, comm)
     plex.setRefinementUniform(True)
     for i in range(refinement_level):
         plex = plex.refine()
@@ -629,7 +629,7 @@ def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
 
 
 def UnitIcosahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
-                              comm=None):
+                              comm=COMM_WORLD):
     """Generate an icosahedral approximation to the unit sphere.
 
     :kwarg refinement_level: optional number of refinements (0 is an
@@ -774,7 +774,7 @@ def _cubedsphere_cells_and_coords(radius, refinement_level):
 
 def CubedSphereMesh(radius, refinement_level=0, degree=1,
                     reorder=None, use_dmplex_refinement=False,
-                    comm=None):
+                    comm=COMM_WORLD):
     """Generate an cubed approximation to the surface of the
     sphere.
 
@@ -813,7 +813,7 @@ def CubedSphereMesh(radius, refinement_level=0, degree=1,
                           [0, 2, 6, 4],
                           [1, 3, 7, 5]], dtype=np.int32)
 
-        plex = mesh._from_cell_list(2, faces, vertices, comm=comm)
+        plex = mesh._from_cell_list(2, faces, vertices, comm)
         plex.setRefinementUniform(True)
         for i in range(refinement_level):
             plex = plex.refine()
@@ -825,7 +825,7 @@ def CubedSphereMesh(radius, refinement_level=0, degree=1,
         coords *= scale
     else:
         cells, coords = _cubedsphere_cells_and_coords(radius, refinement_level)
-        plex = mesh._from_cell_list(2, cells, coords, comm=comm)
+        plex = mesh._from_cell_list(2, cells, coords, comm)
 
     m = mesh.Mesh(plex, dim=3, reorder=reorder)
 
@@ -839,7 +839,7 @@ def CubedSphereMesh(radius, refinement_level=0, degree=1,
     return m
 
 
-def UnitCubedSphereMesh(refinement_level=0, degree=1, reorder=None, comm=None):
+def UnitCubedSphereMesh(refinement_level=0, degree=1, reorder=None, comm=COMM_WORLD):
     """Generate a cubed approximation to the unit sphere.
 
     :kwarg refinement_level: optional number of refinements (0 is a cube).
@@ -853,7 +853,7 @@ def UnitCubedSphereMesh(refinement_level=0, degree=1, reorder=None, comm=None):
                            degree=degree, reorder=reorder, comm=comm)
 
 
-def TorusMesh(nR, nr, R, r, quadrilateral=False, reorder=None, comm=None):
+def TorusMesh(nR, nr, R, r, quadrilateral=False, reorder=None, comm=COMM_WORLD):
     """Generate a toroidal mesh
 
     :arg nR: The number of cells in the major direction (min 3)
@@ -887,13 +887,13 @@ def TorusMesh(nR, nr, R, r, quadrilateral=False, reorder=None, comm=None):
         # two cells per cell above...
         cells = cells[:, [0, 1, 3, 1, 2, 3]].reshape(-1, 3)
 
-    plex = mesh._from_cell_list(2, cells, vertices, comm=comm)
+    plex = mesh._from_cell_list(2, cells, vertices, comm)
     m = mesh.Mesh(plex, dim=3, reorder=reorder)
     return m
 
 
 def CylinderMesh(nr, nl, radius=1, depth=1, longitudinal_direction="z",
-                 quadrilateral=False, reorder=None, comm=None):
+                 quadrilateral=False, reorder=None, comm=COMM_WORLD):
     """Generates a cylinder mesh.
 
     :arg nr: number of cells the cylinder circumference should be
@@ -946,7 +946,7 @@ def CylinderMesh(nr, nl, radius=1, depth=1, longitudinal_direction="z",
         vertices = np.dot(vertices, rotation.T)
     elif longitudinal_direction != "z":
         raise ValueError("Unknown longitudinal direction '%s'" % longitudinal_direction)
-    plex = mesh._from_cell_list(2, cells, vertices, comm=comm)
+    plex = mesh._from_cell_list(2, cells, vertices, comm)
 
     plex.createLabel("boundary_ids")
     plex.markBoundaryFaces("boundary_faces")
@@ -972,7 +972,7 @@ def CylinderMesh(nr, nl, radius=1, depth=1, longitudinal_direction="z",
     return m
 
 
-def PartiallyPeriodicRectangleMesh(nx, ny, Lx, Ly, direction="x", quadrilateral=False, reorder=None, comm=None):
+def PartiallyPeriodicRectangleMesh(nx, ny, Lx, Ly, direction="x", quadrilateral=False, reorder=None, comm=COMM_WORLD):
     """Generates RectangleMesh that is periodic in the x or y direction.
 
     :arg nx: The number of cells in the x direction

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -126,7 +126,7 @@ class NonlinearVariationalSolver(object):
 
         ctx = solving_utils._SNESContext(problem)
 
-        self.snes = PETSc.SNES().create()
+        self.snes = PETSc.SNES().create(comm=problem.dm.comm)
 
         self.snes.setOptionsPrefix(self._opt_prefix)
 

--- a/firedrake/vector.py
+++ b/firedrake/vector.py
@@ -56,6 +56,7 @@ class Vector(object):
             self.dat = x
         else:
             raise RuntimeError("Don't know how to build a Vector from a %r" % type(x))
+        self.comm = self.dat.comm
 
     def axpy(self, a, x):
         """Add a*x to self.
@@ -150,7 +151,7 @@ class Vector(object):
         if hasattr(self, '_size'):
             return self._size
         lsize = self.local_size()
-        self._size = op2.MPI.comm.allreduce(lsize, op=MPI.SUM)
+        self._size = self.comm.allreduce(lsize, op=MPI.SUM)
         return self._size
 
     def inner(self, other):

--- a/scripts/firedrake-clean
+++ b/scripts/firedrake-clean
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 
 from firedrake.tsfc_interface import clear_cache, TSFCKernel
-from firedrake.utility_meshes import _clear_cachedir as clear_mesh_cache, _cachedir as mesh_cachedir
 from pyop2.compilation import clear_cache as pyop2_clear_cache
 
 
 if __name__ == '__main__':
     print 'Removing cached TSFC kernels from %s' % TSFCKernel._cachedir
     clear_cache()
-    print 'Removing cached generated meshes from %s' % mesh_cachedir
-    clear_mesh_cache()
     pyop2_clear_cache(prompt=True)

--- a/tests/extrusion/test_offset_computation.py
+++ b/tests/extrusion/test_offset_computation.py
@@ -52,7 +52,7 @@ def run_offset_parallel():
 
     offset = V.exterior_facet_boundary_node_map("topological").offset
 
-    offsets = op2.MPI.comm.allgather(offset)
+    offsets = m.comm.allgather(offset)
     assert all((o == offset).all() for o in offsets)
 
 

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -58,11 +58,6 @@ def test_box():
     assert abs(integrate_one(BoxMesh(3, 3, 3, 1, 2, 3)) - 6) < 1e-3
 
 
-def test_unit_circle():
-    pytest.importorskip('gmshpy')
-    assert abs(integrate_one(UnitCircleMesh(4)) - pi * 0.5 ** 2) < 0.02
-
-
 def test_unit_triangle():
     assert abs(integrate_one(UnitTriangleMesh()) - 0.5) < 1e-3
 
@@ -99,12 +94,6 @@ def test_unit_square_parallel():
 @pytest.mark.parallel
 def test_unit_cube_parallel():
     assert abs(integrate_one(UnitCubeMesh(3, 3, 3)) - 1) < 1e-3
-
-
-@pytest.mark.skipif("gmshpy is None", reason='gmshpy not available')
-@pytest.mark.parallel
-def test_unit_circle_parallel():
-    assert abs(integrate_one(UnitCircleMesh(4)) - pi * 0.5 ** 2) < 0.02
 
 
 def assert_num_exterior_facets_equals_zero(m):

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -103,7 +103,7 @@ def test_dict_order_parallel(f):
         consts.append(Constant(i, domain=mesh))
 
     arg = {}
-    if op2.MPI.comm.rank == 0:
+    if mesh.comm.rank == 0:
         arg['d'] = (d, WRITE)
 
         for i, c in enumerate(consts):

--- a/tests/regression/test_slepc.py
+++ b/tests/regression/test_slepc.py
@@ -38,7 +38,7 @@ def test_laplace_physical_ev(parallel=False):
     A.assemble()
 
     E = SLEPc.EPS()
-    E.create()
+    E.create(comm=mesh.comm)
     E.setOperators(A, M)
     st = E.getST()
     st.setType('sinvert')

--- a/tests/test_tsfc_interface.py
+++ b/tests/test_tsfc_interface.py
@@ -66,7 +66,7 @@ class TestTSFCCache:
     def test_tsfc_cache_read_from_disk(self, cache_key):
         """Loading an TSFCKernel from disk should yield the right object."""
         assert tsfc_interface.TSFCKernel._read_from_disk(
-            cache_key).cache_key == cache_key
+            cache_key, COMM_WORLD).cache_key == cache_key
 
     def test_tsfc_same_form(self, mass):
         """Compiling the same form twice should load kernels from cache."""


### PR DESCRIPTION
Allow specifying a communicator when building a `Mesh`.  All subsequent operations are then only collective over that communicator, rather than implicitly over COMM_WORLD.  Needs OP2/PyOP2#489.