### PR TITLE
Octahedral mesh

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -881,7 +881,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
         COMM_WORLD).
     """
     if refinement_level < 0 or refinement_level % 1:
-            raise RuntimeError("Number of refinements must be a non-negative integer")
+        raise ValueError("Number of refinements must be a non-negative integer")
 
     if degree < 1:
         raise ValueError("Mesh coordinate degree must be at least 1")

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -27,6 +27,7 @@ __all__ = ['IntervalMesh', 'UnitIntervalMesh',
            'CubedSphereMesh', 'UnitCubedSphereMesh',
            'TorusMesh', 'CylinderMesh']
 
+
 def IntervalMesh(ncells, length_or_left, right=None, comm=COMM_WORLD):
     """
     Generate a uniform mesh of an interval.
@@ -904,22 +905,22 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
     for i in range(refinement_level):
         plex = plex.refine()
 
-    #build the initial mesh
+    # build the initial mesh
     m = mesh.Mesh(plex, dim=3, reorder=reorder)
     if degree > 1:
-        #use it to build a higher-order mesh
+        # use it to build a higher-order mesh
         new_coords = function.Function(functionspace.VectorFunctionSpace(m, "CG", degree))
         x, y, z = ufl.SpatialCoordinate(m)
         new_coords.interpolate(ufl.as_vector([x, y, z]))
         m = mesh.Mesh(new_coords)
 
-    #remap to a cone
+    # remap to a cone
     x, y, z = ufl.SpatialCoordinate(m)
     tol = 1.0e-8
     rnew = ufl.Max(1 - abs(z), 0)
     x0 = x/(rnew + tol)
     y0 = y/(rnew + tol)
-    theta = ufl.conditional(ufl.ge(y0,0),
+    theta = ufl.conditional(ufl.ge(y0, 0),
                             ufl.pi/2*(1-x0),
                             ufl.pi/2.0*(x0-1))
     Vc = m.coordinates.function_space()
@@ -927,16 +928,17 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
                                                     ufl.sin(theta)*rnew, z]))
     m.coordinates.assign(xcone)
 
-    if(True):
-        phi = ufl.pi*z/2
-        rnew += tol
-        rnew2 = ufl.cos(phi) + tol
-        znew = ufl.sin(phi)
-        xsphere = Function(Vc).interpolate(ufl.as_vector([x*rnew2/rnew,
-                                                          y*rnew2/rnew, znew]))
-        m.coordinates.assign(xsphere*radius)
+    # push out to a sphere
+    phi = ufl.pi*z/2
+    rnew += tol
+    rnew2 = ufl.cos(phi) + tol
+    znew = ufl.sin(phi)
+    xsphere = Function(Vc).interpolate(ufl.as_vector([x*rnew2/rnew,
+                                                      y*rnew2/rnew, znew]))
+    m.coordinates.assign(xsphere*radius)
     m._octahedral_sphere = radius
     return m
+
 
 def UnitOctahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
                              comm=COMM_WORLD):
@@ -953,6 +955,7 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
     return OctahedralSphereMesh(1.0, refinement_level=refinement_level,
                                 degree=degree, reorder=reorder,
                                 comm=comm)
+
 
 def _cubedsphere_cells_and_coords(radius, refinement_level):
     """Generate vertex and face lists for cubed sphere """

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -969,7 +969,8 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
         COMM_WORLD).
     """
     return OctahedralSphereMesh(1.0, refinement_level=refinement_level,
-                                degree=degree, reorder=reorder,
+                                degree=degree, hemisphere=hemisphere,
+                                reorder=reorder,
                                 comm=comm)
 
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -864,7 +864,8 @@ def UnitIcosahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
                                  comm=comm)
 
 
-def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
+def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
+                         hemisphere=False, reorder=None,
                          comm=COMM_WORLD):
     """Generate an octahedral approximation to the surface of the
     sphere.
@@ -874,6 +875,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
         octahedron).
     :kwarg degree: polynomial degree of coordinate space (defaults
         to 1: flat triangles)
+    :kwarg hemisphere: if True, mesh Northern Hemisphere only
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).
@@ -884,21 +886,33 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
     if degree < 1:
         raise ValueError("Mesh coordinate degree must be at least 1")
     # vertices of an octahedron of radius 1
-    vertices = np.array([[1.0, 0.0, 0.0],
-                         [0.0, 1.0, 0.0],
-                         [0.0, 0.0, 1.0],
-                         [-1.0, 0.0, 0.0],
-                         [0.0, -1.0, 0.0],
-                         [0.0, 0.0, -1.0]])
-    # faces of the base octahedron
-    faces = np.array([[0, 1, 2],
-                      [0, 1, 5],
-                      [0, 2, 4],
-                      [0, 4, 5],
-                      [1, 2, 3],
-                      [1, 3, 5],
-                      [2, 3, 4],
-                      [3, 4, 5]], dtype=np.int32)
+    if hemisphere:
+        vertices = np.array([[1.0, 0.0, 0.0],
+                             [0.0, 1.0, 0.0],
+                             [0.0, 0.0, 1.0],
+                             [-1.0, 0.0, 0.0],
+                             [0.0, -1.0, 0.0]])
+        # faces of the base octahedron
+        faces = np.array([[0, 1, 2],
+                          [0, 2, 4],
+                          [1, 2, 3],
+                          [2, 3, 4]], dtype=np.int32)
+    else:
+        vertices = np.array([[1.0, 0.0, 0.0],
+                             [0.0, 1.0, 0.0],
+                             [0.0, 0.0, 1.0],
+                             [-1.0, 0.0, 0.0],
+                             [0.0, -1.0, 0.0],
+                             [0.0, 0.0, -1.0]])
+        # faces of the base octahedron
+        faces = np.array([[0, 1, 2],
+                          [0, 1, 5],
+                          [0, 2, 4],
+                          [0, 4, 5],
+                          [1, 2, 3],
+                          [1, 3, 5],
+                          [2, 3, 4],
+                          [3, 4, 5]], dtype=np.int32)
 
     plex = mesh._from_cell_list(2, faces, vertices, comm)
     plex.setRefinementUniform(True)
@@ -940,7 +954,8 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
     return m
 
 
-def UnitOctahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
+def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
+                             hemisphere=False, reorder=None,
                              comm=COMM_WORLD):
     """Generate an octahedral approximation to the unit sphere.
 
@@ -948,6 +963,7 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
         octahedron).
     :kwarg degree: polynomial degree of coordinate space (defaults
         to 1: flat triangles)
+    :kwarg hemisphere: if True, mesh Northern Hemisphere only
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -222,6 +222,36 @@ def test_octahedral_sphere_mesh_num_exterior_facets():
     run_octahedral_sphere_mesh_num_exterior_facets()
 
 
+@pytest.mark.parametrize("kind", ("both", "north", "south"))
+def test_hemispherical_octa(kind):
+    expected_bbox = {"both": np.asarray([[-1, -1, -1],
+                                         [1, 1, 1]]),
+                     "north": np.asarray([[-1, -1, 0],
+                                          [1, 1, 1]]),
+                     "south": np.asarray([[-1, -1, -1],
+                                          [1, 1, 0]])}[kind]
+    mesh = UnitOctahedralSphereMesh(1, hemisphere=kind)
+    coords = mesh.coordinates.dat.data_ro
+    bbox = np.asarray([np.min(coords, axis=0), np.max(coords, axis=0)])
+    assert np.allclose(bbox, expected_bbox)
+
+
+def test_invalid_hemispherical_octa():
+    with pytest.raises(ValueError):
+        UnitOctahedralSphereMesh(1, hemisphere="east")
+
+
+@pytest.mark.parametrize("refinement", (-1, 1.2))
+def test_invalid_octa_refinement(refinement):
+    with pytest.raises(ValueError):
+        UnitOctahedralSphereMesh(refinement)
+
+
+def test_invalid_octa_degree():
+    with pytest.raises(ValueError):
+        UnitOctahedralSphereMesh(2, degree=0)
+
+
 @pytest.mark.parallel(nprocs=2)
 def test_octahedral_sphere_mesh_num_exterior_facets_parallel():
     run_octahedral_sphere_mesh_num_exterior_facets()

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -213,6 +213,20 @@ def test_icosahedral_sphere_mesh_num_exterior_facets_parallel():
     run_icosahedral_sphere_mesh_num_exterior_facets()
 
 
+def run_octahedral_sphere_mesh_num_exterior_facets():
+    m = UnitOctahedralSphereMesh(0)
+    assert_num_exterior_facets_equals_zero(m)
+
+
+def test_octahedral_sphere_mesh_num_exterior_facets():
+    run_octahedral_sphere_mesh_num_exterior_facets()
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_octahedral_sphere_mesh_num_exterior_facets_parallel():
+    run_octahedral_sphere_mesh_num_exterior_facets()
+
+
 def run_cubed_sphere_mesh_num_exterior_facets():
     m = UnitCubedSphereMesh(0)
     assert_num_exterior_facets_equals_zero(m)
@@ -260,6 +274,36 @@ def test_bendy_icos_parallel(degree):
 @pytest.mark.parallel(nprocs=2)
 def test_bendy_icos_unit_parallel(degree):
     return run_bendy_icos_unit(degree)
+
+
+def run_bendy_octa(degree):
+    m = OctahedralSphereMesh(5.0, refinement_level=1, degree=degree)
+    coords = m.coordinates.dat.data
+    assert np.allclose(np.linalg.norm(coords, axis=1), 5.0)
+
+
+def run_bendy_octa_unit(degree):
+    m = UnitOctahedralSphereMesh(refinement_level=1, degree=degree)
+    coords = m.coordinates.dat.data
+    assert np.allclose(np.linalg.norm(coords, axis=1), 1.0)
+
+
+def test_bendy_octa(degree):
+    return run_bendy_octa(degree)
+
+
+def test_bendy_octa_unit(degree):
+    return run_bendy_octa_unit(degree)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_bendy_octa_parallel(degree):
+    return run_bendy_octa(degree)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_bendy_octa_unit_parallel(degree):
+    return run_bendy_octa_unit(degree)
 
 
 def run_bendy_cube(degree):


### PR DESCRIPTION
Provide a utility octahedral sphere mesh.

This is generated by hierarchically refining an octahedron, then transforming to two cones stuck together (so that horizontal lines stay horizontal and points are equispaced on those lines), and then mapping out to the sphere (so that points are equispaced on lines of longitude).