### PR TITLE
firedrake-install: check that PETSC_DIR is defined

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -954,6 +954,11 @@ If you really want to use your own PETSc build, please run again with the
 --honour-petsc-dir option.
 """)
 
+if "PETSC_DIR" not in os.environ and args.honour_petsc_dir:
+    quit("""The --honour-petsc-dir is set, but PETSC_DIR environment variable is
+not defined. If you have compiled PETSc manually, set PETSC_DIR
+(and optionally PETSC_ARCH) variables to point to the build directory.
+""")
 
 log.debug("*** Current environment (output of 'env') ***")
 log.debug(check_output(["env"]))


### PR DESCRIPTION
If the user installs with --honour-petsc-dir, but has forgotten to set the PETSC_DIR variable, the install script will run for some time before eventually failing at install h5py stage. This checks the sanity of the options up front.