### PR TITLE
Owner computes

### DIFF
--- a/firedrake/dmplex.pyx
+++ b/firedrake/dmplex.pyx
@@ -658,13 +658,13 @@ def mark_entity_classes(PETSc.DM plex):
     pStart, pEnd = plex.getChart()
     cStart, cEnd = plex.getHeightStratum(0)
 
-    plex.createLabel("core")
-    plex.createLabel("owned")
-    plex.createLabel("ghost")
+    plex.createLabel("pyop2_core")
+    plex.createLabel("pyop2_owned")
+    plex.createLabel("pyop2_ghost")
 
-    CHKERR(DMGetLabel(plex.dm, "core", &lbl_core))
-    CHKERR(DMGetLabel(plex.dm, "owned", &lbl_owned))
-    CHKERR(DMGetLabel(plex.dm, "ghost", &lbl_ghost))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_core", &lbl_core))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_owned", &lbl_owned))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_ghost", &lbl_ghost))
 
     if plex.comm.size > 1:
         # Mark ghosts from point overlap SF
@@ -737,9 +737,9 @@ def get_entity_classes(PETSc.DM plex):
         eStart[d] = start
         eEnd[d] = end
 
-    for i, op2class in enumerate(["core",
-                                  "owned",
-                                  "ghost"]):
+    for i, op2class in enumerate([b"pyop2_core",
+                                  b"pyop2_owned",
+                                  b"pyop2_ghost"]):
         class_is = plex.getStratumIS(op2class, 1)
         class_size = plex.getStratumSize(op2class, 1)
         if class_size > 0:
@@ -885,9 +885,9 @@ def get_facets_by_class(PETSc.DM plex, label,
     facet_classes = [0, 0, 0]
     fi = 0
 
-    for i, op2class in enumerate([b"core",
-                                  b"owned",
-                                  b"ghost"]):
+    for i, op2class in enumerate([b"pyop2_core",
+                                  b"pyop2_owned",
+                                  b"pyop2_ghost"]):
         CHKERR(DMGetLabel(plex.dm, op2class, &lbl_class))
         CHKERR(DMLabelCreateIndex(lbl_class, pStart, pEnd))
         nclass = plex.getStratumSize(op2class, 1)
@@ -994,9 +994,9 @@ def plex_renumbering(PETSc.DM plex,
     ncells = np.zeros(3, dtype=IntType)
 
     # Get label pointers and label-specific array indices
-    CHKERR(DMGetLabel(plex.dm, "core", &labels[0]))
-    CHKERR(DMGetLabel(plex.dm, "owned", &labels[1]))
-    CHKERR(DMGetLabel(plex.dm, "ghost", &labels[2]))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_core", &labels[0]))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_owned", &labels[1]))
+    CHKERR(DMGetLabel(plex.dm, b"pyop2_ghost", &labels[2]))
     for l in range(3):
         CHKERR(DMLabelCreateIndex(labels[l], pStart, pEnd))
     entity_classes = entity_classes.astype(IntType)

--- a/firedrake/dmplexinc.pxi
+++ b/firedrake/dmplexinc.pxi
@@ -11,12 +11,12 @@ cdef extern from "petsc.h":
        PETSC_OWN_POINTER,
        PETSC_USE_POINTER
 
-cdef extern from "petscsys.h":
+cdef extern from "petscsys.h" nogil:
    int PetscMalloc1(PetscInt,void*)
    int PetscFree(void*)
    int PetscSortIntWithArray(PetscInt,PetscInt[],PetscInt[])
 
-cdef extern from "petscdmplex.h":
+cdef extern from "petscdmplex.h" nogil:
     int DMPlexGetHeightStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
     int DMPlexGetDepthStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
 
@@ -29,9 +29,9 @@ cdef extern from "petscdmplex.h":
     int DMPlexGetTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
     int DMPlexRestoreTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
     int DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI.MPI_Datatype,void*,PETSc.PetscSection,void**)
-    int DMPlexSetAdjacencyUser(PETSc.PetscDM,int(*)(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt[]))
+    int DMPlexSetAdjacencyUser(PETSc.PetscDM,int(*)(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt[],void*),void*)
 
-cdef extern from "petscdmlabel.h":
+cdef extern from "petscdmlabel.h" nogil:
     struct _n_DMLabel
     ctypedef _n_DMLabel* DMLabel "DMLabel"
     int DMLabelCreateIndex(DMLabel, PetscInt, PetscInt)
@@ -42,17 +42,17 @@ cdef extern from "petscdmlabel.h":
     int DMLabelGetValue(DMLabel, PetscInt, PetscInt*)
     int DMLabelClearValue(DMLabel, PetscInt, PetscInt)
 
-cdef extern from "petscdm.h":
+cdef extern from "petscdm.h" nogil:
     int DMGetLabel(PETSc.PetscDM,char[],DMLabel*)
 
-cdef extern from "petscis.h":
+cdef extern from "petscis.h" nogil:
     int PetscSectionGetOffset(PETSc.PetscSection,PetscInt,PetscInt*)
     int PetscSectionGetDof(PETSc.PetscSection,PetscInt,PetscInt*)
     int ISGetIndices(PETSc.PetscIS,PetscInt*[])
     int ISRestoreIndices(PETSc.PetscIS,PetscInt*[])
     int ISGeneralSetIndices(PETSc.PetscIS,PetscInt,PetscInt[],PetscCopyMode)
 
-cdef extern from "petscsf.h":
+cdef extern from "petscsf.h" nogil:
     struct PetscSFNode:
         PetscInt rank
         PetscInt index
@@ -65,7 +65,7 @@ cdef extern from "petscsf.h":
     int PetscSFReduceBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
     int PetscSFReduceEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
 
-cdef extern from "petscbt.h":
+cdef extern from "petscbt.h" nogil:
     ctypedef char * PetscBT
     int PetscBTCreate(PetscInt,PetscBT*)
     int PetscBTDestroy(PetscBT*)

--- a/firedrake/dmplexinc.pxi
+++ b/firedrake/dmplexinc.pxi
@@ -29,12 +29,14 @@ cdef extern from "petscdmplex.h":
     int DMPlexGetTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
     int DMPlexRestoreTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
     int DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI.MPI_Datatype,void*,PETSc.PetscSection,void**)
+    int DMPlexSetAdjacencyUser(PETSc.PetscDM,int(*)(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt[]))
 
 cdef extern from "petscdmlabel.h":
     struct _n_DMLabel
     ctypedef _n_DMLabel* DMLabel "DMLabel"
     int DMLabelCreateIndex(DMLabel, PetscInt, PetscInt)
     int DMLabelDestroyIndex(DMLabel)
+    int DMLabelDestroy(DMLabel*)
     int DMLabelHasPoint(DMLabel, PetscInt, PetscBool*)
     int DMLabelSetValue(DMLabel, PetscInt, PetscInt)
     int DMLabelGetValue(DMLabel, PetscInt, PetscInt*)

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -489,6 +489,8 @@ class Function(ufl.Coefficient):
         """
         # Need to ensure data is up-to-date for reading
         self.dat._force_evaluation(read=True, write=False)
+        self.dat.global_to_local_begin(op2.READ)
+        self.dat.global_to_local_end(op2.READ)
         from mpi4py import MPI
 
         if args:

--- a/firedrake/halo.py
+++ b/firedrake/halo.py
@@ -1,6 +1,8 @@
-from pyop2.utils import maybe_setflags
+from pyop2 import op2
+from pyop2 import utils
 from mpi4py import MPI
 
+from firedrake.petsc import PETSc
 import firedrake.dmplex as dmplex
 
 
@@ -33,20 +35,27 @@ def _get_mtype(dat):
         return typ
 
 
-class Halo(object):
+class Halo(op2.Halo):
     """Build a Halo for a function space.
 
-    :arg dm:  The DM describing the data layout (has a Section attached).
+    :arg dm:  The DMPlex describing the topology.
+    :arg section: The data layout.
 
     The halo is implemented using a PETSc SF (star forest) object and
     is usable as a PyOP2 :class:`pyop2.Halo`."""
 
-    def __init__(self, dm):
-        lsec = dm.getDefaultSection()
-        gsec = dm.getDefaultGlobalSection()
-        dm.createDefaultSF(lsec, gsec)
-        sf = dm.getDefaultSF()
+    def __init__(self, dm, section):
+        super(Halo, self).__init__()
+        # Use a DM to create the halo SFs
+        self.dm = PETSc.DMShell().create(dm.comm)
+        self.dm.setPointSF(dm.getPointSF())
+        self.dm.setDefaultSection(section)
 
+    @utils.cached_property
+    def sf(self):
+        lsec = self.dm.getDefaultSection()
+        gsec = self.dm.getDefaultGlobalSection()
+        self.dm.createDefaultSF(lsec, gsec)
         # The full SF is designed for GlobalToLocal or LocalToGlobal
         # where the input and output buffers are different.  So on the
         # local rank, it copies data from input to output.  However,
@@ -54,50 +63,46 @@ class Halo(object):
         # (so we don't need to do the local copy).  To facilitate
         # this, prune the SF to remove all the roots that reference
         # the local rank.
-        self.sf = dmplex.prune_sf(sf)
-        self.comm = self.sf.comm.tompi4py()
-        self.sf.setFromOptions()
-        if self.sf.getType() != self.sf.Type.BASIC:
+        sf = dmplex.prune_sf(self.dm.getDefaultSF())
+        sf.setFromOptions()
+        if sf.getType() != sf.Type.BASIC:
             raise RuntimeError("Windowed SFs expose bugs in OpenMPI (use -sf_type basic)")
-        if self.comm.size == 1:
-            self._gnn2unn = None
-        self._gnn2unn = dmplex.make_global_numbering(lsec, gsec)
+        return sf
 
-    def begin(self, dat, reverse=False):
-        """Begin a halo exchange.
+    @utils.cached_property
+    def comm(self):
+        return self.dm.comm.tompi4py()
 
-        :arg dat: The :class:`pyop2.Dat` to start a halo exchange on.
-        :arg reverse: (optional) perform a reverse halo exchange.
+    @utils.cached_property
+    def local_to_global_numbering(self):
+        lsec = self.dm.getDefaultSection()
+        gsec = self.dm.getDefaultGlobalSection()
+        return dmplex.make_global_numbering(lsec, gsec)
 
-        .. note::
-
-           If ``reverse`` is ``True`` then the input buffer
-           may not be touched before calling :meth:`.end`."""
-        if self.comm.size == 1:
-            return
-        mtype = _get_mtype(dat)
-        dmplex.halo_begin(self.sf, dat, mtype, reverse)
-
-    def end(self, dat, reverse=False):
-        """End a halo exchange.
-
-        :arg dat: The :class:`pyop2.Dat` to end a halo exchange on.
-        :arg reverse: (optional) perform a reverse halo exchange.
-
-        See also :meth:`.begin`."""
+    def global_to_local_begin(self, dat, insert_mode):
+        assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
         if self.comm.size == 1:
             return
         mtype = _get_mtype(dat)
-        maybe_setflags(dat._data, write=True)
-        dmplex.halo_end(self.sf, dat, mtype, reverse)
-        maybe_setflags(dat._data, write=False)
+        dmplex.halo_begin(self.sf, dat, mtype, False)
 
-    def verify(self, *args):
-        """No-op"""
-        pass
+    def global_to_local_end(self, dat, insert_mode):
+        assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
+        if self.comm.size == 1:
+            return
+        mtype = _get_mtype(dat)
+        dmplex.halo_end(self.sf, dat, mtype, False)
 
-    @property
-    def global_to_petsc_numbering(self):
-        """Return a mapping from global (process-local) to universal
-    (process-global) numbers"""
-        return self._gnn2unn
+    def local_to_global_begin(self, dat, insert_mode):
+        assert insert_mode is op2.INC, "Only INC LtoG supported"
+        if self.comm.size == 1:
+            return
+        mtype = _get_mtype(dat)
+        dmplex.halo_begin(self.sf, dat, mtype, True)
+
+    def local_to_global_end(self, dat, insert_mode):
+        assert insert_mode is op2.INC, "Only INC LtoG supported"
+        if self.comm.size == 1:
+            return
+        mtype = _get_mtype(dat)
+        dmplex.halo_end(self.sf, dat, mtype, True)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -49,7 +49,7 @@ class _Facets(object):
 
         self.mesh = mesh
 
-        classes = as_tuple(classes, int, 4)
+        classes = as_tuple(classes, int, 3)
         self.classes = classes
 
         self.kind = kind

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -372,8 +372,10 @@ class MeshTopology(object):
         def callback(self):
             """Finish initialisation."""
             del self._callback
-            if self.comm.size > 1:
+            if self.comm.size > 1 and distribute:
+                dmplex.set_adjacency_callback(self._plex)
                 self._plex.distributeOverlap(1)
+                dmplex.clear_adjacency_callback(self._plex)
             self._grown_halos = True
 
             if reorder:

--- a/firedrake/mg/impl.pyx
+++ b/firedrake/mg/impl.pyx
@@ -487,7 +487,7 @@ def create_cell_node_map(coarse, fine, np.ndarray[PetscInt, ndim=2, mode="c"] c2
 
     nfdof = indices.shape[0]
     nfcell = 2**tdim
-    new_cell_map = -np.ones((ncoarse, nfdof), dtype=PETSc.IntType)
+    new_cell_map = np.full((coarse.mesh().cell_set.total_size, nfdof), -1, dtype=PETSc.IntType)
 
     cell_map = np.empty(nfcell*ndof, dtype=PETSc.IntType)
     for ccell in range(ncoarse):

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -51,10 +51,9 @@ class MeshHierarchy(object):
             # facets.  Interior facets will be relabeled in Mesh
             # construction below.
             impl.filter_exterior_facet_labels(rdm)
-            rdm.removeLabel("op2_core")
-            rdm.removeLabel("op2_non_core")
-            rdm.removeLabel("op2_exec_halo")
-            rdm.removeLabel("op2_non_exec_halo")
+            rdm.removeLabel("core")
+            rdm.removeLabel("owned")
+            rdm.removeLabel("ghost")
 
             dm_hierarchy.append(rdm)
             cdm = rdm

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -51,9 +51,9 @@ class MeshHierarchy(object):
             # facets.  Interior facets will be relabeled in Mesh
             # construction below.
             impl.filter_exterior_facet_labels(rdm)
-            rdm.removeLabel("core")
-            rdm.removeLabel("owned")
-            rdm.removeLabel("ghost")
+            rdm.removeLabel("pyop2_core")
+            rdm.removeLabel("pyop2_owned")
+            rdm.removeLabel("pyop2_ghost")
 
             dm_hierarchy.append(rdm)
             cdm = rdm

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -38,7 +38,7 @@ def coarse_to_fine_node_map(coarse, fine):
     except KeyError:
         from .impl import create_cell_node_map
         map_vals, offset = create_cell_node_map(coarse, fine, c2f, vperm)
-        return cache.setdefault(key, op2.Map(op2.LocalSet(mesh.cell_set),
+        return cache.setdefault(key, op2.Map(mesh.cell_set,
                                              fine.node_set,
                                              map_vals.shape[1],
                                              map_vals, offset=offset))
@@ -104,7 +104,7 @@ def get_restriction_weights(coarse, fine):
             weights = firedrake.Function(fine)
         c2f_map = coarse_to_fine_node_map(coarse, fine)
         kernel = get_count_kernel(c2f_map.arity)
-        op2.par_loop(kernel, op2.LocalSet(mesh.cell_set),
+        op2.par_loop(kernel, c2f_map.iterset,
                      weights.dat(op2.INC, c2f_map[op2.i[0]]))
         weights.assign(1/weights)
         return cache.setdefault(key, weights)

--- a/tests/regression/test_parallel_cr.py
+++ b/tests/regression/test_parallel_cr.py
@@ -1,0 +1,26 @@
+from firedrake import *
+import pytest
+import numpy
+
+
+@pytest.mark.parallel(nprocs=3)
+def test_cr_facet_integral_parallel():
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CR", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    M = assemble(avg(v)*avg(u)*dS)
+    M.force_evaluation()
+    M = M.petscmat
+
+    x, y = SpatialCoordinate(mesh)
+    u1 = Function(V)
+    u2 = Function(V)
+    u1.interpolate(x)
+    u2.interpolate(y)
+    expect = assemble(x*y*dS)
+    assert numpy.allclose(expect, assemble(avg(u1)*avg(u2)*dS))
+    with u2.dat.vec_ro as u2v, u1.dat.vec_ro as u1v:
+        y = M.createVecLeft()
+        M.mult(u2v, y)
+        assert numpy.allclose(expect, u1v.dot(y))

--- a/tests/regression/test_stokes_hdiv_parallel.py
+++ b/tests/regression/test_stokes_hdiv_parallel.py
@@ -1,0 +1,127 @@
+from firedrake import *
+import pytest
+import numpy
+
+
+@pytest.fixture(params=["aij", "nest", "matfree"])
+def mat_type(request):
+    return request.param
+
+
+@pytest.fixture(params=[(("RT", 3), ("DG", 2)),
+                        (("BDM", 2), ("DG", 1))],
+                ids=["RT3-DG2", "BDM2-DG1"])
+def element_pair(request):
+    return request.param
+
+
+@pytest.mark.parallel(nprocs=3)
+def test_stokes_hdiv_parallel(mat_type, element_pair):
+    err_u = []
+    err_p = []
+    err_div = []
+    hdiv, l2 = element_pair
+    for n in [8, 16, 32, 64]:
+        mesh = UnitSquareMesh(n, n)
+
+        V = FunctionSpace(mesh, *hdiv)
+        Q = FunctionSpace(mesh, *l2)
+        W = V * Q
+
+        x, y = SpatialCoordinate(mesh)
+        uxexpr = sin(pi*x)*sin(pi*y)
+        uyexpr = cos(pi*x)*cos(pi*y)
+        ppexpr = sin(pi*x)*cos(pi*y)
+        srcxexpr = 2.0*pi*pi*sin(pi*x)*sin(pi*y) + pi*cos(pi*x)*cos(pi*y)
+        srcyexpr = 2.0*pi*pi*cos(pi*x)*cos(pi*y) - pi*sin(pi*x)*sin(pi*y)
+
+        u_exact = as_vector([uxexpr, uyexpr])
+        p_exact = ppexpr
+        source = as_vector([srcxexpr, srcyexpr])
+
+        (u, p) = TrialFunctions(W)
+        (v, q) = TestFunctions(W)
+
+        n = FacetNormal(mesh)
+        h = CellSize(mesh)
+        sigma = 10.0
+
+        # Manually specify integration degree due to non-polynomial
+        # source terms.
+        a = (inner(grad(u), grad(v)) - p*div(v) - q*div(u))*dx(degree=6)
+
+        a += (- inner(avg(grad(u)), outer(jump(v), n("+")))
+              - inner(avg(grad(v)), outer(jump(u), n("+")))
+              + (sigma/avg(h))*inner(jump(u), jump(v)))*dS(degree=6)
+
+        a += (- inner(grad(u), outer(v, n))
+              - inner(grad(v), outer(u, n))
+              + (sigma/h)*inner(u, v))*ds(degree=6)
+
+        L = (inner(source, v)*dx(degree=6)
+             + (sigma/h)*inner(u_exact, v)*ds(degree=6)
+             - inner(grad(v), outer(u_exact, n))*ds(degree=6))
+
+        # left = 1
+        # right = 2
+        # bottom = 3
+        # top = 4
+        bcfunc_left = Function(V).project(as_vector([u_exact[0], 0]))
+        bcfunc_right = Function(V).project(as_vector([u_exact[0], 0]))
+        bcfunc_bottom = Function(V).project(as_vector([0, u_exact[1]]))
+        bcfunc_top = Function(V).project(as_vector([0, u_exact[1]]))
+        bcs = [DirichletBC(W.sub(0), bcfunc_left, 1),
+               DirichletBC(W.sub(0), bcfunc_right, 2),
+               DirichletBC(W.sub(0), bcfunc_bottom, 3),
+               DirichletBC(W.sub(0), bcfunc_top, 4)]
+
+        UP = Function(W)
+
+        nullspace = MixedVectorSpaceBasis(W, [W.sub(0), VectorSpaceBasis(constant=True)])
+
+        parameters = {
+            "mat_type": mat_type,
+            "pmat_type": "matfree",
+            "ksp_type": "fgmres",
+            "ksp_max_it": "30",
+            "ksp_atol": "1.e-16",
+            "ksp_rtol": "1.e-11",
+            "ksp_monitor_true_residual": True,
+            "pc_type": "fieldsplit",
+            "pc_fieldsplit_type": "multiplicative",
+
+            "fieldsplit_0_ksp_type": "preonly",
+            "fieldsplit_0_pc_type": "python",
+            "fieldsplit_0_pc_python_type": "firedrake.AssembledPC",
+            "fieldsplit_0_assembled_pc_type": "lu",
+            "fieldsplit_0_assembled_pc_factor_mat_solver_package": "mumps",
+
+            "fieldsplit_1_ksp_type": "preonly",
+            "fieldsplit_1_pc_type": "python",
+            "fieldsplit_1_pc_python_type": "firedrake.MassInvPC",
+            "fieldsplit_1_Mp_ksp_type": "preonly",
+            "fieldsplit_1_Mp_pc_type": "lu",
+            "fieldsplit_1_Mp_pc_factor_mat_solver_package": "mumps"
+        }
+
+        # Switch sign of pressure mass matrix
+        mu = Constant(-1.0)
+        appctx = {"mu": mu, "pressure_space": 1}
+
+        UP.assign(0)
+        solve(a == L, UP, bcs=bcs, nullspace=nullspace, solver_parameters=parameters,
+              appctx=appctx)
+
+        u, p = UP.split()
+        u_error = u - u_exact
+        p_error = p - p_exact
+        err_u.append(sqrt(abs(assemble(dot(u_error, u_error)*dx))))
+        err_p.append(sqrt(abs(assemble(p_error*p_error*dx))))
+        err_div.append(sqrt(assemble(div(u)**2*dx)))
+    err_u = numpy.asarray(err_u)
+    err_p = numpy.asarray(err_p)
+    err_div = numpy.asarray(err_div)
+
+    assert numpy.allclose(err_div, 0, atol=1e-7, rtol=1e-5)
+    assert (numpy.log2(err_u[:-1] / err_u[1:]) > 2.8).all()
+    assert (numpy.log2(err_p[:-1] / err_p[1:]) > 1.8).all()


### PR DESCRIPTION
Switch to an owner computes model.  This shrinks the halos.  We now only exchange data that is in the closure of the support of boundary facets.

Not ready for merge yet, because the PETSc change necessary is not merged right now, but opening for discussion.

Fixes subtle issues to do with assembling over interior facets in parallel when the field in question is not discontinuous.