### PR TITLE
Remove xcode check from firedrake-install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -955,10 +955,6 @@ if travis:
 osname = platform.uname()[0]
 if osname == "Darwin":
     if options["package_manager"]:
-        try:
-            check_call(["xcodebuild", "-version"])
-        except:
-            quit("Xcode not found. Please install xcode from the App Store and try again.")
 
         log.info("Installing command line tools...")
         try:


### PR DESCRIPTION
Using a brand new, clean, Mac Mini I have just confirmed @francispoulin's previous observation that we don't actually need XCode -  the command line tools suffice.