### PR TITLE
Split mixed coefficients for interpolation

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -226,11 +226,23 @@ def compile_ufl_kernel(expression, to_pts, to_element, fs):
         return ValueError("Cannot interpolate UFL expression with Arguments!")
 
     builder = KernelBuilderBase()
-    args = []
+    coefficient_split = {}
 
-    coefficients = extract_coefficients(expression)
-    for i, coefficient in enumerate(coefficients):
-        args.append(builder._coefficient(coefficient, "w_%d" % i))
+    coefficients = []
+    args = []
+    for i, coefficient in enumerate(extract_coefficients(expression)):
+        if type(coefficient.ufl_element()) == ufl.MixedElement:
+            coefficient_split[coefficient] = []
+            for j, element in enumerate(coefficient.ufl_element().sub_elements()):
+                subcoeff = ufl.Coefficient(ufl.FunctionSpace(coefficient.ufl_domain(), element))
+                coefficient_split[coefficient].append(subcoeff)
+                args.append(builder._coefficient(subcoeff, "w_%d_%d" % (i, j)))
+            coefficients.extend(coefficient.split())
+        else:
+            args.append(builder._coefficient(coefficient, "w_%d" % (i,)))
+            coefficients.append(coefficient)
+
+    expression = ufl_utils.split_coefficients(expression, coefficient_split)
 
     point_index = gem.Index(name='p')
     ir = fem.compile_ufl(expression,


### PR DESCRIPTION
Mixed coefficients are split for compiling interpolation kernels. We did the same thing for assembling forms in #775. This patch applies the same change for UFL interpolation.

Required by TSFC/FInAT since `tsfc.MixedElement` will be retired.