### PR TITLE
install: Temporary workaround for coin-or/pulp#123

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -526,7 +526,12 @@ def pip_requirements(package):
     if os.path.isfile("%s/requirements-ext.txt" % package):
         run_pip_install(["-r", "%s/requirements-ext.txt" % package])
     elif os.path.isfile("%s/requirements.txt" % package):
-        run_pip_install(["-r", "%s/requirements.txt" % package])
+        if package == "COFFEE":
+            # FIXME: Horrible hack to work around
+            # https://github.com/coin-or/pulp/issues/123
+            run_pip_install(["--no-deps", "-r", "%s/requirements.txt" % package])
+        else:
+            run_pip_install(["-r", "%s/requirements.txt" % package])
     else:
         log.info("No dependencies found. Skipping.")
 


### PR DESCRIPTION
All the dependencies of coffee's requirements are already installed,
so pass no-deps to pip in that case.