### PR TITLE
Label facet subdomains

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -551,12 +551,15 @@ class MeshTopology(object):
 
     @utils.cached_property
     def cell_to_facets(self):
-        """Return a :class:`op2.Dat` that maps from a cell index to the local
+        """Returns a :class:`op2.Dat` that maps from a cell index to the local
         facet types on each cell, including the relevant subdomain markers.
 
-        The i-th local facet is exterior if the 0th value of this array
-        is :data:`0` and interior if the value is :data:`1`. The second
-        entry returns the facet subdomain marker.
+        The `i`-th local facet on a cell with index `c` has data
+        `cell_facet[c][i]`. The local facet is exterior if
+        `cell_facet[c][i][0] == 0`, and interior if the value is `1`.
+        The value `cell_facet[c][i][1]` returns the subdomain marker of the
+        facet. For interior facets, this is `-1`, and for exterior facets this
+        is some positive integer.
         """
         cell_facets = dmplex.cell_facet_labeling(self._facets("exterior"),
                                                  self._plex,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -563,8 +563,7 @@ class MeshTopology(object):
         cell_facets = dmplex.cell_facet_labeling(self._plex,
                                                  self._cell_numbering,
                                                  self.cell_closure)
-        nfacets = cell_facets.shape[1]
-        dataset = DataSet(self.cell_set, dim=(nfacets, 2))
+        dataset = DataSet(self.cell_set, dim=cell_facets.shape[1:])
         return op2.Dat(dataset, cell_facets, dtype=cell_facets.dtype,
                        name="cell-to-local-facet-dat")
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -9,6 +9,7 @@ from ufl.classes import ReferenceGrad
 
 from pyop2.datatypes import IntType
 from pyop2 import op2
+from pyop2.base import DataSet
 from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
 from pyop2.profiling import timed_function, timed_region
 from pyop2.utils import as_tuple, tuplify
@@ -551,16 +552,19 @@ class MeshTopology(object):
     @utils.cached_property
     def cell_to_facets(self):
         """Return a :class:`op2.Dat` that maps from a cell index to the local
-        facet types on each cell.
+        facet types on each cell, including the relevant subdomain markers.
 
-        The i-th local facet is exterior if the value of this array is :data:`0`
-        and interior if the value is :data:`1`.
+        The i-th local facet is exterior if the 0th value of this array
+        is :data:`0` and interior if the value is :data:`1`. The second
+        entry returns the facet subdomain marker.
         """
-        cell_facets = dmplex.cell_facet_labeling(self._plex,
+        cell_facets = dmplex.cell_facet_labeling(self._facets("exterior"),
+                                                 self._plex,
                                                  self._cell_numbering,
                                                  self.cell_closure)
-        nfacet = cell_facets.shape[1]
-        return op2.Dat(self.cell_set**nfacet, cell_facets, dtype=cell_facets.dtype,
+        nfacets = cell_facets.shape[1]
+        dataset = DataSet(self.cell_set, dim=(nfacets, 2))
+        return op2.Dat(dataset, cell_facets, dtype=cell_facets.dtype,
                        name="cell-to-local-facet-dat")
 
     def create_section(self, nodes_per_entity):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -558,11 +558,9 @@ class MeshTopology(object):
         `cell_facet[c][i]`. The local facet is exterior if
         `cell_facet[c][i][0] == 0`, and interior if the value is `1`.
         The value `cell_facet[c][i][1]` returns the subdomain marker of the
-        facet. For interior facets, this is `-1`, and for exterior facets this
-        is some positive integer.
+        facet.
         """
-        cell_facets = dmplex.cell_facet_labeling(self._facets("exterior"),
-                                                 self._plex,
+        cell_facets = dmplex.cell_facet_labeling(self._plex,
                                                  self._cell_numbering,
                                                  self.cell_closure)
         nfacets = cell_facets.shape[1]

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -360,6 +360,17 @@ def tensor_assembly_calls(builder):
                                  for it_type in ("exterior_facet",
                                                  "exterior_facet_vert")]))
 
+        # Generate logical statements for handling exterior facet
+        # integrals on subdomains (these are all of type "exterior")
+        if builder.subdomain_calls:
+            subdomain_calls = builder.subdomain_calls
+            for k in subdomain_calls:
+                if_sd = ast.Eq(ast.Symbol(builder.cell_facet_sym,
+                                          rank=(builder.it_sym, 1)), k)
+                calls = subdomain_calls[k]
+                stmt = ast.If(if_sd, (ast.Block(calls, open_scope=True),))
+                ext_calls.append(stmt)
+
         # Compute the number of facets to loop over
         domain = builder.expression.ufl_domain()
         if domain.cell_set._extruded:

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -366,7 +366,7 @@ def tensor_assembly_calls(builder):
         for sd_type in ("subdomains_exterior_facet", "subdomains_interior_facet"):
             stmts = []
             for sd, sd_calls in groupby(assembly_calls[sd_type], lambda x: x[0]):
-                calls = [sd_call[1] for sd_call in sd_calls]
+                _, calls = zip(*sd_calls)
                 if_sd = ast.Eq(ast.Symbol(builder.cell_facet_sym, rank=(builder.it_sym, 1)), sd)
                 stmts.append(ast.If(if_sd, (ast.Block(calls, open_scope=True),)))
 

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -50,6 +50,7 @@ class LocalKernelBuilder(object):
     coord_sym = ast.Symbol("coords")
     cell_orientations_sym = ast.Symbol("cell_orientations")
     cell_facet_sym = ast.Symbol("cell_facets")
+    cell_facet_arg = ast.Symbol("arg_cell_facets")
     it_sym = ast.Symbol("i0")
     mesh_layer_sym = ast.Symbol("layer")
 

--- a/tests/slate/test_darcy_hybridized_mixed.py
+++ b/tests/slate/test_darcy_hybridized_mixed.py
@@ -1,0 +1,65 @@
+from firedrake import *
+import pytest
+
+
+@pytest.mark.parametrize(("degree", "hdiv_family"),
+                         [(1, "RT"), (1, "BDM")])
+def test_darcy_flow_hybridization(degree, hdiv_family):
+    """
+    Solves Darcy's equation:
+
+    sigma - grad(u) = 0; div(sigma) = -f, in [0, 1] x [0, 1]
+    u = 0 on {(0, y).union(1, y)}
+    sigma.n = sin(5x) on {(0, x).union(1, x)}
+    """
+    # Create a mesh
+    mesh = UnitSquareMesh(6, 6)
+    U = FunctionSpace(mesh, hdiv_family, degree)
+    V = FunctionSpace(mesh, "DG", degree - 1)
+    W = U * V
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+    n = FacetNormal(mesh)
+
+    # Define the source function
+    x, y = SpatialCoordinate(mesh)
+    f = Function(V)
+    f.interpolate(10*exp(-(pow(x - 0.5, 2) + pow(y - 0.5, 2)) / 0.02))
+
+    # Define the variational forms
+    a = (dot(sigma, tau) + div(tau) * u + v * div(sigma)) * dx
+    L = -f * v * dx + Constant(0.0) * dot(tau, n) * (ds(3) + ds(4))
+
+    # Compare hybridized solution with non-hybridized
+    w = Function(W)
+    bc1 = DirichletBC(W[0], as_vector([0.0, -sin(5*x)]), 1)
+    bc2 = DirichletBC(W[0], as_vector([0.0, sin(5*y)]), 2)
+    bcs = [bc1, bc2]
+
+    hybrid_params = {'mat_type': 'matfree',
+                     'ksp_type': 'preonly',
+                     'pc_type': 'python',
+                     'pc_python_type': 'firedrake.HybridizationPC',
+                     'hybridization': {'ksp_type': 'preonly',
+                                       'pc_type': 'lu'}}
+    solve(a == L, w, bcs=bcs, solver_parameters=hybrid_params)
+    sigma_h, u_h = w.split()
+
+    w2 = Function(W)
+    sc_params = {'pc_type': 'fieldsplit',
+                 'pc_fieldsplit_type': 'schur',
+                 'ksp_type': 'gmres',
+                 'pc_fieldsplit_schur_fact_type': 'FULL',
+                 'fieldsplit_0': {'ksp_type': 'cg',
+                                  'pc_factor_shift_type': 'INBLOCKS'},
+                 'fieldsplit_1': {'ksp_type': 'cg',
+                                  'pc_factor_shift_type': 'INBLOCKS'}}
+    solve(a == L, w2, bcs=bcs, solver_parameters=sc_params)
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8

--- a/tests/slate/test_slate_hybridized_mixed_bcs.py
+++ b/tests/slate/test_slate_hybridized_mixed_bcs.py
@@ -2,12 +2,10 @@ import pytest
 from firedrake import *
 
 
-@pytest.mark.parametrize("subdomain", ["on_boundary",
-                                       pytest.mark.xfail(reason="Subdomains not yet implemented in Slate", strict=True)((1, 2))])
 @pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
                          [(1, "RT", False), (1, "RTCF", True),
                           (2, "RT", False), (2, "RTCF", True)])
-def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral, subdomain):
+def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
     # Create a mesh
     mesh = UnitSquareMesh(6, 6, quadrilateral=quadrilateral)
     RT = FunctionSpace(mesh, hdiv_family, degree)
@@ -34,7 +32,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral, subdom
               'pc_python_type': 'firedrake.HybridizationPC',
               'hybridization': {'ksp_type': 'preonly',
                                 'pc_type': 'lu'}}
-    bcs = [DirichletBC(W[0], Constant((0., 0.)), subdomain)]
+    bcs = [DirichletBC(W[0], Constant((0., 0.)), "on_boundary")]
 
     solve(a == L, w, solver_parameters=params, bcs=bcs)
     sigma_h, u_h = w.split()

--- a/tests/slate/test_subdomains.py
+++ b/tests/slate/test_subdomains.py
@@ -1,0 +1,49 @@
+import pytest
+import numpy as np
+from firedrake import *
+
+
+@pytest.fixture(scope='module', params=[False, True])
+def mesh_2d(request):
+    m = UnitSquareMesh(2, 2, quadrilateral=request.param)
+    return m
+
+
+@pytest.fixture(scope='module')
+def mesh_3d(request):
+    m = UnitCubeMesh(2, 2, 2)
+    return m
+
+
+@pytest.mark.parametrize("subdomain", (1, 2, 3, 4))
+def test_2d_facet_subdomains(mesh_2d, subdomain):
+    DG = VectorFunctionSpace(mesh_2d, "DG", 1)
+    n = FacetNormal(mesh_2d)
+    u = TestFunction(DG)
+
+    x, y = SpatialCoordinate(mesh_2d)
+    f = project(as_vector([x, y]), DG)
+
+    form = dot(f[0]*f[1]*u, n)*ds(subdomain)
+
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)
+
+
+@pytest.mark.parametrize("subdomain", (1, 2, 3, 4, 5, 6))
+def test_3d_facet_subdomains(mesh_3d, subdomain):
+    DG = VectorFunctionSpace(mesh_3d, "DG", 1)
+    n = FacetNormal(mesh_3d)
+    u = TestFunction(DG)
+
+    x, y, z = SpatialCoordinate(mesh_3d)
+    f = project(as_vector([x, y, z]), DG)
+
+    form = dot(f[0]*f[1]*f[2]*u, n)*ds(subdomain)
+
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)

--- a/tests/slate/test_subdomains.py
+++ b/tests/slate/test_subdomains.py
@@ -15,6 +15,12 @@ def mesh_3d(request):
     return m
 
 
+@pytest.fixture(scope='module', params=[False, True])
+def mesh_extr(request):
+    m = UnitSquareMesh(2, 2, quadrilateral=request.param)
+    return ExtrudedMesh(m, layers=4, layer_height=0.25)
+
+
 @pytest.mark.parametrize("subdomain", (1, 2, 3, 4))
 def test_2d_facet_subdomains(mesh_2d, subdomain):
     DG = VectorFunctionSpace(mesh_2d, "DG", 1)
@@ -42,6 +48,75 @@ def test_3d_facet_subdomains(mesh_3d, subdomain):
     f = project(as_vector([x, y, z]), DG)
 
     form = dot(f[0]*f[1]*f[2]*u, n)*ds(subdomain)
+
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)
+
+
+@pytest.mark.parametrize("subdomain", (1, 2, 3, 4))
+def test_extr_vert_facet_subdomains(mesh_extr, subdomain):
+    DG = VectorFunctionSpace(mesh_extr, "DG", 1)
+    n = FacetNormal(mesh_extr)
+    u = TestFunction(DG)
+
+    x, y, z = SpatialCoordinate(mesh_extr)
+    f = project(as_vector([z, y, x]), DG)
+
+    form = dot(f[0]*f[1]*f[2]*u, n)*ds_v(subdomain)
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)
+
+
+def test_multiple_subdomains_2d(mesh_2d):
+    DG = VectorFunctionSpace(mesh_2d, "DG", 1)
+    n = FacetNormal(mesh_2d)
+    u = TestFunction(DG)
+
+    x, y = SpatialCoordinate(mesh_2d)
+    f = project(as_vector([x, y]), DG)
+
+    ds_sd = ds(1) + ds(2) + ds(3) + ds(4)
+    form = dot(f[0]*f[1]*u, n)*ds_sd
+
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)
+
+
+def test_multiple_subdomains_3d(mesh_3d):
+    DG = VectorFunctionSpace(mesh_3d, "DG", 1)
+    n = FacetNormal(mesh_3d)
+    u = TestFunction(DG)
+
+    x, y, z = SpatialCoordinate(mesh_3d)
+    f = project(as_vector([x, y, z]), DG)
+
+    ds_sd = ds(1)
+    for i in range(2, 7):
+        ds_sd += ds(i)
+    form = dot(f[0]*f[1]*f[2]*u, n)*ds_sd
+
+    A = assemble(Tensor(form)).dat.data
+    ref = assemble(form).dat.data
+
+    assert np.allclose(A, ref, rtol=1e-14)
+
+
+def test_multiple_subdomains_extr(mesh_extr):
+    DG = VectorFunctionSpace(mesh_extr, "DG", 1)
+    n = FacetNormal(mesh_extr)
+    u = TestFunction(DG)
+
+    x, y, z = SpatialCoordinate(mesh_extr)
+    f = project(as_vector([z, y, x]), DG)
+
+    ds_vsd = ds_v(1) + ds_v(2) + ds_v(3) + ds_v(4)
+    form = dot(f[0]*f[1]*f[2]*u, n)*ds_vsd
 
     A = assemble(Tensor(form)).dat.data
     ref = assemble(form).dat.data


### PR DESCRIPTION
This PR extends the `cell_to_facets` map on `MeshTopology` to also include labeling of exterior facet subdomains.

As a consequence, Slate can handle exterior facet integrals over specific subdomains (addresses an issue in #975).