### PR TITLE
Fix/kernel cache

### DIFF
--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -95,8 +95,8 @@ class TSFCKernel(Cached):
         # unnecessary repeated calls to TSFC when actually only the kernel code
         # needs to be regenerated
         return md5((form.signature() + name
-                   + str(default_parameters["coffee"])
-                   + str(parameters)
+                    + str(sorted(default_parameters["coffee"].items()))
+                    + str(sorted(parameters.items()))
                     + str(number_map)).encode()).hexdigest(), form.ufl_domains()[0].comm
 
     def __init__(self, form, name, parameters, number_map):


### PR DESCRIPTION
I was wondering why the test suite with a warm disk cache was taking so long.  Turns out we screwed up in the py3 switch-over so the TSFCKernel cache key was not consistent across invocations.