### PR TITLE
Custom callbacks

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -167,6 +167,10 @@ class _SNESContext(object):
     :arg appctx: Any extra information used in the assembler.  For the
         matrix-free case this will contain the Newton state in
         ``"state"``.
+    :arg pre_jacobian_callback: User-defined function called immediately
+        before Jacobian assembly
+    :arg pre_function_callback: User-defined function called immediately
+        before residual assembly
 
     The idea here is that the SNES holds a shell DM which contains
     this object as "user context".  When the SNES calls back to the
@@ -174,7 +178,7 @@ class _SNESContext(object):
     get the context (which is one of these objects) to find the
     Firedrake level information.
     """
-    def __init__(self, problem, mat_type, pmat_type, appctx=None):
+    def __init__(self, problem, mat_type, pmat_type, appctx=None, pre_jacobian_callback=None, pre_function_callback=None):
         from firedrake.assemble import allocate_matrix, create_assembly_callable
         if pmat_type is None:
             pmat_type = mat_type
@@ -185,6 +189,8 @@ class _SNESContext(object):
         pmatfree = pmat_type == 'matfree'
 
         self._problem = problem
+        self._pre_jacobian_callback = pre_jacobian_callback
+        self._pre_function_callback = pre_function_callback
 
         fcp = problem.form_compiler_parameters
         # Function to hold current guess
@@ -333,6 +339,9 @@ class _SNESContext(object):
         with ctx._x.dat.vec as v:
             X.copy(v)
 
+        if ctx._pre_function_callback is not None:
+            ctx._pre_function_callback(X)
+
         ctx._assemble_residual()
 
         # no mat_type -- it's a vector!
@@ -368,6 +377,9 @@ class _SNESContext(object):
         # copy guess in from X.
         with ctx._x.dat.vec as v:
             X.copy(v)
+
+        if ctx._pre_jacobian_callback is not None:
+            ctx._pre_jacobian_callback(X)
 
         ctx._assemble_jac()
         ctx._jac.force_evaluation()

--- a/tests/regression/test_custom_callbacks.py
+++ b/tests/regression/test_custom_callbacks.py
@@ -27,16 +27,40 @@ def test_callbacks():
 
         # introduce current-solution-dependent behaviour
         if temp.dat.data[0] == 0.0:
-            beta.assign(1.5)  # this branch is hit at the first iteration
+            # this is reached when calculating the initial residual
+            beta.assign(1.5)
         else:
+            # this is reached when calculating the residual after one iteration
             beta.assign(2.0)
 
     problem = NonlinearVariationalProblem(F, u)
 
+    # Perform only one iteration; expect to get u = 1.5
+    params = {"snes_linesearch_type": "basic",
+              "snes_max_it": 1}
+
     solver = NonlinearVariationalSolver(problem,
                                         pre_jacobian_callback=update_alpha,
-                                        pre_function_callback=update_beta)
+                                        pre_function_callback=update_beta,
+                                        solver_parameters=params)
+    try:
+        # This will error as beta is set to 2.0 when the residual is
+        # recalculated, so the SNES hasn't converged
+        solver.solve()
+    except:
+        pass
 
+    assert np.allclose(u.dat.data, 1.5)
+
+    # Perform two iterations; now get u = 2.0 as expected
+    u.assign(0)
+
+    new_params = {"snes_linesearch_type": "basic",
+                  "snes_max_it": 2}
+
+    solver = NonlinearVariationalSolver(problem,
+                                        pre_function_callback=update_beta,
+                                        solver_parameters=new_params)
     solver.solve()
 
     assert np.allclose(u.dat.data, 2.0)

--- a/tests/regression/test_custom_callbacks.py
+++ b/tests/regression/test_custom_callbacks.py
@@ -1,0 +1,47 @@
+from firedrake import *
+import numpy as np
+import pytest
+
+
+def test_callbacks():
+    mesh = UnitIntervalMesh(10)
+
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = Function(V)
+    v = TestFunction(V)
+
+    f = Function(V).assign(1)
+    temp = Function(V)
+    alpha = Constant(0.0)
+    beta = Constant(0.0)
+
+    F = alpha*u*v*dx - beta*f*v*dx  # we will override alpha and beta later
+
+    def update_alpha(current_solution):
+        alpha.assign(1.0)
+
+    def update_beta(current_solution):
+        with temp.dat.vec as foo:
+            current_solution.copy(foo)
+
+        # introduce current-solution-dependent behaviour
+        if temp.dat.data[0] == 0.0:
+            beta.assign(1.5)  # this branch is hit at the first iteration
+        else:
+            beta.assign(2.0)
+
+    problem = NonlinearVariationalProblem(F, u)
+
+    solver = NonlinearVariationalSolver(problem,
+                                        pre_jacobian_callback=update_alpha,
+                                        pre_function_callback=update_beta)
+
+    solver.solve()
+
+    assert np.allclose(u.dat.data, 2.0)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
This adds the ability for the user to call custom functionality before Jacobian and residual assembly in nonlinear problems (e.g. if the user has non-UFL operations to perform).  We're using this in the Monge-Ampère quasi-Newton work, for example.

If we think the `init` is going to grow out of control, we should find a way to rewrite this sooner rather than later.

Travis showed X but all the Linux builds passed.
