### PR TITLE
Adopt FIAT reference cell changes

### DIFF
--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -21,8 +21,7 @@ import FIAT
 from decorator import decorator
 
 
-from FIAT.finite_element import facet_support_dofs
-from FIAT.tensor_product import horiz_facet_support_dofs, vert_facet_support_dofs
+from FIAT.finite_element import entity_support_dofs
 
 from coffee import base as ast
 
@@ -198,11 +197,12 @@ def get_bt_masks(mesh, key, fiat_element):
     # comes last [-1], before that the horizontal facet [-2], before
     # that vertical facets [-3]. We need the horizontal facets here.
     closure_dofs = fiat_element.entity_closure_dofs()
-    b_mask = closure_dofs[sorted(closure_dofs.keys())[-2]][0]
-    t_mask = closure_dofs[sorted(closure_dofs.keys())[-2]][1]
+    horiz_facet_dim = sorted(closure_dofs.keys())[-2]
+    b_mask = closure_dofs[horiz_facet_dim][0]
+    t_mask = closure_dofs[horiz_facet_dim][1]
     bt_masks["topological"] = (b_mask, t_mask)  # conversion to tuple
     # Geometric facet dofs
-    facet_dofs = horiz_facet_support_dofs(fiat_element)
+    facet_dofs = entity_support_dofs(fiat_element, horiz_facet_dim)
     bt_masks["geometric"] = (facet_dofs[0], facet_dofs[1])
     return bt_masks
 
@@ -346,14 +346,10 @@ class FunctionSpaceData(object):
         if method == "topological":
             boundary_dofs = el.entity_closure_dofs()[dim]
         elif method == "geometric":
-            if self.extruded:
-                # This function is only called on extruded meshes when
-                # asking for the nodes that live on the "vertical"
-                # exterior facets.  Hence we don't need to worry about
-                # horiz_facet_support_dofs as well.
-                boundary_dofs = vert_facet_support_dofs(el)
-            else:
-                boundary_dofs = facet_support_dofs(el)
+            # This function is only called on extruded meshes when
+            # asking for the nodes that live on the "vertical"
+            # exterior facets.
+            boundary_dofs = entity_support_dofs(el, dim)
 
         nodes_per_facet = \
             len(boundary_dofs[0])

--- a/firedrake/mg/impl.pyx
+++ b/firedrake/mg/impl.pyx
@@ -457,7 +457,8 @@ def create_cell_node_map(coarse, fine, np.ndarray[PetscInt, ndim=2, mode="c"] c2
 
     cell = coarse.fiat_element.get_reference_element()
     if isinstance(cell, FIAT.reference_element.TensorProductCell):
-        tdim = cell.A.get_spatial_dimension()
+        basecell, _ = cell.cells
+        tdim = basecell.get_spatial_dimension()
     else:
         tdim = cell.get_spatial_dimension()
 

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -37,7 +37,7 @@ def get_transformations(fiat_cell):
     """
     if isinstance(fiat_cell, FIAT.reference_element.TensorProductCell):
         extruded = True
-        cell = fiat_cell.A
+        cell, _ = fiat_cell.cells
     else:
         extruded = False
         cell = fiat_cell
@@ -113,7 +113,7 @@ def get_unique_indices(fiat_element, nonunique_map, vperm, offset=None):
     order = -np.ones_like(nonunique_map)
     cell = fiat_element.get_reference_element()
     if isinstance(cell, FIAT.reference_element.TensorProductCell):
-        cell = cell.A
+        cell, _ = cell.cells
     tdim = cell.get_spatial_dimension()
     nvtx = len(cell.get_vertices())
     ncell = 2**tdim
@@ -142,7 +142,7 @@ def get_unique_indices(fiat_element, nonunique_map, vperm, offset=None):
 def get_transforms_to_fine(cell):
     if isinstance(cell, FIAT.reference_element.TensorProductCell):
         extruded = True
-        cell = cell.A
+        cell, _ = cell.cells
     else:
         extruded = False
 

--- a/tests/extrusion/test_facet_support_dofs.py
+++ b/tests/extrusion/test_facet_support_dofs.py
@@ -1,119 +1,11 @@
 from firedrake import *
-from FIAT.tensor_product import horiz_facet_support_dofs, vert_facet_support_dofs
+from FIAT.finite_element import entity_support_dofs
 import pytest
-
-
-@pytest.fixture(scope='module')
-def quad_mesh():
-    return ExtrudedMesh(UnitIntervalMesh(1), 1)
-
-
-@pytest.fixture(scope='module')
-def prism_mesh():
-    return ExtrudedMesh(UnitTriangleMesh(), 1)
 
 
 @pytest.fixture(scope='module')
 def hex_mesh():
     return ExtrudedMesh(UnitSquareMesh(1, 1, quadrilateral=True), 1)
-
-
-@pytest.mark.parametrize(('args', 'kwargs', 'horiz_expected', 'vert_expected'),
-                         [(("DQ", 0), dict(),
-                           {0: [0], 1: [0]},
-                           {0: [0], 1: [0]}),
-                          (("DQ", 1), dict(),
-                           {0: [0, 2], 1: [1, 3]},
-                           {0: [0, 1], 1: [2, 3]}),
-                          (("Q", 1), dict(),
-                           {0: [0, 2], 1: [1, 3]},
-                           {0: [0, 1], 1: [2, 3]}),
-                          (("DG", 0), dict(vfamily="CG", vdegree=1),
-                           {0: [0], 1: [1]},
-                           {0: [0, 1], 1: [0, 1]}),
-                          (("CG", 1), dict(vfamily="DG", vdegree=0),
-                           {0: [0, 1], 1: [0, 1]},
-                           {0: [0], 1: [1]}),
-                          (("RTCF", 1), dict(),
-                           {0: [0, 1, 2], 1: [0, 1, 3]},
-                           {0: [0, 2, 3], 1: [1, 2, 3]}),
-                          (("RTCE", 1), dict(),
-                           {0: [0, 1, 2], 1: [0, 1, 3]},
-                           {0: [0, 2, 3], 1: [1, 2, 3]})])
-def test_quad(quad_mesh, args, kwargs, horiz_expected, vert_expected):
-    V = FunctionSpace(quad_mesh, *args, **kwargs)
-    assert horiz_expected == horiz_facet_support_dofs(V.fiat_element)
-    assert vert_expected == vert_facet_support_dofs(V.fiat_element)
-
-
-@pytest.mark.parametrize(('args', 'kwargs', 'horiz_expected', 'vert_expected'),
-                         [(("DG", 0), dict(),
-                           {0: [0], 1: [0]},
-                           {0: [0], 1: [0], 2: [0]}),
-                          (("DG", 1), dict(),
-                           {0: [0, 2, 4], 1: [1, 3, 5]},
-                           {0: [2, 3, 4, 5], 1: [0, 1, 4, 5], 2: [0, 1, 2, 3]}),
-                          (("CG", 1), dict(),
-                           {0: [0, 2, 4], 1: [1, 3, 5]},
-                           {0: [2, 3, 4, 5], 1: [0, 1, 4, 5], 2: [0, 1, 2, 3]}),
-                          (("DG", 0), dict(vfamily="CG", vdegree=1),
-                           {0: [0], 1: [1]},
-                           {0: [0, 1], 1: [0, 1], 2: [0, 1]}),
-                          (("CG", 1), dict(vfamily="DG", vdegree=0),
-                           {0: [0, 1, 2], 1: [0, 1, 2]},
-                           {0: [1, 2], 1: [0, 2], 2: [0, 1]})])
-def test_prism(prism_mesh, args, kwargs, horiz_expected, vert_expected):
-    V = FunctionSpace(prism_mesh, *args, **kwargs)
-    assert horiz_expected == horiz_facet_support_dofs(V.fiat_element)
-    assert vert_expected == vert_facet_support_dofs(V.fiat_element)
-
-
-@pytest.mark.parametrize(('space', 'degree', 'horiz_expected', 'vert_expected'),
-                         [("RT", 1,
-                           {0: [0, 1, 2, 3], 1: [0, 1, 2, 4]},
-                           {0: range(5), 1: range(5), 2: range(5)}),
-                          ("BDM", 1,
-                           {0: [0, 1, 2, 3, 4, 5, 6], 1: [0, 1, 2, 3, 4, 5, 7]},
-                           {0: range(8), 1: range(8), 2: range(8)})])
-def test_prism_hdiv(prism_mesh, space, degree, horiz_expected, vert_expected):
-    W0_h = FiniteElement(space, "triangle", degree)
-    W1_h = FiniteElement("DG", "triangle", degree - 1)
-
-    W0_v = FiniteElement("DG", "interval", degree - 1)
-    W0 = HDiv(TensorProductElement(W0_h, W0_v))
-
-    W1_v = FiniteElement("CG", "interval", degree)
-    W1 = HDiv(TensorProductElement(W1_h, W1_v))
-
-    V = FunctionSpace(prism_mesh, W0+W1)
-    assert horiz_expected == horiz_facet_support_dofs(V.fiat_element)
-    assert vert_expected == vert_facet_support_dofs(V.fiat_element)
-
-
-@pytest.mark.parametrize(('space', 'degree', 'horiz_expected', 'vert_expected'),
-                         [("RT", 1,
-                           {0: [0, 1, 2, 3, 5, 7], 1: [0, 1, 2, 4, 6, 8]},
-                           {0: [1, 2] + range(3, 9),
-                            1: [0, 2] + range(3, 9),
-                            2: [0, 1] + range(3, 9)}),
-                          ("BDM", 1,
-                           {0: range(3) + range(3, 15, 2), 1: range(3) + range(4, 15, 2)},
-                           {0: [1, 2] + range(3, 15),
-                            1: [0, 2] + range(3, 15),
-                            2: [0, 1] + range(3, 15)})])
-def test_prism_hcurl(prism_mesh, space, degree, horiz_expected, vert_expected):
-    W0_h = FiniteElement("CG", "triangle", degree)
-    W1_h = FiniteElement(space, "triangle", degree)
-
-    W0_v = FiniteElement("DG", "interval", degree - 1)
-    W0 = HCurl(TensorProductElement(W0_h, W0_v))
-
-    W1_v = FiniteElement("CG", "interval", degree)
-    W1 = HCurl(TensorProductElement(W1_h, W1_v))
-
-    V = FunctionSpace(prism_mesh, W0+W1)
-    assert horiz_expected == horiz_facet_support_dofs(V.fiat_element)
-    assert vert_expected == vert_facet_support_dofs(V.fiat_element)
 
 
 @pytest.mark.parametrize(('args', 'kwargs', 'horiz_expected', 'vert_expected'),
@@ -146,8 +38,8 @@ def test_prism_hcurl(prism_mesh, space, degree, horiz_expected, vert_expected):
                             3: [1, 3, 4, 5, 6, 7, 10, 11]})])
 def test_hex(hex_mesh, args, kwargs, horiz_expected, vert_expected):
     V = FunctionSpace(hex_mesh, *args, **kwargs)
-    assert horiz_expected == horiz_facet_support_dofs(V.fiat_element)
-    assert vert_expected == vert_facet_support_dofs(V.fiat_element)
+    assert horiz_expected == entity_support_dofs(V.fiat_element, (2, 0))
+    assert vert_expected == entity_support_dofs(V.fiat_element, (1, 1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Depends on [FIAT pull request #20](https://bitbucket.org/fenics-project/fiat/pull-requests/20).

Most facet support DoFs tests move to FIAT, except for the ones on hexahedra because they need the quadrilateral patching that is in TSFC.