### PR TITLE
Cause only the Linux builder to be used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 pipeline {
-  agent any
+  agent {
+    label 'linux'
+  }
   environment {
     TEST_FILES = "tests/extrusion/test_facet_integrals_2D.py tests/extrusion/test_mixed_bcs.py tests/extrusion/test_steady_advection_2D_extr.py tests/multigrid/test_two_poisson_gmg.py tests/output tests/regression/test_facet_orientation.py tests/regression/test_matrix_free.py tests/regression/test_nested_fieldsplit_solves.py tests/regression/test_nullspace.py tests/regression/test_point_eval_api.py tests/regression/test_point_eval_cells.py tests/regression/test_point_eval_fs.py tests/regression/test_solving_interface.py tests/regression/test_steady_advection_2D.py"
     PATH = "/usr/local/bin:/usr/bin:/bin"


### PR DESCRIPTION
The Mac builders are now active, so this is just a trivial patch to ensure that the Linux build does not get pushed onto a Mac builder.

Integrating the Mac builders into the test cycle requires a bit more work. Currently there is a separate branch for this. The issue appears to be that the Mac is suffering from intermittent network issues which cause the build to fail because one or other package won't download.