### PR TITLE
Hybridmixedbcs

### DIFF
--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -157,7 +157,12 @@ class HybridizationPC(PCBase):
                 if bc.function_space().index != self.vidx:
                     raise NotImplementedError("Dirichlet bc set on unsupported space.")
                 # append the set of sub domains
-                neumann_subdomains |= set([bc.sub_domain])
+                subdom = bc.sub_domain
+                if isinstance(subdom, str):
+                    neumann_subdomains |= set([subdom])
+                else:
+                    neumann_subdomains |= set(as_tuple(subdom, int))
+
             # separate out the top and bottom bcs
             extruded_neumann_subdomains = neumann_subdomains & {"top", "bottom"}
             neumann_subdomains = neumann_subdomains.difference(extruded_neumann_subdomains)

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -157,7 +157,7 @@ class HybridizationPC(PCBase):
                 if bc.function_space().index != self.vidx:
                     raise NotImplementedError("Dirichlet bc set on unsupported space.")
                 # append the set of sub domains
-                neumann_subdomains |= set(bc.sub_domain)
+                neumann_subdomains |= set([bc.sub_domain])
             # separate out the top and bottom bcs
             extruded_neumann_subdomains = neumann_subdomains & {"top", "bottom"}
             neumann_subdomains = neumann_subdomains.difference(extruded_neumann_subdomains)

--- a/tests/slate/test_slate_hybridized_mixed_bcs.py
+++ b/tests/slate/test_slate_hybridized_mixed_bcs.py
@@ -2,10 +2,12 @@ import pytest
 from firedrake import *
 
 
+@pytest.mark.parametrize("subdomain", ["on_boundary",
+                                       pytest.mark.xfail(reason="Subdomains not yet implemented in Slate", strict=True)((1, 2))])
 @pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
                          [(1, "RT", False), (1, "RTCF", True),
                           (2, "RT", False), (2, "RTCF", True)])
-def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
+def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral, subdomain):
     # Create a mesh
     mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
     RT = FunctionSpace(mesh, hdiv_family, degree)
@@ -36,63 +38,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
                                                   'ksp_rtol': 1e-14},
                                 'hdiv_projection': {'ksp_type': 'cg',
                                                     'ksp_rtol': 1e-14}}}
-    bcs = [DirichletBC(W[0], Constant((0., 0.)), "on_boundary")]
-
-    solve(a == L, w, solver_parameters=params, bcs=bcs)
-    sigma_h, u_h = w.split()
-
-    # (Non-hybrid)
-    w2 = Function(W)
-    solve(a == L, w2,
-          solver_parameters={'pc_type': 'lu',
-                             'mat_type': 'aij',
-                             'ksp_type': 'preonly'}, bcs=bcs)
-    nh_sigma, nh_u = w2.split()
-
-    # Return the L2 error
-    sigma_err = errornorm(sigma_h, nh_sigma)
-    u_err = errornorm(u_h, nh_u)
-
-    assert sigma_err < 1e-11
-    assert u_err < 1e-11
-
-
-@pytest.mark.xfail(reason="Subdomains not yet implemented in Slate")
-@pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
-                         [(1, "RT", False), (1, "RTCF", True),
-                          (2, "RT", False), (2, "RTCF", True)])
-def test_slate_hybridized_12_bcs(degree, hdiv_family, quadrilateral):
-    # Create a mesh
-    mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
-    RT = FunctionSpace(mesh, hdiv_family, degree)
-    DG = FunctionSpace(mesh, "DG", degree - 1)
-    W = RT * DG
-    sigma, u = TrialFunctions(W)
-    tau, v = TestFunctions(W)
-
-    # Define the source function
-    f = Function(DG)
-    x, y = SpatialCoordinate(mesh)
-    f.interpolate((1+8*pi*pi)*cos(x*pi*2)*cos(y*pi*2))
-
-    # Define the variational forms
-    a = (dot(sigma, tau) - div(tau) * u + u * v + v * div(sigma)) * dx
-    L = f * v * dx
-
-    # Compare hybridized solution with non-hybridized
-    # (Hybrid) Python preconditioner, pc_type slate.HybridizationPC
-    w = Function(W)
-    params = {'mat_type': 'matfree',
-              'ksp_type': 'preonly',
-              'pc_type': 'python',
-              'pc_python_type': 'firedrake.HybridizationPC',
-              'hybridization': {'ksp_type': 'preonly',
-                                'pc_type': 'lu',
-                                'hdiv_residual': {'ksp_type': 'cg',
-                                                  'ksp_rtol': 1e-14},
-                                'hdiv_projection': {'ksp_type': 'cg',
-                                                    'ksp_rtol': 1e-14}}}
-    bcs = [DirichletBC(W[0], Constant((0., 0.)), (1, 2))]
+    bcs = [DirichletBC(W[0], Constant((0., 0.)), subdomain)]
 
     solve(a == L, w, solver_parameters=params, bcs=bcs)
     sigma_h, u_h = w.split()

--- a/tests/slate/test_slate_hybridized_mixed_bcs.py
+++ b/tests/slate/test_slate_hybridized_mixed_bcs.py
@@ -1,0 +1,174 @@
+import pytest
+from firedrake import *
+
+
+@pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
+                         [(1, "RT", False), (1, "RTCF", True),
+                          (2, "RT", False), (2, "RTCF", True)])
+def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
+    # Create a mesh
+    mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
+    RT = FunctionSpace(mesh, hdiv_family, degree)
+    DG = FunctionSpace(mesh, "DG", degree - 1)
+    W = RT * DG
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    # Define the source function
+    f = Function(DG)
+    x, y = SpatialCoordinate(mesh)
+    f.interpolate((1+8*pi*pi)*cos(x*pi*2)*cos(y*pi*2))
+
+    # Define the variational forms
+    a = (dot(sigma, tau) - div(tau) * u + u * v + v * div(sigma)) * dx
+    L = f * v * dx
+
+    # Compare hybridized solution with non-hybridized
+    # (Hybrid) Python preconditioner, pc_type slate.HybridizationPC
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'preonly',
+                                'pc_type': 'lu',
+                                'hdiv_residual': {'ksp_type': 'cg',
+                                                  'ksp_rtol': 1e-14},
+                                'hdiv_projection': {'ksp_type': 'cg',
+                                                    'ksp_rtol': 1e-14}}}
+    bcs = [DirichletBC(W[0], Constant((0., 0.)), "on_boundary")]
+
+    solve(a == L, w, solver_parameters=params, bcs=bcs)
+    sigma_h, u_h = w.split()
+
+    # (Non-hybrid)
+    w2 = Function(W)
+    solve(a == L, w2,
+          solver_parameters={'pc_type': 'lu',
+                             'mat_type': 'aij',
+                             'ksp_type': 'preonly'}, bcs=bcs)
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 1e-11
+    assert u_err < 1e-11
+
+
+@pytest.mark.xfail(reason="Subdomains not yet implemented in Slate")
+@pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
+                         [(1, "RT", False), (1, "RTCF", True),
+                          (2, "RT", False), (2, "RTCF", True)])
+def test_slate_hybridized_12_bcs(degree, hdiv_family, quadrilateral):
+    # Create a mesh
+    mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
+    RT = FunctionSpace(mesh, hdiv_family, degree)
+    DG = FunctionSpace(mesh, "DG", degree - 1)
+    W = RT * DG
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    # Define the source function
+    f = Function(DG)
+    x, y = SpatialCoordinate(mesh)
+    f.interpolate((1+8*pi*pi)*cos(x*pi*2)*cos(y*pi*2))
+
+    # Define the variational forms
+    a = (dot(sigma, tau) - div(tau) * u + u * v + v * div(sigma)) * dx
+    L = f * v * dx
+
+    # Compare hybridized solution with non-hybridized
+    # (Hybrid) Python preconditioner, pc_type slate.HybridizationPC
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'preonly',
+                                'pc_type': 'lu',
+                                'hdiv_residual': {'ksp_type': 'cg',
+                                                  'ksp_rtol': 1e-14},
+                                'hdiv_projection': {'ksp_type': 'cg',
+                                                    'ksp_rtol': 1e-14}}}
+    bcs = [DirichletBC(W[0], Constant((0., 0.)), (1, 2))]
+
+    solve(a == L, w, solver_parameters=params, bcs=bcs)
+    sigma_h, u_h = w.split()
+
+    # (Non-hybrid)
+    w2 = Function(W)
+    solve(a == L, w2,
+          solver_parameters={'pc_type': 'lu',
+                             'mat_type': 'aij',
+                             'ksp_type': 'preonly'}, bcs=bcs)
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 1e-11
+    assert u_err < 1e-11
+
+
+@pytest.mark.parametrize(("degree", "hdiv_family"),
+                         [(1, "RTCF"),
+                          (2, "RTCF")])
+def test_slate_hybridized_extruded_bcs(degree, hdiv_family):
+    # Create a mesh
+    m = UnitIntervalMesh(6)
+    mesh = ExtrudedMesh(m, 6)
+    RT = FunctionSpace(mesh, hdiv_family, degree)
+    DG = FunctionSpace(mesh, "DG", degree - 1)
+    W = RT * DG
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    # Define the source function
+    f = Function(DG)
+    x, y = SpatialCoordinate(mesh)
+    f.interpolate((1+8*pi*pi)*cos(x*pi*2)*cos(y*pi*2))
+
+    # Define the variational forms
+    a = (dot(sigma, tau) - div(tau) * u + u * v + v * div(sigma)) * dx
+    L = f * v * dx
+
+    # Compare hybridized solution with non-hybridized
+    # (Hybrid) Python preconditioner, pc_type slate.HybridizationPC
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'preonly',
+                                'pc_type': 'lu',
+                                'hdiv_residual': {'ksp_type': 'cg',
+                                                  'ksp_rtol': 1e-14},
+                                'hdiv_projection': {'ksp_type': 'cg',
+                                                    'ksp_rtol': 1e-14}}}
+    bcs = [DirichletBC(W[0], Constant((0., 0.)), "top"),
+           DirichletBC(W[0], Constant((0., 0.)), "bottom")]
+    solve(a == L, w, solver_parameters=params, bcs=bcs)
+    sigma_h, u_h = w.split()
+
+    # (Non-hybrid)
+    w2 = Function(W)
+    solve(a == L, w2,
+          solver_parameters={'pc_type': 'lu',
+                             'mat_type': 'aij',
+                             'ksp_type': 'preonly'}, bcs=bcs)
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 1e-11
+    assert u_err < 1e-11
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Incorporate some more BC support into the hybrid mixed preconditioner.

Presence of Dirichlet conditions for the Hdiv field means we need to 
add surface integrals. 
Absence of Dirichlet conditions for the Hdiv field means we need to 
add Dirichlet conditions for the trace field (to avoid an overdetermined
system).

Code was added to sort through the BCs and adjust the forms and 
create Trace bcs as appropriate.

Tests verify that the hybridised preconditioner and standard LU solver
produce the same results in 3 cases: on_boundary and two sides of 
the square for non-extruded, and top/bottom for extruded. The two 
sides case is currently xfailed, because there is not yet subdomain
support in SLATE, so we can't assemble the tensors with the extra
surface terms in that case.

However, on_boundary and top/bottom are now handled which covers 
a lot of use-cases for me.
