### PR TITLE
Dirichlet sub vfs

### DIFF
--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -795,7 +795,7 @@ class ProxyFunctionSpace(FunctionSpace):
         :raises ValueError: if :attr:`no_dats` is ``True``.
         """
         if self.no_dats:
-            raise ValueError("Can't build Function on %s function space" % self.typ)
+            raise ValueError("Can't build Function on %s function space" % self.identifier)
         return super(ProxyFunctionSpace, self).make_dat(*args, **kwargs)
 
 

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -839,5 +839,4 @@ def ComponentFunctionSpace(parent, component):
     new.identifier = "component"
     new.component = component
     new.parent = parent
-    new.no_dats = True
     return new

--- a/tests/regression/test_vfs_component_bcs.py
+++ b/tests/regression/test_vfs_component_bcs.py
@@ -85,8 +85,13 @@ def test_poisson_in_components(V):
 
 
 @pytest.mark.parametrize("nested",
-                         [False, True])
-def test_poisson_in_mixed_plus_vfs_components(V, nested):
+                         [False, True], ids=["nest", "monolithic"])
+@pytest.mark.parametrize("make_val",
+                         [lambda x: x,
+                          pytest.mark.xfail(reason="Can't make dat")(
+                              lambda x: Expression("%g" % x))],
+                         ids=["UFL value", "C expression"])
+def test_poisson_in_mixed_plus_vfs_components(V, nested, make_val):
     # Solve five decoupled poisson problems with different boundary
     # conditions in a mixed space composed of two VectorFunctionSpaces
     # and one scalar FunctionSpace.
@@ -97,18 +102,18 @@ def test_poisson_in_mixed_plus_vfs_components(V, nested):
 
     g = Function(W)
 
-    bcs = [DirichletBC(W.sub(0).sub(0), 0, 1),
-           DirichletBC(W.sub(0).sub(0), 42, 2),
-           DirichletBC(W.sub(0).sub(1), 10, 3),
-           DirichletBC(W.sub(0).sub(1), 15, 4),
+    bcs = [DirichletBC(W.sub(0).sub(0), make_val(0), 1),
+           DirichletBC(W.sub(0).sub(0), make_val(42), 2),
+           DirichletBC(W.sub(0).sub(1), make_val(10), 3),
+           DirichletBC(W.sub(0).sub(1), make_val(15), 4),
 
-           DirichletBC(W.sub(1), 4, 1),
-           DirichletBC(W.sub(1), 10, 2),
+           DirichletBC(W.sub(1), make_val(4), 1),
+           DirichletBC(W.sub(1), make_val(10), 2),
 
-           DirichletBC(W.sub(2).sub(0), -10, 1),
-           DirichletBC(W.sub(2).sub(0), 10, 2),
-           DirichletBC(W.sub(2).sub(1), 15, 3),
-           DirichletBC(W.sub(2).sub(1), 5, 4)]
+           DirichletBC(W.sub(2).sub(0), make_val(-10), 1),
+           DirichletBC(W.sub(2).sub(0), make_val(10), 2),
+           DirichletBC(W.sub(2).sub(1), make_val(15), 3),
+           DirichletBC(W.sub(2).sub(1), make_val(5), 4)]
 
     u, p, r = TrialFunctions(W)
     v, q, s = TestFunctions(W)

--- a/tests/regression/test_vfs_component_bcs.py
+++ b/tests/regression/test_vfs_component_bcs.py
@@ -88,8 +88,7 @@ def test_poisson_in_components(V):
                          [False, True], ids=["nest", "monolithic"])
 @pytest.mark.parametrize("make_val",
                          [lambda x: x,
-                          pytest.mark.xfail(reason="Can't make dat")(
-                              lambda x: Expression("%g" % x))],
+                          lambda x: Expression("%g" % x)],
                          ids=["UFL value", "C expression"])
 def test_poisson_in_mixed_plus_vfs_components(V, nested, make_val):
     # Solve five decoupled poisson problems with different boundary


### PR DESCRIPTION
Fixes a regression Justin reported on the mailing list

> Hi all,

> Last year (~8 months ago) the following worked: 

```python
from firedrake import *
mesh = UnitSquareMesh(10,10)
V = VectorFunctionSpace(mesh, "CG", 1)
P = FunctionSpace(mesh, "CG", 1)
W = V*Q
bc1 = DirichletBC(W.sub(0).sub(0), Expression("cos(pi*x[0])*sin(pi*x[1])"), (1,2))
```