### PR TITLE
Fix to mesh plotting

### DIFF
--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -140,8 +140,8 @@ def plot_mesh(mesh, axes=None, **kwargs):
         # Pad 1D array with zeros
         coords = np.dstack((coords, np.zeros_like(coords))).reshape(-1, 2)
     vertices = coords[cell[:, idx]]
-    figure = plt.figure()
     if axes is None:
+        figure = plt.figure()
         axes = figure.add_subplot(111, projection=projection, **kwargs)
 
     lines = Lines(vertices)


### PR DESCRIPTION
Most of the routines in the plot.py module check if the user has passed in an axes object to plot on before creating a new figure. The mesh plotting function does not, which can lead to extra empty figures when you do try to plot onto some existing axes. This patch makes the mesh plotting consistent with the rest of the functions in the plotting module.