### PR TITLE
Disable linux builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,6 @@ matrix:
         TEST_ADJOINT="TRUE"
         PACKAGE_MANAGER=""
         SLEPC=""
-    - os: linux
-      env:
-        TEST_FILES="tests/regression"
-    - os: linux
-      env:
-        TEST_FILES="tests/benchmarks tests/extrusion tests/output tests/multigrid tests/demos"
-        TEST_ADJOINT="TRUE"
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update; brew install python; brew link --overwrite python ;  fi
   - pip install -U --user pip


### PR DESCRIPTION
The Travis linux builders are constantly timing out, so it's time to get a little more assertive about moving to Drone. The .yml isn't fully cleaned up as a pure Mac builder because this is intended to be temporary until we can get Mac over onto drone too.