### PR TITLE
Fix test_facet_orientation

### DIFF
--- a/tests/regression/test_facet_orientation.py
+++ b/tests/regression/test_facet_orientation.py
@@ -26,7 +26,7 @@ def test_consistent_facet_orientation(mesh_thunk):
 
     Q = FunctionSpace(mesh, "DG", 0)  # result space
 
-    expression = Expression("x[0]*(x[0] + sqrt(2.0)) + x[1] + x[2]*x[2]*x[2]")
+    expression = Expression("x[0]*(x[0] + sqrt(2.0)) + x[1]")
     f = Function(V).interpolate(expression)
     g = Function(W).interpolate(expression)
 


### PR DESCRIPTION
Cannot access x[2] as UnitSquareMesh is being tested, and x[2] would represent the Z direction

fixes #820 