### PR TITLE
Generate point evaluation code with the help of TSFC

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -606,7 +606,7 @@ def make_c_evaluate(function, c_name="evaluate", ldargs=None, tolerance=None):
 
     mesh = function.ufl_domain()
     src = pq_utils.src_locate_cell(mesh, tolerance=tolerance)
-    src += compile_element(function)
+    src += compile_element(function, mesh.coordinates)
 
     args = []
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -540,7 +540,7 @@ class Function(ufl.Coefficient):
                 if mixed:
                     l_result.append((i, tuple(f.at(p) for f in split)))
                 else:
-                    p_result = np.empty(value_shape, dtype=float)
+                    p_result = np.zeros(value_shape, dtype=float)
                     single_eval(points[i:i+1], p_result)
                     l_result.append((i, p_result))
             except PointNotInDomainError:
@@ -600,13 +600,25 @@ def make_c_evaluate(function, c_name="evaluate", ldargs=None, tolerance=None):
     from firedrake.pointeval_utils import compile_element
     from pyop2 import compilation
     from pyop2.utils import get_petsc_dir
+    from pyop2.base import build_itspace
+    from pyop2.sequential import generate_cell_wrapper
     import firedrake.pointquery_utils as pq_utils
 
-    function_space = function.function_space()
+    mesh = function.ufl_domain()
+    src = pq_utils.src_locate_cell(mesh, tolerance=tolerance)
+    src += compile_element(function)
 
-    src = pq_utils.src_locate_cell(function_space.mesh(), tolerance=tolerance)
-    src += compile_element(function_space.ufl_element(), function_space.dim)
-    src += pq_utils.make_wrapper(function,
+    args = []
+
+    arg = mesh.coordinates.dat(op2.READ, mesh.coordinates.cell_node_map())
+    arg.position = 0
+    args.append(arg)
+
+    arg = function.dat(op2.READ, function.cell_node_map())
+    arg.position = 1
+    args.append(arg)
+
+    src += generate_cell_wrapper(build_itspace(args, mesh.cell_set), args,
                                  forward_args=["double*", "double*"],
                                  kernel_name="evaluate_kernel",
                                  wrapper_name="wrap_evaluate")

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -86,6 +86,13 @@ def compile_element(expression, coordinates, parameters=None):
         return_variable = gem.Indexed(gem.Variable('R', (1,)), (0,))
         result_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('R', rank=(1,)))
 
+    # Unroll
+    max_extent = parameters["unroll_indexsum"]
+    if max_extent:
+        def predicate(index):
+            return index.extent <= max_extent
+        result, = gem.optimise.unroll_indexsum([result], predicate=predicate)
+
     # Translate GEM -> COFFEE
     result, = gem.impero_utils.preprocess_gem([result])
     impero_c = gem.impero_utils.compile_gem([(return_variable, result)], tensor_indices)

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -1,202 +1,100 @@
 from __future__ import absolute_import, print_function, division
-from six.moves import map
 
-import collections
-import numpy
-import sympy
 from pyop2.datatypes import IntType, as_cstr
 
 from coffee import base as ast
 
+from ufl import TensorProductCell
+from ufl.corealg.map_dag import map_expr_dags
+from ufl.algorithms import extract_arguments, extract_coefficients
 
-def operands_and_reconstruct(expr):
-    if isinstance(expr, sympy.Expr):
-        return (expr.args,
-                lambda children: expr.func(*children))
-    else:
-        # e.g. floating-point numbers
-        return (), None
+import gem
 
-
-class SSATransformer(object):
-    def __init__(self, prefix=None):
-        self._regs = {}
-        self._code = collections.OrderedDict()
-        self._prefix = prefix or "r"
-
-    def _new_reg(self):
-        return sympy.Symbol('%s%d' % (self._prefix, len(self._regs)))
-
-    def __call__(self, e):
-        ops, reconstruct = operands_and_reconstruct(e)
-        if len(ops) == 0:
-            return e
-        elif e in self._regs:
-            return self._regs[e]
-        else:
-            s = reconstruct(list(map(self, ops)))
-            r = self._new_reg()
-            self._regs[e] = r
-            self._code[r] = s
-            return r
-
-    @property
-    def code(self):
-        return self._code.items()
+import tsfc
+import tsfc.kernel_interface.firedrake as firedrake_interface
+from tsfc.coffee import SCALAR_TYPE, generate as generate_coffee
+from tsfc.parameters import default_parameters
 
 
-def rounding(expr):
-    from firedrake.pointquery_utils import format
-    eps = format["epsilon"]
-
-    if isinstance(expr, (float, sympy.numbers.Float)):
-        v = float(expr)
-        if abs(v - round(v, 1)) < eps:
-            return round(v, 1)
-    elif isinstance(expr, sympy.Expr):
-        if expr.args:
-            return expr.func(*map(rounding, expr.args))
-
-    return expr
-
-
-def ssa_arrays(args, prefix=None):
-    transformer = SSATransformer(prefix=prefix)
-
-    refs = []
-    for arg in args:
-        ref = numpy.zeros_like(arg, dtype=object)
-        arg_flat = arg.reshape(-1)
-        ref_flat = ref.reshape(-1)
-        for i, e in enumerate(arg_flat):
-            ref_flat[i] = transformer(rounding(e))
-        refs.append(ref)
-
-    return transformer.code, refs
-
-
-class _CPrinter(sympy.printing.StrPrinter):
-    """sympy.printing.StrPrinter uses a Pythonic syntax which is invalid in C.
-    This subclass replaces the printing of power with C compatible code."""
-
-    def _print_Pow(self, expr, rational=False):
-        # WARNING: Code mostly copied from sympy source code!
-        from sympy.core import S
-        from sympy.printing.precedence import precedence
-
-        PREC = precedence(expr)
-
-        if expr.exp is S.Half and not rational:
-            return "sqrt(%s)" % self._print(expr.base)
-
-        if expr.is_commutative:
-            if -expr.exp is S.Half and not rational:
-                # Note: Don't test "expr.exp == -S.Half" here, because that will
-                # match -0.5, which we don't want.
-                return "1/sqrt(%s)" % self._print(expr.base)
-            if expr.exp is -S.One:
-                # Similarly to the S.Half case, don't test with "==" here.
-                return '1/%s' % self.parenthesize(expr.base, PREC)
-
-        e = self.parenthesize(expr.exp, PREC)
-        if self.printmethod == '_sympyrepr' and expr.exp.is_Rational and expr.exp.q != 1:
-            # the parenthesized exp should be '(Rational(a, b))' so strip parens,
-            # but just check to be sure.
-            if e.startswith('(Rational'):
-                e = e[1:-1]
-
-        # Changes below this line!
-        if e == "2":
-            return '{0}*{0}'.format(self.parenthesize(expr.base, PREC))
-        elif e == "3":
-            return '{0}*{0}*{0}'.format(self.parenthesize(expr.base, PREC))
-        else:
-            return 'pow(%s,%s)' % (self.parenthesize(expr.base, PREC), e)
-
-
-def c_print(expr):
-    printer = _CPrinter(dict(order=None))
-    return printer.doprint(expr)
-
-
-def compile_element(expression):
+def compile_element(expression, coordinates, parameters=None):
     """Generates C code for point evaluations.
 
-    :arg ufl_element: UFL expression
+    :arg expression: UFL expression
+    :arg coordinates: coordinate field
+    :arg parameters: form compiler parameters
     :returns: C code as string
     """
-    import collections
-    from ufl.algorithms.apply_function_pullbacks import apply_function_pullbacks
-    from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
-    from ufl.algorithms.apply_derivatives import apply_derivatives
-    from ufl.algorithms.apply_geometry_lowering import apply_geometry_lowering
-    from ufl.algorithms import extract_arguments, extract_coefficients
-    from gem import gem, impero_utils
-    from tsfc import coffee, kernel_interface, pointeval, ufl_utils
+    if parameters is None:
+        parameters = default_parameters()
+    else:
+        _ = default_parameters()
+        _.update(parameters)
+        parameters = _
 
-    # Imitate the compute_form_data processing pipeline
-    #
-    # Unfortunately, we cannot call compute_form_data here, since
-    # we only have an expression, not a form
-    expression = apply_algebra_lowering(expression)
-    expression = apply_derivatives(expression)
-    expression = apply_function_pullbacks(expression)
-    expression = apply_geometry_lowering(expression)
-    expression = apply_derivatives(expression)
-    expression = apply_geometry_lowering(expression)
-    expression = apply_derivatives(expression)
-
+    # No arguments, please!
     if extract_arguments(expression):
         return ValueError("Cannot interpolate UFL expression with Arguments!")
 
-    # Prepare Coefficients
-    arglist = []
-    coefficient_map = {}
+    # Apply UFL preprocessing
+    expression = tsfc.ufl_utils.preprocess_expression(expression)
 
+    # Collect required coefficients
     coefficient, = extract_coefficients(expression)
-    funarg, prepare_, variable = kernel_interface.prepare_coefficient(coefficient, "f")
-    arglist.append(funarg)
-    assert not prepare_
-    coefficient_map[coefficient] = variable
 
     # Replace coordinates (if any)
     domain = expression.ufl_domain()
-    assert domain
-    coordinate_coefficient = ufl_utils.coordinate_coefficient(domain)
-    expression = ufl_utils.replace_coordinates(expression, coordinate_coefficient)
-    funarg, prepare_, variable = kernel_interface.prepare_coefficient(coordinate_coefficient, "x")
-    arglist.insert(0, funarg)
-    assert not prepare_
-    coefficient_map[coordinate_coefficient] = variable
+    assert coordinates.ufl_domain() == domain
+    expression = tsfc.ufl_utils.replace_coordinates(expression, coordinates)
 
-    X = gem.Variable('X', (domain.ufl_cell().topological_dimension(),))
-    arglist.insert(0, ast.Decl("double", ast.Symbol('X', rank=(domain.ufl_cell().topological_dimension(),))))
+    # Initialise kernel builder
+    builder = firedrake_interface.KernelBuilderBase()
+    x_arg = builder._coefficient(coordinates, "x")
+    f_arg = builder._coefficient(coefficient, "f")
 
-    tabman = pointeval.TabulationManager()
-    ic = collections.defaultdict(gem.Index)
-    result = pointeval.process(expression, tabman, X, coefficient_map, ic)
+    # Point evaluation of mixed coefficients not supported here
+    # expression = ufl_utils.split_coefficients(expression, builder.coefficient_split)
+
+    # Translate to GEM
+    cell = domain.ufl_cell()
+    dim = cell.topological_dimension()
+    point = gem.Variable('X', (dim,))
+    point_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('X', rank=(dim,)))
+
+    config = dict(interface=builder,
+                  ufl_cell=coordinates.ufl_domain().ufl_cell(),
+                  precision=parameters["precision"],
+                  point_indices=(),
+                  point_expr=point)
+    # TODO: restore this for expression evaluation!
+    # config["cellvolume"] = cellvolume_generator(coordinates.ufl_domain(), coordinates, config)
+    context = tsfc.fem.GemPointContext(**config)
+
+    # Abs-simplification
+    expression = tsfc.ufl_utils.simplify_abs(expression)
+
+    # Translate UFL -> GEM
+    translator = tsfc.fem.Translator(context)
+    result, = map_expr_dags(translator, [expression])
 
     tensor_indices = ()
     if expression.ufl_shape:
         tensor_indices = tuple(gem.Index() for s in expression.ufl_shape)
-        retvar = gem.Indexed(gem.Variable('R', expression.ufl_shape), tensor_indices)
-        R_sym = ast.Symbol('R', rank=expression.ufl_shape)
+        return_variable = gem.Indexed(gem.Variable('R', expression.ufl_shape), tensor_indices)
+        result_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('R', rank=expression.ufl_shape))
         result = gem.Indexed(result, tensor_indices)
     else:
-        R_sym = ast.Symbol('R', rank=(1,))
-        retvar = gem.Indexed(gem.Variable('R', (1,)), (0,))
+        return_variable = gem.Indexed(gem.Variable('R', (1,)), (0,))
+        result_arg = ast.Decl(SCALAR_TYPE, ast.Symbol('R', rank=(1,)))
 
-    impero_c = impero_utils.compile_gem([retvar], [result], ())
-    body = coffee.generate(impero_c, [])
+    # Translate GEM -> COFFEE
+    result, = gem.impero_utils.preprocess_gem([result])
+    impero_c = gem.impero_utils.compile_gem([(return_variable, result)], tensor_indices)
+    body = generate_coffee(impero_c, {}, parameters["precision"])
 
-    # Build kernel
-    arglist.insert(0, ast.Decl("double", R_sym))
-    kernel_code = ast.FunDecl("void", "evaluate_kernel", arglist, body, pred=["static", "inline"])
+    # Build kernel tuple
+    kernel_code = builder.construct_kernel("evaluate_kernel", [result_arg, point_arg, x_arg, f_arg], body)
 
-    from ufl import TensorProductCell
-
-    # Create FIAT element
-    cell = domain.ufl_cell()
+    # Fill the code template
     extruded = isinstance(cell, TensorProductCell)
 
     code = {

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -4,7 +4,7 @@ from pyop2.datatypes import IntType, as_cstr
 
 from coffee import base as ast
 
-from ufl import TensorProductCell
+from ufl import MixedElement, TensorProductCell
 from ufl.corealg.map_dag import map_expr_dags
 from ufl.algorithms import extract_arguments, extract_coefficients
 
@@ -41,6 +41,10 @@ def compile_element(expression, coordinates, parameters=None):
     # Collect required coefficients
     coefficient, = extract_coefficients(expression)
 
+    # Point evaluation of mixed coefficients not supported here
+    if type(coefficient.ufl_element()) == MixedElement:
+        raise NotImplementedError("Cannot point evaluate mixed elements yet!")
+
     # Replace coordinates (if any)
     domain = expression.ufl_domain()
     assert coordinates.ufl_domain() == domain
@@ -51,7 +55,7 @@ def compile_element(expression, coordinates, parameters=None):
     x_arg = builder._coefficient(coordinates, "x")
     f_arg = builder._coefficient(coefficient, "f")
 
-    # Point evaluation of mixed coefficients not supported here
+    # TODO: restore this for expression evaluation!
     # expression = ufl_utils.split_coefficients(expression, builder.coefficient_split)
 
     # Translate to GEM

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, print_function, division
 from six.moves import range
 
 from os import path
+import collections
 import numpy
+import sympy
 
 from pyop2 import op2
 from pyop2.datatypes import IntType, as_cstr
@@ -149,6 +151,115 @@ def set_float_formatting(precision):
     format["epsilon"] = 10.0*eval("1e-%s" % precision)
 
 
+def operands_and_reconstruct(expr):
+    if isinstance(expr, sympy.Expr):
+        return (expr.args,
+                lambda children: expr.func(*children))
+    else:
+        # e.g. floating-point numbers
+        return (), None
+
+
+class SSATransformer(object):
+    def __init__(self, prefix=None):
+        self._regs = {}
+        self._code = collections.OrderedDict()
+        self._prefix = prefix or "r"
+
+    def _new_reg(self):
+        return sympy.Symbol('%s%d' % (self._prefix, len(self._regs)))
+
+    def __call__(self, e):
+        ops, reconstruct = operands_and_reconstruct(e)
+        if len(ops) == 0:
+            return e
+        elif e in self._regs:
+            return self._regs[e]
+        else:
+            s = reconstruct(list(map(self, ops)))
+            r = self._new_reg()
+            self._regs[e] = r
+            self._code[r] = s
+            return r
+
+    @property
+    def code(self):
+        return self._code.items()
+
+
+def rounding(expr):
+    eps = format["epsilon"]
+
+    if isinstance(expr, (float, sympy.numbers.Float)):
+        v = float(expr)
+        if abs(v - round(v, 1)) < eps:
+            return round(v, 1)
+    elif isinstance(expr, sympy.Expr):
+        if expr.args:
+            return expr.func(*map(rounding, expr.args))
+
+    return expr
+
+
+def ssa_arrays(args, prefix=None):
+    transformer = SSATransformer(prefix=prefix)
+
+    refs = []
+    for arg in args:
+        ref = numpy.zeros_like(arg, dtype=object)
+        arg_flat = arg.reshape(-1)
+        ref_flat = ref.reshape(-1)
+        for i, e in enumerate(arg_flat):
+            ref_flat[i] = transformer(rounding(e))
+        refs.append(ref)
+
+    return transformer.code, refs
+
+
+class _CPrinter(sympy.printing.StrPrinter):
+    """sympy.printing.StrPrinter uses a Pythonic syntax which is invalid in C.
+    This subclass replaces the printing of power with C compatible code."""
+
+    def _print_Pow(self, expr, rational=False):
+        # WARNING: Code mostly copied from sympy source code!
+        from sympy.core import S
+        from sympy.printing.precedence import precedence
+
+        PREC = precedence(expr)
+
+        if expr.exp is S.Half and not rational:
+            return "sqrt(%s)" % self._print(expr.base)
+
+        if expr.is_commutative:
+            if -expr.exp is S.Half and not rational:
+                # Note: Don't test "expr.exp == -S.Half" here, because that will
+                # match -0.5, which we don't want.
+                return "1/sqrt(%s)" % self._print(expr.base)
+            if expr.exp is -S.One:
+                # Similarly to the S.Half case, don't test with "==" here.
+                return '1/%s' % self.parenthesize(expr.base, PREC)
+
+        e = self.parenthesize(expr.exp, PREC)
+        if self.printmethod == '_sympyrepr' and expr.exp.is_Rational and expr.exp.q != 1:
+            # the parenthesized exp should be '(Rational(a, b))' so strip parens,
+            # but just check to be sure.
+            if e.startswith('(Rational'):
+                e = e[1:-1]
+
+        # Changes below this line!
+        if e == "2":
+            return '{0}*{0}'.format(self.parenthesize(expr.base, PREC))
+        elif e == "3":
+            return '{0}*{0}*{0}'.format(self.parenthesize(expr.base, PREC))
+        else:
+            return 'pow(%s,%s)' % (self.parenthesize(expr.base, PREC), e)
+
+
+def c_print(expr):
+    printer = _CPrinter(dict(order=None))
+    return printer.doprint(expr)
+
+
 def compile_coordinate_element(ufl_coordinate_element, contains_eps):
     """Generates C code for changing to reference coordinates.
 
@@ -157,7 +268,6 @@ def compile_coordinate_element(ufl_coordinate_element, contains_eps):
     """
     from tsfc import default_parameters
     from tsfc.fiatinterface import create_element
-    from firedrake.pointeval_utils import ssa_arrays, c_print
     from FIAT.reference_element import TensorProductCell as two_product_cell
     import sympy as sp
     import numpy as np


### PR DESCRIPTION
This only affects the generation of that code which evaluates a function at a given reference point. The new code generation will employ TSFC so that this will generalises for the point evaluation of UFL expressions, not just single functions. The point evaluation of UFL expressions, however, will not be available yet with this pull request, since:

1. No API exists for that functionality.
2. Data structures and wrappers cannot deal with more than one coefficient at the moment.

I would like to note that point 2 would not be an issue for things like point evaluations of derivatives of functions.

Immediate advantages:
- Better code generation for "structured" elements thanks to FInAT.
Same code generation for all other elements.
- Piola transformation applied correctly on nonaffine geometries. Current `master` applies them with an affine approximation which calculates the Jacobian at the right place, but assumes that the second derivative of the coordinate space is zero.

Regressions:
- The Jacobian calculated during the Newton iteration that finds the reference coordinates is no longer reused.

Requires FInAT/FInAT#28 and firedrakeproject/tsfc#121.