### PR TITLE
Fix mixed coefficient handling in Slate

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -15,7 +15,6 @@ all low-level numerical linear algebra operations are performed using
 this templated function library.
 """
 from __future__ import absolute_import, print_function, division
-from six import iteritems
 from six.moves import range
 
 from coffee import base as ast
@@ -81,6 +80,9 @@ def compile_expression(slate_expr, tsfc_parameters=None):
     # simply reuse the produced kernel.
     if slate_expr._metakernel_cache is not None:
         return slate_expr._metakernel_cache
+
+    # Initialize coefficients, shape and statements list
+    expr_coeffs = slate_expr.coefficients()
 
     # We treat scalars as 1x1 MatrixBase objects, so we give
     # the right shape to do so and everything just falls out.
@@ -244,12 +246,12 @@ def compile_expression(slate_expr, tsfc_parameters=None):
         args.append(ast.Decl("int **", cell_orientations))
 
     # Coefficient information
-    for c, csym_info in iteritems(builder.coefficient_map):
+    for c in expr_coeffs:
         if isinstance(c, Constant):
             ctype = "%s *" % SCALAR_TYPE
         else:
             ctype = "%s **" % SCALAR_TYPE
-        args.extend([ast.Decl(ctype, csym) for csym in csym_info])
+        args.extend([ast.Decl(ctype, csym) for csym in builder.coefficient(c)])
 
     # Facet information
     if builder.needs_cell_facets:
@@ -287,7 +289,6 @@ def compile_expression(slate_expr, tsfc_parameters=None):
 
     # Send back a "TSFC-like" SplitKernel object with an
     # index and KernelInfo
-    expr_coeffs = slate_expr.coefficients()
     kinfo = KernelInfo(kernel=op2kernel,
                        integral_type=builder.integral_type,
                        oriented=builder.oriented,

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -145,8 +145,11 @@ class KernelBuilder(object):
 
         for splitkernel in splitkernels:
             oriented = oriented or splitkernel.kinfo.oriented
+
             # TODO: Extend multiple domains support
-            assert splitkernel.kinfo.subdomain_id == "otherwise"
+            if splitkernel.kinfo.subdomain_id != "otherwise":
+                raise NotImplementedError("Subdomains not implemented yet.")
+
             kast = transformer.visit(splitkernel.kinfo.kernel._ast)
             kernel_list.append(kast)
 

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -99,7 +99,7 @@ def test_assemble_matrix_into_tensor(mesh):
     assert np.allclose(M.M.values, 2*assemble(Tensor(u * v * dx)).M.values, rtol=1e-14)
 
 
-def test_mixed_coefficient_tensor(mesh):
+def test_mixed_coefficient_matrix(mesh):
     V = FunctionSpace(mesh, "CG", 1)
     U = FunctionSpace(mesh, "DG", 0)
     W = V * U
@@ -107,10 +107,19 @@ def test_mixed_coefficient_tensor(mesh):
     f.assign(1)
     u = TrialFunction(V)
     v = TestFunction(V)
-    T = Tensor(f[0] * u * v * dx)
-    ref = assemble(f[0] * u * v * dx)
+    T = Tensor((f[0] + f[1]) * u * v * dx)
+    ref = assemble((f[0] + f[1]) * u * v * dx)
 
-    assert np.allclose(assemble(T).M.values, ref.M.values)
+    assert np.allclose(assemble(T).M.values, ref.M.values, rtol=1e-14)
+
+
+def test_mixed_coefficient_scalar(mesh):
+    V = FunctionSpace(mesh, "DG", 0)
+    W = V * V
+    f = Function(W)
+    g, h = f.split()
+    f.assign(1)
+    assert np.allclose(assemble(Tensor((g + f[0] + h + f[1])*dx)), 4.0)
 
 
 @pytest.mark.xfail(raises=NotImplementedError)


### PR DESCRIPTION
This PR addresses a bug described in https://github.com/firedrakeproject/firedrake/issues/1074. The changes here corrects how Slate handles mixed coefficients by providing a mapping from coefficient to it's split components.