### PR TITLE
Multiple domains

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -221,6 +221,8 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
         # Ensure mesh is "initialised" (could have got here without
         # building a functionspace (e.g. if integrating a constant)).
         m.init()
+        if m.topology != domains[0].topology:
+            raise NotImplementedError("All integration domains must share a mesh topology.")
 
     # These will be used to correctly interpret the "otherwise"
     # subdomain

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -214,16 +214,13 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
             tensor = op2.Global(1, [0.0])
         result = lambda: tensor.data[0]
 
-    subdomain_data = f.subdomain_data()
     coefficients = f.coefficients()
     domains = f.ufl_domains()
-    if len(domains) != 1:
-        raise NotImplementedError("Assembly of forms with more than one domain not supported")
-    m = domains[0]
-    # Ensure mesh is "initialised" (could have got here without
-    # building a functionspace (e.g. if integrating a constant)).
-    m.init()
-    subdomain_data = subdomain_data[m]
+
+    for m in domains:
+        # Ensure mesh is "initialised" (could have got here without
+        # building a functionspace (e.g. if integrating a constant)).
+        m.init()
 
     # These will be used to correctly interpret the "otherwise"
     # subdomain
@@ -247,7 +244,9 @@ def _assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
     # assemble it.
     def thunk(bcs):
         zero_tensor()
-        for indices, (kernel, integral_type, needs_orientations, subdomain_id, coeff_map) in kernels:
+        for indices, (kernel, integral_type, needs_orientations, subdomain_id, domain_number, coeff_map) in kernels:
+            m = domains[domain_number]
+            subdomain_data = f.subdomain_data()[m]
             # Find argument space indices
             if is_mat:
                 i, j = indices

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -132,6 +132,7 @@ KernelInfo = collections.namedtuple("KernelInfo",
                                      "integral_type",
                                      "oriented",
                                      "subdomain_id",
+                                     "domain_number",
                                      "coefficient_map"])
 
 
@@ -194,7 +195,7 @@ class TSFCKernel(Cached):
         return md5(form.signature() + name + Kernel._backend.__name__
                    + str(default_parameters["coffee"])
                    + str(parameters)
-                   + str(number_map)).hexdigest(), form.ufl_domain().comm
+                   + str(number_map)).hexdigest(), form.ufl_domains()[0].comm
 
     def __init__(self, form, name, parameters, number_map):
         """A wrapper object for one or more TSFC kernels compiled from a given :class:`~ufl.classes.Form`.
@@ -220,6 +221,7 @@ class TSFCKernel(Cached):
                                       integral_type=kernel.integral_type,
                                       oriented=kernel.oriented,
                                       subdomain_id=kernel.subdomain_id,
+                                      domain_number=kernel.domain_number,
                                       coefficient_map=numbers))
         self.kernels = tuple(kernels)
         self._initialized = True


### PR DESCRIPTION
Allow assembly over multiple domains that share topology.  Useful for implementing ALE where you select which terms are integrated on which mesh by doing `term1*dx(domain=mesh1) + term2*dx(domain=mesh2)`.  All arguments must be defined on a function space on one of the meshes.  See https://bitbucket.org/fenics-project/ufl/issues/86/domain-handling-for-forms-with-multiple for ongoing discussion.

Opening up for comments now.  Needs firedrakeproject/tsfc#51 to land at the same time.