### PR TITLE
Parallel code-generation and cell orientations in Slate

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -103,13 +103,16 @@ def compile_expression(slate_expr, tsfc_parameters=None):
     mesh_layer_sym = ast.Symbol("layer")
     inc = []
 
+    declared_temps = set()
     for cxt_kernel in builder.context_kernels:
         exp = cxt_kernel.tensor
         t = builder.get_temporary(exp)
 
-        # Declare and initialize the temporary
-        statements.append(ast.Decl(eigen_matrixbase_type(exp.shape), t))
-        statements.append(ast.FlatBlock("%s.setZero();\n" % t))
+        if t not in declared_temps:
+            # Declare and initialize the temporary
+            statements.append(ast.Decl(eigen_matrixbase_type(exp.shape), t))
+            statements.append(ast.FlatBlock("%s.setZero();\n" % t))
+            declared_temps.add(t)
 
         it_type = cxt_kernel.original_integral_type
 

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -142,6 +142,9 @@ def compile_expression(slate_expr, tsfc_parameters=None):
                 clist = [c for ci in kinfo.coefficient_map
                          for c in builder.coefficient(exp.coefficients()[ci])]
 
+                if kinfo.oriented:
+                    clist.append(ast.FlatBlock("cell_orientations"))
+
                 incl.extend(kinfo.kernel._include_dirs)
                 tensor = eigen_tensor(exp, t, index)
                 statements.append(ast.FunCall(kinfo.kernel.name,
@@ -225,8 +228,17 @@ def compile_expression(slate_expr, tsfc_parameters=None):
                                                        context_temps))
     statements.append(ast.Incr(result_sym, cpp_string))
 
+    # Finalize AST for macro kernel construction
+    builder._finalize_kernels_and_update()
+
     # Generate arguments for the macro kernel
     args = [result, ast.Decl("%s **" % SCALAR_TYPE, coordsym)]
+
+    # Orientation information
+    if builder.oriented:
+        args.append(ast.Decl("int **", ast.Symbol("cell_orientations")))
+
+    # Coefficient information
     for c in expr_coeffs:
         if isinstance(c, Constant):
             ctype = "%s *" % SCALAR_TYPE
@@ -234,6 +246,7 @@ def compile_expression(slate_expr, tsfc_parameters=None):
             ctype = "%s **" % SCALAR_TYPE
         args.extend([ast.Decl(ctype, csym) for csym in builder.coefficient(c)])
 
+    # Facet information
     if builder.needs_cell_facets:
         args.append(ast.Decl("char *", cellfacetsym))
 
@@ -321,6 +334,9 @@ def extruded_int_horiz_facet(exp, builder, top_sks, bottom_sks,
         clist = [c for ci in coefficient_map
                  for c in builder.coefficient(exp.coefficients()[ci])]
 
+        if top.kinfo.oriented and btm.kinfo.oriented:
+            clist.append(ast.FlatBlock("cell_orientations"))
+
         dirs = top.kinfo.kernel._include_dirs + btm.kinfo.kernel._include_dirs
         incl.extend(tuple(OrderedDict.fromkeys(dirs)))
 
@@ -368,6 +384,9 @@ def extruded_top_bottom_facet(cxt_kernel, builder, coordsym, mesh_layer_sym):
         # if any are required
         clist = [c for ci in kinfo.coefficient_map
                  for c in builder.coefficient(exp.coefficients()[ci])]
+
+        if kinfo.oriented:
+            clist.append(ast.FlatBlock("cell_orientations"))
 
         incl.extend(kinfo.kernel._include_dirs)
         tensor = eigen_tensor(exp, t, index)
@@ -438,6 +457,9 @@ def facet_integral_loop(cxt_kernel, builder, coordsym, cellfacetsym):
 
         incl.extend(kinfo.kernel._include_dirs)
         tensor = eigen_tensor(exp, t, index)
+
+        if kinfo.oriented:
+            clist.append(ast.FlatBlock("cell_orientations"))
 
         clist.append(ast.FlatBlock("&%s" % itsym))
         funcalls.append(ast.FunCall(kinfo.kernel.name,

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -168,7 +168,10 @@ class KernelBuilder(object):
         assert isinstance(macro_kernels, list), (
             "Please wrap all macro kernel functions in a list"
         )
-        self._finalize_kernels_and_update()
+        assert self.finalized_ast, (
+            "AST not finalized. Did you forget to call "
+            "builder._finalize_kernels_and_update()?"
+        )
         kernel_ast = self.finalized_ast
         kernel_ast.extend(macro_kernels)
 

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import, print_function, division
+from six import iteritems
+
+from collections import OrderedDict
 
 from coffee import base as ast
 
@@ -41,7 +44,11 @@ class KernelBuilder(object):
         self.coefficient_map = prepare_coefficients(expression)
         # Initialize temporaries and any auxiliary expressions for special
         # handling
-        self.temps, self.aux_exprs = generate_expr_data(expression)
+        temps, aux_exprs = generate_expr_data(expression)
+        # Sort by temporary str: 'T0', 'T1', etc.
+        self.temps = OrderedDict(sorted(iteritems(temps),
+                                        key=lambda x: str(x[1])))
+        self.aux_exprs = aux_exprs
 
     @property
     def integral_type(self):


### PR DESCRIPTION
This PR fixes a bug in the code-generation bit of Slate when running problems in parallel. In addition, I also added support for problems that require `cell_orientations` (such as hybridizing on a spherical domain).