### PR TITLE
Shorten names of cell and facet sets for use as profiling tags

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -77,7 +77,7 @@ class _Facets(object):
             else:
                 base = self.mesh._base_mesh.exterior_facets.set
             return op2.ExtrudedSet(base, layers=self.mesh.layers)
-        return op2.Set(size, "%s_%s_facets" % (self.mesh.name, self.kind),
+        return op2.Set(size, "%sFacets" % self.kind.capitalize()[:3],
                        comm=self.mesh.comm)
 
     @utils.cached_property
@@ -634,7 +634,7 @@ class MeshTopology(object):
     @utils.cached_property
     def cell_set(self):
         size = list(self._entity_classes[self.cell_dimension(), :])
-        return op2.Set(size, "%s_cells" % self.name, comm=self.comm)
+        return op2.Set(size, "Cells", comm=self.comm)
 
     def cell_subset(self, subdomain_id, all_integer_subdomain_ids=None):
         """Return a subset over cells with the given subdomain_id.


### PR DESCRIPTION
Goes alongside OP2/Pyop2#516 to provide kernel-specific profiling.