### PR TITLE
logging: Introduce firedrake logger

### DIFF
--- a/demos/benney_luke/benney_luke.py.rst
+++ b/demos/benney_luke/benney_luke.py.rst
@@ -82,11 +82,6 @@ The implementation of this problem in Firedrake requires solving two nonlinear v
 
   from firedrake import *
 
-We turn off some of firedrake's chattier output, by setting the
-logging level for PyOP2 to ``"WARNING"``::
-
-  parameters["pyop2_options"]["log_level"] = "WARNING"
-
 Now we move on to defining parameters::
 
   T = 2.0

--- a/demos/saddle_point_pc/saddle_point_systems.py.rst
+++ b/demos/saddle_point_pc/saddle_point_systems.py.rst
@@ -56,11 +56,6 @@ As ever, we begin by importing the Firedrake module::
 
     from firedrake import *
 
-We'll also turn off some of the more verbose output that Firedrake
-produces.  We turn off chatty output from PyOP2_::
-
-    parameters["pyop2_options"]["log_level"] = "WARNING"
-
 Bulding the problem
 -------------------
 

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -59,7 +59,7 @@ from firedrake.version import __version__ as ver, __version_info__, check  # noq
 
 from firedrake.logging import *
 # Set default log level
-set_log_level(INFO)
+set_log_level(WARNING)
 
 check()
 del check

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -60,6 +60,7 @@ from firedrake.version import __version__ as ver, __version_info__, check  # noq
 from firedrake.logging import *
 # Set default log level
 set_log_level(WARNING)
+set_log_handlers(comm=COMM_WORLD)
 
 check()
 del check

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -23,9 +23,6 @@ except AttributeError:
     pass
 del ufl
 from ufl import *
-from pyop2.logger import set_log_level, info_red, info_green, info_blue, log  # noqa
-from pyop2.logger import debug, info, warning, error, critical  # noqa
-from pyop2.logger import DEBUG, INFO, WARNING, ERROR, CRITICAL  # noqa
 from pyop2 import op2                                           # noqa
 from pyop2.mpi import COMM_WORLD, COMM_SELF                     # noqa
 
@@ -60,6 +57,7 @@ from firedrake.variational_solver import *
 from firedrake.vector import *
 from firedrake.version import __version__ as ver, __version_info__, check  # noqa
 
+from firedrake.logging import *
 # Set default log level
 set_log_level(INFO)
 

--- a/firedrake/assembly_cache.py
+++ b/firedrake/assembly_cache.py
@@ -35,9 +35,9 @@ import numpy as np
 import weakref
 from collections import defaultdict
 
-from pyop2.logger import debug, warning
 from pyop2.mpi import COMM_WORLD, MPI, dup_comm, free_comm
 
+from firedrake.logging import debug, warning
 from firedrake.parameters import parameters
 from firedrake.petsc import PETSc
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -8,9 +8,9 @@ from ctypes import POINTER, c_int, c_double, c_void_p
 import coffee.base as ast
 
 from pyop2 import op2
-from pyop2.logger import warning
 
 from firedrake import functionspaceimpl
+from firedrake.logging import warning
 from firedrake import utils
 from firedrake import vector
 try:

--- a/firedrake/logging.py
+++ b/firedrake/logging.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+import logging
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Ensure that the relevant loggers have been created.
+import tsfc.logging
+import pyop2.logger
+import coffee.logger
+from ufl.log import ufl_logger
+
+from pyop2.mpi import COMM_WORLD
+
+
+__all__ = ('set_level', 'set_log_level', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',
+           'log', 'debug', 'info', 'warning', 'error', 'critical',
+           'info_red', 'info_green', 'info_blue',
+           "RED", "GREEN", "BLUE")
+
+
+packages = ("COFFEE", "pyop2", "tsfc", "firedrake", "UFL")
+
+
+for package in packages:
+    if package != "UFL":
+        logger = logging.getLogger(package)
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+
+    # Only print on rank 0.
+    if COMM_WORLD.rank == 0:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(fmt="%(name)s:%(levelname)s %(message)s"))
+    else:
+        handler = logging.NullHandler()
+
+    if package == "UFL":
+        ufl_logger.set_handler(handler)
+    else:
+        logger.addHandler(handler)
+
+logger = logging.getLogger("firedrake")
+log = logger.log
+debug = logger.debug
+info = logger.info
+warning = logger.warning
+error = logger.error
+critical = logger.critical
+
+RED = "\033[1;37;31m%s\033[0m"
+BLUE = "\033[1;37;34m%s\033[0m"
+GREEN = "\033[1;37;32m%s\033[0m"
+
+
+# Mimic dolfin
+def info_red(message, *args, **kwargs):
+    ''' Write info message in red.
+
+    :arg message: the message to be printed. '''
+    info(RED % message, *args, **kwargs)
+
+
+def info_green(message, *args, **kwargs):
+    ''' Write info message in green.
+
+    :arg message: the message to be printed. '''
+    info(GREEN % message, *args, **kwargs)
+
+
+def info_blue(message, *args, **kwargs):
+    ''' Write info message in blue.
+
+    :arg message: the message to be printed. '''
+    info(BLUE % message, *args, **kwargs)
+
+
+def set_log_level(level):
+    """Set the log level for Firedrake components.
+
+    :arg level: The level to use.
+
+    This controls what level of logging messages are printed to
+    stderr.  The higher the level, the fewer the number of messages.
+
+    """
+    for package in packages:
+        if package == "UFL":
+            from ufl.log import ufl_logger as logger
+            logger.set_level(level)
+        else:
+            logger = logging.getLogger(package)
+            logger.setLevel(level)
+
+
+set_level = set_log_level

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 
 from pyop2 import op2
 from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
-from pyop2.logger import info_red
 from pyop2.profiling import timed_function, timed_region
 from pyop2.utils import as_tuple
 
@@ -19,6 +18,7 @@ import firedrake.dmplex as dmplex
 import firedrake.extrusion_utils as eutils
 import firedrake.spatialindex as spatialindex
 import firedrake.utils as utils
+from firedrake.logging import info_red
 from firedrake.parameters import parameters
 from firedrake.petsc import PETSc
 

--- a/firedrake/norms.py
+++ b/firedrake/norms.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
-from pyop2.logger import warning
 from ufl import inner, div, grad, curl, sqrt, dx
 
 from firedrake.assemble import assemble
 from firedrake import function
 from firedrake import functionspace
+from firedrake.logging import warning
 from firedrake import projection
 
 __all__ = ['errornorm', 'norm']

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -503,6 +503,6 @@ class File(object):
                 f.write(self._footer)
 
     def __lshift__(self, arg):
-        from pyop2.logger import warning, RED
+        from firedrake.logging import warning, RED
         warning(RED % "The << syntax is deprecated, use File.write")
         self.write(arg)

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -75,7 +75,6 @@ pyop2_opts.set_update_function(lambda k, v: configuration.unsafe_reconfigure(**{
 
 # Override values
 pyop2_opts["type_check"] = True
-pyop2_opts["log_level"] = "INFO"
 
 # PyOP2 must know about the COFFEE optimization level chosen by Firedrake
 pyop2_opts["opt_level"] = coffee_default_optlevel

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -22,8 +22,6 @@ __all__ = ["solve"]
 
 import ufl
 
-from pyop2.logger import progress, INFO
-
 import firedrake.linear_solver as ls
 import firedrake.variational_solver as vs
 
@@ -145,8 +143,7 @@ def _solve_varproblem(*args, **kwargs):
                                             nullspace=nullspace,
                                             transpose_nullspace=nullspace_T,
                                             options_prefix=options_prefix)
-        with progress(INFO, 'Solving linear variational problem'):
-            solver.solve()
+        solver.solve()
 
     # Solve nonlinear variational problem
     else:
@@ -163,8 +160,7 @@ def _solve_varproblem(*args, **kwargs):
                                                nullspace=nullspace,
                                                transpose_nullspace=nullspace_T,
                                                options_prefix=options_prefix)
-        with progress(INFO, 'Solving nonlinear variational problem'):
-            solver.solve()
+        solver.solve()
 
 
 def _la_solve(A, x, b, **kwargs):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 import ufl
 
-from pyop2.logger import warning, RED
 from pyop2.utils import as_tuple
 
 from firedrake.mg import utils
 from firedrake import function
+from firedrake.logging import warning, RED
 from firedrake.petsc import PETSc
 
 

--- a/tests/test_0init.py
+++ b/tests/test_0init.py
@@ -12,7 +12,8 @@ def test_pyop2_custom_init():
     """PyOP2 init parameters set by the user should be retained."""
     op2.init(debug=3, log_level='CRITICAL')
     UnitIntervalMesh(2)
-    from pyop2.logger import logger
+    import logging
+    logger = logging.getLogger('pyop2')
     assert logger.getEffectiveLevel() == CRITICAL
     assert op2.configuration['debug'] == 3
     op2.configuration.reset()


### PR DESCRIPTION
Rather than directly importing PyOP2's logger, create a separate one for
firedrake.  Additionally, set up loggers of sub-packages such that they
only print on rank 0.  And make set_log_level the one-stop-shop to shut
everything up.

Wants OP2/PyOP2#491 too.  Also relies on firedrakeproject/tsfc#45.