### PR TITLE
Allow LVS jacobian to be invalidated by user

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -283,3 +283,9 @@ class LinearVariationalSolver(NonlinearVariationalSolver):
         parameters.setdefault('ksp_rtol', 1.0e-7)
         kwargs["solver_parameters"] = parameters
         super(LinearVariationalSolver, self).__init__(*args, **kwargs)
+
+    def invalidate_jacobian(self):
+        """
+        Forces the matrix to be reassembled next time it is required.
+        """
+        self._ctx._jacobian_assembled = False

--- a/tests/regression/test_jacobian_invalidation.py
+++ b/tests/regression/test_jacobian_invalidation.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import, print_function, division
+import numpy as np
+import pytest
+
+from firedrake import *
+
+
+def test_jac_invalid():
+    mesh = UnitIntervalMesh(5)
+    V = FunctionSpace(mesh, "P", 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    f = Function(V).assign(1)
+
+    # set up trivial projection problem
+    a = u*v*dx
+    L = f*v*dx
+
+    out = Function(V)
+    problem = LinearVariationalProblem(a, L, out)
+    solver = LinearVariationalSolver(problem)
+    solver.solve()
+
+    assert np.allclose(out.dat.data, 1.0)
+    # re-zero output vector, else action(a, out) - L,
+    # the residual, is still zero
+    out.assign(0)
+
+    # change mesh without invalidating assembled matrix
+    mesh.coordinates.dat.data[:] *= 2.0
+    solver.solve()
+
+    # wrong answer will be produced
+    assert not np.allclose(out.dat.data, 1.0)
+    out.assign(0)
+
+    # now invalidate the assembled matrix, forcing reassembly on modified mesh
+    solver.invalidate_jacobian()
+    solver.solve()
+
+    # correct answer produced
+    assert np.allclose(out.dat.data, 1.0)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Sometimes, setting `constant_jacobian=False` in the LVP is overkill, e.g. if the underlying mesh remains constant for several timesteps before being adapted, or similar.  What is presented here is a bit nicer than periodically remaking the entire solver object.

Presumably not necessary to implement this for NVP/NLS (though would be simple to implement), since `constant_jacobian` is automatically `False`.