### PR TITLE
Fix null space computation for hybridization

### DIFF
--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -142,7 +142,7 @@ class HybridizationPC(PCBase):
         Smat = self.S.petscmat
 
         # Nullspace for the multiplier problem
-        nullspace = create_schur_nullspace(P, K * Atilde.inv,
+        nullspace = create_schur_nullspace(P, -(K * K.T).inv * K * Atilde,
                                            V, V_d, TraceSpace,
                                            pc.comm)
         if nullspace:
@@ -330,4 +330,8 @@ def create_schur_nullspace(P, forward, V, V_d, TraceSpace, comm):
             new_vecs.append(v.copy())
 
     schur_nullspace = PETSc.NullSpace().create(vectors=new_vecs, comm=comm)
+
+    # Normalize
+    for schur_vecs in schur_nullspace.getVecs():
+        schur_vecs.normalize()
     return schur_nullspace

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -142,7 +142,7 @@ class HybridizationPC(PCBase):
         Smat = self.S.petscmat
 
         # Nullspace for the multiplier problem
-        nullspace = create_schur_nullspace(P, -(K * K.T).inv * K * Atilde,
+        nullspace = create_schur_nullspace(P, -K * Atilde,
                                            V, V_d, TraceSpace,
                                            pc.comm)
         if nullspace:

--- a/tests/slate/test_hybrid_nullspace.py
+++ b/tests/slate/test_hybrid_nullspace.py
@@ -54,7 +54,7 @@ def test_hybrid_nullspace(W):
     nullsp._build_monolithic_basis()
     A.petscmat.setNullSpace(nullsp._nullspace)
 
-    Snullsp = create_schur_nullspace(A.petscmat, -(K * K.T).inv * K * Atilde,
+    Snullsp = create_schur_nullspace(A.petscmat, -K * Atilde,
                                      W, Wd, T, COMM_WORLD)
     v = Snullsp.getVecs()[0]
 

--- a/tests/slate/test_hybrid_nullspace.py
+++ b/tests/slate/test_hybrid_nullspace.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, print_function, division
+
+from firedrake import *
+from firedrake.slate.preconditioners import create_schur_nullspace
+import numpy as np
+
+import pytest
+
+
+@pytest.fixture(scope='module', params=[False, True])
+def W(request):
+    quadrilateral = request.param
+    if quadrilateral:
+        mesh = UnitCubedSphereMesh(2)
+        mesh.init_cell_orientations(SpatialCoordinate(mesh))
+        V = FunctionSpace(mesh, "RTCF", 1)
+        Q = FunctionSpace(mesh, "DQ", 0)
+    else:
+        mesh = UnitIcosahedralSphereMesh(2)
+        mesh.init_cell_orientations(SpatialCoordinate(mesh))
+        V = FunctionSpace(mesh, "RT", 1)
+        Q = FunctionSpace(mesh, "DG", 0)
+
+    W = V*Q
+
+    return W
+
+
+def test_hybrid_nullspace(W):
+    """Tests that the singular vector associated with the Schur
+    complement generated via the Hybridization PC is identical
+    (subject to tolerance and sign) with the SVD computed singular
+    vector.
+    """
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    a = (dot(sigma, tau) + div(sigma)*v + div(tau)*u)*dx
+    A = assemble(a, mat_type="aij")
+
+    T = FunctionSpace(W.mesh(), "HDiv Trace", 0)
+    gamma = TestFunction(T)
+
+    Wd = FunctionSpace(W.mesh(), MixedElement([BrokenElement(Wi.ufl_element())
+                                               for Wi in W]))
+
+    Atilde = Tensor(replace(a, dict(zip(a.arguments(),
+                                        (TestFunction(Wd),
+                                         TrialFunction(Wd))))))
+    sigma, _ = TrialFunctions(Wd)
+    K = Tensor(gamma('+') * dot(sigma, FacetNormal(W.mesh())) * dS)
+
+    nullsp = MixedVectorSpaceBasis(W, [W[0], VectorSpaceBasis(constant=True)])
+    nullsp._build_monolithic_basis()
+    A.petscmat.setNullSpace(nullsp._nullspace)
+
+    Snullsp = create_schur_nullspace(A.petscmat, -(K * K.T).inv * K * Atilde,
+                                     W, Wd, T, COMM_WORLD)
+    v = Snullsp.getVecs()[0]
+
+    S = K * Atilde.inv * K.T
+    _, _, vv = np.linalg.svd(assemble(S, mat_type="aij").M.values)
+    singular_vector = vv[-1]
+
+    assert np.allclose(np.linalg.norm(v), 1.0, 1e-13)
+    assert np.allclose(v.array_r.min(), v.array_r.max(), 1e-13)
+    assert np.allclose(np.absolute(v.array_r),
+                       np.absolute(singular_vector), 1e-13)


### PR DESCRIPTION
This addresses the bug in https://github.com/firedrakeproject/firedrake/issues/1068. Previously I thought that the null space basis vectors could be generated by applying the same forward eliminations to each basis vector. However, this turns out to be incorrect.

Instead, I arrived at an expression for the nullspace vectors for the Schur complement operator in terms of the null space vectors of the original operator (projected into the broken space):
```
A * x_z + K.T * lambda_z = 0
K * x_z                  = 0
```
Using the first equation, this gives us `lambda_z = -(K * K.T).inv * K * A * x_z` (obtained by multiplying the first equation by `K`), so I instead pass the operator `-(K * K.T).inv * K * A` to generate the null space vectors, then normalize.  This gives the expected constant vectors with norm 1 in the example https://github.com/firedrakeproject/firedrake/issues/1068. It also gives the norm-1 constant vectors with the right magnitude for isocahedral sphere meshes.

Please have a look to make sure everything is sound.