### PR TITLE
Fix coefficient mapping for Slate subkernels

### DIFF
--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -1,8 +1,6 @@
 """This module provides custom python preconditioners utilizing
 the Slate language.
 """
-
-
 import ufl
 
 from firedrake.matrix_free.preconditioners import PCBase

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -136,16 +136,14 @@ def compile_expression(slate_expr, tsfc_parameters=None):
 
             # If tensor is mixed, there will be more than one SplitKernel
             incl = []
-            split_forms = cxt_kernel.form_indices_map
             for splitkernel in cxt_kernel.tsfc_kernels:
                 index = splitkernel.indices
                 kinfo = splitkernel.kinfo
 
                 # Generate an iterable of coefficients to pass to the subkernel
                 # if any are required.
-                sform = split_forms[index]
                 clist = [c for i in kinfo.coefficient_map
-                         for c in builder.coefficient(sform.coefficients()[i])]
+                         for c in builder.coefficient(cxt_kernel.coefficients[i])]
 
                 if kinfo.oriented:
                     clist.insert(0, cell_orientations)
@@ -328,7 +326,6 @@ def extruded_int_horiz_facet(cxt_kernel, builder, coordsym, mesh_layer_sym,
     incl = []
     top_calls = []
     bottom_calls = []
-    split_forms = cxt_kernel.form_indices_map
     for top, btm in zip(top_sks, bottom_sks):
         assert top.indices == btm.indices, (
             "Top and bottom kernels must have the same indices"
@@ -340,10 +337,8 @@ def extruded_int_horiz_facet(cxt_kernel, builder, coordsym, mesh_layer_sym,
         c_set = top.kinfo.coefficient_map + btm.kinfo.coefficient_map
         coefficient_map = tuple(OrderedDict.fromkeys(c_set))
 
-        # Split form for this particular splitkernel
-        sform = split_forms[index]
         clist = [c for i in coefficient_map
-                 for c in builder.coefficient(sform.coefficients()[i])]
+                 for c in builder.coefficient(cxt_kernel.coefficients[i])]
 
         if top.kinfo.oriented and btm.kinfo.oriented:
             clist.insert(0, cell_orientations)
@@ -390,17 +385,14 @@ def extruded_top_bottom_facet(cxt_kernel, builder, coordsym, mesh_layer_sym,
 
     incl = []
     body = []
-    split_forms = cxt_kernel.form_indices_map
     for splitkernel in cxt_kernel.tsfc_kernels:
         index = splitkernel.indices
         kinfo = splitkernel.kinfo
 
         # Generate an iterable of coefficients to pass to the subkernel
         # if any are required.
-        # Split form for this particular splitkernel
-        sform = split_forms[index]
         clist = [c for i in kinfo.coefficient_map
-                 for c in builder.coefficient(sform.coefficients()[i])]
+                 for c in builder.coefficient(cxt_kernel.coefficients[i])]
 
         if kinfo.oriented:
             clist.insert(0, cell_orientations)
@@ -466,17 +458,14 @@ def facet_integral_loop(cxt_kernel, builder, coordsym, cellfacetsym,
     incl = []
     funcalls = []
     checker = chker[it_type]
-    split_forms = cxt_kernel.form_indices_map
     for splitkernel in cxt_kernel.tsfc_kernels:
         index = splitkernel.indices
         kinfo = splitkernel.kinfo
 
         # Generate an iterable of coefficients to pass to the subkernel
         # if any are required.
-        # Split form for this particular splitkernel
-        sform = split_forms[index]
         clist = [c for i in kinfo.coefficient_map
-                 for c in builder.coefficient(sform.coefficients()[i])]
+                 for c in builder.coefficient(cxt_kernel.coefficients[i])]
 
         incl.extend(kinfo.kernel._include_dirs)
         tensor = eigen_tensor(exp, t, index)

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -11,27 +11,22 @@ from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl import Form
 
 
-ContextKernel_ = collections.namedtuple("ContextKernel",
-                                        ["tensor",
-                                         "form_indices_map",
-                                         "original_integral_type",
-                                         "tsfc_kernels"])
+ContextKernel = collections.namedtuple("ContextKernel",
+                                       ["tensor",
+                                        "form_indices_map",
+                                        "original_integral_type",
+                                        "tsfc_kernels"])
+ContextKernel.__doc__ = """\
+A bundled object containing all relevant information to
+evaluate a terminal Slate tensor.
 
-
-class ContextKernel(ContextKernel_):
-    """A bundled object containing all relevant information to
-    evaluate a terminal Slate tensor.
-
-    :param tensor: The terminal Slate tensor.
-    :param form_indices_map: A `dict` mapping local form index
-                             to the corresponding (split) form.
-    :param original_integral_type: The unmodified measure type
-                                   of the form integrals.
-    :param tsfc_kernels: A list of local tensor assembly kernels
-                         provided by TSFC.
-    """
-
-    pass
+:param tensor: The terminal Slate tensor.
+:param form_indices_map: A `dict` mapping local form index
+                         to the corresponding (split) form.
+:param original_integral_type: The unmodified measure type
+                               of the form integrals.
+:param tsfc_kernels: A list of local tensor assembly kernels
+                     provided by TSFC."""
 
 
 def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None):

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -2,7 +2,6 @@ import collections
 
 from functools import partial
 
-from firedrake.formmanipulation import split_form
 from firedrake.slate.slate import Tensor
 from firedrake.slate.slac.utils import RemoveRestrictions
 from firedrake.tsfc_interface import compile_form as tsfc_compile
@@ -13,16 +12,17 @@ from ufl import Form
 
 ContextKernel = collections.namedtuple("ContextKernel",
                                        ["tensor",
-                                        "form_indices_map",
+                                        "coefficients",
                                         "original_integral_type",
                                         "tsfc_kernels"])
 ContextKernel.__doc__ = """\
-A bundled object containing all relevant information to
-evaluate a terminal Slate tensor.
+A bundled object containing TSFC subkernels corresponding to a
+particular integral type.
 
-:param tensor: The terminal Slate tensor.
-:param form_indices_map: A `dict` mapping local form index
-                         to the corresponding (split) form.
+:param tensor: The terminal Slate tensor corresponding to the
+               list of TSFC assembly kernels.
+:param coefficients: The local coefficients of the tensor contained
+                     in the integrands (arguments for TSFC subkernels).
 :param original_integral_type: The unmodified measure type
                                of the form integrals.
 :param tsfc_kernels: A list of local tensor assembly kernels
@@ -65,7 +65,7 @@ def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None):
                                subkernel_prefix,
                                parameters=tsfc_parameters)
         cxt_k = ContextKernel(tensor=tensor,
-                              form_indices_map=dict(split_form(form)),
+                              coefficients=form.coefficients(),
                               original_integral_type=orig_it_type,
                               tsfc_kernels=kernels)
         cxt_kernels.append(cxt_k)

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -1,4 +1,3 @@
-
 import collections
 
 from coffee import base as ast


### PR DESCRIPTION
A small, but important change. Basically forms with several coefficients weren't properly being organized and led to nasty errors in the generated code (discovered by Colin). The cause: coefficients weren't being mapped properly to their corresponding assembly kernels. This appears to fix it up.

Some additional minor changes were also made (rearranging code blocks, deleting extra whitespace, etc.)