### PR TITLE
Safety check for user PYTHONPATH

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,7 +45,7 @@ build:
 
     # Install firedrake
     - cd $FIREDRAKE_HOME
-    - $DRONE_BUILD_DIR/scripts/firedrake-install --disable-ssh --minimal-petsc --slepc --adjoint --slope --package-branch firedrake $DRONE_COMMIT
+    - $DRONE_BUILD_DIR/scripts/firedrake-install --disable-ssh --minimal-petsc --slepc --adjoint --slope --honour-pythonpath --package-branch firedrake $DRONE_COMMIT
 
     # Activate the virtualenv
     - . firedrake/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
   - export CC=mpicc
   - mkdir tmp
   - cd tmp
-  - ../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --adjoint --slope ${PACKAGE_MANAGER}
+  - ../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --honour-pythonpath --adjoint --slope ${PACKAGE_MANAGER}
   - . ./firedrake/bin/activate
   # Test that running firedrake-update works
   - firedrake-update

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -86,6 +86,8 @@ honoured.""",
                         help="Minimise the set of petsc dependencies installed. This creates faster build times (useful for build testing).")
     parser.add_argument("--honour-petsc-dir", "--honour_petsc_dir", action="store_true",
                         help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
+    parser.add_argument("--honour-pythonpath", "--honour_pythonpath", action="store_true",
+                        help="Pointing to external Python packages is usually a user error. Set this option if you know that you want PYTHONPATH set.")
     parser.add_argument("--rebuild-script", "--rebuild_script", action="store_true",
                         help="Only rebuild the firedrake-install script. Use this option if your firedrake-install script is broken and a fix has been released in upstream Firedrake. You will need to specify any other options which you wish to be honoured by your new update script (eg. --developer or --sudo).")
     parser.add_argument("--package-branch", "--package_branch", type=str, nargs=2, action="append", metavar=("PACKAGE", "BRANCH"),
@@ -124,6 +126,8 @@ else:
                         help="Install SLEPc along with PETSc")
     parser.add_argument("--honour-petsc-dir", action="store_true",
                         help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
+    parser.add_argument("--honour-pythonpath", "--honour_pythonpath", action="store_true", dest="pythonpath",
+                        help="Pointing to external Python packages is usually a user error. Set this option if you know that you want PYTHONPATH set.")
     parser.add_argument("--clean", action='store_true',
                         help="Delete any remnants of obsolete Firedrake components.")
     parser.add_argument("--log", action='store_true',
@@ -138,6 +142,8 @@ else:
     args.rebuild_script = False
     args.mpicc = False
     args.disable_ssh = False
+    args.honour_pythonpath = False
+    args.honour_pythonpath = args.honour_pythonpath or args.pythonpath
     args.show_petsc_configure_options = False
     args.adjoint = False
     args.adjoint = args.adjoint or args.install_adjoint
@@ -147,6 +153,7 @@ else:
     args.slepc = args.slepc or args.install_slepc
     args.virtualenv_name = False
     args.virtualenv_name = args.virtualenv_name or "firedrake"
+
 
 class directory(object):
     """Context manager that executes body in a given directory"""
@@ -297,6 +304,7 @@ def git_url(plain_url, protocol):
         return "https://%s" % plain_url
     else:
         raise ValueError("Unknown git protocol: %s" % protocol)
+
 
 def git_clone(url):
     name, plain_url, branch = split_requirements_url(url)
@@ -758,7 +766,7 @@ def build_update_script():
 
     for switch in ["developer", "sudo", "package_manager", "minimal_petsc",
                    "mpicc", "disable_ssh", "show_petsc_configure_options", "adjoint",
-                   "virtualenv_name"]:
+                   "virtualenv_name", "honour_pythonpath"]:
         update_script = update_script.replace("args.%s = False" % switch,
                                               "args.%s = %r" % (switch, args.__getattribute__(switch)))
     try:
@@ -799,6 +807,12 @@ if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
 If you really want to use your own PETSc build, please run again with the
 --honour-petsc-dir option.
+""")
+
+if "PYTHONPATH" in os.environ and not args.honour_pythonpath:
+    quit("""The PYTHONPATH environment variable is set. This is probably an error.
+If you really want to use your own Python packages, please run again with the
+--honour-pythonpath option.
 """)
 
 if travis:


### PR DESCRIPTION
Having a `PYTHONPATH` variable pointing at all sorts of extraneous things is a frequent cause of user pain. This makes having `PYTHONPATH` set a fatal error at install or upgrade time. The user can override this with the `--honour-pythonpath` option, and this override will be remembered for this installation. 