### PR TITLE
Fix libspatialindex upgrade path

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -872,15 +872,14 @@ def build_and_install_libspatialindex():
     log.info("Installing libspatialindex\n")
     if os.path.exists("libspatialindex"):
         log.info("Updating the git repository for libspatialindex")
-        os.chdir("libspatialindex")
-        check_call(["git", "fetch"])
-        git_sha = check_output(["git", "rev-parse", "HEAD"])
-        git_sha_new = check_output(["git", "rev-parse", "@{u}"])
-        libspatialindex_changed = git_sha != git_sha_new
-        if libspatialindex_changed:
-            check_call(["git", "reset", "--hard"])
-            check_call(["git", "pull"])
-        os.chdir("..")
+        with directory("libspatialindex"):
+            check_call(["git", "fetch"])
+            git_sha = check_output(["git", "rev-parse", "HEAD"])
+            git_sha_new = check_output(["git", "rev-parse", "@{u}"])
+            libspatialindex_changed = git_sha != git_sha_new
+            if libspatialindex_changed:
+                check_call(["git", "reset", "--hard"])
+                check_call(["git", "pull"])
     else:
         git_clone("git+https://github.com/firedrakeproject/libspatialindex.git")
         libspatialindex_changed = True

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -871,7 +871,16 @@ def build_and_install_glpsol():
 def build_and_install_libspatialindex():
     log.info("Installing libspatialindex\n")
     if os.path.exists("libspatialindex"):
-        libspatialindex_changed = git_update("libspatialindex")
+        log.info("Updating the git repository for libspatialindex")
+        os.chdir("libspatialindex")
+        check_call(["git", "fetch"])
+        git_sha = check_output(["git", "rev-parse", "HEAD"])
+        git_sha_new = check_output(["git", "rev-parse", "@{u}"])
+        libspatialindex_changed = git_sha != git_sha_new
+        if libspatialindex_changed:
+            check_call(["git", "reset", "--hard"])
+            check_call(["git", "pull"])
+        os.chdir("..")
     else:
         git_clone("git+https://github.com/firedrakeproject/libspatialindex.git")
         libspatialindex_changed = True


### PR DESCRIPTION
Tried to test syncing our libspatialindex fork with upstream, however, `git pull` fails because of the local changes applied to the source tree.