### PR TITLE
Fix mesh marking regression

### DIFF
--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -740,6 +740,13 @@ def mark_entity_classes(PETSc.DM plex):
                         non_exec = PETSC_FALSE
         if non_exec:
             CHKERR(DMLabelSetValue(lbl_non_exec, facets[f], 1))
+
+    # Remove exec marks from facets in non-exec label
+    for f in range(nfacets):
+        if not (fStart <= facets[f] < fEnd):
+            continue
+        CHKERR(DMLabelHasPoint(lbl_non_exec, facets[f], &has_point))
+        if has_point:
             # Remove facet from exec-halo label
             CHKERR(DMLabelClearValue(lbl_exec, facets[f], 1))
 

--- a/firedrake/dmplexinc.pxi
+++ b/firedrake/dmplexinc.pxi
@@ -33,6 +33,7 @@ cdef extern from "petscdmlabel.h":
     struct _n_DMLabel
     ctypedef _n_DMLabel* DMLabel "DMLabel"
     int DMLabelCreateIndex(DMLabel, PetscInt, PetscInt)
+    int DMLabelDestroyIndex(DMLabel)
     int DMLabelHasPoint(DMLabel, PetscInt, PetscBool*)
     int DMLabelSetValue(DMLabel, PetscInt, PetscInt)
     int DMLabelGetValue(DMLabel, PetscInt, PetscInt*)


### PR DESCRIPTION
This fixes a performance regression for the creation of meshes in parallel (62ccbc1).  And also tidies up label index usage.

I run:
```shell
$ cat > foo.py << EOF
from firedrake import *
mesh = UnitCubeMesh(80, 80, 80)
mesh.init()
EOF
$ mpiexec -n 16 -bind-to-core python foo.py -log_view
```

Before this change:

```
Summary of Stages:   ----- Time ------  ----- Flops -----  --- Messages ---  -- Message Lengths --  -- Reductions --
                        Avg     %Total     Avg     %Total   counts   %Total     Avg         %Total   counts   %Total 
 0:      Main Stage: 5.6913e+02 100.0%  0.0000e+00   0.0%  1.423e+04 100.0%  3.717e+05      100.0%  1.100e+02  99.1% 

------------------------------------------------------------------------------------------------------------------------
Event                Count      Time (sec)     Flops                             --- Global ---  --- Stage ---   Total
                   Max Ratio  Max     Ratio   Max  Ratio  Mess   Avg len Reduct  %T %F %M %L %R  %T %F %M %L %R Mflop/s
------------------------------------------------------------------------------------------------------------------------

--- Event Stage 0: Main Stage

BuildTwoSided         44 1.0 8.5218e+0016.3 0.00e+00 0.0 3.5e+03 4.0e+00 4.4e+01  1  0 25  0 40   1  0 25  0 40     0
VecSet                 4 1.0 6.2819e-03 1.4 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
Mesh Partition         2 1.0 1.8045e+01 1.0 0.00e+00 0.0 5.3e+03 8.4e+04 2.3e+01  3  0 37  8 21   3  0 37  8 21     0
Mesh Migration         2 1.0 5.1994e+00 1.0 0.00e+00 0.0 8.2e+03 5.4e+05 5.4e+01  1  0 58 84 49   1  0 58 84 49     0
DMPlexInterp           1 1.0 2.0668e+01 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00  4  0  0  0  2   4  0  0  0  2     0
DMPlexDistribute       1 1.0 2.1004e+01 1.0 0.00e+00 0.0 2.9e+03 8.8e+05 2.7e+01  4  0 20 49 24   4  0 20 49 25     0
DMPlexDistCones        2 1.0 1.1024e+00 1.0 0.00e+00 0.0 1.2e+03 1.3e+06 4.0e+00  0  0  8 28  4   0  0  8 28  4     0
DMPlexDistLabels       2 1.0 3.2046e+00 1.0 0.00e+00 0.0 5.0e+03 4.9e+05 2.2e+01  1  0 35 47 20   1  0 35 47 20     0
DMPlexDistribOL        1 1.0 2.4593e+00 1.0 0.00e+00 0.0 1.1e+04 2.5e+05 5.0e+01  0  0 75 51 45   0  0 75 51 45     0
DMPlexDistField        3 1.0 1.4348e-01 1.0 0.00e+00 0.0 1.5e+03 1.2e+05 8.0e+00  0  0 11  4  7   0  0 11  4  7     0
DMPlexDistData         2 1.0 8.3865e+0018.4 0.00e+00 0.0 3.9e+03 4.9e+04 6.0e+00  1  0 28  4  5   1  0 28  4  5     0
DMPlexStratify         6 1.0 6.0848e+0112.1 0.00e+00 0.0 0.0e+00 0.0e+00 6.0e+00 10  0  0  0  5  10  0  0  0  5     0
SFSetGraph            47 1.0 6.1890e-01 1.3 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFBcastBegin          93 1.0 9.0055e+00 4.0 0.00e+00 0.0 1.4e+04 3.8e+05 4.1e+01  1  0 96 98 37   1  0 96 98 37     0
SFBcastEnd            93 1.0 2.9585e+00 4.8 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFReduceBegin          4 1.0 3.0405e-02 2.2 0.00e+00 0.0 4.5e+02 2.6e+05 3.0e+00  0  0  3  2  3   0  0  3  2  3     0
SFReduceEnd            4 1.0 7.9590e-02 1.3 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFFetchOpBegin         1 1.0 1.7095e-0413.3 0.00e+00 0.0 4.8e+01 1.9e+04 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFFetchOpEnd           1 1.0 1.6320e-03 2.3 0.00e+00 0.0 4.8e+01 1.9e+04 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
CreateMesh             4 1.0 5.0586e+02 1.0 0.00e+00 0.0 1.4e+04 3.8e+05 8.1e+01 89  0 96 99 73  89  0 96 99 74     0
Mesh: reorder          1 1.0 1.7533e-01 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00  0  0  0  0  2   0  0  0  0  2     0
Mesh: numbering        1 1.0 4.7827e+02 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00 84  0  0  0  2  84  0  0  0  2     0
CreateFunctionSpace       1 1.0 1.0375e+00 1.0 0.00e+00 0.0 5.8e+02 7.6e+04 5.0e+00  0  0  4  1  5   0  0  4  1  5     0
```

Note in particular that `Mesh: numbering` takes around 480 seconds, and the total time is 570 seconds.

Afterwards:
```
Summary of Stages:   ----- Time ------  ----- Flops -----  --- Messages ---  -- Message Lengths --  -- Reductions --
                        Avg     %Total     Avg     %Total   counts   %Total     Avg         %Total   counts   %Total 
 0:      Main Stage: 9.3644e+01 100.0%  0.0000e+00   0.0%  1.423e+04 100.0%  3.717e+05      100.0%  1.100e+02  99.1% 

------------------------------------------------------------------------------------------------------------------------
Event                Count      Time (sec)     Flops                             --- Global ---  --- Stage ---   Total
                   Max Ratio  Max     Ratio   Max  Ratio  Mess   Avg len Reduct  %T %F %M %L %R  %T %F %M %L %R Mflop/s
------------------------------------------------------------------------------------------------------------------------

--- Event Stage 0: Main Stage

BuildTwoSided         44 1.0 9.6943e+0018.0 0.00e+00 0.0 3.5e+03 4.0e+00 4.4e+01  9  0 25  0 40   9  0 25  0 40     0
VecSet                 4 1.0 6.2602e-03 1.5 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
Mesh Partition         2 1.0 1.9274e+01 1.0 0.00e+00 0.0 5.3e+03 8.4e+04 2.3e+01 21  0 37  8 21  21  0 37  8 21     0
Mesh Migration         2 1.0 5.4132e+00 1.0 0.00e+00 0.0 8.2e+03 5.4e+05 5.4e+01  6  0 58 84 49   6  0 58 84 49     0
DMPlexInterp           1 1.0 2.0595e+01 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00 22  0  0  0  2  22  0  0  0  2     0
DMPlexDistribute       1 1.0 2.2406e+01 1.0 0.00e+00 0.0 2.9e+03 8.8e+05 2.7e+01 24  0 20 49 24  24  0 20 49 25     0
DMPlexDistCones        2 1.0 1.1475e+00 1.0 0.00e+00 0.0 1.2e+03 1.3e+06 4.0e+00  1  0  8 28  4   1  0  8 28  4     0
DMPlexDistLabels       2 1.0 3.3368e+00 1.0 0.00e+00 0.0 5.0e+03 4.9e+05 2.2e+01  4  0 35 47 20   4  0 35 47 20     0
DMPlexDistribOL        1 1.0 2.5152e+00 1.0 0.00e+00 0.0 1.1e+04 2.5e+05 5.0e+01  3  0 75 51 45   3  0 75 51 45     0
DMPlexDistField        3 1.0 1.4832e-01 1.0 0.00e+00 0.0 1.5e+03 1.2e+05 8.0e+00  0  0 11  4  7   0  0 11  4  7     0
DMPlexDistData         2 1.0 9.5285e+0021.0 0.00e+00 0.0 3.9e+03 4.9e+04 6.0e+00  9  0 28  4  5   9  0 28  4  5     0
DMPlexStratify         6 1.0 6.0388e+0112.0 0.00e+00 0.0 0.0e+00 0.0e+00 6.0e+00 61  0  0  0  5  61  0  0  0  5     0
SFSetGraph            47 1.0 6.1696e-01 1.3 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  1  0  0  0  0   1  0  0  0  0     0
SFBcastBegin          93 1.0 1.0188e+01 4.3 0.00e+00 0.0 1.4e+04 3.8e+05 4.1e+01 10  0 96 98 37  10  0 96 98 37     0
SFBcastEnd            93 1.0 3.0884e+00 4.9 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  3  0  0  0  0   3  0  0  0  0     0
SFReduceBegin          4 1.0 3.2338e-02 2.3 0.00e+00 0.0 4.5e+02 2.6e+05 3.0e+00  0  0  3  2  3   0  0  3  2  3     0
SFReduceEnd            4 1.0 8.2460e-02 1.2 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFFetchOpBegin         1 1.0 2.0599e-0415.7 0.00e+00 0.0 4.8e+01 1.9e+04 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
SFFetchOpEnd           1 1.0 4.8490e-03 5.2 0.00e+00 0.0 4.8e+01 1.9e+04 0.0e+00  0  0  0  0  0   0  0  0  0  0     0
CreateMesh             4 1.0 3.0792e+01 1.0 0.00e+00 0.0 1.4e+04 3.8e+05 8.1e+01 33  0 96 99 73  33  0 96 99 74     0
Mesh: reorder          1 1.0 1.9583e-01 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00  0  0  0  0  2   0  0  0  0  2     0
Mesh: numbering        1 1.0 1.7605e+00 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 2.0e+00  2  0  0  0  2   2  0  0  0  2     0
CreateFunctionSpace       1 1.0 1.0778e+00 1.0 0.00e+00 0.0 5.8e+02 7.6e+04 5.0e+00  1  0  4  1  5   1  0  4  1  5     0
```

Afterwards, the time for `Mesh: numbering` has drop to around 2 seconds, and the total time to 93 seconds.