### PR TITLE
Add Slate node for assembled data

### DIFF
--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -119,7 +119,7 @@ class LinearSolver(solving_utils.ParametersMixin):
             bc.apply(b)
         from firedrake.assemble import _assemble
         if isinstance(self.A.a, slate.TensorBase):
-            return _assemble(self.A.a * b)
+            return _assemble(self.A.a * slate.AssembledVector(b))
         else:
             return _assemble(ufl.action(self.A.a, b))
 

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -249,12 +249,12 @@ class HybridizationPC(PCBase):
 
         M = D - C * A.inv * B
         R = K_1.T - C * A.inv * K_0.T
-        u_rec = M.inv * f - M.inv * (C * A.inv * g + R * lambdar)
+        u_rec = M.inv * (f - C * A.inv * g - R * lambdar)
         self._sub_unknown = create_assembly_callable(u_rec,
                                                      tensor=u,
                                                      form_compiler_parameters=self.cxt.fc_params)
 
-        sigma_rec = A.inv * g - A.inv * (B * AssembledVector(u) + K_0.T * lambdar)
+        sigma_rec = A.inv * (g - B * AssembledVector(u) - K_0.T * lambdar)
         self._elim_unknown = create_assembly_callable(sigma_rec,
                                                       tensor=sigma,
                                                       form_compiler_parameters=self.cxt.fc_params)

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -83,7 +83,7 @@ def compile_expression(slate_expr, tsfc_parameters=None):
     statements.extend(subkernel_calls)
 
     # Create coefficient temporaries if necessary
-    if builder.action_coefficients:
+    if builder.coefficient_vecs:
         coefficient_temps = coefficient_temporaries(builder, declared_temps)
         statements.extend(coefficient_temps)
 
@@ -243,19 +243,19 @@ def coefficient_temporaries(builder, declared_temps):
                          temporaries. This dictionary is updated
                          as coefficients are assigned temporaries.
 
-    Action computations require creating coefficient temporaries to
-    compute the matrix-vector product. The temporaries are created by
-    inspecting the function space of the coefficient to compute node
-    and dof extents. The coefficient is then assigned values by looping
-    over both the node extent and dof extent (double FOR-loop). A double
-    FOR-loop is needed for each function space (if the function space is
-    mixed, then a loop will be constructed for each component space).
-    The general structure of each coefficient loop will be:
+    'AssembledVector's require creating coefficient temporaries to
+    store data. The temporaries are created by inspecting the function
+    space of the coefficient to compute node and dof extents. The
+    coefficient is then assigned values by looping over both the node
+    extent and dof extent (double FOR-loop). A double FOR-loop is needed
+    for each function space (if the function space is mixed, then a loop
+    will be constructed for each component space). The general structure
+    of each coefficient loop will be:
 
          FOR (i1=0; i1<node_extent; i1++):
              FOR (j1=0; j1<dof_extent; j1++):
-                 wT0[offset + (dof_extent * i1) + j1] = w_0_0[i1][j1]
-                 wT1[offset + (dof_extent * i1) + j1] = w_1_0[i1][j1]
+                 VT0[offset + (dof_extent * i1) + j1] = w_0_0[i1][j1]
+                 VT1[offset + (dof_extent * i1) + j1] = w_1_0[i1][j1]
                  .
                  .
                  .
@@ -271,25 +271,26 @@ def coefficient_temporaries(builder, declared_temps):
     i_sym = ast.Symbol("i1")
     j_sym = ast.Symbol("j1")
     loops = [ast.FlatBlock("/* Loops for coefficient temps */\n")]
-    for (nodes, dofs), cinfo_list in builder.action_coefficients.items():
+    for (nodes, dofs), cinfo_list in builder.coefficient_vecs.items():
         # Collect all coefficients which share the same node/dof extent
         assignments = []
         for cinfo in cinfo_list:
             fs_i = cinfo.space_index
             offset = cinfo.offset_index
             c_shape = cinfo.shape
-            actee = cinfo.coefficient
+            vector = cinfo.vector
+            function = vector._function
 
-            if actee not in declared_temps:
+            if vector not in declared_temps:
                 # Declare and initialize coefficient temporary
                 c_type = eigen_matrixbase_type(shape=c_shape)
-                t = ast.Symbol("wT%d" % len(declared_temps))
+                t = ast.Symbol("VT%d" % len(declared_temps))
                 statements.append(ast.Decl(c_type, t))
                 statements.append(ast.FlatBlock("%s.setZero();\n" % t))
-                declared_temps[actee] = t
+                declared_temps[vector] = t
 
             # Assigning coefficient values into temporary
-            coeff_sym = ast.Symbol(builder.coefficient(actee)[fs_i],
+            coeff_sym = ast.Symbol(builder.coefficient(function)[fs_i],
                                    rank=(i_sym, j_sym))
             index = ast.Sum(offset,
                             ast.Sum(ast.Prod(dofs, i_sym), j_sym))
@@ -469,8 +470,8 @@ def metaphrase_slate_to_cpp(expr, temps, prec=None):
         representation of the `slate.TensorBase` expr.
     """
     # If the tensor is terminal, it has already been declared.
-    # Coefficients in action expressions will have been declared by now,
-    # as well as any other nodes with high reference count.
+    # Coefficients defined as AssembledVectors will have been declared
+    # by now, as well as any other nodes with high reference count.
     if expr in temps:
         return temps[expr].gencode()
 
@@ -495,14 +496,6 @@ def metaphrase_slate_to_cpp(expr, temps, prec=None):
                                op,
                                metaphrase_slate_to_cpp(B, temps, expr.prec))
 
-        return parenthesize(result, expr.prec, prec)
-
-    elif isinstance(expr, slate.Action):
-        tensor, = expr.operands
-        c, = expr.actee
-        result = "(%s) * %s" % (metaphrase_slate_to_cpp(tensor,
-                                                        temps,
-                                                        expr.prec), temps[c])
         return parenthesize(result, expr.prec, prec)
 
     else:

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -487,9 +487,8 @@ def metaphrase_slate_to_cpp(expr, temps, prec=None):
         result = "-%s" % metaphrase_slate_to_cpp(tensor, temps, expr.prec)
         return parenthesize(result, expr.prec, prec)
 
-    elif isinstance(expr, (slate.Add, slate.Sub, slate.Mul)):
+    elif isinstance(expr, (slate.Add, slate.Mul)):
         op = {slate.Add: '+',
-              slate.Sub: '-',
               slate.Mul: '*'}[type(expr)]
         A, B = expr.operands
         result = "%s %s %s" % (metaphrase_slate_to_cpp(A, temps, expr.prec),

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -31,7 +31,7 @@ from ufl.form import Form
 
 __all__ = ['AssembledVector', 'Tensor',
            'Inverse', 'Transpose', 'Negative',
-           'Add', 'Sub', 'Mul', 'Action']
+           'Add', 'Mul', 'Action']
 
 
 class CheckRestrictions(MultiFunction):
@@ -151,7 +151,7 @@ class TensorBase(object, metaclass=ABCMeta):
 
     def __sub__(self, other):
         if isinstance(other, TensorBase):
-            return Sub(self, other)
+            return Add(self, Negative(other))
         else:
             raise NotImplementedError("Type(s) for - not supported: '%s' '%s'"
                                       % (type(self), type(other)))
@@ -564,32 +564,6 @@ class Add(BinaryOp):
         return A.arguments()
 
 
-class Sub(BinaryOp):
-    """Abstract Slate class representing matrix-matrix, vector-vector
-     or scalar-scalar subtraction.
-
-    :arg A: a :class:`TensorBase` object.
-    :arg B: another :class:`TensorBase` object.
-    """
-
-    def __init__(self, A, B):
-        """Constructor for the Sub class."""
-        if A.shape != B.shape:
-            raise ValueError("Illegal op on a %s-tensor with a %s-tensor."
-                             % (A.shape, B.shape))
-        super(Sub, self).__init__(A, B)
-
-    def arguments(self):
-        """Returns a tuple of arguments associated with the tensor."""
-        A, B = self.operands
-        assert [argA.function_space() == argB.function_space()
-                for argA in A.arguments()
-                for argB in B.arguments()], (
-                    "Arguments must share the same function space."
-        )
-        return A.arguments()
-
-
 class Mul(BinaryOp):
     """Abstract Slate class representing the interior product or two tensors.
     By interior product, we mean an operation that results in a tensor of
@@ -685,9 +659,9 @@ class Action(TensorOp):
 
 # Establishes levels of precedence for Slate tensors
 precedences = [
-    [Tensor],
+    [Tensor, AssembledVector],
     [UnaryOp],
-    [Add, Sub],
+    [Add],
     [Mul, Action]
 ]
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -67,7 +67,9 @@ class TensorBase(object, metaclass=ABCMeta):
 
     @abstractmethod
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on. For example, if A is a rank-2 tensor
+        defined on V x W, then this method returns (V, W).
         """
 
     @abstractmethod
@@ -229,14 +231,16 @@ class TensorBase(object, metaclass=ABCMeta):
 
 
 class AssembledVector(TensorBase):
-    """
+    """This class is a symbolic representation of an assembled
+    vector of data contained in a :class:`firedrake.Function`.
+
+    :arg function: A firedrake function.
     """
 
     operands = ()
 
     def __init__(self, function):
-        """
-        """
+        """Constructor for the AssembledVector class."""
         if not isinstance(function, Function):
             raise TypeError("Object must be a firedrake function.")
 
@@ -245,7 +249,8 @@ class AssembledVector(TensorBase):
         self._function = function
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         return (self._function.function_space(),)
 
@@ -272,7 +277,6 @@ class AssembledVector(TensorBase):
         """Returns a mapping on the tensor:
         ``{domain:{integral_type: subdomain_data}}``.
         """
-        # FIXME: ???
         return {self.ufl_domain(): {"cell": None}}
 
     def _output_string(self, prec=None):
@@ -336,7 +340,8 @@ class Tensor(TensorBase):
         self.form = form
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         return tuple(arg.function_space() for arg in self.arguments())
 
@@ -458,7 +463,8 @@ class Inverse(UnaryOp):
         super(Inverse, self).__init__(A)
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         tensor, = self.operands
         return tensor.arg_function_spaces()[::-1]
@@ -480,7 +486,8 @@ class Transpose(UnaryOp):
     """An abstract Slate class representing the transpose of a tensor."""
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         tensor, = self.operands
         return tensor.arg_function_spaces()[::-1]
@@ -502,7 +509,8 @@ class Negative(UnaryOp):
     """Abstract Slate class representing the negation of a tensor object."""
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         tensor, = self.operands
         return tensor.arg_function_spaces()
@@ -586,7 +594,8 @@ class Add(BinaryOp):
         self._args = A.arguments()
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         A, _ = self.operands
         return A.arg_function_spaces()
@@ -624,7 +633,8 @@ class Mul(BinaryOp):
         self._args = A.arguments()[:-1] + B.arguments()[1:]
 
     def arg_function_spaces(self):
-        """
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
         """
         A, B = self.operands
         return A.arg_function_spaces()[:-1] + B.arg_function_spaces()[1:]

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -254,14 +254,17 @@ class AssembledVector(TensorBase):
         """
         return (self._function.function_space(),)
 
+    @cached_property
+    def _argument(self):
+        """Generates a 'test function' associated with this class."""
+        from firedrake.ufl_expr import TestFunction
+
+        V, = self.arg_function_spaces()
+        return TestFunction(V)
+
     def arguments(self):
         """Returns a tuple of arguments associated with the tensor."""
-        return ()
-
-    @cached_property
-    def rank(self):
-        """Returns the rank information of the tensor object."""
-        return 1
+        return (self._argument,)
 
     def coefficients(self):
         """Returns a tuple of coefficients associated with the tensor."""

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -71,14 +71,15 @@ def rank_two_tensor(mass):
 
 
 def test_tensor_action(mass, f):
-    V = assemble(Tensor(mass) * f)
+    V = assemble(Tensor(mass) * AssembledVector(f))
     ref = assemble(action(mass, f))
     assert isinstance(V, Function)
     assert np.allclose(V.dat.data, ref.dat.data, rtol=1e-14)
 
 
 def test_sum_tensor_actions(mass, f, g):
-    V = assemble(Tensor(mass) * f + Tensor(0.5*mass) * g)
+    V = assemble(Tensor(mass) * AssembledVector(f)
+                 + Tensor(0.5*mass) * AssembledVector(g))
     ref = assemble(action(mass, f) + action(0.5*mass, g))
     assert isinstance(V, Function)
     assert np.allclose(V.dat.data, ref.dat.data, rtol=1e-14)

--- a/tests/slate/test_linear_algebra.py
+++ b/tests/slate/test_linear_algebra.py
@@ -87,6 +87,8 @@ def test_aggressive_unaryop_nesting():
     g = Function(V)
     f.assign(1.0)
     g.assign(0.5)
+    F = AssembledVector(f)
+    G = AssembledVector(g)
     u = TrialFunction(V)
     v = TestFunction(V)
 
@@ -94,7 +96,7 @@ def test_aggressive_unaryop_nesting():
     B = Tensor(2.0*u*v*dx)
 
     # This is a very silly way to write the vector of ones
-    foo = (B.T*A.inv).T*g + (-A.inv.T*B.T).inv*f + B.inv*(A.T).T*f
+    foo = (B.T*A.inv).T*G + (-A.inv.T*B.T).inv*F + B.inv*(A.T).T*F
     assert np.allclose(assemble(foo).dat.data, np.ones(V.node_count))
 
 

--- a/tests/slate/test_slate_infrastructure.py
+++ b/tests/slate/test_slate_infrastructure.py
@@ -175,8 +175,8 @@ def test_equality_relations(function_space):
     V = function_space
     u = TrialFunction(V)
     v = TestFunction(V)
-    f = Function(V)
 
+    f = AssembledVector(Function(V))
     A = Tensor(u * v * dx)
     B = Tensor(inner(grad(u), grad(v)) * dx)
 


### PR DESCRIPTION
This PR adds a new class: `AssembledVector`. This object associates firedrake functions with local element vectors. With this new class, the `Action` node is now obsolete and the `Mul` node can now handle these "actions." I also removed the `Sub` node, as it was basically just duplicate code which could be eliminated by writing A - B as A + -B.

TL;DR: Slate is officially closed under all binary operations. No need for the hacky `Action` node.