### PR TITLE
Give an option to not pre-apply BCs.

### DIFF
--- a/firedrake/mg/solver_hierarchy.py
+++ b/firedrake/mg/solver_hierarchy.py
@@ -178,6 +178,8 @@ class NLVSHierarchy(object):
         :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
              :class:`.MixedVectorSpaceBasis`) spanning the null space of the
              operator.
+        :kwarg pre_apply_bcs: if True (default), apply the BCs to the
+               initial guess. Set to False for consistency with DOLFIN.
         :kwarg solver_parameters: Solver parameters to pass to PETSc.
             This should be a dict mapping PETSc options to values.
             PETSc flag options should be specified with `bool`
@@ -196,7 +198,7 @@ class NLVSHierarchy(object):
         """
         # Do this first so __del__ doesn't barf horribly if we get an
         # error in __init__
-        parameters, nullspace, tnullspace, options_prefix \
+        parameters, nullspace, tnullspace, options_prefix, pre_apply_bcs \
             = firedrake.solving_utils._extract_kwargs(**kwargs)
 
         if options_prefix is not None:
@@ -225,7 +227,8 @@ class NLVSHierarchy(object):
         pmat_type = parameters.get("pmat_type")
         ctx = firedrake.solving_utils._SNESContext(problems,
                                                    mat_type=mat_type,
-                                                   pmat_type=pmat_type)
+                                                   pmat_type=pmat_type,
+                                                   pre_apply_bcs=pre_apply_bcs)
 
         if nullspace is not None or tnullspace is not None:
             raise NotImplementedError("Coarsening nullspaces not yet implemented")

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -128,7 +128,7 @@ def _solve_varproblem(*args, **kwargs):
     # Extract arguments
     eq, u, bcs, J, Jp, M, form_compiler_parameters, \
         solver_parameters, nullspace, nullspace_T, \
-        options_prefix = _extract_args(*args, **kwargs)
+        options_prefix, pre_apply_bcs = _extract_args(*args, **kwargs)
 
     appctx = kwargs.get("appctx", {})
     # Solve linear variational problem
@@ -160,6 +160,7 @@ def _solve_varproblem(*args, **kwargs):
                                                nullspace=nullspace,
                                                transpose_nullspace=nullspace_T,
                                                options_prefix=options_prefix,
+                                               pre_apply_bcs=pre_apply_bcs,
                                                appctx=appctx)
         solver.solve()
 
@@ -243,7 +244,7 @@ def _extract_args(*args, **kwargs):
     valid_kwargs = ["bcs", "J", "Jp", "M",
                     "form_compiler_parameters", "solver_parameters",
                     "nullspace", "transpose_nullspace",
-                    "options_prefix", "appctx"]
+                    "options_prefix", "appctx", "pre_apply_bcs"]
     transfer_nest = False
     if "nest" in kwargs:
         from firedrake.logging import warning, RED
@@ -292,13 +293,14 @@ def _extract_args(*args, **kwargs):
     form_compiler_parameters = kwargs.get("form_compiler_parameters", {})
     solver_parameters = kwargs.get("solver_parameters", {})
     options_prefix = kwargs.get("options_prefix", None)
+    pre_apply_bcs = kwargs.get("pre_apply_bcs", True)
 
     if transfer_nest and nest is not None:
         solver_parameters["mat_type"] = "nest" if nest else "aij"
         if Jp is not None:
             solver_parameters["pmat_type"] = solver_parameters["mat_type"]
     return eq, u, bcs, J, Jp, M, form_compiler_parameters, \
-        solver_parameters, nullspace, nullspace_T, options_prefix
+        solver_parameters, nullspace, nullspace_T, options_prefix, pre_apply_bcs
 
 
 def _extract_bcs(bcs):


### PR DESCRIPTION
This is essential for Newton convergence in some sticky problems (Allen-Cahn, at least).

Turning it on doesn't make the firedrake residual history the same as DOLFIN, though. Something deeper must be different; further investigation is required. This pull request is provisional until then (i.e. a venue for a conversation, rather than an actual request that you merge this.)

The only thing I had to change that I was uncomfortable with: removal of `@classmethod` from form_function. I don't know why it was there in the first place, but it might have been important.