### PR TITLE
Wire in and test pyadjoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         sh 'mkdir tmp'
         dir('tmp') {
           timestamps {
-            sh '../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --adjoint --slope --install thetis --install gusto ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
+            sh '../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --adjoint --slope --install thetis --install gusto --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
           }
         }
       }
@@ -63,6 +63,18 @@ python -m pytest -n 4 --cov firedrake -v tests
             sh '''
 . ./firedrake/bin/activate
 cd firedrake/src/dolfin-adjoint; python -m pytest -n 4 -v tests_firedrake
+'''
+          }
+        }
+      }
+    }
+    stage('Test pyadjoint'){
+      steps {
+        dir('tmp') {
+          timestamps {
+            sh '''
+. ./firedrake/bin/activate
+cd firedrake/src/pyadjoint; python -m pytest -v tests/firedrake_adjoint
 '''
           }
         }

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -24,7 +24,9 @@ firedrake_apps = {
     "gusto": ("""Atmospheric dynamical core library. http://firedrakeproject.org/gusto""",
               "git+ssh://github.com/firedrakeproject/gusto#egg=gusto"),
     "thetis": ("""Coastal ocean model. http://thetisproject.org""",
-               "git+ssh://github.com/thetisproject/thetis#egg=thetis")
+               "git+ssh://github.com/thetisproject/thetis#egg=thetis"),
+    "pyadjoint": ("""New generation adjoint. https://bitbucket.org/dolfin-adjoint/pyadjoint""",
+                  "git+ssh://bitbucket.org/dolfin-adjoint/pyadjoint.git#egg=pyadjoint"),
 }
 
 


### PR DESCRIPTION
Wire in pyadjoint.

* pyadjoint can be installed by passing `--install pyadjoint` to `firedrake-install` or `firedrake-update`
* Jenkins tests pyadjoint. This adds around 75 seconds to the test cycle.

This PR doesn't switch the behaviour of --adjoint yet. Installing both dolfin-adjoint and pyadjoint will result in a module name clash, however this will go away once we transition fully.