### PR TITLE
Rewrite Mesh.init_cell_orientations

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1095,6 +1095,11 @@ values from f.)"""
                 raise NotImplementedError('Only implemented for 3-vectors')
 
             expr = interpolate(expr, functionspace.VectorFunctionSpace(self, 'DG', 0))
+        elif isinstance(expr, ufl.classes.Expr):
+            if expr.ufl_shape != (3,):
+                raise NotImplementedError('Only implemented for 3-vectors')
+        else:
+            raise TypeError("UFL expression or Expression object expected!")
 
         fs = functionspace.FunctionSpace(self, 'DG', 0)
         x = ufl.SpatialCoordinate(self)

--- a/tests/regression/test_helmholtz_sphere.py
+++ b/tests/regression/test_helmholtz_sphere.py
@@ -6,10 +6,10 @@ import numpy as np
 from firedrake import *
 
 
-def run_helmholtz_sphere(MeshClass, r):
-    m = MeshClass(refinement_level=r)
+def run_helmholtz_sphere(MeshClass, r, d):
+    m = MeshClass(refinement_level=r, degree=d)
     m.init_cell_orientations(Expression(('x[0]', 'x[1]', 'x[2]')))
-    V = FunctionSpace(m, 'CG', 2)
+    V = FunctionSpace(m, 'CG', d)
 
     u = TrialFunction(V)
     v = TestFunction(V)
@@ -20,20 +20,20 @@ def run_helmholtz_sphere(MeshClass, r):
     L = f * v * dx
 
     u = Function(V)
-    solve(a == L, u)
+    solve(a == L, u, solver_parameters={"ksp_type": "cg"})
 
     f.interpolate(Expression("x[0]*x[1]*x[2]/13.0"))
     return errornorm(f, u, degree_rise=0)
 
 
-def run_helmholtz_mixed_sphere(MeshClass, r):
-    m = MeshClass(refinement_level=r)
+def run_helmholtz_mixed_sphere(MeshClass, r, meshd, eltd):
+    m = MeshClass(refinement_level=r, degree=meshd)
     m.init_cell_orientations(Expression(('x[0]', 'x[1]', 'x[2]')))
     if m.ufl_cell().cellname() == "triangle":
-        V = FunctionSpace(m, 'RT', 1)
+        V = FunctionSpace(m, 'RT', eltd+1)
     elif m.ufl_cell().cellname() == "quadrilateral":
-        V = FunctionSpace(m, 'RTCF', 1)
-    Q = FunctionSpace(m, 'DG', 0)
+        V = FunctionSpace(m, 'RTCF', eltd+1)
+    Q = FunctionSpace(m, 'DG', eltd)
     W = V*Q
 
     u, p = TrialFunctions(W)
@@ -46,7 +46,12 @@ def run_helmholtz_mixed_sphere(MeshClass, r):
 
     soln = Function(W)
 
-    solve(a == L, soln)
+    solve(a == L, soln, solver_parameters={'pc_type': 'fieldsplit',
+                                           'pc_fieldsplit_type': 'schur',
+                                           'ksp_type': 'cg',
+                                           'pc_fieldsplit_schur_fact_type': 'FULL',
+                                           'fieldsplit_0_ksp_type': 'cg',
+                                           'fieldsplit_1_ksp_type': 'cg'})
 
     _, u = soln.split()
     f.interpolate(Expression("x[0]*x[1]*x[2]/13.0"))
@@ -54,36 +59,51 @@ def run_helmholtz_mixed_sphere(MeshClass, r):
 
 
 @pytest.mark.parametrize('MeshClass', [UnitIcosahedralSphereMesh, UnitCubedSphereMesh])
-def test_helmholtz_sphere(MeshClass):
-    errors = [run_helmholtz_sphere(MeshClass, r) for r in range(1, 5)]
+def test_helmholtz_sphere_lowestorder(MeshClass):
+    errors = [run_helmholtz_sphere(MeshClass, r, 1) for r in range(2, 5)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])
 
-    assert (l2conv > 1.6).all()
+    assert (l2conv > 1.7).all()
 
 
 @pytest.mark.parametrize('MeshClass', [UnitIcosahedralSphereMesh, UnitCubedSphereMesh])
-def test_helmholtz_mixed_sphere(MeshClass):
-    errors = [run_helmholtz_mixed_sphere(MeshClass, r) for r in range(2, 5)]
+def test_helmholtz_sphere_higherorder(MeshClass):
+    errors = [run_helmholtz_sphere(MeshClass, r, 2) for r in range(2, 5)]
+    errors = np.asarray(errors)
+    l2conv = np.log2(errors[:-1] / errors[1:])
+
+    assert (l2conv > 2.99).all()
+
+
+@pytest.mark.parametrize('MeshClass', [UnitIcosahedralSphereMesh, UnitCubedSphereMesh])
+def test_helmholtz_mixed_sphere_lowestorder(MeshClass):
+    errors = [run_helmholtz_mixed_sphere(MeshClass, r, 1, 0) for r in range(2, 5)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])
 
     # Note, due to "magic hybridisation stuff" we expect the numerical
     # solution to converge to the projection of the exact solution to
     # DG0 at second order (ccotter, pers comm).
-    assert (l2conv > 1.6).all()
+    assert (l2conv > 1.7).all()
+
+
+@pytest.mark.parametrize('MeshClass', [UnitIcosahedralSphereMesh, UnitCubedSphereMesh])
+def test_helmholtz_mixed_sphere_higherorder(MeshClass):
+    errors = [run_helmholtz_mixed_sphere(MeshClass, r, 2, 2) for r in range(2, 5)]
+    errors = np.asarray(errors)
+    l2conv = np.log2(errors[:-1] / errors[1:])
+
+    assert (l2conv > 2.7).all()
 
 
 @pytest.mark.parallel
 def test_helmholtz_mixed_cubedsphere_parallel():
-    errors = [run_helmholtz_mixed_sphere(UnitCubedSphereMesh, r) for r in range(2, 5)]
+    errors = [run_helmholtz_mixed_sphere(UnitCubedSphereMesh, r, 2, 2) for r in range(2, 5)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])
 
-    # Note, due to "magic hybridisation stuff" we expect the numerical
-    # solution to converge to the projection of the exact solution to
-    # DG0 at second order (ccotter, pers comm).
-    assert (l2conv > 1.6).all()
+    assert (l2conv > 2.7).all()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- `Mesh.init_cell_orientations` now works correctly for higher-order quadrilaterals. Fixes #1038.
- Test cases included, supersedes #1040.
- Replaces hand-written COFFEE AST with neat UFL.
- `Mesh.init_cell_orientations` now also accepts UFL expressions.