### PR TITLE
Shut up the assembly cache

### DIFF
--- a/firedrake/assembly_cache.py
+++ b/firedrake/assembly_cache.py
@@ -207,7 +207,7 @@ class AssemblyCache(object):
         if self.invalid_count[key] > parameters["assembly_cache"]["max_misses"]:
             if self.invalid_count[key] == \
                parameters["assembly_cache"]["max_misses"] + 1:
-                debug("form %s missed too many times, excluding from cache." % form)
+                debug("form %s missed too many times, excluding from cache.", form)
 
         else:
             cache_entry = _CacheEntry(obj, form, bcs)


### PR DESCRIPTION
One of the usual Python eager evaluation issues: the debug message is evaluated even if it's never going to be emitted. Since a recent UFL change, this produces command line chatter.