### PR TITLE
Vec wo

### DIFF
--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -230,7 +230,7 @@ class DumbCheckpoint(object):
             raise ValueError("Can only load functions")
         name = name or function.name()
         group = self._get_data_group()
-        with function.dat.vec as v:
+        with function.dat.vec_wo as v:
             self.vwr.pushGroup(group)
             oname = v.getName()
             v.setName(name)
@@ -418,7 +418,7 @@ class HDF5File(object):
             suffix = "/%.15e" % timestamp
             path = path + suffix
 
-        with function.dat.vec as v:
+        with function.dat.vec_wo as v:
             dset = self._h5file[path]
             v.array[:] = dset[slice(*v.getOwnershipRange())]
 

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -147,7 +147,11 @@ class LinearSolver(solving_utils.ParametersMixin):
             b = b_bc
         with self.inserted_options():
             with b.dat.vec_ro as rhs:
-                with x.dat.vec as solution:
+                if self.ksp.getInitialGuessNonzero():
+                    acc = x.dat.vec
+                else:
+                    acc = x.dat.vec_wo
+                with acc as solution:
                     self.ksp.solve(rhs, solution)
 
         r = self.ksp.getConvergedReason()

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -121,7 +121,7 @@ class ImplicitMatrixContext(object):
                                                           form_compiler_parameters=self.fc_params)
 
     def mult(self, mat, X, Y):
-        with self._x.dat.vec as v:
+        with self._x.dat.vec_wo as v:
             X.copy(v)
 
         # if we are a block on the diagonal, then the matrix has an
@@ -145,7 +145,7 @@ class ImplicitMatrixContext(object):
         if self.on_diag:
             if len(self.row_bcs) > 0:
                 # TODO, can we avoid the copy?
-                with self._xbc.dat.vec as v:
+                with self._xbc.dat.vec_wo as v:
                     X.copy(v)
             for bc in self.row_bcs:
                 bc.set(self._y, self._xbc)
@@ -158,7 +158,7 @@ class ImplicitMatrixContext(object):
 
     def multTranspose(self, mat, Y, X):
         # As for mult, just everything swapped round.
-        with self._y.dat.vec as v:
+        with self._y.dat.vec_wo as v:
             Y.copy(v)
 
         for bc in self.row_bcs:
@@ -169,7 +169,7 @@ class ImplicitMatrixContext(object):
         if self.on_diag:
             if len(self.col_bcs) > 0:
                 # TODO, can we avoid the copy?
-                with self._ybc.dat.vec as v:
+                with self._ybc.dat.vec_wo as v:
                     Y.copy(v)
             for bc in self.col_bcs:
                 bc.set(self._x, self._ybc)

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -225,7 +225,7 @@ class Interpolation(object):
         self.fbcs = fbcs or []
 
     def mult(self, mat, x, y, inc=False):
-        with self.cfn.dat.vec as v:
+        with self.cfn.dat.vec_wo as v:
             x.copy(v)
         firedrake.prolong(self.cfn, self.ffn)
         for bc in self.fbcs:
@@ -244,7 +244,7 @@ class Interpolation(object):
             w.axpy(1.0, y)
 
     def multTranspose(self, mat, x, y, inc=False):
-        with self.ffn.dat.vec as v:
+        with self.ffn.dat.vec_wo as v:
             x.copy(v)
         firedrake.restrict(self.ffn, self.cfn)
         for bc in self.cbcs:
@@ -270,7 +270,7 @@ class Injection(object):
         self.cbcs = cbcs or []
 
     def multTranspose(self, mat, x, y):
-        with self.ffn.dat.vec as v:
+        with self.ffn.dat.vec_wo as v:
             x.copy(v)
         firedrake.inject(self.ffn, self.cfn)
         for bc in self.cbcs:

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -292,7 +292,7 @@ class HybridizationPC(PCBase):
         """
 
         with timed_region("HybridBreak"):
-            with self.unbroken_residual.dat.vec as v:
+            with self.unbroken_residual.dat.vec_wo as v:
                 x.copy(v)
 
             # Transfer unbroken_rhs into broken_rhs
@@ -309,7 +309,7 @@ class HybridizationPC(PCBase):
             # Once `g` is obtained, we take the inner product against broken
             # HDiv test functions to obtain a broken residual.
             with self.unbroken_residual.split()[self.vidx].dat.vec_ro as r:
-                with self._primal_r.dat.vec as g:
+                with self._primal_r.dat.vec_wo as g:
                     self.hdiv_mass_ksp.solve(r, g)
 
         with timed_region("HybridRHS"):
@@ -322,7 +322,11 @@ class HybridizationPC(PCBase):
         with timed_region("HybridSolve"):
             # Solve the system for the Lagrange multipliers
             with self.schur_rhs.dat.vec_ro as b:
-                with self.trace_solution.dat.vec as x_trace:
+                if self.trace_ksp.getInitialGuessNonzero():
+                    acc = self.trace_solution.dat.vec
+                else:
+                    acc = self.trace_solution.dat.vec_wo
+                with acc as x_trace:
                     self.trace_ksp.solve(b, x_trace)
 
         # Reconstruct the unknowns
@@ -337,7 +341,7 @@ class HybridizationPC(PCBase):
             # Compute the hdiv projection of the broken hdiv solution
             self._assemble_projection_rhs()
             with self._projection_rhs.dat.vec_ro as b_proj:
-                with self.unbroken_solution.split()[self.vidx].dat.vec as sol:
+                with self.unbroken_solution.split()[self.vidx].dat.vec_wo as sol:
                     self.hdiv_projection_ksp.solve(b_proj, sol)
 
             with self.unbroken_solution.dat.vec_ro as v:
@@ -396,7 +400,7 @@ def create_schur_nullspace(P, forward, V, V_d, TraceSpace, comm):
     forward_action = forward * tmp_b
     new_vecs = []
     for v in vecs:
-        with tmp.dat.vec as t:
+        with tmp.dat.vec_wo as t:
             v.copy(t)
 
         project(tmp, tmp_b)

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -339,7 +339,7 @@ class _SNESContext(object):
 
     def set_function(self, snes):
         """Set the residual evaluation function"""
-        with self._F.dat.vec as v:
+        with self._F.dat.vec_wo as v:
             snes.setFunction(self.form_function, v)
 
     def set_jacobian(self, snes):
@@ -416,7 +416,7 @@ class _SNESContext(object):
         problem = ctx._problem
         # X may not be the same vector as the vec behind self._x, so
         # copy guess in from X.
-        with ctx._x.dat.vec as v:
+        with ctx._x.dat.vec_wo as v:
             X.copy(v)
 
         if ctx._pre_function_callback is not None:
@@ -455,7 +455,7 @@ class _SNESContext(object):
 
         # X may not be the same vector as the vec behind self._x, so
         # copy guess in from X.
-        with ctx._x.dat.vec as v:
+        with ctx._x.dat.vec_wo as v:
             X.copy(v)
 
         if ctx._pre_jacobian_callback is not None:

--- a/firedrake/vector.py
+++ b/firedrake/vector.py
@@ -143,7 +143,7 @@ class Vector(object):
         """Set process local values
 
         :arg values: a numpy array of values of length :func:`Vector.local_size`"""
-        with self.dat.vec as v:
+        with self.dat.vec_wo as v:
             v.array[:] = values
 
     def local_size(self):


### PR DESCRIPTION
Use the new `vec_wo` context manager for cases where we know we're not going to read from the vec (especially, for example, in residual evaluation).

Needs OP2/PyOP2#527.