### PR TITLE
Clean h5py directory before install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -710,7 +710,7 @@ def build_and_install_h5py():
     os.environ["CC"] = options["mpicc"] or "mpicc"
     os.environ["HDF5_DIR"] = hdf5_dir
     os.environ["HDF5_MPI"] = "ON"
-    if changed:
+    if changed or args.rebuild:
         # Only uninstall if things changed.
         pip_uninstall("h5py")
         # Pip installing from dirty directory is potentially unsafe.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -713,6 +713,9 @@ def build_and_install_h5py():
     if changed:
         # Only uninstall if things changed.
         pip_uninstall("h5py")
+        # Pip installing from dirty directory is potentially unsafe.
+        with directory("h5py/"):
+            check_call(["git", "clean", "-fdx"])
         install("h5py/")
     if oldcc is None:
         del os.environ["CC"]


### PR DESCRIPTION
Don't want any build artifacts around, because the setup process doesn't
notice and then we get breakages.