### PR TITLE
Allow to restart pvd output from a defined count.

### DIFF
--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -244,7 +244,7 @@ class File(object):
         :kwarg project_output: Should the output be projected to
             linears?  Default is to use interpolation.
         :kwarg comm: The MPI communicator to use.
-        :kwarg restart: Restart at timestep.
+        :kwarg restart: Restart at count.
 
         .. note::
 


### PR DESCRIPTION
This is a work in progress to support restarting and resuming of simulations with the ability to use the same output directories for the pvd files. Cf. #772.

- [x] Custom numbering for restarts.
- [x] Tests