### PR TITLE
More robust cleaning

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -15,6 +15,8 @@ adjoint_deps = {
     "dolfin-adjoint": "git+https://bitbucket.org/dolfin-adjoint/dolfin-adjoint.git"
 }
 
+# Packages which we wish to ensure are always recompiled
+wheel_blacklist = ["mpi4py"]
 
 class InstallError(Exception):
     # Exception for generic install problems.
@@ -275,7 +277,7 @@ else:
 # virtualenv install
 # Use the pip from the virtualenv
 sudopip = ["%s/bin/pip" % firedrake_env]
-pipinstall = sudopip + ["install"]
+pipinstall = sudopip + ["install", "--no-binary", ",".join(wheel_blacklist)]
 python = ["%s/bin/python" % firedrake_env]
 pyinstall = python + ["setup.py", "install"]
 sitepackages = "%s/lib/python%d.%d/site-packages" % (firedrake_env, v.major, v.minor)

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,11 @@ cmdclass = versioneer.get_cmdclass()
 
 if "clean" in sys.argv[1:]:
     # Forcibly remove the results of Cython.
-    def cythonclean(arg, dirname, files):
+    for dirname, dirs, files in os.walk("firedrake"):
         for f in files:
             base, ext = os.path.splitext(f)
             if ext in (".c", ".cpp", ".so") and base + ".pyx" in files:
                 os.remove(os.path.join(dirname, f))
-    os.path.walk("firedrake", cythonclean, None)
 
 try:
     from Cython.Distutils import build_ext

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 from glob import glob
 from os import environ as env, path
+import os
 import sys
 import numpy as np
 import petsc4py
@@ -30,6 +31,15 @@ http://firedrakeproject.org/obtaining_pyop2.html#petsc
 import versioneer
 
 cmdclass = versioneer.get_cmdclass()
+
+if "clean" in sys.argv[1:]:
+    # Forcibly remove the results of Cython.
+    def cythonclean(arg, dirname, files):
+        for f in files:
+            base, ext = os.path.splitext(f)
+            if ext in (".c", ".cpp", ".so") and base + ".pyx" in files:
+                os.remove(os.path.join(dirname, f))
+    os.path.walk("firedrake", cythonclean, None)
 
 try:
     from Cython.Distutils import build_ext


### PR DESCRIPTION
Fix two problems which sometimes occur on install or upgrade:

1. Ensure that mpi4py is always built from source. This avoids the issue of having a cached wheel linked against the wrong mpi.

2. Ensure that setup.py clean actually removes Cython generated files from Firedrake. A similar change will be made to PyOP2.