### PR TITLE
Assume yes for apt-get on non-interactive stdin

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -242,7 +242,11 @@ def apt_check(name):
 
 def apt_install(names):
     log.info("Installing missing packages: %s." % ", ".join(names))
-    subprocess.check_call(["sudo", "apt-get", "install"] + names)
+    if sys.stdin.isatty():
+        subprocess.check_call(["sudo", "apt-get", "install"] + names)
+    else: 
+        log.info("Non-interactive stdin detected; installing without prompts")
+        subprocess.check_call(["sudo", "apt-get", "-y", "install"] + names)
 
 
 def split_requirements_url(url):


### PR DESCRIPTION
If firedrake-install is run non-interactively, apt-get fails unlessit defaults to assume yes. This pull request proposes adding a test of whether stdin is a terminal, and if not it runs apt-get with '-y' and logs a warning of that behaviour.
