### PR TITLE
Allow one to specify boundary conditions when using the Projector

### DIFF
--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -128,13 +128,6 @@ class Projector(object):
                              v_out.function_space())
         self.v = v
         self.v_out = v_out
-        if bcs:
-            try:
-                bcs = tuple(bcs)
-            except TypeError:
-                bcs = (bcs,)
-            if any(bc.function_space() != v_out.function_space() for bc in bcs):
-                raise ValueError("bcs must be enforced on the space of the result function.")
         self.bcs = bcs
 
         if not self._same_fspace or self.bcs:

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -246,29 +246,35 @@ def test_projector_expression():
 @pytest.mark.parametrize('tensor', ['scalar', 'vector', 'tensor'])
 def test_projector_bcs(tensor):
     mesh = UnitSquareMesh(2, 2)
+    x = SpatialCoordinate(mesh)
     if tensor == 'scalar':
         V = FunctionSpace(mesh, "CG", 1)
         V_ho = FunctionSpace(mesh, "CG", 5)
         bcs = [DirichletBC(V_ho, Constant(0.5), (1, 3)),
                DirichletBC(V_ho, Constant(-0.5), (2, 4))]
-        expr = Expression('cos(x[0]*pi*2)*sin(x[1]*pi*2)')
+        fct = cos(x[0]*pi*2)*sin(x[1]*pi*2)
+        v = Function(V).interpolate(fct)
     elif tensor == 'vector':
         V = VectorFunctionSpace(mesh, "CG", 1)
         V_ho = VectorFunctionSpace(mesh, "CG", 5)
-        bcs = [DirichletBC(V_ho, Expression(("0.5", "0.5")), (1, 3)),
-               DirichletBC(V_ho, Expression(("-0.5", "-0.5")), (2, 4))]
-        expr = Expression(['cos(x[0]*pi*2)*sin(x[1]*pi*2)']*2)
+        bcs = [DirichletBC(V_ho, Constant((0.5, 0.5)), (1, 3)),
+               DirichletBC(V_ho, Constant((-0.5, -0.5)), (2, 4))]
+        fct = as_vector([cos(x[0]*pi*2)*sin(x[1]*pi*2),
+                         cos(x[0]*pi*2)*sin(x[1]*pi*2)])
+        v = Function(V).project(fct)
     elif tensor == 'tensor':
         V = TensorFunctionSpace(mesh, "CG", 1)
         V_ho = TensorFunctionSpace(mesh, "CG", 5)
-        bcs = [DirichletBC(V_ho, Expression(("0.5", "0.5",
-                                             "0.5", "0.5")), (1, 3)),
-               DirichletBC(V_ho, Expression(("-0.5", "-0.5",
-                                             "-0.5", "-0.5")), (2, 4))]
-        expr = Expression(['cos(x[0]*pi*2)*sin(x[1]*pi*2)']*4)
+        bcs = [DirichletBC(V_ho, Constant(((0.5, 0.5),
+                                           (0.5, 0.5))), (1, 3)),
+               DirichletBC(V_ho, Constant(((-0.5, -0.5),
+                                           (-0.5, -0.5))), (2, 4))]
+        fct = as_tensor([[cos(x[0]*pi*2)*sin(x[1]*pi*2),
+                          cos(x[0]*pi*2)*sin(x[1]*pi*2)],
+                         [cos(x[0]*pi*2)*sin(x[1]*pi*2),
+                          cos(x[0]*pi*2)*sin(x[1]*pi*2)]])
+        v = Function(V).project(fct)
 
-    v = Function(V)
-    v.interpolate(expr)
     ret = Function(V_ho)
     projector = Projector(v, ret, bcs=bcs, solver_parameters={"ksp_type": "preonly",
                                                               "pc_type": "lu"})
@@ -280,7 +286,7 @@ def test_projector_bcs(tensor):
     # projector does the same thing (up to machine precision).
     project(v, ref, bcs=bcs, solver_parameters={"ksp_type": "preonly",
                                                 "pc_type": "lu"})
-    assert sqrt(assemble(inner((ret - ref), (ret - ref)) * dx)) < 1e-10
+    assert errornorm(ret, ref) < 1.0e-10
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It would be nice to be able to specify any strong boundary conditions on the function space you want to project into using the ``Projector``. This PR allows one to do just that. Have a look at it to make sure the approach is correct.