### PR TITLE
fix TypeError when writing bibtex file

### DIFF
--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -173,7 +173,7 @@ if args.release_tag:
 
 If the release has only just been created, then the information may not yet have propagated to Zenodo yet. Please try again later.""")
         sys.exit(1)
-    open(args.bibtex_file[0], "w").write(bibtex)
+    open(args.bibtex_file[0], "wb").write(bibtex)
     log.info("Bibliography written to %s" % args.bibtex_file[0])
     sys.exit(0)
 


### PR DESCRIPTION
Without this, I get
```
(firedrake) andrew@ubuntu:~/sph-geom-paper$ firedrake-zenodo --bibtex Firedrake_20171018.0
Retrieving BibTeX data for Firedrake release Firedrake_20171018.0.
This may take a few seconds.
Traceback (most recent call last):
  File "/home/andrew/firedrake/bin/firedrake-zenodo", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/andrew/firedrake/src/firedrake/scripts/firedrake-zenodo", line 176, in <module>
    open(args.bibtex_file[0], "w").write(bibtex)
TypeError: write() argument must be str, not bytes
```