### PR TITLE
Add error checking inside derivative for u.split()

### DIFF
--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -3,7 +3,7 @@ import ufl
 import ufl.argument
 from ufl.assertions import ufl_assert
 from ufl.split_functions import split
-from ufl.algorithms.analysis import extract_arguments
+from ufl.algorithms import extract_arguments, extract_coefficients
 
 from firedrake import function
 from firedrake import utils
@@ -131,8 +131,16 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
     :arg coefficient_derivatives: an optional :class:`dict` to
          provide the derivative of a coefficient function.
 
+    :raises ValueError: If any of the coefficients in ``form`` were
+        obtained from ``u.split()``.  UFL doesn't notice that these
+        are related to ``u`` and so therefore the derivative is
+        wrong (instead one should have written ``split(u)``).
+
     See also :func:`ufl.derivative`.
     """
+    if set(extract_coefficients(form)) & set(u.split()):
+        raise ValueError("Taking derivative of form wrt u, but form contains coefficients from u.split()."
+                         "\nYou probably meant to write split(u) when defining your form.")
     if du is None:
         if isinstance(u, function.Function):
             V = u.function_space()

--- a/tests/regression/test_split.py
+++ b/tests/regression/test_split.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 import pytest
 from firedrake import *
+import numpy as np
 
 
 def test_assemble_split_derivative():
@@ -17,6 +18,47 @@ def test_assemble_split_derivative():
     F = (inner(u, v) + v[1]*p)*dx
 
     assert assemble(derivative(F, x))
+
+
+def test_function_split_raises():
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "DG", 0)
+
+    W = V*V
+
+    f = Function(W)
+
+    u, p = f.split()
+
+    phi = u*dx + p*dx
+
+    with pytest.raises(ValueError):
+        derivative(phi, f)
+
+
+def test_split_function_derivative():
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "DG", 0)
+
+    W = V*V
+
+    f = Function(W)
+
+    u, p = f.split()
+
+    f.assign(1)
+
+    phi = u**2*dx + p*dx
+
+    actual = assemble(derivative(phi, u))
+    expect = assemble(2*TestFunction(V)*dx)
+
+    assert np.allclose(actual.dat.data_ro, expect.dat.data_ro)
+
+    actual = assemble(derivative(derivative(phi, u), u))
+    expect = assemble(2*TestFunction(V)*TrialFunction(V)*dx)
+
+    assert np.allclose(actual.M.values, expect.M.values)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If one defines a form with u.split(), rather than split(u), and then
attempts to take a derivative wrt u, bad things happen.  In
particular, UFL does not notice that the form has dependence on u, and
therefore the resulting form is always zero.  Since this is an easy
mistake to make, we should catch it.  I extract the coefficients from
the form and check if any of them are in the set of u.split().  If so,
raise a ValueError suggesting a fix.  No false positives occur in the
test suite, so I'm going with a exception, rather than a warning,
because no-one reads those anyway.