### PR TITLE
Pefarrell/hdf5file

### DIFF
--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -328,7 +328,7 @@ class HDF5File(object):
             self.mode = FILE_UPDATE
 
         self._filename = filename
-        self._timestamps = []
+        self._timestamps = []#np.array((0,), dtype = float)
         self.new_file()
 
     def set_timestamp(self, t):
@@ -339,8 +339,10 @@ class HDF5File(object):
         self._timestamps.append(t)        
         if self.mode == FILE_READ:
             return
-        attr = self.attributes("/")["stored_timestamps"]
-        attr.append(self._timestamps[-1])
+        attrs = self.attributes("/")
+        timestamps = attrs.get("stored_timestamps", [])
+        #timestamps.append(self._timestamps[-1])
+        attrs["stored_timestamps"] = np.concatenate((timestamps, [self._timestamps[-1]]))
 
     def new_file(self):
         """

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -290,6 +290,7 @@ class DumbCheckpoint(object):
             free_comm(self.comm)
             del self.comm
 
+
 class HDF5File(object):
 
     """An object to mimic the DOLFIN HDF5File class.

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -293,7 +293,7 @@ class DumbCheckpoint(object):
 
 class HDF5File(object):
 
-    """An object to mimic the DOLFIN HDF5File class.
+    """An object to facilitate checkpointing.
 
     This checkpoint object is capable of writing :class:`~.Function`\s
     to disk in parallel (using HDF5) and reloading them on the same
@@ -304,8 +304,6 @@ class HDF5File(object):
          :data:`~.FILE_CREATE`, or :data:`~.FILE_UPDATE`)
     :arg comm: communicator the writes should be collective
          over.
-
-    The argument names are carefully chosen to match DOLFIN's HDF5File.
 
     This object can be used in a context manager (in which case it
     closes the file when the scope is exited).

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -332,8 +332,8 @@ class HDF5File(object):
         exists = os.path.exists(filename)
         if self.mode == FILE_READ and not exists:
             raise IOError("File '%s' does not exist, cannot be opened for reading" % filename)
-        if file_mode == FILE_UPDATE and not exists:
-            file_mode = FILE_CREATE
+        if self.mode == FILE_UPDATE and not exists:
+            self.mode = FILE_CREATE
 
         # Create the directory if necessary
         dirname = os.path.dirname(filename)
@@ -342,9 +342,9 @@ class HDF5File(object):
         except OSError:
             pass
 
-        self._vwr = PETSc.ViewerHDF5().create(filename, mode=file_mode,
+        self._vwr = PETSc.ViewerHDF5().create(filename, mode=self.mode,
                                               comm=self.comm)
-        if file_mode == FILE_READ:
+        if self.mode == FILE_READ:
             nprocs = self.attributes('/')['nprocs']
             if nprocs != self.comm.size:
                 raise ValueError("Process mismatch: written on %d, have %d" %
@@ -413,8 +413,8 @@ class HDF5File(object):
             name = os.path.basename(path)
         else:
             suffix = "/%.15e" % timestamp
-            stampedpath = path + suffix
-            name = os.path.basename(stampedpath)
+            path = path + suffix
+            name = os.path.basename(path)
 
         group = os.path.dirname(path)
 
@@ -427,7 +427,7 @@ class HDF5File(object):
             self.vwr.popGroup()
 
         if timestamp is not None:
-            attr = self.attributes(stampedpath)
+            attr = self.attributes(path)
             attr["timestamp"] = timestamp
             self._set_timestamp(timestamp)
 

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -363,6 +363,11 @@ class HDF5File(object):
         """Close the checkpoint file (flushing any pending writes)"""
         if hasattr(self, '_h5file'):
             self._h5file.flush()
+            # Need to explicitly close the h5py File so that all
+            # objects referencing it are cleaned up, otherwise we
+            # close the file, but there are still open objects and we
+            # get a refcounting error in HDF5.
+            self._h5file.close()
             del self._h5file
 
     def flush(self):

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -681,8 +681,10 @@ def build_and_install_h5py():
     log.info("Installing h5py\n")
     # Clean up old downloads
     if os.path.exists("h5py-2.5.0"):
+        log.info("Removing old h5py-2.5.0 source")
         shutil.rmtree("h5py-2.5.0")
     if os.path.exists("h5py.tar.gz"):
+        log.info("Removing old h5py.tar.gz")
         os.remove("h5py.tar.gz")
     if os.path.exists("h5py"):
         changed = git_update("h5py")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -647,14 +647,6 @@ def clean(package):
     os.chdir("..")
 
 
-def get_h5py():
-    log.info("Downloading h5py\n")
-    import urllib
-    urllib.urlretrieve("https://codeload.github.com/h5py/h5py/tar.gz/2.5.0",
-                       "h5py.tar.gz")
-    run_cmd(["tar", "-zxvf", "h5py.tar.gz"])
-
-
 def pip_uninstall(package):
     log.info("Removing existing %s installations\n" % package)
     # Uninstalling something with pip is an absolute disaster.  We
@@ -681,19 +673,21 @@ def pip_uninstall(package):
                 again = True
         i += 1
         if i > 10:
-            raise InstallError("pip claims it uninstalled h5py more than 10 times.  Something is probably broken.")
+            raise InstallError("pip claims it uninstalled %s more than 10 times.  Something is probably broken.", package)
 
 
 def build_and_install_h5py():
-    pip_uninstall("h5py")
-
     log.info("Installing h5py\n")
+    # Clean up old downloads
     if os.path.exists("h5py-2.5.0"):
-        clean("h5py-2.5.0")
+        os.rmdir("h5py-2.5.0")
+    if os.path.exists("h5py.tar.gz"):
+        os.remove("h5py.tar.gz")
+    if os.path.exists("h5py"):
+        changed = git_update("h5py")
     else:
-        get_h5py()
-
-    os.chdir("h5py-2.5.0")
+        git_clone("git+https://github.com/h5py/h5py.git")
+        changed = True
 
     if args.honour_petsc_dir:
         petsc_dir = os.environ["PETSC_DIR"]
@@ -711,14 +705,16 @@ def build_and_install_h5py():
     log.info("Linking h5py against PETSc found in %s\n" % hdf5_dir)
     oldcc = os.environ.get("CC", None)
     os.environ["CC"] = options["mpicc"] or "mpicc"
-    run_cmd(python + ["setup.py", "configure", "--hdf5=%s" % hdf5_dir])
-    run_cmd(python + ["setup.py", "build"])
-    run_cmd(pyinstall)
+    os.environ["HDF5_DIR"] = hdf5_dir
+    os.environ["HDF5_MPI"] = "ON"
+    if changed:
+        # Only uninstall if things changed.
+        pip_uninstall("h5py")
+        install("h5py/")
     if oldcc is None:
         del os.environ["CC"]
     else:
         os.environ["CC"] = oldcc
-    os.chdir("..")
 
 
 def build_and_install_glpsol():

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -677,10 +677,11 @@ def pip_uninstall(package):
 
 
 def build_and_install_h5py():
+    import shutil
     log.info("Installing h5py\n")
     # Clean up old downloads
     if os.path.exists("h5py-2.5.0"):
-        os.rmdir("h5py-2.5.0")
+        shutil.rmtree("h5py-2.5.0")
     if os.path.exists("h5py.tar.gz"):
         os.remove("h5py.tar.gz")
     if os.path.exists("h5py"):

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -85,9 +85,9 @@ def test_attributes(f, dumpfile):
         with pytest.raises(KeyError):
             attrs = h5.attributes("/foo")
             attrs["nprocs"] = 1
-            with pytest.raises(KeyError):
-                attrs = h5.attributes("/bar")
-                attrs["nprocs"]
+        with pytest.raises(KeyError):
+            attrs = h5.attributes("/bar")
+            attrs["nprocs"]
 
         h5.write(mesh.coordinates, "/coords")
         attrs = h5.attributes("/coords")

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -2,6 +2,7 @@ import pytest
 from firedrake import *
 import numpy as np
 from mpi4py import MPI
+import math
 
 
 @pytest.fixture(scope="module",
@@ -55,6 +56,11 @@ def run_store_load(mesh, fs, degree, dumpfile):
 
     assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
 
+    with HDF5File(dumpfile, "w", comm=mesh.comm) as h5:
+        h5.write(f, "/solution", timestamp=math.pi)
+        h5.read(f2, "/solution", timestamp=math.pi)
+
+    assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
 
 def test_checkpoint_fails_for_non_function(dumpfile):
     dumpfile = MPI.COMM_WORLD.bcast(dumpfile, root=0)

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -10,17 +10,21 @@ from mpi4py import MPI
 def mesh(request):
     return UnitSquareMesh(2, 2, quadrilateral=request.param)
 
+
 @pytest.fixture(params=range(1, 4))
 def degree(request):
     return request.param
+
 
 @pytest.fixture(params=["CG"])
 def fs(request):
     return request.param
 
+
 @pytest.fixture
 def dumpfile(tmpdir):
     return str(tmpdir.join("dump.h5"))
+
 
 @pytest.fixture(scope="module")
 def f():
@@ -29,6 +33,7 @@ def f():
     f = Function(V, name="f")
     f.interpolate(Expression("x[0]*x[1]"))
     return f
+
 
 def run_store_load(mesh, fs, degree, dumpfile):
 
@@ -50,23 +55,28 @@ def run_store_load(mesh, fs, degree, dumpfile):
 
     assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
 
+
 def test_checkpoint_fails_for_non_function(dumpfile):
     dumpfile = MPI.COMM_WORLD.bcast(dumpfile, root=0)
     with HDF5File(dumpfile, "w", comm=MPI.COMM_WORLD) as h5:
         with pytest.raises(ValueError):
             h5.write(np.arange(10), "/solution")
 
+
 def test_store_load(mesh, fs, degree, dumpfile):
     run_store_load(mesh, fs, degree, dumpfile)
+
 
 @pytest.mark.parallel(nprocs=2)
 def test_store_load_parallel(mesh, fs, degree, dumpfile):
     run_store_load(mesh, fs, degree, dumpfile)
 
+
 def test_checkpoint_read_not_exist_ioerror(dumpfile):
     with pytest.raises(IOError):
         with HDF5File(dumpfile, file_mode="r"):
             pass
+
 
 def test_attributes(f, dumpfile):
     mesh = f.function_space().mesh()
@@ -77,13 +87,14 @@ def test_attributes(f, dumpfile):
             attrs["nprocs"] = 1
             with pytest.raises(KeyError):
                 attrs = h5.attributes("/bar")
-                out = attrs["nprocs"]
+                attrs["nprocs"]
 
         h5.write(mesh.coordinates, "/coords")
         attrs = h5.attributes("/coords")
         attrs["dimension"] = mesh.coordinates.dat.cdim
 
         assert attrs["dimension"] == mesh.coordinates.dat.cdim
+
 
 if __name__ == "__main__":
     import os

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -106,11 +106,11 @@ def test_store_read_only_ioerror(f, dumpfile):
 def test_multiple_timestamps(f, dumpfile):
     with HDF5File(dumpfile, "w") as h5:
         h5.set_timestamp(0.1)
-        h5.store(f, "/solution")
+        h5.write(f, "/solution")
         h5.set_timestamp(0.2)
-        h5.store(f, "/solution")
+        h5.write(f, "/solution")
 
-        timestamps = h5.attributes("/")[stored_timestamps]
+        timestamps = h5.attributes("/")["stored_timestamps"]
 
         assert np.allclose(timestamps, [0.1, 0.2])
 

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -1,0 +1,90 @@
+import pytest
+from firedrake import *
+import numpy as np
+from mpi4py import MPI
+
+
+@pytest.fixture(scope="module",
+                params=[False, True],
+                ids=["simplex", "quad"])
+def mesh(request):
+    return UnitSquareMesh(2, 2, quadrilateral=request.param)
+
+@pytest.fixture(params=range(1, 4))
+def degree(request):
+    return request.param
+
+@pytest.fixture(params=["CG"])
+def fs(request):
+    return request.param
+
+@pytest.fixture
+def dumpfile(tmpdir):
+    return str(tmpdir.join("dump.h5"))
+
+@pytest.fixture(scope="module")
+def f():
+    m = UnitSquareMesh(2, 2)
+    V = FunctionSpace(m, 'CG', 1)
+    f = Function(V, name="f")
+    f.interpolate(Expression("x[0]*x[1]"))
+    return f
+
+def run_store_load(mesh, fs, degree, dumpfile):
+
+    V = FunctionSpace(mesh, fs, degree)
+
+    f = Function(V, name="f")
+
+    expr = Expression("x[0]*x[1]")
+
+    f.interpolate(expr)
+
+    f2 = Function(V, name="f")
+
+    dumpfile = mesh.comm.bcast(dumpfile, root=0)
+
+    with HDF5File(dumpfile, "w", comm=mesh.comm) as h5:
+        h5.write(f, "/solution")
+        h5.read(f2, "/solution")
+
+    assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
+
+def test_checkpoint_fails_for_non_function(dumpfile):
+    dumpfile = MPI.COMM_WORLD.bcast(dumpfile, root=0)
+    with HDF5File(dumpfile, "w", comm=MPI.COMM_WORLD) as h5:
+        with pytest.raises(ValueError):
+            h5.write(np.arange(10), "/solution")
+
+def test_store_load(mesh, fs, degree, dumpfile):
+    run_store_load(mesh, fs, degree, dumpfile)
+
+@pytest.mark.parallel(nprocs=2)
+def test_store_load_parallel(mesh, fs, degree, dumpfile):
+    run_store_load(mesh, fs, degree, dumpfile)
+
+def test_checkpoint_read_not_exist_ioerror(dumpfile):
+    with pytest.raises(IOError):
+        with HDF5File(dumpfile, file_mode="r"):
+            pass
+
+def test_attributes(f, dumpfile):
+    mesh = f.function_space().mesh()
+    dumpfile = mesh.comm.bcast(dumpfile, root=0)
+    with HDF5File(dumpfile, file_mode="w", comm=mesh.comm) as h5:
+        with pytest.raises(KeyError):
+            attrs = h5.attributes("/foo")
+            attrs["nprocs"] = 1
+            with pytest.raises(KeyError):
+                attrs = h5.attributes("/bar")
+                out = attrs["nprocs"]
+
+        h5.write(mesh.coordinates, "/coords")
+        attrs = h5.attributes("/coords")
+        attrs["dimension"] = mesh.coordinates.dat.cdim
+
+        assert attrs["dimension"] == mesh.coordinates.dat.cdim
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -95,6 +95,26 @@ def test_attributes(f, dumpfile):
 
         assert attrs["dimension"] == mesh.coordinates.dat.cdim
 
+def test_store_read_only_ioerror(f, dumpfile):
+    # Make file
+    with HDF5File(dumpfile, "w") as h5:
+        pass
+    with HDF5File(dumpfile, "r") as h5:
+        with pytest.raises(IOError):
+            h5.write(f, "/function")
+
+def test_multiple_timestamps(f, dumpfile):
+    with HDF5File(dumpfile, "w") as h5:
+        h5.set_timestamp(0.1)
+        h5.store(f, "/solution")
+        h5.set_timestamp(0.2)
+        h5.store(f, "/solution")
+
+        timestamps = h5.attributes("/")[stored_timestamps]
+
+        assert np.allclose(timestamps, [0.1, 0.2])
+
+
 
 if __name__ == "__main__":
     import os

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -62,6 +62,7 @@ def run_store_load(mesh, fs, degree, dumpfile):
 
     assert np.allclose(f.dat.data_ro, f2.dat.data_ro)
 
+
 def test_checkpoint_fails_for_non_function(dumpfile):
     dumpfile = MPI.COMM_WORLD.bcast(dumpfile, root=0)
     with HDF5File(dumpfile, "w", comm=MPI.COMM_WORLD) as h5:

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -105,12 +105,10 @@ def test_store_read_only_ioerror(f, dumpfile):
 
 def test_multiple_timestamps(f, dumpfile):
     with HDF5File(dumpfile, "w") as h5:
-        h5.set_timestamp(0.1)
-        h5.write(f, "/solution")
-        h5.set_timestamp(0.2)
-        h5.write(f, "/solution")
+        h5.write(f, "/solution", timestamp=0.1)
+        h5.write(f, "/solution", timestamp=0.2)
 
-        timestamps = h5.attributes("/")["stored_timestamps"]
+        timestamps = h5.get_timestamps()
 
         assert np.allclose(timestamps, [0.1, 0.2])
 

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -101,6 +101,7 @@ def test_attributes(f, dumpfile):
 
         assert attrs["dimension"] == mesh.coordinates.dat.cdim
 
+
 def test_store_read_only_ioerror(f, dumpfile):
     # Make file
     with HDF5File(dumpfile, "w") as h5:
@@ -108,6 +109,7 @@ def test_store_read_only_ioerror(f, dumpfile):
     with HDF5File(dumpfile, "r") as h5:
         with pytest.raises(IOError):
             h5.write(f, "/function")
+
 
 def test_multiple_timestamps(f, dumpfile):
     with HDF5File(dumpfile, "w") as h5:
@@ -117,7 +119,6 @@ def test_multiple_timestamps(f, dumpfile):
         timestamps = h5.get_timestamps()
 
         assert np.allclose(timestamps, [0.1, 0.2])
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supersedes #944 

- Only uses h5py for writing (avoiding horrible reference counting issues)

- Updates firedrake-install to build h5py from git (since this is the only sane way we can build with pip and require MPI support)

@pefarrell, @APaganini, please confirm this works for you.