### PR TITLE
Matrix improvements

### DIFF
--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -457,6 +457,40 @@ precondition the Krylov system solving for :math:`S`, you can also use
 a `least squares commutator <LSC_>`_, see the relevant section of the
 `PETSc manual pages <fieldsplit_>`_ for more details.
 
+Specifying assembled matrix types
++++++++++++++++++++++++++++++++++
+
+Firedrake supports assembling linear operators in a number of
+different formats.  Either as assembled sparse matrices, or as
+matrix-free operators that only provide matrix-vector products.  Since
+matrix-free actions require special preconditioning, they have
+:doc:`their own section in the manual <matrix-free>`.  Even in the
+sparse matrix case there are a few options.  Firedrake can build
+nested block matrices, or monolithic sparse matrices.  The latter
+admit a wider range of preconditioners, but are memory-inefficient
+when using fieldsplit preconditioning.  Even monolithic matrices have
+choices, specifically, if there is a block structure, whether that
+should be exploited or not.  Again the trade-off is between memory
+efficiency (in the block case) and access to a slightly smaller range
+of preconditioners.
+
+The default matrix type can be set with the global parameter
+``parameters["default_matrix_type"]``.  In the case where the matrix
+is assembled as a nested matrix, there is a choice as to the type of
+the blocks (they may be "aij" or "baij").  The default choice can be
+controlled with ``parameters["default_sub_matrix_type"]``.  For
+finer-grained control over the matrix type, one can provide it when
+calling :func:`~.assemble` through the ``mat_type`` and
+``sub_mat_type`` keyword arguments.  When using variational solvers,
+the matrix type is controlled through use of the ``solver_parameters``
+dictionary by specifying the ``"mat_type"`` entry.
+
+.. note::
+
+   It is not currently possible to control the matrix type of
+   sub-matrices through the solving interface.  If you need this
+   functionality, please :doc:`get in touch <contact>`
+
 More block preconditioners
 ++++++++++++++++++++++++++
 

--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -460,7 +460,7 @@ a `least squares commutator <LSC_>`_, see the relevant section of the
 Specifying assembled matrix types
 +++++++++++++++++++++++++++++++++
 
-Firedrake supports assembling linear operators in a number of
+Firedrake supports the assembly of linear operators in a number of
 different formats.  Either as assembled sparse matrices, or as
 matrix-free operators that only provide matrix-vector products.  Since
 matrix-free actions require special preconditioning, they have

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -97,8 +97,10 @@ class ImplicitMatrixContext(object):
         # These are temporary storage for holding the BC
         # values during matvec application.  _xbc is for
         # the action and ._ybc is for transpose.
-        self._xbc = function.Function(trial_space)
-        self._ybc = function.Function(test_space)
+        if len(self.row_bcs) > 0:
+            self._xbc = function.Function(trial_space)
+        if len(self.col_bcs) > 0:
+            self._ybc = function.Function(test_space)
 
         # Get size information from template vecs on test and trial spaces
         trial_vec = trial_space.dof_dset.layout_vec
@@ -133,10 +135,6 @@ class ImplicitMatrixContext(object):
 
         # If we are not, then the matrix just has 0s in the rows and columns.
 
-        if self.on_diag:  # stash BC values for later
-            with self._xbc.dat.vec as v:
-                X.copy(v)
-
         for bc in self.col_bcs:
             bc.zero(self._x)
 
@@ -145,6 +143,10 @@ class ImplicitMatrixContext(object):
         # This sets the essential boundary condition values on the
         # result.
         if self.on_diag:
+            if len(self.row_bcs) > 0:
+                # TODO, can we avoid the copy?
+                with self._xbc.dat.vec as v:
+                    X.copy(v)
             for bc in self.row_bcs:
                 bc.set(self._y, self._xbc)
         else:
@@ -158,9 +160,6 @@ class ImplicitMatrixContext(object):
         # As for mult, just everything swapped round.
         with self._y.dat.vec as v:
             Y.copy(v)
-        if self.on_diag:  # stash BC values for later
-            with self._ybc.dat.vec as v:
-                Y.copy(v)
 
         for bc in self.row_bcs:
             bc.zero(self._y)
@@ -168,6 +167,10 @@ class ImplicitMatrixContext(object):
         self._assemble_actionT()
 
         if self.on_diag:
+            if len(self.col_bcs) > 0:
+                # TODO, can we avoid the copy?
+                with self._ybc.dat.vec as v:
+                    Y.copy(v)
             for bc in self.col_bcs:
                 bc.set(self._x, self._ybc)
         else:
@@ -185,6 +188,26 @@ class ImplicitMatrixContext(object):
             return
         viewer.printfASCII("Firedrake matrix-free operator %s\n" %
                            type(self).__name__)
+
+    def getInfo(self, mat, info=None):
+        from mpi4py import MPI
+        memory = self._x.dat.nbytes + self._y.dat.nbytes
+        if hasattr(self, "_xbc"):
+            memory += self._xbc.dat.nbytes
+        if hasattr(self, "_ybc"):
+            memory += self._ybc.dat.nbytes
+        if info is None:
+            info = PETSc.Mat.InfoType.GLOBAL_SUM
+        if info == PETSc.Mat.InfoType.LOCAL:
+            return {"memory": memory}
+        elif info == PETSc.Mat.InfoType.GLOBAL_SUM:
+            gmem = mat.comm.tompi4py().allreduce(memory, op=MPI.SUM)
+            return {"memory": gmem}
+        elif info == PETSc.Mat.InfoType.GLOBAL_MAX:
+            gmem = mat.comm.tompi4py().allreduce(memory, op=MPI.MAX)
+            return {"memory": gmem}
+        else:
+            raise ValueError("Unknown info type %s" % info)
 
     # Now, to enable fieldsplit preconditioners, we need to enable submatrix
     # extraction for our custom matrix type.  Note that we are splitting UFL

--- a/firedrake/matrix_free/preconditioners.py
+++ b/firedrake/matrix_free/preconditioners.py
@@ -131,9 +131,10 @@ class AssembledPC(PCBase):
 
     def view(self, pc, viewer=None):
         super(AssembledPC, self).view(pc, viewer)
-        viewer.printfASCII("PC to apply inverse\n")
         viewer.pushASCIITab()
-        self.pc.view(viewer)
+        if hasattr(self, "pc"):
+            viewer.printfASCII("PC to apply inverse\n")
+            self.pc.view(viewer)
         viewer.popASCIITab()
 
 
@@ -339,7 +340,7 @@ class PCDPC(PCBase):
         super(PCDPC, self).view(pc, viewer)
         viewer.printfASCII("Pressure-Convection-Diffusion inverse K^-1 F_p M^-1:\n")
         viewer.pushASCIITab()
-        viewer.printfASCII("Reynolds number in F_p (applied matrix-free) is %g\n" %
+        viewer.printfASCII("Reynolds number in F_p (applied matrix-free) is %s\n" %
                            str(self.Re))
         viewer.printfASCII("KSP solver for K^-1:\n")
         viewer.pushASCIITab()

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -79,8 +79,10 @@ parameters.add(Parameters("form_compiler", **default_parameters()))
 
 parameters["reorder_meshes"] = True
 
-# One of nest, aij or matfree
+# One of nest, aij, baij or matfree
 parameters["default_matrix_type"] = "nest"
+# One of aij or baij
+parameters["default_sub_matrix_type"] = "baij"
 
 parameters["type_check_safe_par_loops"] = False
 

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -254,12 +254,8 @@ def _extract_args(*args, **kwargs):
                     "form_compiler_parameters", "solver_parameters",
                     "nullspace", "transpose_nullspace", "near_nullspace",
                     "options_prefix", "appctx"]
-    transfer_nest = False
     if "nest" in kwargs:
-        from firedrake.logging import warning, RED
-        warning(RED % "The 'nest' argument is deprecated, please set 'mat_type' in the solver parameters")
-        nest = kwargs.pop("nest")
-        transfer_nest = True
+        raise DeprecationWarning("The 'nest' argument is deprecated, please set 'mat_type' in the solver parameters")
 
     for kwarg in kwargs.iterkeys():
         if kwarg not in valid_kwargs:
@@ -304,10 +300,6 @@ def _extract_args(*args, **kwargs):
     solver_parameters = kwargs.get("solver_parameters", {})
     options_prefix = kwargs.get("options_prefix", None)
 
-    if transfer_nest and nest is not None:
-        solver_parameters["mat_type"] = "nest" if nest else "aij"
-        if Jp is not None:
-            solver_parameters["pmat_type"] = solver_parameters["mat_type"]
     return eq, u, bcs, J, Jp, M, form_compiler_parameters, \
         solver_parameters, nullspace, nullspace_T, near_nullspace, options_prefix
 

--- a/tests/regression/test_matrix_free.py
+++ b/tests/regression/test_matrix_free.py
@@ -259,3 +259,36 @@ def test_matrix_free_split_communicators():
 
         expect = Function(V).interpolate(Constant((1, 0)))
         assert np.allclose(expect.dat.data, f.dat.data)
+
+
+@pytest.mark.parallel(nprocs=2)
+@pytest.mark.parametrize("infotype",
+                         ["local", "sum", "max"])
+def test_get_info(a, bcs, infotype):
+    A = assemble(a, mat_type="matfree")
+    ctx = A.petscmat.getPythonContext()
+
+    itype = {"local": A.petscmat.InfoType.LOCAL,
+             "sum": A.petscmat.InfoType.GLOBAL_SUM,
+             "max": A.petscmat.InfoType.GLOBAL_MAX}[infotype]
+    info = ctx.getInfo(A.petscmat, info=itype)
+    test, trial = a.arguments()
+    expect = ((test.function_space().dof_dset.total_size
+               * test.function_space().dim)
+              + (trial.function_space().dof_dset.total_size
+                 * trial.function_space().dim))
+
+    expect *= np.float64().itemsize
+
+    if infotype == "sum":
+        expect = A.comm.allreduce(expect, op=MPI.SUM)
+    elif infotype == "max":
+        expect = A.comm.allreduce(expect, op=MPI.MAX)
+
+    assert info["memory"] == expect
+
+    if bcs is not None:
+        A = assemble(a, mat_type="matfree", bcs=bcs)
+        ctx = A.petscmat.getPythonContext()
+        info = ctx.getInfo(A.petscmat, info=itype)
+        assert info["memory"] == 2*expect

--- a/tests/regression/test_nested_fieldsplit_solves.py
+++ b/tests/regression/test_nested_fieldsplit_solves.py
@@ -164,6 +164,34 @@ def test_create_subdm_caching(W):
     assert iset1 is iset3
 
 
+def test_matrix_types(W):
+    a = inner(TestFunction(W), TrialFunction(W))*dx
+
+    with pytest.raises(ValueError):
+        assemble(a, mat_type="baij")
+
+    A = assemble(a)
+    assert A.M.handle.getType() == parameters["default_matrix_type"]
+
+    A = assemble(a, mat_type="aij")
+
+    assert A.M.handle.getType() == "seqaij"
+
+    A = assemble(a, mat_type="nest")
+
+    assert A.M.handle.getType() == "nest"
+
+    assert A.M[1, 1].handle.getType() == "seq" + parameters["default_sub_matrix_type"]
+
+    A = assemble(a, mat_type="nest", sub_mat_type="aij")
+
+    assert A.M[1, 1].handle.getType() == "seqaij"
+
+    A = assemble(a, mat_type="nest", sub_mat_type="baij")
+
+    assert A.M[1, 1].handle.getType() == "seqbaij"
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -124,7 +124,6 @@ def test_near_nullspace(tmpdir):
     mesh = UnitSquareMesh(100, 100)
     x, y = SpatialCoordinate(mesh)
     dim = 2
-    parameters["pyop2_options"]["block_sparsity"] = False
     V = VectorFunctionSpace(mesh, "Lagrange", 1)
     u = TrialFunction(V)
     v = TestFunction(V)
@@ -157,13 +156,15 @@ def test_near_nullspace(tmpdir):
     solve(lhs(F) == rhs(F), w1, bcs=bcs, solver_parameters={
         'ksp_monitor_short': "ascii:%s:" % w_nns_log,
         'ksp_rtol': 1e-8, 'ksp_atol': 1e-8, 'ksp_type': 'cg',
-        'pc_type': 'gamg'}, near_nullspace=nsp)
+        'pc_type': 'gamg',
+        'mat_type': 'aij'}, near_nullspace=nsp)
 
     w2 = Function(V)
     solve(lhs(F) == rhs(F), w2, bcs=bcs, solver_parameters={
         'ksp_monitor_short': "ascii:%s:" % wo_nns_log,
         'ksp_rtol': 1e-8, 'ksp_atol': 1e-8, 'ksp_type': 'cg',
-        'pc_type': 'gamg'})
+        'pc_type': 'gamg',
+        'mat_type': 'aij'})
 
     # check that both solutions are equal to the exact solution
     assert sqrt(assemble(inner(w1-w2, w1-w2)*dx)) < 1e-7


### PR DESCRIPTION
Add ability to get matrix info from matfree matrices, and reduce memory footprint when no boundary conditions are required.

Also, make it possible to specify on a per-solve basis whether to build AIJ or BAIJ matrices.

Doesn't propagate into sub-matrices of nest matrices yet (but that can be controlled globally with `parameters["default_sub_matrix_type"]`.