### PR TITLE
replaced numpy.rank with numpy.ndim in firedrake/interpolation

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -227,8 +227,8 @@ def compile_python_kernel(expression, to_pts, to_element, fs, coords):
             # Pass a slice for the scalar case but just the
             # current vector in the VFS case. This ensures the
             # eval method has a Dolfin compatible API.
-            expression.eval(output[i:i+1, ...] if numpy.rank(output) == 1 else output[i, ...],
-                            X[i:i+1, ...] if numpy.rank(X) == 1 else X[i, ...], **kwargs)
+            expression.eval(output[i:i+1, ...] if numpy.ndim(output) == 1 else output[i, ...],
+                            X[i:i+1, ...] if numpy.ndim(X) == 1 else X[i, ...], **kwargs)
 
     coefficients = [coords]
     for _, arg in expression._user_args:


### PR DESCRIPTION
The goal is to avoid a numpy Deprecation Warning.