### PR TITLE
Python3 fixes for exception handling in demos

### DIFF
--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -220,14 +220,14 @@ image::
   try:
     plot(all_us)
   except Exception as e:
-    warning("Cannot plot figure. Error msg: '%s'" % e.message)
+    warning("Cannot plot figure. Error msg: '%s'" % e)
 
 And finally show the figure::
 
   try:
     plt.show()
   except Exception as e:
-    warning("Cannot show figure. Error msg: '%s'" % e.message)
+    warning("Cannot show figure. Error msg: '%s'" % e)
 
 Alternatively, if running in Jupyter Notebook, an interactive interface will be
 displayed by adding the key word argument `interactive=True`

--- a/demos/helmholtz/helmholtz.py.rst
+++ b/demos/helmholtz/helmholtz.py.rst
@@ -108,7 +108,7 @@ matplotlib.pyplot should be installed and imported::
   try:
     plot(u)
   except Exception as e:
-    warning("Cannot plot figure. Error msg: '%s'" % e.message)
+    warning("Cannot plot figure. Error msg: '%s'" % e)
 
 For a contour plot, it could be plotted by adding an additional key word
 argument::
@@ -116,14 +116,14 @@ argument::
   try:
     plot(u, contour=True)
   except Exception as e:
-    warning("Cannot plot figure. Error msg: '%s'" % e.message)
+    warning("Cannot plot figure. Error msg: '%s'" % e)
 
 Don't forget to show the image::
 
   try:
     plt.show()
   except Exception as e:
-    warning("Cannot show figure. Error msg: '%s'" % e.message)
+    warning("Cannot show figure. Error msg: '%s'" % e)
 
 Alternatively, since we have an analytic solution, we can check the
 :math:`L_2` norm of the error in the solution::

--- a/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
+++ b/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
@@ -229,12 +229,12 @@ we can plot it, ::
   try:
       plot(psi_non)
   except Exception as e:
-      warning("Cannot plot figure. Error msg '%s'" % e.message)
+      warning("Cannot plot figure. Error msg '%s'" % e)
 
   try:
       plt.show()
   except Exception as e:
-      warning("Cannot show figure. Error msg '%s'" % e.message)
+      warning("Cannot show figure. Error msg '%s'" % e)
 
   file = File('Nonlinear Streamfunction.pvd')
   file.write(psi_non)
@@ -249,12 +249,12 @@ nonlinear solution. We do this by defining a weak form.  (Note: other approaches
   try:
       plot(difference)
   except Exception as e:
-      warning("Cannot plot figure. Error msg '%s'" % e.message)
+      warning("Cannot plot figure. Error msg '%s'" % e)
 
   try:
       plt.show()
   except Exception as e:
-      warning("Cannot show figure. Error msg '%s'" % e.message)
+      warning("Cannot show figure. Error msg '%s'" % e)
 
   file = File('Difference between Linear and Nonlinear Streamfunction.pvd')
   file.write(difference) 

--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -157,14 +157,14 @@ matplotlib.pyplot should be installed and imported::
   try:
     plot(u)
   except Exception as e:
-    warning("Cannot plot figure. Error msg '%s'" % e.message)
+    warning("Cannot plot figure. Error msg '%s'" % e)
 
 Don't forget to show the image::
 
   try:
     plt.show()
   except Exception as e:
-    warning("Cannot show figure. Error msg '%s'" % e.message)
+    warning("Cannot show figure. Error msg '%s'" % e)
 
 This demo is based on the corresponding `DOLFIN mixed Poisson demo
 <http://fenicsproject.org/olddocs/dolfin/1.3.0/python/demo/documented/mixed-poisson/python/documentation.html>`__

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1145,7 +1145,7 @@ try:
 except Exception as e:
     log.warning("Unable to save configuration to a JSON file")
     log.warning("Error Message:")
-    log.warning(e.message)
+    log.warning(str(e))
 
 if mode == "update":
     try:


### PR DESCRIPTION
Python3 exceptions do not have a .message attribute, rather the message
is available via the __str__() method.