### PR TITLE
Use FInAT elements for node allocation

### DIFF
--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -421,13 +421,13 @@ def get_cell_nodes(PETSc.Section global_numbering,
 
     :arg global_numbering: Section describing the global DoF numbering
     :arg cell_closures: 2D array of ordered cell closures
-    :arg entity_dofs: FIAT element entity dofs for the cell
+    :arg entity_dofs: FInAT element entity dofs for the cell
 
     Preconditions: This function assumes that cell_closures contains mesh
     entities ordered by dimension, i.e. vertices first, then edges, faces, and
     finally the cell. For quadrilateral meshes, edges corresponding to
-    dimension (0, 1) in the FIAT element must precede edges corresponding to
-    dimension (1, 0) in the FIAT element.
+    dimension (0, 1) in the FInAT element must precede edges corresponding to
+    dimension (1, 0) in the FInAT element.
     """
     cdef:
         int *ceil_ndofs = NULL
@@ -440,7 +440,7 @@ def get_cell_nodes(PETSc.Section global_numbering,
     ncells = cell_closures.shape[0]
     nclosure = cell_closures.shape[1]
 
-    # Extract ordering from FIAT element entity DoFs
+    # Extract ordering from FInAT element entity DoFs
     ndofs_list = []
     flat_index_list = []
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -9,6 +9,7 @@ import ufl
 from coffee import base as ast
 from pyop2 import op2
 
+from tsfc.fiatinterface import create_element
 from tsfc import compile_expression_at_points as compile_ufl_kernel
 
 import firedrake
@@ -136,7 +137,7 @@ def make_interpolator(expr, V, subset):
 
 
 def _interpolator(V, dat, expr, subset):
-    to_element = V.fiat_element
+    to_element = create_element(V.ufl_element(), vector_is_mixed=False)
     to_pts = []
 
     if V.ufl_element().mapping() != "identity":
@@ -208,7 +209,7 @@ def compile_python_kernel(expression, to_pts, to_element, fs, coords):
     function provided."""
 
     coords_space = coords.function_space()
-    coords_element = coords_space.fiat_element
+    coords_element = create_element(coords_space.ufl_element(), vector_is_mixed=False)
 
     X_remap = coords_element.tabulate(0, to_pts).values()[0]
 
@@ -238,7 +239,7 @@ def compile_c_kernel(expression, to_pts, to_element, fs, coords):
     """Produce a :class:`PyOP2.Kernel` from the c expression provided."""
 
     coords_space = coords.function_space()
-    coords_element = coords_space.fiat_element
+    coords_element = create_element(coords_space.ufl_element(), vector_is_mixed=False)
 
     names = {v[0] for v in expression._user_args}
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -583,7 +583,7 @@ class MeshTopology(object):
         """Builds the DoF mapping.
 
         :arg global_numbering: Section describing the global DoF numbering
-        :arg fiat_element: The FIAT element for the cell
+        :arg entity_dofs: FInAT element entity DoFs
         """
         return dmplex.get_cell_nodes(global_numbering,
                                      self.cell_closure,
@@ -593,7 +593,7 @@ class MeshTopology(object):
         """Returns the number of DoFs per plex entity for each stratum,
         i.e. [#dofs / plex vertices, #dofs / plex edges, ...].
 
-        :arg entity_dofs: FIAT element entity DoFs
+        :arg entity_dofs: FInAT element entity DoFs
         """
         return [len(entity_dofs[d][0]) for d in sorted(entity_dofs)]
 
@@ -799,7 +799,7 @@ class ExtrudedMeshTopology(MeshTopology):
         """Builds the DoF mapping.
 
         :arg global_numbering: Section describing the global DoF numbering
-        :arg fiat_element: The FIAT element for the cell
+        :arg entity_dofs: FInAT element entity DoFs
         """
         flat_entity_dofs = {}
         for b, v in entity_dofs:
@@ -824,7 +824,7 @@ class ExtrudedMeshTopology(MeshTopology):
         """Returns the number of DoFs per plex entity for each stratum,
         i.e. [#dofs / plex vertices, #dofs / plex edges, ...].
 
-        :arg entity_dofs: FIAT element entity DoFs
+        :arg entity_dofs: FInAT element entity DoFs
         """
         dofs_per_entity = [0] * (1 + self._base_mesh.cell_dimension())
         for (b, v), entities in entity_dofs.iteritems():
@@ -835,8 +835,8 @@ class ExtrudedMeshTopology(MeshTopology):
         """Returns the offset between the neighbouring cells of a
         column for each DoF.
 
-        :arg entity_dofs: FIAT element entity DoFs
-        :arg ndofs: number of DoFs in the FIAT element
+        :arg entity_dofs: FInAT element entity DoFs
+        :arg ndofs: number of DoFs in the FInAT element
         """
         entity_offset = [0] * (1 + self._base_mesh.cell_dimension())
         for (b, v), entities in entity_dofs.iteritems():

--- a/firedrake/mg/impl.pyx
+++ b/firedrake/mg/impl.pyx
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, division
 
 import FIAT
+from tsfc.fiatinterface import create_element
 
 from firedrake.petsc import PETSc
 import firedrake.mg.utils as utils
@@ -455,7 +456,7 @@ def create_cell_node_map(coarse, fine, np.ndarray[PetscInt, ndim=2, mode="c"] c2
         np.ndarray[PetscInt, ndim=2, mode="c"] new_cell_map, old_cell_map
         PetscInt ccell, fcell, ncoarse, ndof, i, j, perm, nfdof, nfcell, tdim
 
-    cell = coarse.fiat_element.get_reference_element()
+    cell = coarse.finat_element.cell
     if isinstance(cell, FIAT.reference_element.TensorProductCell):
         basecell, _ = cell.cells
         tdim = basecell.get_spatial_dimension()
@@ -465,7 +466,8 @@ def create_cell_node_map(coarse, fine, np.ndarray[PetscInt, ndim=2, mode="c"] c2
     ncoarse = coarse.mesh().cell_set.size
     ndof = coarse.cell_node_map().arity
 
-    perms = utils.get_node_permutations(coarse.fiat_element)
+    fiat_element = create_element(coarse.ufl_element(), vector_is_mixed=False)
+    perms = utils.get_node_permutations(fiat_element)
     permutations = np.empty((len(perms), len(perms.values()[0])), dtype=np.int32)
     for k, v in perms.iteritems():
         if tdim == 1:
@@ -479,7 +481,7 @@ def create_cell_node_map(coarse, fine, np.ndarray[PetscInt, ndim=2, mode="c"] c2
     # We're going to uniquify the maps we get out, so the first step
     # is to apply the permutation to one entry to find out which
     # indices we need to keep.
-    indices, offset = utils.get_unique_indices(coarse.fiat_element,
+    indices, offset = utils.get_unique_indices(fiat_element,
                                                old_cell_map[0, :],
                                                vertex_perm[0, :],
                                                offset=fine.cell_node_map().offset)

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -42,7 +42,7 @@ def is_cg(V):
     :arg V: A FunctionSpace.
     """
     nvertex = V.ufl_domain().ufl_cell().num_vertices()
-    entity_dofs = V.fiat_element.entity_dofs()
+    entity_dofs = V.finat_element.entity_dofs()
     # If there are as many dofs on vertices as there are vertices,
     # assume a continuous space.
     try:
@@ -56,7 +56,7 @@ def is_dg(V):
 
     :arg V: A FunctionSpace.
     """
-    return V.fiat_element.entity_dofs() == V.fiat_element.entity_closure_dofs()
+    return V.finat_element.entity_dofs() == V.finat_element.entity_closure_dofs()
 
 
 def is_linear(V):
@@ -65,7 +65,7 @@ def is_linear(V):
     :arg V: A FunctionSpace.
     """
     nvertex = V.ufl_domain().ufl_cell().num_vertices()
-    return V.fiat_element.space_dimension() == nvertex
+    return V.finat_element.space_dimension() == nvertex
 
 
 def get_topology(coordinates):

--- a/firedrake/parloops.py
+++ b/firedrake/parloops.py
@@ -82,11 +82,11 @@ def _form_kernel(kernel, measure, args, **kwargs):
             if isinstance(func, Indexed):
                 c, i = func.ufl_operands
                 idx = i._indices[0]._value
-                ndof = c.function_space()[idx].fiat_element.space_dimension()
+                ndof = c.function_space()[idx].finat_element.space_dimension()
             else:
                 if len(func.function_space()) > 1:
                     raise NotImplementedError("Must index mixed function in par_loop.")
-                ndof = func.function_space().fiat_element.space_dimension()
+                ndof = func.function_space().finat_element.space_dimension()
             if measure.integral_type() == 'interior_facet':
                 ndof *= 2
             if measure is direct:
@@ -171,10 +171,10 @@ def par_loop(kernel, measure, args, **kwargs):
     adjacent to the facet, and on the facets, edges and vertices
     adjacent to those facets.
 
-    For volume measures the DoFs are guaranteed to be in the FIAT
+    For volume measures the DoFs are guaranteed to be in the FInAT
     local DoFs order. For facet measures, the DoFs will be in sorted
     first by the cell to which they are adjacent. Within each cell,
-    they will be in FIAT order. Note that if a continuous
+    they will be in FInAT order. Note that if a continuous
     :class:`.Function` is accessed via an internal facet measure, the
     DoFs on the interface between the two facets will be accessible
     twice: once via each cell. The orientation of the cell(s) relative

--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 from six.moves import range, zip
 import numpy as np
 from ufl import Cell
+from tsfc.fiatinterface import create_element
 from firedrake import Function, SpatialCoordinate, FunctionSpace
 from firedrake.mesh import MeshGeometry
 
@@ -368,7 +369,8 @@ def _calculate_values(function, points, dimension, cell_mask=None):
     function_space = function.function_space()
     keys = {1: (0,),
             2: (0, 0)}
-    elem = function_space.fiat_element.tabulate(0, points)[keys[dimension]]
+    fiat_element = create_element(function_space.ufl_element(), vector_is_mixed=False)
+    elem = fiat_element.tabulate(0, points)[keys[dimension]]
     cell_node_list = function_space.cell_node_list
     if cell_mask is not None:
         cell_mask = np.tile(cell_mask.reshape(-1, 1), cell_node_list.shape[1])
@@ -533,7 +535,8 @@ def _bezier_calculate_points(function):
     """
     deg = function.function_space().ufl_element().degree()
     M = np.empty([deg + 1, deg + 1], dtype=float)
-    basis = function.function_space().fiat_element.dual_basis()
+    fiat_element = create_element(function.function_space().ufl_element(), vector_is_mixed=False)
+    basis = fiat_element.dual_basis()
     for i in range(deg + 1):
         for j in range(deg + 1):
             M[i, j] = _bernstein(basis[j].get_point_dict().keys()[0][0],

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -479,7 +479,7 @@ def auxiliary_information(builder):
             # compute its shape to declare as an Eigen::MatrixBase object
             temp = ast.Symbol("C%d" % i)
             V = actee.function_space()
-            node_extent = V.fiat_element.space_dimension()
+            node_extent = V.finat_element.space_dimension()
             dof_extent = np.prod(V.ufl_element().value_shape())
             typ = eigen_matrixbase_type(shape=(dof_extent * node_extent,))
             aux_statements.append(ast.Decl(typ, temp))

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -76,7 +76,7 @@ class TensorBase(with_metaclass(ABCMeta)):
         """
         shapes = {}
         for i, arg in enumerate(self.arguments()):
-            shapes[i] = tuple(fs.fiat_element.space_dimension() * fs.dim
+            shapes[i] = tuple(fs.finat_element.space_dimension() * fs.dim
                               for fs in arg.function_space())
         return shapes
 

--- a/tests/extrusion/test_facet_support_dofs.py
+++ b/tests/extrusion/test_facet_support_dofs.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, division
 from firedrake import *
-from FIAT.finite_element import entity_support_dofs
+from finat.finiteelementbase import entity_support_dofs
 import pytest
 
 
@@ -39,8 +39,8 @@ def hex_mesh():
                             3: [1, 3, 4, 5, 6, 7, 10, 11]})])
 def test_hex(hex_mesh, args, kwargs, horiz_expected, vert_expected):
     V = FunctionSpace(hex_mesh, *args, **kwargs)
-    assert horiz_expected == entity_support_dofs(V.fiat_element, (2, 0))
-    assert vert_expected == entity_support_dofs(V.fiat_element, (1, 1))
+    assert horiz_expected == entity_support_dofs(V.finat_element, (2, 0))
+    assert vert_expected == entity_support_dofs(V.finat_element, (1, 1))
 
 
 if __name__ == '__main__':

--- a/tests/regression/test_multiple_domains.py
+++ b/tests/regression/test_multiple_domains.py
@@ -40,7 +40,7 @@ def test_functional(mesh1, mesh2):
 
     val = assemble(c*dx(domain=mesh1))
 
-    cell_volume = mesh1.coordinates.function_space().fiat_element.get_reference_element().volume()
+    cell_volume = mesh1.coordinates.function_space().finat_element.cell.volume()
     assert np.allclose(val, cell_volume)
 
     val = assemble(c*dx(domain=mesh2))
@@ -62,7 +62,7 @@ def test_one_form(mesh1, mesh2, form, expect):
 
     v = TestFunction(V)
 
-    cell_volume = mesh1.coordinates.function_space().fiat_element.get_reference_element().volume()
+    cell_volume = mesh1.coordinates.function_space().finat_element.cell.volume()
     dim = mesh1.topological_dimension()
 
     form = form(v, mesh1, mesh2)
@@ -83,7 +83,7 @@ def test_two_form(mesh1, mesh2, form, expect):
     v = TestFunction(V)
     u = TrialFunction(V)
 
-    cell_volume = mesh1.coordinates.function_space().fiat_element.get_reference_element().volume()
+    cell_volume = mesh1.coordinates.function_space().finat_element.cell.volume()
     dim = mesh1.topological_dimension()
 
     form = form(u, v, mesh1, mesh2)


### PR DESCRIPTION
Resolves #967. Requires FInAT/FInAT#23. FIAT elements are still used when the dual is required.