### PR TITLE
Updating URL for h5py download

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -511,7 +511,7 @@ def clean(package):
 def get_h5py():
     log.info("Downloading h5py\n")
     import urllib
-    urllib.urlretrieve("https://github.com/h5py/h5py/archive/2.5.0.tar.gz",
+    urllib.urlretrieve("https://codeload.github.com/h5py/h5py/tar.gz/2.5.0",
                        "h5py.tar.gz")
     run_cmd(["tar", "-zxvf", "h5py.tar.gz"])
 


### PR DESCRIPTION
The h5py URL in firedrake-install is now a redirect, which curl doesn't follow. This commit updates the URL to point to the real file referenced by the redirect.