### PR TITLE
tests: Fix issue running with pytest-xdist

### DIFF
--- a/tests/benchmarks/test_assembly_overheads.py
+++ b/tests/benchmarks/test_assembly_overheads.py
@@ -2,7 +2,10 @@ from firedrake import *
 import pytest
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+benchmark = pytest.mark.benchmark(warmup=True, disable_gc=True, warmup_iterations=1)
+
+
+@benchmark
 @pytest.mark.parametrize("fresh_form",
                          [False, True],
                          ids=["reuse_form", "fresh_form"])
@@ -29,7 +32,7 @@ def test_assemble_residual(fresh_tensor, fresh_form, benchmark):
     benchmark(lambda: call())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("fresh_form",
                          [False, True],
                          ids=["reuse_form", "fresh_form"])
@@ -56,7 +59,7 @@ def test_assemble_mass(fresh_tensor, fresh_form, benchmark):
     benchmark(lambda: call())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("fresh_tensor",
                          [False, True],
                          ids=["reuse_tensor", "fresh_tensor"])
@@ -77,7 +80,7 @@ def test_assemble_mass_with_bcs(fresh_tensor, benchmark):
     benchmark(lambda: call())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("nspaces", range(2, 6))
 @pytest.mark.parametrize("fresh_tensor",
                          [False, True],
@@ -98,7 +101,7 @@ def test_assemble_mixed_mass(fresh_tensor, nspaces, benchmark):
     benchmark(lambda: call())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 def test_dat_zero(benchmark):
     m = UnitTriangleMesh()
     V = FunctionSpace(m, 'DG', 0)
@@ -106,7 +109,7 @@ def test_dat_zero(benchmark):
     benchmark(lambda: f.dat.zero())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 def test_assign_zero(benchmark):
     m = UnitTriangleMesh()
     V = FunctionSpace(m, 'DG', 0)
@@ -114,7 +117,7 @@ def test_assign_zero(benchmark):
     benchmark(lambda: f.assign(0))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 def test_assign_function(benchmark):
     m = UnitTriangleMesh()
     V = FunctionSpace(m, 'DG', 0)
@@ -123,7 +126,7 @@ def test_assign_function(benchmark):
     benchmark(lambda: f.assign(g))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("fresh_expr",
                          [False, True],
                          ids=["reuse_expr", "fresh_expr"])
@@ -140,7 +143,7 @@ def test_assign_complicated(fresh_expr, benchmark):
     benchmark(lambda: f.assign(expr()))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("val",
                          [lambda V: Constant(0),
                           lambda V: Expression("0"),

--- a/tests/benchmarks/test_solver_overheads.py
+++ b/tests/benchmarks/test_solver_overheads.py
@@ -2,7 +2,10 @@ from firedrake import *
 import pytest
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+benchmark = pytest.mark.benchmark(warmup=True, disable_gc=True, warmup_iterations=1)
+
+
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_linearsolver(bcs, benchmark):
@@ -30,7 +33,7 @@ def test_linearsolver(bcs, benchmark):
     benchmark(lambda: solver.solve(f, b))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_assembled_solve(bcs, benchmark):
@@ -56,7 +59,7 @@ def test_assembled_solve(bcs, benchmark):
     benchmark(lambda: solve(A, f, b, bcs=bcs))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_linearvariationalsolver(bcs, benchmark):
@@ -82,7 +85,7 @@ def test_linearvariationalsolver(bcs, benchmark):
     benchmark(lambda: solver.solve())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_nonlinearvariationalsolver(bcs, benchmark):
@@ -104,7 +107,7 @@ def test_nonlinearvariationalsolver(bcs, benchmark):
     benchmark(lambda: solver.solve())
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_linear_solve(bcs, benchmark):
@@ -128,7 +131,7 @@ def test_linear_solve(bcs, benchmark):
     benchmark(lambda: solve(a == L, f, bcs=bcs))
 
 
-@pytest.mark.benchmark(warmup=True, disable_gc=True)
+@benchmark
 @pytest.mark.parametrize("bcs", [False, True],
                          ids=["no bcs", "bcs"])
 def test_nonlinear_solve(bcs, benchmark):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,23 +71,3 @@ def pytest_runtest_call(item):
     if item.get_marker("parallel") and MPI.COMM_WORLD.size == 1:
         # Spawn parallel processes to run test
         parallel(item)
-
-
-def pytest_cmdline_preparse(config, args):
-    if 'PYTEST_VERBOSE' in os.environ and '-v' not in args:
-        args.insert(0, '-v')
-    if 'PYTEST_EXITFIRST' in os.environ and '-x' not in args:
-        args.insert(0, '-x')
-    if 'PYTEST_NOCAPTURE' in os.environ and '-s' not in args:
-        args.insert(0, '-s')
-    if 'PYTEST_TBNATIVE' in os.environ:
-        args.insert(0, '--tb=native')
-    if 'PYTEST_WATCH' in os.environ and '-f' not in args:
-        args.insert(0, '-f')
-    try:
-        import pytest_benchmark   # noqa: Checking for availability of plugin
-        # Set number of warmup iteration to 1
-        if "--benchmark-warmup-iterations" not in args:
-            args.insert(0, "--benchmark-warmup-iterations=1")
-    except ImportError:
-        pass


### PR DESCRIPTION
Don't munge the commandline arguments at all, which causes problems with
modern pytest for some reason.