### PR TITLE
Splitting clone/checkout to allow sha1 'branch'

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -274,6 +274,11 @@ def git_url(plain_url, protocol):
     else:
         raise ValueError("Unknown git protocol: %s" % protocol)
 
+def pushd(targetDir):
+    originalDir = os.getcwd()
+    os.chdir(targetDir)
+    yield
+    os.chdir(originalDir)
 
 def git_clone(url):
     name, plain_url, branch = split_requirements_url(url)
@@ -286,14 +291,20 @@ def git_clone(url):
     try:
         if args.disable_ssh:
             raise Exception
-        check_call(["git", "clone", "-q", "-b", branch, git_url(plain_url, "ssh")])
-        log.info("Successfully cloned %s branch %s." % (name, branch))
+        check_call(["git", "clone", "-q", git_url(plain_url, "ssh")])
+        log.info("Successfully cloned repository %s" % name)
+        with pushd(name):
+            check_call(["git", "checkout", "-q", branch])
+            log.info("Successfully checked out branch %s" % branch)
     except:
         if not args.disable_ssh:
             log.warn("Failed to clone %s using ssh, falling back to https." % name)
         try:
-            check_call(["git", "clone", "-q", "-b", branch, git_url(plain_url, "https")])
-            log.info("Successfully cloned %s branch %s." % (name, branch))
+            check_call(["git", "clone", "-q", git_url(plain_url, "https")])
+            log.info("Successfully cloned repository %s." % name)
+            with pushd(name):
+                check_call(["git", "checkout", "-q", branch])
+                log.info("Successfully checked out branch %s" % branch)
         except subprocess.CalledProcessError:
             log.error("Failed to clone %s branch %s." % (name, branch))
             raise

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -136,6 +136,18 @@ else:
     args.virtualenv_name = False
     args.virtualenv_name = args.virtualenv_name or "firedrake"
 
+class directory(object):
+    """Context manager that executes body in a given directory"""
+    def __init__(self, dir):
+        self.dir = dir
+
+    def __enter__(self):
+        self.olddir = os.path.abspath(os.getcwd())
+        os.chdir(self.dir)
+
+    def __exit__(self, *args):
+        os.chdir(self.olddir)
+
 
 # Where are packages installed relative to --root?
 # This is a bit of a hack.
@@ -274,12 +286,6 @@ def git_url(plain_url, protocol):
     else:
         raise ValueError("Unknown git protocol: %s" % protocol)
 
-def pushd(targetDir):
-    originalDir = os.getcwd()
-    os.chdir(targetDir)
-    yield
-    os.chdir(originalDir)
-
 def git_clone(url):
     name, plain_url, branch = split_requirements_url(url)
     if name == "petsc" and args.honour_petsc_dir:
@@ -293,7 +299,7 @@ def git_clone(url):
             raise Exception
         check_call(["git", "clone", "-q", git_url(plain_url, "ssh")])
         log.info("Successfully cloned repository %s" % name)
-        with pushd(name):
+        with directory(name):
             check_call(["git", "checkout", "-q", branch])
             log.info("Successfully checked out branch %s" % branch)
     except:
@@ -302,7 +308,7 @@ def git_clone(url):
         try:
             check_call(["git", "clone", "-q", git_url(plain_url, "https")])
             log.info("Successfully cloned repository %s." % name)
-            with pushd(name):
+            with directory(name):
                 check_call(["git", "checkout", "-q", branch])
                 log.info("Successfully checked out branch %s" % branch)
         except subprocess.CalledProcessError:
@@ -393,18 +399,6 @@ def pip_requirements(package):
 if travis:
     # Only enabled in travis mode
     # Utilise travis directory caching for petsc/petsc4py dependencies
-    class directory(object):
-        """Context manager that executes body in a given directory"""
-        def __init__(self, dir):
-            self.dir = dir
-
-        def __enter__(self):
-            self.olddir = os.path.abspath(os.getcwd())
-            os.chdir(self.dir)
-
-        def __exit__(self, *args):
-            os.chdir(self.olddir)
-
     def get_src_hash(dir):
         with directory(dir):
             try:


### PR DESCRIPTION
If a sha1 is passed via --package-branch as opposed to a branch name the current behaviour generates a 'remote branch not found' error. To allow a specific sha1 to be passed for building, the initial git clone just clones the repository, and then (via a pushed directory) checks out the branch/sha1 as passed at script invocation. Thanks to David Ham for help identifying and fixing this.