### PR TITLE
Clear cache on upgrade

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -86,16 +86,6 @@ Firedrake and all its dependencies.
    You should activate the virtualenv_ before running
    `firedrake-update`.
 
-Cleaning disk caches after upgrade
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-After upgrading, you may need to clear any disk caches that Firedrake
-maintains to ensure that your problem does not pick up any out of date
-compiled modules. To do this run::
-
-  firedrake-clean
-
-You will need to activate the virtualenv first.
 
 Recovering from a broken installation script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/scripts/firedrake-clean
+++ b/scripts/firedrake-clean
@@ -7,4 +7,4 @@ from pyop2.compilation import clear_cache as pyop2_clear_cache
 if __name__ == '__main__':
     print 'Removing cached TSFC kernels from %s' % TSFCKernel._cachedir
     clear_cache()
-    pyop2_clear_cache(prompt=True)
+    pyop2_clear_cache()

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1159,6 +1159,20 @@ if args.slepc:
 if args.slope:
     build_and_install_slope()
 
+
+if mode == "update":
+    try:
+        log.info("Clearing just in time compilation caches.")
+        from firedrake.tsfc_interface import clear_cache, TSFCKernel
+        from pyop2.compilation import clear_cache as pyop2_clear_cache
+        print 'Removing cached TSFC kernels from %s' % TSFCKernel._cachedir
+        clear_cache()
+        pyop2_clear_cache()
+    except:
+        # Unconditional except in order to avoid upgrade script failures.
+        log.error("Failed to clear caches. Try running firedrake-clean.")
+
+
 os.chdir("../..")
 
 log.info("Successfully installed Firedrake.\n")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1175,7 +1175,7 @@ if mode == "update":
 
 os.chdir("../..")
 
-log.info("Successfully installed Firedrake.\n")
+log.info("\n\nSuccessfully installed Firedrake.\n")
 
 log.info("To upgrade firedrake, run %s/bin/firedrake-update" % firedrake_env)
 


### PR DESCRIPTION
Always clear the caches when upgrading. This should reduce user issues with stale caches.

On the side, remove the interactive prompt when running firedrake-clean.