### PR TITLE
Split "DG advection on extruded mesh" into two demos

### DIFF
--- a/demos/DG_advection/DG_advection.py.rst
+++ b/demos/DG_advection/DG_advection.py.rst
@@ -186,20 +186,22 @@ negative.  This will be useful in the upwind terms.  We now define our
 right-hand-side form ``L1`` as :math:`\Delta t` times the sum of four integrals.
 
 The first integral is a straightforward cell integral of
-:math:`q\nabla(\phi\vec{u})`.  The second integral represents the inflow
+:math:`q\nabla\cdot(\phi\vec{u})`.  The second integral represents the inflow
 boundary condition.  We only want this to contribute on the inflow part of the
 boundary, where :math:`\vec{u}\cdot\vec{n} < 0` (recall that :math:`\vec{n}` is
 an outward-pointing normal).  Where this is true, the condition gives the
 desired expression :math:`\phi q_\mathrm{in}\vec{u}\cdot\vec{n}`, otherwise the
 condition gives zero.  The third integral operates in a similar way to give
-the outflow boundary condition.  The last integral represents the integral over
-interior facets.  The quantity ``un``, which is either :math:`\vec{u}\cdot\vec{n}`
-or zero, is used to select the correct upwind quantity for :math:`\widetilde{q}`.
-Although it is not obvious at first sight, the expression given is equivalent
-to the desired expression
-:math:`\widetilde{q}(\phi_+ \vec{u} \cdot \vec{n}_+ + \phi_- \vec{u} \cdot \vec{n}_-)`,
-at least if :math:`\vec{n}_- = -\vec{n}_+`, and is written in a way that avoids
-using conditionals to define :math:`\widetilde{q}`. ::
+the outflow boundary condition.  The last integral represents the integral
+:math:`\widetilde{q}(\phi_+ \vec{u} \cdot \vec{n}_+ + \phi_- \vec{u} \cdot \vec{n}_-)`
+over interior facets.  We could again use a conditional in order to represent
+the upwind value :math:`\widetilde{q}` by the correct choice of :math:`q_+` or
+:math:`q_-`, depending on the sign of :math:`\vec{u}\cdot\vec{n_+}`, say.
+Instead, we make use of the quantity ``un``, which is either
+:math:`\vec{u}\cdot\vec{n}` or zero, in order to avoid writing explicit
+conditionals. Although it is not obvious at first sight, the expression given in
+code is equivalent to the desired expression, assuming
+:math:`\vec{n}_- = -\vec{n}_+`. ::
 
   n = FacetNormal(mesh)
   un = 0.5*(dot(u, n) + abs(dot(u, n)))

--- a/demos/DG_advection/DG_advection.py.rst
+++ b/demos/DG_advection/DG_advection.py.rst
@@ -1,0 +1,277 @@
+DG advection equation with upwinding
+====================================
+
+We next consider the advection equation
+
+.. math::
+
+  \frac{\partial q}{\partial t} + (\vec{u}\cdot\nabla)q = 0
+
+in a domain :math:`\Omega`, where :math:`\vec{u}` is a prescribed vector field,
+and :math:`q(\vec{x}, t)` is an unknown scalar field. The value of :math:`q` is
+known initially:
+
+.. math::
+
+  q(\vec{x}, 0) = q_0(\vec{x}),
+
+and the value of :math:`q` is known for all time on the subset of the boundary
+:math:`\Gamma` in which :math:`\vec{u}` is directed towards the interior of the
+domain:
+
+.. math::
+
+  q(\vec{x}, t) = q_\mathrm{in}(\vec{x}, t) \quad \text{on} \ \Gamma_\mathrm{inflow}
+
+where :math:`\Gamma_\mathrm{inflow}` is defined appropriately.
+
+We will look for a solution :math:`q` in a space of *discontinuous* functions
+:math:`V`.  A weak form of the continuous equation in each element :math:`e` is
+
+.. math::
+
+   \int_e \! \phi_e \frac{\partial q}{\partial t} \, \mathrm{d} x
+   + \int_e \! \phi_e (\vec{u}\cdot\nabla)q \, \mathrm{d} x = 0, \qquad
+   \forall \phi_e \in V_e,
+
+where we explicitly introduce the subscript :math:`e` since the test functions
+:math:`\phi_e` are local to each element.  Using integration by parts on the
+second term, we get
+
+.. math::
+
+   \int_e \! \phi_e \frac{\partial q}{\partial t} \, \mathrm{d} x
+   = \int_e \! q \nabla \cdot (\phi_e \vec{u}) \, \mathrm{d} x
+   - \int_{\partial e} \! \phi_e q \vec{u} \cdot \vec{n}_e \, \mathrm{d} S,
+   \qquad \forall \phi_e \in V_e,
+
+where :math:`\vec{n}_e` is an outward-pointing unit normal.
+
+Since :math:`q` is discontinuous, we have to make a choice about how to define
+:math:`q` on facets when we assemble the equations globally.  We will use
+upwinding: we choose the *upstream* value of :math:`q` on facets, with respect
+to the velocity field :math:`\vec{u}`.  We note that there are three types of
+facets that we may encounter:
+
+1. Interior facets. Here, the value of :math:`q` from the upstream side, denoted
+   :math:`\widetilde{q}`, is used.
+2. Inflow boundary facets, where :math:`\vec{u}` points towards the interior.
+   Here, the upstream value is the prescribed boundary value :math:`q_\mathrm{in}`.
+3. Outflow boundary facets, where :math:`\vec{u}` points towards the outside.
+   Here, the upstream value is the interior solution value :math:`q`.
+
+We must now express our problem in terms of integrals over the entire mesh and
+over the sets of interior and exterior facets.  This is done by summing our
+earlier expression over all elements :math:`e`.  The cell integrals are easy to
+handle, since :math:`\sum_e \int_e \cdot  \,\mathrm{d}x = \int_\Omega \cdot \,\mathrm{d}x`.
+The interior facet integrals are more difficult to express, since each facet
+in the set of interior facets :math:`\Gamma_\mathrm{int}` appears twice in the
+:math:`\sum_e \int_{\partial e}`.  In other words, contributions arise from both
+of the neighbouring cells.
+
+In Firedrake, the separate quantities in the two cells neighbouring an interior
+facet are denoted by + and -.  These markings are arbitrary -- there is no
+built-in concept of upwinding, for example -- and the user is responsible for
+providing a form that works in all cases.  We will give an example shortly.  The
+exterior facet integrals are easier to handle, since each facet in the set of
+exterior facets :math:`\Gamma_\mathrm{ext}` appears exactly once in
+:math:`\sum_e \int_{\partial e}`. The full equations are then
+
+.. math::
+
+   \int_\Omega \! \phi \frac{\partial q}{\partial t} \, \mathrm{d} x
+   = \int_\Omega \! q \nabla \cdot (\phi \vec{u}) \, \mathrm{d} x
+   - \int_{\Gamma_\mathrm{int}} \! \widetilde{q}(\phi_+ \vec{u} \cdot \vec{n}_+
+     + \phi_- \vec{u} \cdot \vec{n}_-) \, \mathrm{d} S
+   - \int_{\Gamma_\rlap{\mathrm{ext, inflow}}} \phi q_\mathrm{in} \vec{u} \cdot
+   \vec{n} \, \mathrm{d} s
+   - \int_{\Gamma_\rlap{\mathrm{ext, outflow}}} \phi q \vec{u} \cdot
+   \vec{n} \, \mathrm{d} s
+   \qquad \forall \phi \in V.
+
+As a timestepping scheme, we use the three-stage strong-stability-preserving
+Runge-Kutta (SSPRK) scheme from :cite:`Shu:1988`: to discretise
+:math:`\frac{\partial q}{\partial t} = \mathcal{L}(q)`, we set
+
+.. math::
+
+   q^{(1)} &= q^n + \Delta t \mathcal{L}(q^n)\\
+   q^{(2)} &= \frac{3}{4}q^n + \frac{1}{4}(q^{(1)} + \Delta t \mathcal{L}(q^{(1)}))\\
+   q^{n+1} &= \frac{1}{3}q^n + \frac{2}{3}(q^{(2)} + \Delta t \mathcal{L}(q^{(2)}))\\
+
+In this worked example, we reproduce the classic
+cosine-bell--cone--slotted-cylinder advection test case of :cite:`LeVeque:1996`.
+The domain :math:`\Omega` is the unit square :math:`\Omega = [0,1] \times [0,1]`,
+and the velocity field corresponds to solid body rotation
+:math:`\vec{u} = (0.5 - y, x - 0.5)`. Each side of the domain has a section of
+inflow and a section of outflow boundary.  We therefore perform both the inflow
+and outflow integrals over the entire boundary, but construct them so that they
+only contribute in the correct places.
+
+As usual, we start by importing Firedrake.  We also import the math library to
+give us access to the value of pi.  We use a 40-by-40 mesh of squares. ::
+
+  from firedrake import *
+  import math
+
+  mesh = UnitSquareMesh(40, 40, quadrilateral=True)
+
+We set up a function space of discontinous bilinear elements for :math:`q`, and
+a vector-valued continuous function space for our velocity field. ::
+
+  V = FunctionSpace(mesh, "DQ", 1)
+  W = VectorFunctionSpace(mesh, "CG", 1)
+
+We set up the initial velocity field using a simple analytic expression. ::
+
+  x, y = SpatialCoordinate(mesh)
+
+  velocity = as_vector((0.5 - y, x - 0.5))
+  u = Function(W).interpolate(velocity)
+
+Now, we set up the cosine-bell--cone--slotted-cylinder initial coniditon. The
+first four lines declare various parameters relating to the positions of these
+objects, while the analytic expressions appear in the last three lines. ::
+
+  bell_r0 = 0.15; bell_x0 = 0.25; bell_y0 = 0.5
+  cone_r0 = 0.15; cone_x0 = 0.5; cone_y0 = 0.25
+  cyl_r0 = 0.15; cyl_x0 = 0.5; cyl_y0 = 0.75
+  slot_left = 0.475; slot_right = 0.525; slot_top = 0.85
+
+  bell = 0.25*(1+cos(math.pi*min_value(sqrt(pow(x-bell_x0, 2) + pow(y-bell_y0, 2))/bell_r0, 1.0)))
+  cone = 1.0 - min_value(sqrt(pow(x-cone_x0, 2) + pow(y-cone_y0, 2))/cyl_r0, 1.0)
+  slot_cyl = conditional(sqrt(pow(x-cyl_x0, 2) + pow(y-cyl_y0, 2)) < cyl_r0,
+               conditional(And(And(x > slot_left, x < slot_right), y < slot_top),
+                 0.0, 1.0), 0.0)
+
+We then declare the inital condition of :math:`q` to be the sum of these fields.
+Furthermore, we add 1 to this, so that the initial field lies between 1 and 2,
+rather than between 0 and 1.  This ensures that we can't get away with
+neglecting the inflow boundary condition.  We also save the initial state so
+that we can check the :math:`L^2`-norm error at the end. ::
+
+  q = Function(V).interpolate(1.0 + bell + cone + slot_cyl)
+  q_init = Function(V).assign(q)
+
+We declare the output filename, and write out the initial condition. ::
+
+  outfile = File("DGadv.pvd")
+  outfile.write(q)
+
+We will run for time :math:`2\pi`, a full rotation.  We take 500 steps, giving
+a timestep close to the CFL limit.  We declare an extra variable ``dtc``; for
+technical reasons, this means that Firedrake does not have to compile new C code
+if the user tries different timesteps.  Finally, we define the inflow boundary
+condition, :math:`q_\mathrm{in}`.  In general, this would be a ``Function``, but
+here we just use a ``Constant`` value. ::
+
+  T = 2*math.pi
+  dt = T/500.0
+  dtc = Constant(dt)
+  q_in = Constant(1.0)
+
+Now we declare our variational forms.  Solving for :math:`\Delta q` at each
+stage, the explicit timestepping scheme means that the left hand side is just a
+mass matrix. ::
+
+  dq_trial = TrialFunction(V)
+  phi = TestFunction(V)
+  a = phi*dq_trial*dx
+
+The right-hand-side is more interesting.  We define ``n`` to be the built-in
+``FacetNormal`` object; a unit normal vector that can be used in integrals over
+exterior and interior facets.  We next define ``un`` to be an object which is
+equal to :math:`\vec{u}\cdot\vec{n}` if this is positive, and zero if this is
+negative.  This will be useful in the upwind terms.  We now define our
+right-hand-side form ``L1`` as :math:`\Delta t` times the sum of four integrals.
+
+The first integral is a straightforward cell integral of
+:math:`q\nabla(\phi\vec{u})`.  The second integral represents the inflow
+boundary condition.  We only want this to contribute on the inflow part of the
+boundary, where :math:`\vec{u}\cdot\vec{n} < 0` (recall that :math:`\vec{n}` is
+an outward-pointing normal).  Where this is true, the condition gives the
+desired expression :math:`\phi q_\mathrm{in}\vec{u}\cdot\vec{n}`, otherwise the
+condition gives zero.  The third integral operates in a similar way to give
+the outflow boundary condition.  The last integral represents the integral over
+interior facets.  The quantity ``un``, which is either :math:`\vec{u}\cdot\vec{n}`
+or zero, is used to select the correct upwind quantity for :math:`\widetilde{q}`.
+Although it is not obvious at first sight, the expression given is equivalent
+to the desired expression
+:math:`\widetilde{q}(\phi_+ \vec{u} \cdot \vec{n}_+ + \phi_- \vec{u} \cdot \vec{n}_-)`,
+at least if :math:`\vec{n}_- = -\vec{n}_+`, and is written in a way that avoids
+using conditionals to define :math:`\widetilde{q}`. ::
+
+  n = FacetNormal(mesh)
+  un = 0.5*(dot(u, n) + abs(dot(u, n)))
+
+  L1 = dtc*(q*div(phi*u)*dx
+            - conditional(dot(u, n) < 0, phi*dot(u, n)*q_in, 0.0)*ds
+            - conditional(dot(u, n) > 0, phi*dot(u, n)*q, 0.0)*ds
+            - (phi('+') - phi('-'))*(un('+')*q('+') - un('-')*q('-'))*dS)
+
+In our Runge-Kutta scheme, the first step uses :math:`q^n` to obtain
+:math:`q^{(1)}`.  We therefore declare similar forms that use :math:`q^{(1)}`
+to obtain :math:`q^{(2)}`, and :math:`q^{(2)}` to obtain :math:`q^{n+1}`. We
+make use of UFL's ``replace`` feature to avoid writing out the form repeatedly. ::
+
+  q1 = Function(V); q2 = Function(V)
+  L2 = replace(L1, {q: q1}); L3 = replace(L1, {q: q2})
+
+We now declare a variable to hold the temporary increments at each stage. ::
+
+  dq = Function(V)
+
+Since we want to perform hundreds of timesteps, ideally we should avoid
+reassembling the left-hand-side mass matrix each step, as this does not change.
+We therefore make use of the ``LinearVariationalProblem`` and
+``LinearVariationalSolver`` objects for each of our Runge-Kutta stages. These
+cache and reuse the assembled left-hand-side matrix.  Since the DG mass matrices
+are block-diagonal, we use the 'preconditioner' ILU(0) to solve the linear
+systems. ::
+
+  params = {'ksp_type': 'preonly', 'pc_type': 'ilu'}
+  prob1 = LinearVariationalProblem(a, L1, dq)
+  solv1 = LinearVariationalSolver(prob1, solver_parameters=params)
+  prob2 = LinearVariationalProblem(a, L2, dq)
+  solv2 = LinearVariationalSolver(prob2, solver_parameters=params)
+  prob3 = LinearVariationalProblem(a, L3, dq)
+  solv3 = LinearVariationalSolver(prob3, solver_parameters=params)
+
+We now run the time loop.  This consists of three Runge-Kutta stages, and every
+20 steps we write out the solution to file and print the current time to the
+terminal. ::
+
+  t = 0.0
+  step = 0
+  while t < T - 0.5*dt:
+      solv1.solve()
+      q1.assign(q + dq)
+
+      solv2.solve()
+      q2.assign(0.75*q + 0.25*(q1 + dq))
+
+      solv3.solve()
+      q.assign((1.0/3.0)*q + (2.0/3.0)*(q2 + dq))
+
+      step += 1
+      t += dt
+
+      if step % 20 == 0:
+          outfile.write(q)
+          print "t=", t
+
+Finally, we display the normalised :math:`L^2` error, by comparing to the
+initial condition. ::
+
+  L2_err = sqrt(assemble((q - q_init)*(q - q_init)*dx))
+  L2_init = sqrt(assemble(q_init*q_init*dx))
+  print L2_err/L2_init
+
+This demo can be found as a script in
+`DG_advection.py <DG_advection.py>`__.
+
+
+.. rubric:: References
+
+.. bibliography:: demo_references.bib
+   :filter: docname in docnames

--- a/demos/DG_advection/DG_advection.py.rst
+++ b/demos/DG_advection/DG_advection.py.rst
@@ -182,8 +182,13 @@ The right-hand-side is more interesting.  We define ``n`` to be the built-in
 ``FacetNormal`` object; a unit normal vector that can be used in integrals over
 exterior and interior facets.  We next define ``un`` to be an object which is
 equal to :math:`\vec{u}\cdot\vec{n}` if this is positive, and zero if this is
-negative.  This will be useful in the upwind terms.  We now define our
-right-hand-side form ``L1`` as :math:`\Delta t` times the sum of four integrals.
+negative.  This will be useful in the upwind terms. ::
+
+  n = FacetNormal(mesh)
+  un = 0.5*(dot(u, n) + abs(dot(u, n)))
+
+We now define our right-hand-side form ``L1`` as :math:`\Delta t` times the
+sum of four integrals.
 
 The first integral is a straightforward cell integral of
 :math:`q\nabla\cdot(\phi\vec{u})`.  The second integral represents the inflow
@@ -202,9 +207,6 @@ Instead, we make use of the quantity ``un``, which is either
 conditionals. Although it is not obvious at first sight, the expression given in
 code is equivalent to the desired expression, assuming
 :math:`\vec{n}_- = -\vec{n}_+`. ::
-
-  n = FacetNormal(mesh)
-  un = 0.5*(dot(u, n) + abs(dot(u, n)))
 
   L1 = dtc*(q*div(phi*u)*dx
             - conditional(dot(u, n) < 0, phi*dot(u, n)*q_in, 0.0)*ds

--- a/demos/demo_references.bib
+++ b/demos/demo_references.bib
@@ -1,3 +1,25 @@
+@Article{Shu:1988,
+  author =       {Shu, Chi-Wang and Osher, Stanley},
+  title =        {{Efficient Implementation of Essentially Non-oscillatory Shock-Capturing Schemes}},
+  journal =      {Journal of Computational Physics},
+  year =         1988,
+  volume =       77,
+  number =       2,
+  pages =        {439--471},
+  doi =          {10.1016/0021-9991(88)90177-5}
+}
+
+@Article{LeVeque:1996,
+  author =       {LeVeque, Randall J.},
+  title =        {{High-Resolution Conservative Algorithms for Advection in Incompressible Flow}},
+  journal =      {SIAM Journal on Numerical Analysis},
+  year =         1996,
+  volume =       33,
+  number =       2,
+  pages =        {627--665},
+  doi =          {10.1137/0733033}
+}
+
 @Book{1989:KdV,
   author =       {P.G. Drazin and R.S. Johnson},
   title =        {Solitons: an Introduction},

--- a/demos/extruded_continuity/extruded_continuity.py.rst
+++ b/demos/extruded_continuity/extruded_continuity.py.rst
@@ -1,5 +1,5 @@
-Steady-state advection equation with upwinding
-==============================================
+Steady-state continuity equation on an extruded mesh
+====================================================
 
 We next consider the equation
 
@@ -187,4 +187,4 @@ We finally compare our solution to the expected solution: ::
   assert max(abs(out.dat.data - exact.dat.data)) < 1e-10
 
 This demo can be found as a script in
-`upwind_advection.py <upwind_advection.py>`__.
+`extruded_continuity.py <extruded_continuity.py>`__.

--- a/demos/extruded_continuity/extruded_continuity.py.rst
+++ b/demos/extruded_continuity/extruded_continuity.py.rst
@@ -1,100 +1,60 @@
 Steady-state continuity equation on an extruded mesh
 ====================================================
 
-We next consider the equation
+This demo showcases the use of extruded meshes, including the new regions of
+integration and the construction of sophisticated finite element spaces.
+
+We now consider the equation
 
 .. math::
 
-   \nabla\cdot(\vec{u_0}D) = 0
+   \nabla\cdot(\vec{u}q) &= 0 \\
+   q &= q_\mathrm{in} \quad \text{on} \ \Gamma_\mathrm{inflow},
 
-in a domain :math:`\Omega`, where :math:`\vec{u_0}` is a prescribed vector
-field, and :math:`D` is an unknown scalar field. The value of :math:`D` is known
-on the subset of the boundary :math:`\Gamma` in which :math:`\vec{u_0}` is
-directed towards the interior of the domain:
+in a domain :math:`\Omega`, where :math:`\vec{u}` is a prescribed vector field,
+and :math:`q` is an unknown scalar field. The value of :math:`q` is known on the
+'inflow' part of the boundary :math:`\Gamma`, where :math:`\vec{u}` is directed
+towards the interior of the domain. :math:`q` can be interpreted as the
+steady-state distribution of a passive tracer carried by a fluid with velocity
+field :math:`\vec{u}`.
 
-.. math::
-
-  D = D_0 \quad \mathrm{on} \ \Gamma_\mathrm{inflow}
-
-where :math:`\Gamma_\mathrm{inflow}` is defined appropriately. :math:`D` can
-be interpreted as the steady-state distribution of a passive tracer carried by a
-fluid with velocity field :math:`\vec{u_0}`.
-
-A weak form of the continuous equation is
+We apply an upwind DG method, as we saw in the previous example.  Denoting the
+upwind value of :math:`q` on interior facets by :math:`\widetilde{q}`, the full
+set of equations are then
 
 .. math::
 
-   \int_\Omega \! \phi \nabla \cdot (\vec{u_0} D) \, \mathrm{d} x &= 0 \quad
-   \forall \ \phi \in D(\Omega), \\
-   
-   D &= D_0 \quad \mathrm{on} \ \Gamma_\mathrm{inflow}
-
-where :math:`D(\Omega)` is the space of smooth *test functions* with compact
-support in :math:`\Omega`. We will look for a solution :math:`D` in a space of
-*discontinuous* functions :math:`V`. This suggests using integration by parts to
-avoid taking the derivative of a discontinuous quantity:
-
-.. math::
-
-   \sum_e \left( \int_{\partial e} \! \phi_e D \vec{u_0} \cdot \vec{n} \,
-   \mathrm{d} S - \int_e \! D \vec{u_0} \cdot \nabla \phi \, \mathrm{d} x \right) = 0
-   \quad \forall \ \phi \in V, \\
-   
-   D = D_0 \quad \mathrm{on} \ \Gamma_\mathrm{inflow}
-
-where the sum is taken over all elements. Since :math:`D` is discontinuous, we
-have to make a choice about how it is defined on facets in order to evaluate
-the first integral. We will use upwinding: the *upstream* value of :math:`D` is
-used on the facet. In light of this, there are three distinct situations we may
-encounter:
-
-1. Boundary facets where :math:`\vec{u_0}` points towards the interior of the
-   domain. Here, the prescribed boundary value :math:`D_0` is used.
-2. Boundary facets where :math:`\vec{u_0}` points away from the interior of the
-   domain. Here, the (unknown) interior solution value :math:`D` is used.
-3. Interior facets. Here, the upstream value of :math:`D`,
-   :math:`\widetilde{D}`, is used.
-
-Note that each of the interior facets contributes to the integral twice. The two
-contributions differ in the choice of test function: a subscript :math:`\phi_e`
-was used to make this explicit. The full set of equations are then
-
-.. math::
-
-   -\int_\Omega \! D \vec{u_0} \cdot \nabla \phi \, \mathrm{d} x 
-   + \int_{\Gamma_\rlap{\mathrm{ext, outflow}}} \! \phi D \vec{u_0} \cdot \vec{n}
-   \, \mathrm{d} s 
-   + \int_{\Gamma_\mathrm{int}} \! (\phi_+ - \phi_-) \widetilde{D}
-   \vec{u_0} \cdot \vec{n} \, \mathrm{d} S
+   -\int_\Omega \! q \vec{u_0} \cdot \nabla \phi \, \mathrm{d} x
+   + \int_{\Gamma_\rlap{\mathrm{ext, outflow}}} \! \phi q \vec{u} \cdot \vec{n}
+   \, \mathrm{d} s
+   + \int_{\Gamma_\mathrm{int}} \! (\phi_+ \vec{u} \cdot \vec{n}_+ +
+     \phi_- \vec{u} \cdot \vec{n}_-) \widetilde{q} \, \mathrm{d} S
    \quad = \quad
-   -\int_{\Gamma_\rlap{\mathrm{ext, inflow}}} \phi D_0 \vec{u_0} \cdot
+   -\int_{\Gamma_\rlap{\mathrm{ext, inflow}}} \phi q_\mathrm{in} \vec{u} \cdot
    \vec{n} \, \mathrm{d} s \quad \forall \ \phi \in V,
 
-   D = D_0 \quad \mathrm{on} \ \Gamma_\mathrm{inflow}
-
-In this worked example, we will take the domain :math:`\Omega` to be the cuboid
-:math:`\Omega = [0,1] \times [0,1] \times [0,0.2]`. We will use the constant
-velocity field :math:`\vec{u_0} = (0, 0, 1)`. :math:`\Gamma_\mathrm{inflow}`
+We will take the domain :math:`\Omega` to be the cuboid
+:math:`\Omega = [0,1] \times [0,1] \times [0,0.2]`. We will use the uniform
+velocity field :math:`\vec{u} = (0, 0, 1)`. :math:`\Gamma_\mathrm{inflow}`
 is therefore the base of the cuboid, while :math:`\Gamma_\mathrm{outflow}`
 is the top. The four vertical sides can be ignored, since
-:math:`\vec{u_0} \cdot \vec{n} = 0` on these faces.
+:math:`\vec{u} \cdot \vec{n} = 0` on these faces.
 
-Firedrake code for this example is as follows:
-
-We will use an *extruded* mesh, where the base mesh is a 20 by 20 unit square,
-with 10 evenly-spaced vertical layers. This gives prism-shaped cells. ::
+We use an *extruded* mesh, where the base mesh is a 20 by 20 unit square,
+divided into triangles, with 10 evenly-spaced vertical layers. This gives
+prism-shaped cells. ::
 
   from firedrake import *
   m = UnitSquareMesh(20, 20)
   mesh = ExtrudedMesh(m, layers=10, layer_height=0.02)
 
 We will use a simple piecewise-constant function space for the unknown scalar
-:math:`D`: ::
+:math:`q`: ::
 
   V = FunctionSpace(mesh, "DG", 0)
 
 Our velocity will live in a low-order Raviart-Thomas space. The construction of
-this is more complicated than element spaces you will have seen previously. The
+this is more complicated than element spaces that have appeared previously. The
 horizontal and vertical components of the field are specified separately. They
 are combined into a single element which is used to build a FunctionSpace. ::
 
@@ -124,53 +84,51 @@ Or even: ::
 
 Next, we set the prescribed velocity field: ::
 
-  velocity = as_vector([0.0, 0.0, 1.0])
-  u0 = project(velocity, W)
-  
+  velocity = as_vector((0.0, 0.0, 1.0))
+  u = project(velocity, W)
+
   # if we had used W = VectorFunctionSpace(mesh, "CG", 1), we could have done
-  # u0 = Function(W)
-  # u0.interpolate(velocity)
+  # u = Function(W)
+  # u.interpolate(velocity)
 
 Next, we will set the boundary value on our scalar to be a simple indicator
 function over part of the bottom of the domain: ::
 
-  x = SpatialCoordinate(mesh)
-  inflow = conditional(And(x[2] < 0.02, x[0] > 0.5), 1.0, -1.0)
-  D0 = Function(V)
-  D0.interpolate(inflow)
+  x, y, z = SpatialCoordinate(mesh)
+  inflow = conditional(And(z < 0.02, x > 0.5), 1.0, -1.0)
+  q_in = Function(V)
+  q_in.interpolate(inflow)
 
-Now we will define our forms. There are several new concepts here. Firstly, we
-will define a new variable ``un`` which takes the value
-:math:`\vec{u_0} \cdot \vec{n}` when this is positive, otherwise `0`. This
-will be useful for our upwind terms. ::
+Now we will define our forms.  We use the same trick of defining ``un`` to aid
+with the upwind terms: ::
 
   n = FacetNormal(mesh)
-  un = 0.5*(dot(u0, n) + abs(dot(u0, n)))
+  un = 0.5*(dot(u, n) + abs(dot(u, n)))
 
 We define our trial and test functions in the usual way: ::
 
-  D = TrialFunction(V)
+  q = TrialFunction(V)
   phi = TestFunction(V)
 
 Since we are on an extruded mesh, we have several new integral types at our
-disposal. An integral over the interior of the domain is still denoted by
-``dx``. Boundary integrals now come in several varieties: ``ds_b`` denotes an
-integral over the base of the mesh, while ``ds_t`` denotes an integral over the
-top of the mesh. ``ds_v`` denotes an integral over the sides of a mesh, though
-we will not use that here.
+disposal. An integral over the cells of the domain is still denoted by ``dx``.
+Boundary integrals now come in several varieties: ``ds_b`` denotes an integral
+over the base of the mesh, while ``ds_t`` denotes an integral over the top of
+the mesh. ``ds_v`` denotes an integral over the sides of a mesh, though we will
+not use that here.
 
 Similiarly, interior facet integrals are split into ``dS_h`` and ``dS_v``, over
 *horizontal* interior facets and *vertical* interior facets respectively. Since
 our velocity field is purely in the vertical direction, we will omit the
 integral over vertical interior facets, since we know
-:math:`\vec{u_0} \cdot \vec{n}` is zero for these. ::
+:math:`\vec{u} \cdot \vec{n}` is zero for these. ::
 
-  a1 = -D*dot(u0, grad(phi))*dx
-  a2 = dot(jump(phi), un('+')*D('+') - un('-')*D('-'))*dS_h
-  a3 = dot(phi, un*D)*ds_t  # outflow at top wall
+  a1 = -q*dot(u, grad(phi))*dx
+  a2 = dot(jump(phi), un('+')*q('+') - un('-')*q('-'))*dS_h
+  a3 = dot(phi, un*q)*ds_t  # outflow at top wall
   a = a1 + a2 + a3
 
-  L = -D0*phi*dot(u0, n)*ds_b  # inflow at bottom wall
+  L = -q_in*phi*dot(u, n)*ds_b  # inflow at bottom wall
 
 Finally, we will compute the solution: ::
 
@@ -178,9 +136,9 @@ Finally, we will compute the solution: ::
   solve(a == L, out)
 
 By construction, the exact solution is quite simple: ::
-  
+
   exact = Function(V)
-  exact.interpolate(conditional(x[0] > 0.5, 1.0, -1.0))
+  exact.interpolate(conditional(x > 0.5, 1.0, -1.0))
 
 We finally compare our solution to the expected solution: ::
 

--- a/demos/extruded_continuity/extruded_continuity.py.rst
+++ b/demos/extruded_continuity/extruded_continuity.py.rst
@@ -18,7 +18,8 @@ towards the interior of the domain. :math:`q` can be interpreted as the
 steady-state distribution of a passive tracer carried by a fluid with velocity
 field :math:`\vec{u}`.
 
-We apply an upwind DG method, as we saw in the previous example.  Denoting the
+We apply an upwind DG method, as we saw in the
+:doc:`previous example <demos/DG_advection.py>`.  Denoting the
 upwind value of :math:`q` on interior facets by :math:`\widetilde{q}`, the full
 set of equations are then
 
@@ -99,7 +100,8 @@ function over part of the bottom of the domain: ::
   q_in = Function(V)
   q_in.interpolate(inflow)
 
-Now we will define our forms.  We use the same trick of defining ``un`` to aid
+Now we will define our forms.  We use the same trick as in the
+:doc:`previous example <demos/DG_advection.py>` of defining ``un`` to aid
 with the upwind terms: ::
 
   n = FacetNormal(mesh)

--- a/demos/helmholtz/helmholtz.py.rst
+++ b/demos/helmholtz/helmholtz.py.rst
@@ -1,22 +1,26 @@
 Simple Helmholtz equation
 =========================
 
-Let's start by considering the Helmholtz equation on a unit square,
+Let's start by considering the modified Helmholtz equation on a unit square,
 :math:`\Omega`, with boundary :math:`\Gamma`:
 
 .. math::
 
-   -\nabla^2 u + u = f
+   -\nabla^2 u + u &= f
 
-   \nabla u \cdot \vec{n} = 0 \ \textrm{on}\ \Gamma
+   \nabla u \cdot \vec{n} &= 0 \quad \textrm{on}\ \Gamma
 
 for some known function :math:`f`. The solution to this equation will
-be some function :math:`u\in V` for some suitable function space
-:math:`V` that satisfies these equations. We transform the equation
-into weak form by multiplying by an arbitrary test function in
-:math:`V`, integrating over the domain and then integrating by
-parts. The variational problem so derived reads: find :math:`u\in V`
-such that:
+be some function :math:`u\in V`, for some suitable function space
+:math:`V`, that satisfies these equations. Note that this is the
+Helmholtz equation that appears in meteorology, rather than the
+indefinite Helmholtz equation :math:`\nabla^2 u + u = f` that arises
+in wave problems.
+
+We transform the equation into weak form by multiplying by an arbitrary
+test function in :math:`V`, integrating over the domain and then
+integrating by parts. The variational problem so derived reads: find
+:math:`u \in V` such that:
 
 .. math::
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -47,6 +47,7 @@ PDEs. Below are a few tutorial examples to get you started.
    A basic Helmholtz equation.<demos/helmholtz.py>
    The Burgers equation, a non-linear, unsteady example.<demos/burgers.py>
    A mixed formulation of the Poisson equation.<demos/poisson_mixed.py>
+   A time-dependent DG advection equation using upwinding.<demos/DG_advection.py>
    An extruded mesh example, using a steady-state continuity equation.<demos/extruded_continuity.py>
    A linear wave equation using explicit timestepping.<demos/linear_wave_equation.py>
 

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -49,7 +49,7 @@ PDEs. Below are a few tutorial examples to get you started.
    A mixed formulation of the Poisson equation.<demos/poisson_mixed.py>
    A time-dependent DG advection equation using upwinding.<demos/DG_advection.py>
    An extruded mesh example, using a steady-state continuity equation.<demos/extruded_continuity.py>
-   A linear wave equation using explicit timestepping.<demos/linear_wave_equation.py>
+   A linear wave equation with optional mass lumping.<demos/linear_wave_equation.py>
 
 Jupyter notebooks
 -----------------

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -47,7 +47,7 @@ PDEs. Below are a few tutorial examples to get you started.
    A basic Helmholtz equation.<demos/helmholtz.py>
    The Burgers equation, a non-linear, unsteady example.<demos/burgers.py>
    A mixed formulation of the Poisson equation.<demos/poisson_mixed.py>
-   A steady-state advection equation using upwinding, on an extruded mesh.<demos/upwind_advection.py>
+   An extruded mesh example, using a steady-state continuity equation.<demos/extruded_continuity.py>
    A linear wave equation using explicit timestepping.<demos/linear_wave_equation.py>
 
 Jupyter notebooks


### PR DESCRIPTION
The old demo tried to do too many things.  It was the only demo with DG, but it was a steady-state continuity equation rather than an advection equation with timestepping.  Furthermore, it was on an extruded mesh, which just got in the way.

I've now added a thorough DG-advection-on-nonextruded-mesh demo, reproducing the LeVeque cosine  bell/cone/slotted cylinder test.  I also write a couple of terms using `conditional` before introducing the `0.5(u.n + abs(u.n))` trick, just because it's an extra complication to get one's head around.

This allows me to cut out most of the introduction-to-DG in the steady-state-continuity-on-extruded-mesh demo.  I still use DG for this, as I want to mention all of the `ds_t`, `ds_b`, `ds_v`, `dS_h`, `dS_v` etc., and I can't think of another way to get facet integrals.

Comments welcome.