### PR TITLE
Higher order octahedral meshes

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -958,13 +958,14 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     r = ufl.sqrt(Xlow[0]**2 + Xlow[1]**2 + Xlow[2]**2)
     Xradial = m.coordinates.copy(deepcopy=True).interpolate(Xlow/r)
 
-    dz = 1./2**refinement_level
-    ntaper = 1
-    # when z=1-dz, s=1, when z=1-(ntaper+1)*dz, s=0
-    s = (abs(z)-1+(ntaper+1)*dz)/(ntaper*dz)
-    taper = ufl.conditional(ufl.gt(s, 1),
-                            1,
-                            ufl.conditional(ufl.gt(s, 0), s, 0))
+    zramp = 0.8
+    s = (abs(z) - zramp)/(1-zramp)
+    exp = ufl.exp
+    taper = ufl.conditional(ufl.gt(s, 1.0-tol),
+                            1.0,
+                            ufl.conditional(ufl.gt(s, tol),
+                            exp(-1.0/s)/(exp(-1.0/s) + exp(-1.0/(1.0-s))),
+                            0.))
     m.coordinates.interpolate(taper*Xradial + (1-taper)*Xlatitudinal)
     m._radius = radius
     return m

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -866,7 +866,9 @@ def UnitIcosahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
 
 
 def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
-                         hemisphere="both", reorder=None,
+                         hemisphere="both",
+                         z0=0.8,
+                         reorder=None,
                          comm=COMM_WORLD):
     """Generate an octahedral approximation to the surface of the
     sphere.
@@ -877,6 +879,10 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     :kwarg degree: polynomial degree of coordinate space (defaults
         to 1: flat triangles)
     :kwarg hemisphere: One of "both" (default), "north", or "south"
+    :kwarg z0: for abs(z/R)>z0, blend from a mesh where the higher-order
+    non-vertex nodes are on lines of latitude to a mesh where these nodes
+    are just pushed out radially from the equivalent P1 mesh. (defaults to
+    z0=0.8).
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).
@@ -958,8 +964,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     r = ufl.sqrt(Xlow[0]**2 + Xlow[1]**2 + Xlow[2]**2)
     Xradial = m.coordinates.copy(deepcopy=True).interpolate(Xlow/r)
 
-    zramp = 0.8
-    s = (abs(z) - zramp)/(1-zramp)
+    s = (abs(z) - z0)/(1-z0)
     exp = ufl.exp
     taper = ufl.conditional(ufl.gt(s, 1.0-tol),
                             1.0,
@@ -972,7 +977,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
 
 
 def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
-                             hemisphere="both", reorder=None,
+                             hemisphere="both", z0=0.8, reorder=None,
                              comm=COMM_WORLD):
     """Generate an octahedral approximation to the unit sphere.
 
@@ -981,12 +986,17 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
     :kwarg degree: polynomial degree of coordinate space (defaults
         to 1: flat triangles)
     :kwarg hemisphere: One of "both" (default), "north", or "south"
+    :kwarg z0: for abs(z/R)>z0, blend from a mesh where the higher-order
+    non-vertex nodes are on lines of latitude to a mesh where these nodes
+    are just pushed out radially from the equivalent P1 mesh. (defaults to
+    z0=0.8).
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).
     """
     return OctahedralSphereMesh(1.0, refinement_level=refinement_level,
                                 degree=degree, hemisphere=hemisphere,
+                                z0=z0,
                                 reorder=reorder,
                                 comm=comm)
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -887,9 +887,9 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
         to 1: flat triangles)
     :kwarg hemisphere: One of "both" (default), "north", or "south"
     :kwarg z0: for abs(z/R)>z0, blend from a mesh where the higher-order
-    non-vertex nodes are on lines of latitude to a mesh where these nodes
-    are just pushed out radially from the equivalent P1 mesh. (defaults to
-    z0=0.8).
+        non-vertex nodes are on lines of latitude to a mesh where these nodes
+        are just pushed out radially from the equivalent P1 mesh. (defaults to
+        z0=0.8).
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).
@@ -962,14 +962,15 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     znew = ufl.sin(phi)
     # Make a copy of the coordinates so that we can blend two different
     # mappings near the pole
-    Xlatitudinal = m.coordinates.copy(deepcopy=True)
-    Xlatitudinal.interpolate(Constant(radius)*ufl.as_vector([x*scale,
-                                                             y*scale,
-                                                             znew]))
+    Vc = m.coordinates.function_space()
+    Xlatitudinal = interpolate(Constant(radius)*ufl.as_vector([x*scale,
+                                                               y*scale,
+                                                               znew]),
+                               Vc)
     Vlow = VectorFunctionSpace(m, "CG", 1)
-    Xlow = Function(Vlow).interpolate(Xlatitudinal)
+    Xlow = interpolate(Xlatitudinal, Vlow)
     r = ufl.sqrt(Xlow[0]**2 + Xlow[1]**2 + Xlow[2]**2)
-    Xradial = m.coordinates.copy(deepcopy=True).interpolate(Xlow/r)
+    Xradial = Constant(radius)*Xlow/r
 
     s = (abs(z) - z0)/(1-z0)
     exp = ufl.exp
@@ -994,9 +995,9 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
         to 1: flat triangles)
     :kwarg hemisphere: One of "both" (default), "north", or "south"
     :kwarg z0: for abs(z)>z0, blend from a mesh where the higher-order
-    non-vertex nodes are on lines of latitude to a mesh where these nodes
-    are just pushed out radially from the equivalent P1 mesh. (defaults to
-    z0=0.8).
+        non-vertex nodes are on lines of latitude to a mesh where these nodes
+        are just pushed out radially from the equivalent P1 mesh. (defaults to
+        z0=0.8).
     :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on (defaults to
         COMM_WORLD).

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -984,13 +984,8 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
 
 
 def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
-<<<<<<< HEAD
                              hemisphere="both", z0=0.8, reorder=None,
-                             comm=COMM_WORLD):
-=======
-                             hemisphere="both", reorder=None,
                              distribute=None, comm=COMM_WORLD):
->>>>>>> master
     """Generate an octahedral approximation to the unit sphere.
 
     :kwarg refinement_level: optional number of refinements (0 is an

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -949,12 +949,14 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     znew = ufl.sin(phi)
     # Make a copy of the coordinates so that we can blend two different
     # mappings near the pole
-    Xhigh = m.coordinates.copy(deepcopy=True)
-    Xhigh.interpolate(Constant(radius)*ufl.as_vector([x*scale,
-                                                      y*scale,
-                                                      znew]))
+    Xlatitudinal = m.coordinates.copy(deepcopy=True)
+    Xlatitudinal.interpolate(Constant(radius)*ufl.as_vector([x*scale,
+                                                             y*scale,
+                                                             znew]))
     Vlow = VectorFunctionSpace(m, "CG", 1)
-    Xlow = Function(Vlow).interpolate(Xhigh)
+    Xlow = Function(Vlow).interpolate(Xlatitudinal)
+    r = ufl.sqrt(Xlow[0]**2 + Xlow[1]**2 + Xlow[2]**2)
+    Xradial = m.coordinates.copy(deepcopy=True).interpolate(Xlow/r)
 
     dz = 1./2**refinement_level
     ntaper = 1
@@ -963,7 +965,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     taper = ufl.conditional(ufl.gt(s, 1),
                             1,
                             ufl.conditional(ufl.gt(s, 0), s, 0))
-    m.coordinates.interpolate(taper*Xlow + (1-taper)*Xhigh)
+    m.coordinates.interpolate(taper*Xradial + (1-taper)*Xlatitudinal)
     m._radius = radius
     return m
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -986,7 +986,7 @@ def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
     :kwarg degree: polynomial degree of coordinate space (defaults
         to 1: flat triangles)
     :kwarg hemisphere: One of "both" (default), "north", or "south"
-    :kwarg z0: for abs(z/R)>z0, blend from a mesh where the higher-order
+    :kwarg z0: for abs(z)>z0, blend from a mesh where the higher-order
     non-vertex nodes are on lines of latitude to a mesh where these nodes
     are just pushed out radially from the equivalent P1 mesh. (defaults to
     z0=0.8).

--- a/tests/regression/test_octahedral_hemisphere.py
+++ b/tests/regression/test_octahedral_hemisphere.py
@@ -41,12 +41,6 @@ def run_test(degree, refinements, hemisphere):
     solve(a == L, u, bcs=bc,
           solver_parameters={"ksp_type": "preonly",
                              "pc_type": "lu"})
-
-    f = File('octa_'+str(refinements)+'.pvd')
-    uerr = Function(V).interpolate(exact)
-    f.write(uerr)
-    uerr -= u
-    f.write(uerr)
     return errornorm(u, interpolate(exact, V))
 
 

--- a/tests/regression/test_octahedral_hemisphere.py
+++ b/tests/regression/test_octahedral_hemisphere.py
@@ -53,5 +53,4 @@ def run_test(degree, refinements, hemisphere):
 def test_octahedral_hemisphere(degree, hemisphere, convergence):
     errs = numpy.asarray([run_test(degree, r, hemisphere) for r in range(3, 6)])
     l2conv = numpy.log2(errs[:-1] / errs[1:])
-    print(l2conv)
     assert (l2conv > convergence).all()

--- a/tests/regression/test_octahedral_hemisphere.py
+++ b/tests/regression/test_octahedral_hemisphere.py
@@ -4,8 +4,7 @@ from firedrake import *
 import numpy
 
 
-@pytest.fixture(params=[1, 2,
-                        pytest.mark.xfail(reason="Grid imprinting near pole?")(3)])
+@pytest.fixture(params=[1, 2, 3])
 def degree(request):
     return request.param
 
@@ -43,10 +42,16 @@ def run_test(degree, refinements, hemisphere):
           solver_parameters={"ksp_type": "preonly",
                              "pc_type": "lu"})
 
+    f = File('octa_'+str(refinements)+'.pvd')
+    uerr = Function(V).interpolate(exact)
+    f.write(uerr)
+    uerr -= u
+    f.write(uerr)
     return errornorm(u, interpolate(exact, V))
 
 
 def test_octahedral_hemisphere(degree, hemisphere, convergence):
     errs = numpy.asarray([run_test(degree, r, hemisphere) for r in range(3, 6)])
     l2conv = numpy.log2(errs[:-1] / errs[1:])
+    print(l2conv)
     assert (l2conv > convergence).all()


### PR DESCRIPTION
Higher order octahedral meshes

This fixes a previous xfail noted by Lawrence, that there was a
convergence loss for higher order meshes near the pole.

This turned out to be because the coordinate mapping from the
octahedron to the sphere always maps the top four triangles to
pi/2 sectors. The shape of the edges doesn't matter for P1
coordinates, but higher order coordinates lead to a curved edge
around the cell and these cells never converge to flat triangles
as the mesh is refined. I fixed this by making a second
coordinate field that is interpolated from the equivalent P1
mesh, and then pushed out radially to the sphere. This mesh does
not have nodes aligned along lines of constant latitude, so the final
step is to blend between the two meshes. For z/R<z0, we keep the
latitudinally aligned mesh. For z/r>z0 we blend between the two
meshes using a C_infty ramping function, so that near the pole,
the mesh looks like the second coordinate field.