### PR TITLE
Extruded trace testing and hybridization

### DIFF
--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -115,17 +115,13 @@ class HybridizationPC(PCBase):
         # boundary. Extruded cells will have both horizontal and vertical
         # facets
         if mesh.cell_set._extruded:
-            zero_trace_condition = [DirichletBC(TraceSpace, Constant(0.0),
-                                                "on_boundary"),
-                                    DirichletBC(TraceSpace, Constant(0.0),
-                                                "bottom"),
-                                    DirichletBC(TraceSpace, Constant(0.0),
-                                                "top")]
+            trace_bcs = [DirichletBC(TraceSpace, Constant(0.0), "on_boundary"),
+                         DirichletBC(TraceSpace, Constant(0.0), "bottom"),
+                         DirichletBC(TraceSpace, Constant(0.0), "top")]
             K = Tensor(gammar('+') * ufl.dot(sigma, n) * ufl.dS_h +
                        gammar('+') * ufl.dot(sigma, n) * ufl.dS_v)
         else:
-            zero_trace_condition = [DirichletBC(TraceSpace, Constant(0.0),
-                                                "on_boundary")]
+            trace_bcs = [DirichletBC(TraceSpace, Constant(0.0), "on_boundary")]
             K = Tensor(gammar('+') * ufl.dot(sigma, n) * ufl.dS)
 
         # Assemble the Schur complement operator and right-hand side
@@ -138,12 +134,12 @@ class HybridizationPC(PCBase):
         schur_comp = K * Atilde.inv * K.T
 
         self.S = allocate_matrix(schur_comp,
-                                 bcs=zero_trace_condition,
+                                 bcs=trace_bcs,
                                  form_compiler_parameters=self.cxt.fc_params)
         self._assemble_S = create_assembly_callable(
             schur_comp,
             tensor=self.S,
-            bcs=zero_trace_condition,
+            bcs=trace_bcs,
             form_compiler_parameters=self.cxt.fc_params)
 
         self._assemble_S()

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -124,6 +124,12 @@ class HybridizationPC(PCBase):
             trace_bcs = [DirichletBC(TraceSpace, Constant(0.0), "on_boundary")]
             K = Tensor(gammar('+') * ufl.dot(sigma, n) * ufl.dS)
 
+        # If boundary conditions are contained in the ImplicitMatrixContext:
+        if self.cxt.row_bcs:
+            raise NotImplementedError(
+                "Strong BCs not currently handled. Try imposing them weakly."
+            )
+
         # Assemble the Schur complement operator and right-hand side
         self.schur_rhs = Function(TraceSpace)
         self._assemble_Srhs = create_assembly_callable(

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -219,7 +219,7 @@ class HybridizationPC(PCBase):
 
         M = D - C * A.inv * B
         R = K_1.T - C * A.inv * K_0.T
-        u_rec = M.inv * f - M.inv * (R * lambdar + C * A.inv * g)
+        u_rec = M.inv * f - M.inv * (C * A.inv * g + R * lambdar)
         self._assemble_sub_unknown = create_assembly_callable(
             u_rec,
             tensor=u,

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -339,7 +339,7 @@ if options["minimal_petsc"]:
     if options["petsc_int_type"] == "int64":
         petsc_opts = """--download-metis --download-parmetis --download-hdf5 --download-hypre --download-eigen --with-64-bit-indices"""
     else:
-        petsc_opts = """--download-chaco --download-hdf5 --download-hypre --download-eigen"""
+        petsc_opts = """--download-chaco --download-hdf5 --download-hypre --download-mumps --download-eigen"""
 else:
     if options["petsc_int_type"] == "int64":
         petsc_opts = """--download-metis --download-parmetis --download-hypre --download-netcdf --download-hdf5 --download-exodusii --download-eigen --with-64-bit-indices"""

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -339,7 +339,7 @@ if options["minimal_petsc"]:
     if options["petsc_int_type"] == "int64":
         petsc_opts = """--download-metis --download-parmetis --download-hdf5 --download-hypre --download-eigen --with-64-bit-indices"""
     else:
-        petsc_opts = """--download-chaco --download-hdf5 --download-hypre --download-mumps --download-eigen"""
+        petsc_opts = """--download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre --download-mumps --download-hdf5 --download-eigen"""
 else:
     if options["petsc_int_type"] == "int64":
         petsc_opts = """--download-metis --download-parmetis --download-hypre --download-netcdf --download-hdf5 --download-exodusii --download-eigen --with-64-bit-indices"""

--- a/tests/extrusion/test_trace_extr.py
+++ b/tests/extrusion/test_trace_extr.py
@@ -1,0 +1,42 @@
+"""Tests projections onto the HDiv Trace space on extruded meshes"""
+from __future__ import absolute_import, print_function, division
+import pytest
+
+from firedrake import *
+
+
+@pytest.mark.parametrize('quad', [False, True])
+@pytest.mark.parametrize('degree', range(2))
+def test_trace_galerkin_projection_extr(degree, quad):
+    mesh = ExtrudedMesh(UnitSquareMesh(4, 4, quadrilateral=quad), 2)
+    f = Function(FunctionSpace(mesh, "CG", degree + 1))
+    x, y, z = SpatialCoordinate(mesh)
+    f.interpolate(cos(2*pi*x)*cos(2*pi*y)*cos(2*pi*z))
+
+    # degree=('horizontal degree', 'vertical degree')
+    T = FunctionSpace(mesh, "HDiv Trace", degree=(degree + 1, degree + 1))
+    u = TrialFunction(T)
+    v = TestFunction(T)
+
+    a_ds = u*v*ds_t + u*v*ds_b + u*v*ds_v
+    a_dS = u('+')*v('+')*dS_h + u('+')*v('+')*dS_v
+    A = a_ds + a_dS
+    l_ds = f*v*ds_t + f*v*ds_b + f*v*ds_v
+    l_dS = f('+')*v('+')*dS_h + f('+')*v('+')*dS_v
+    L = l_ds + l_dS
+
+    sol = Function(T)
+    solve(A == L, sol, solver_parameters={'ksp_rtol': 1e-14})
+
+    m = FacetArea(mesh)
+    diff = sol - f
+    error = (m*diff*diff*ds_t + m*diff*diff*ds_b + m*diff*diff*ds_v
+             + m*diff('+')*diff('+')*dS_h + m*diff('+')*diff('+')*dS_v)
+
+    trace_error = sqrt(assemble(error))
+    assert trace_error < 1e-12
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/regression/test_trace_galerkin_projection.py
+++ b/tests/regression/test_trace_galerkin_projection.py
@@ -23,14 +23,17 @@ import numpy as np
 from firedrake import *
 
 
-def trace_galerkin_projection(degree, conv_test_flag=0, mesh_res=None):
+def trace_galerkin_projection(degree, quad=False,
+                              conv_test_flag=0, mesh_res=None):
     # Create mesh if needed
     if mesh_res is None:
-        mesh = UnitSquareMesh(10, 10)
+        mesh = UnitSquareMesh(10, 10, quadrilateral=quad)
     elif isinstance(mesh_res, int):
-        mesh = UnitSquareMesh(2 ** mesh_res, 2 ** mesh_res)
+        mesh = UnitSquareMesh(2 ** mesh_res, 2 ** mesh_res, quadrilateral=quad)
     else:
         raise ValueError("Integers or None are only accepted for mesh_res.")
+
+    x, y = SpatialCoordinate(mesh)
 
     # Define the Trace Space
     T = FunctionSpace(mesh, "HDiv Trace", degree)
@@ -48,13 +51,13 @@ def trace_galerkin_projection(degree, conv_test_flag=0, mesh_res=None):
         f = Function(hdv)
     else:
         raise ValueError("conv_test should be either 0 or 1")
-    f.interpolate(Expression("cos(x[0]*pi*2)*cos(x[1]*pi*2)"))
+    f.interpolate(cos(x*pi*2)*cos(y*pi*2))
 
     # Construct bilinear form
-    a = lambdar*gammar*ds + avg(lambdar)*avg(gammar)*dS
+    a = lambdar*gammar*ds + lambdar('+')*gammar('+')*dS
 
     # Construct linear form
-    l = f*gammar*ds + avg(f)*avg(gammar)*dS
+    l = f*gammar*ds + f('+')*gammar('+')*dS
 
     # Compute the solution
     t = Function(T)
@@ -67,18 +70,26 @@ def trace_galerkin_projection(degree, conv_test_flag=0, mesh_res=None):
 
 
 @pytest.mark.parametrize('degree', range(1, 4))
-def test_trace_galerkin_projection(degree):
+@pytest.mark.parametrize('quad', [False, True])
+def test_trace_galerkin_projection(degree, quad):
     """Tests the accuracy of the trace solution for the Galerkin
     projection problem."""
-    tr_err = trace_galerkin_projection(degree, 0)
+    tr_err = trace_galerkin_projection(degree=degree,
+                                       quad=quad,
+                                       conv_test_flag=0)
     assert tr_err < 1e-13
 
 
 @pytest.mark.parametrize(('testdegree', 'convrate'),
                          [(1, 1.5), (2, 2.5), (3, 3.5)])
-def test_convergence_rates_trace_galerkin_projection(testdegree, convrate):
+@pytest.mark.parametrize('quad', [False, True])
+def test_convergence_rates_trace_galerkin_projection(testdegree,
+                                                     convrate, quad):
     """Tests for degree + (1/2) order convergence of the trace problem."""
-    l2errors = np.array([trace_galerkin_projection(testdegree, 1, r)
+    l2errors = np.array([trace_galerkin_projection(degree=testdegree,
+                                                   quad=quad,
+                                                   conv_test_flag=1,
+                                                   mesh_res=r)
                          for r in range(1, 5)])
     conv = np.log2(l2errors[:-1] / l2errors[1:])[-1]
     print("Convergence order: ", conv)

--- a/tests/slate/test_facet_tensors_extr.py
+++ b/tests/slate/test_facet_tensors_extr.py
@@ -83,6 +83,25 @@ def test_vert_facet_exterior(mesh):
     assert np.allclose(A, ref, rtol=1e-8)
 
 
+def test_total_facet(mesh):
+    DG = VectorFunctionSpace(mesh, "DG", 1)
+    n = FacetNormal(mesh)
+    u = TestFunction(DG)
+
+    x, y, z = SpatialCoordinate(mesh)
+    f = project(as_vector([z, y, x]), DG)
+
+    top = dot(f[0]*f[1]*u, n)*ds_t
+    bottom = dot(f[2]*f[1]*u, n)*ds_b
+    horiz = dot(f[0]*u, n)*dS_h
+    vert = dot(f[2]*u, n)*dS_v
+    A = assemble(Tensor(top + bottom + horiz + vert)).dat.data
+    ref_form = top + bottom + jump(f[2]*u, n=n)*dS_v + jump(f[0]*u, n=n)*dS_h
+    ref = assemble(ref_form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-8)
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -29,11 +29,11 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
     nullsp = MixedVectorSpaceBasis(W, [VectorSpaceBasis(constant=True), W[1]])
     solve(a == L, w,
           nullspace=nullsp,
-          solver_parameters={'ksp_type': 'gmres',
+          solver_parameters={'ksp_type': 'preonly',
                              'mat_type': 'matfree',
                              'pc_type': 'python',
                              'pc_python_type': 'firedrake.HybridizationPC',
-                             'hybridization_pc_type': 'hypre',
+                             'hybridization_pc_type': 'lu',
                              'hybridization_ksp_type': 'preonly',
                              'hybridization_projector_tolerance': 1e-14})
     u_h, _ = w.split()
@@ -41,34 +41,20 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
     return error
 
 
-@pytest.mark.parametrize(('MeshClass', 'hdiv_family'),
-                         [(UnitIcosahedralSphereMesh, 'RT'),
-                          (UnitIcosahedralSphereMesh, 'BDM'),
-                          (UnitCubedSphereMesh, 'RTCF')])
-def test_hybrid_conv(MeshClass, hdiv_family):
-    """Should expect approximately quadratic convergence for lowest order
-    mixed method.
-    """
-    errors = [run_hybrid_poisson_sphere(MeshClass, r, hdiv_family)
-              for r in range(1, 4)]
-    errors = np.asarray(errors)
-    l2conv = np.log2(errors[:-1] / errors[1:])[-1]
-    assert l2conv > 1.7
-
-
 @pytest.mark.parallel
 @pytest.mark.parametrize(('MeshClass', 'hdiv_family'),
                          [(UnitIcosahedralSphereMesh, 'RT'),
+                          (UnitIcosahedralSphereMesh, 'BDM'),
                           (UnitCubedSphereMesh, 'RTCF')])
 def test_hybrid_conv_parallel(MeshClass, hdiv_family):
     """Should expect approximately quadratic convergence for lowest order
     mixed method.
     """
     errors = [run_hybrid_poisson_sphere(MeshClass, r, hdiv_family)
-              for r in range(1, 4)]
+              for r in range(2, 5)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])[-1]
-    assert l2conv > 1.7
+    assert l2conv > 1.8
 
 
 if __name__ == '__main__':

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -43,8 +43,7 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(('MeshClass', 'hdiv_family'),
-                         [(UnitIcosahedralSphereMesh, 'RT'),
-                          (UnitIcosahedralSphereMesh, 'BDM'),
+                         [(UnitIcosahedralSphereMesh, 'BDM'),
                           (UnitCubedSphereMesh, 'RTCF')])
 def test_hybrid_conv_parallel(MeshClass, hdiv_family):
     """Should expect approximately quadratic convergence for lowest order

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -29,7 +29,8 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
     nullsp = MixedVectorSpaceBasis(W, [VectorSpaceBasis(constant=True), W[1]])
     solve(a == L, w,
           nullspace=nullsp,
-          solver_parameters={'mat_type': 'matfree',
+          solver_parameters={'ksp_type': 'gmres',
+                             'mat_type': 'matfree',
                              'pc_type': 'python',
                              'pc_python_type': 'firedrake.HybridizationPC',
                              'hybridization_pc_type': 'hypre',

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -35,6 +35,7 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
                              'pc_python_type': 'firedrake.HybridizationPC',
                              'hybridization_pc_type': 'lu',
                              'hybridization_ksp_type': 'preonly',
+                             'hybridization_pc_factor_mat_solver_package': 'mumps',
                              'hybridization_projector_tolerance': 1e-14})
     u_h, _ = w.split()
     error = errornorm(u_exact, u_h)

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -5,6 +5,7 @@ import numpy as np
 
 
 def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
+    """Test hybridizing lowest order mixed methods on a sphere."""
     mesh = MeshClass(refinement_level=refinement)
     mesh.init_cell_orientations(Expression(("x[0]", "x[1]", "x[2]")))
     x, y, z = SpatialCoordinate(mesh)
@@ -39,27 +40,34 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
     return error
 
 
-def test_hybrid_conv():
+@pytest.mark.parametrize(('MeshClass', 'hdiv_family'),
+                         [(UnitIcosahedralSphereMesh, 'RT'),
+                          (UnitIcosahedralSphereMesh, 'BDM'),
+                          (UnitCubedSphereMesh, 'RTCF')])
+def test_hybrid_conv(MeshClass, hdiv_family):
     """Should expect approximately quadratic convergence for lowest order
     mixed method.
     """
-    errors = [run_hybrid_poisson_sphere(UnitIcosahedralSphereMesh, r, 'BDM')
+    errors = [run_hybrid_poisson_sphere(MeshClass, r, hdiv_family)
               for r in range(1, 4)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])[-1]
-    assert l2conv > 1.8
+    assert l2conv > 1.7
 
 
 @pytest.mark.parallel
-def test_hybrid_conv_parallel():
+@pytest.mark.parametrize(('MeshClass', 'hdiv_family'),
+                         [(UnitIcosahedralSphereMesh, 'RT'),
+                          (UnitCubedSphereMesh, 'RTCF')])
+def test_hybrid_conv_parallel(MeshClass, hdiv_family):
     """Should expect approximately quadratic convergence for lowest order
     mixed method.
     """
-    errors = [run_hybrid_poisson_sphere(UnitIcosahedralSphereMesh, r, 'RT')
+    errors = [run_hybrid_poisson_sphere(MeshClass, r, hdiv_family)
               for r in range(1, 4)]
     errors = np.asarray(errors)
     l2conv = np.log2(errors[:-1] / errors[1:])[-1]
-    assert l2conv > 1.8
+    assert l2conv > 1.7
 
 
 if __name__ == '__main__':

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -59,7 +59,6 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
                              'pc_python_type': 'firedrake.HybridizationPC',
                              'hybridization_ksp_rtol': 1e-8,
                              'hybridization_pc_type': 'lu',
-                             'hybridization_pc_factor_mat_solver_package': 'mumps',
                              'hybridization_ksp_type': 'preonly',
                              'hybridization_projector_tolerance': 1e-14})
     sigma_h, u_h = w.split()

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -54,10 +54,12 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
     w = Function(W)
     solve(a == L, w,
           solver_parameters={'mat_type': 'matfree',
+                             'ksp_type': 'preonly',
                              'pc_type': 'python',
                              'pc_python_type': 'firedrake.HybridizationPC',
                              'hybridization_ksp_rtol': 1e-8,
                              'hybridization_pc_type': 'lu',
+                             'hybridization_pc_factor_mat_solver_package': 'mumps',
                              'hybridization_ksp_type': 'preonly',
                              'hybridization_projector_tolerance': 1e-14})
     sigma_h, u_h = w.split()

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -27,11 +27,13 @@ import pytest
 from firedrake import *
 
 
-@pytest.mark.parametrize("degree", range(1, 3))
-def test_slate_hybridization(degree):
+@pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
+                         [(1, "RT", False), (1, "RTCF", True),
+                          (2, "RT", False), (2, "RTCF", True)])
+def test_slate_hybridization(degree, hdiv_family, quadrilateral):
     # Create a mesh
-    mesh = UnitSquareMesh(8, 8)
-    RT = FunctionSpace(mesh, "RT", degree)
+    mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
+    RT = FunctionSpace(mesh, hdiv_family, degree)
     DG = FunctionSpace(mesh, "DG", degree - 1)
     W = RT * DG
     sigma, u = TrialFunctions(W)

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -54,7 +54,6 @@ def test_slate_hybridization(degree):
           solver_parameters={'mat_type': 'matfree',
                              'pc_type': 'python',
                              'pc_python_type': 'firedrake.HybridizationPC',
-                             'hybridization_fieldsplit_schur_fact_type': 'lower',
                              'hybridization_ksp_rtol': 1e-8,
                              'hybridization_pc_type': 'lu',
                              'hybridization_ksp_type': 'preonly',

--- a/tests/slate/test_slate_hybridization_extr.py
+++ b/tests/slate/test_slate_hybridization_extr.py
@@ -46,7 +46,6 @@ def test_hybrid_extr_helmholtz(quad):
               'pc_python_type': 'firedrake.HybridizationPC',
               'hybridization_ksp_rtol': 1e-8,
               'hybridization_pc_type': 'lu',
-              'hybridization_pc_factor_mat_solver_package': 'mumps',
               'hybridization_ksp_type': 'preonly',
               'hybridization_projector_tolerance': 1e-14}
     solve(a == L, w, solver_parameters=params)

--- a/tests/slate/test_slate_hybridization_extr.py
+++ b/tests/slate/test_slate_hybridization_extr.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import, print_function, division
+import pytest
+from firedrake import *
+
+
+@pytest.mark.parametrize('quad', [False, True])
+def test_hybrid_extr_helmholtz(quad):
+    """Hybridize the lowest order HDiv conforming method using
+    both triangular prism and hexahedron elements.
+    """
+    base = UnitSquareMesh(5, 5, quadrilateral=quad)
+    mesh = ExtrudedMesh(base, layers=5, layer_height=0.2)
+
+    if quad:
+        RT = FiniteElement("RTCF", quadrilateral, 1)
+        DG_v = FiniteElement("DG", interval, 0)
+        DG_h = FiniteElement("DQ", quadrilateral, 0)
+        CG = FiniteElement("CG", interval, 1)
+
+    else:
+        RT = FiniteElement("RT", triangle, 1)
+        DG_v = FiniteElement("DG", interval, 0)
+        DG_h = FiniteElement("DG", triangle, 0)
+        CG = FiniteElement("CG", interval, 1)
+
+    HDiv_ele = EnrichedElement(HDiv(TensorProductElement(RT, DG_v)),
+                               HDiv(TensorProductElement(DG_h, CG)))
+    V = FunctionSpace(mesh, HDiv_ele)
+    U = FunctionSpace(mesh, "DG", 0)
+    W = V * U
+
+    x, y, z = SpatialCoordinate(mesh)
+    f = Function(U)
+    expr = (1+12*pi*pi)*cos(2*pi*x)*cos(2*pi*y)*cos(2*pi*z)
+    f.interpolate(expr)
+
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    a = dot(sigma, tau)*dx + u*v*dx + div(sigma)*v*dx - div(tau)*u*dx
+    L = f*v*dx
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization_ksp_type': 'cg',
+              'hybridization_ksp_rtol': 1e-8,
+              'hybridization_projector_tolerance': 1e-14}
+    solve(a == L, w, solver_parameters=params)
+    sigma_h, u_h = w.split()
+
+    w2 = Function(W)
+    params2 = {'pc_type': 'fieldsplit',
+               'pc_fieldsplit_type': 'schur',
+               'ksp_type': 'cg',
+               'ksp_rtol': 1e-8,
+               'pc_fieldsplit_schur_fact_type': 'FULL',
+               'fieldsplit_0_ksp_type': 'cg',
+               'fieldsplit_1_ksp_type': 'cg'}
+    solve(a == L, w2, solver_parameters=params2)
+    nh_sigma, nh_u = w2.split()
+
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 5e-8
+    assert u_err < 1e-8
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_slate_hybridization_extr.py
+++ b/tests/slate/test_slate_hybridization_extr.py
@@ -41,10 +41,13 @@ def test_hybrid_extr_helmholtz(quad):
     L = f*v*dx
     w = Function(W)
     params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
               'pc_type': 'python',
               'pc_python_type': 'firedrake.HybridizationPC',
-              'hybridization_ksp_type': 'cg',
               'hybridization_ksp_rtol': 1e-8,
+              'hybridization_pc_type': 'lu',
+              'hybridization_pc_factor_mat_solver_package': 'mumps',
+              'hybridization_ksp_type': 'preonly',
               'hybridization_projector_tolerance': 1e-14}
     solve(a == L, w, solver_parameters=params)
     sigma_h, u_h = w.split()


### PR DESCRIPTION
Just adding some generic tests that make sure the trace element works on extruded meshes. Also modifies the hybridization solver to support extruded mixed problems.

I removed a kwarg that was not only a misnomer, but turns out to not be that useful. The hybridization solver will only eliminate the vector unknown first when doing local reconstructions. When we are able to write into mixed dats, local reconstructions will simplify into one clean expression.