### PR TITLE
Appctx stack

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -186,8 +186,8 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         # DM with an app context in place so that if the DM is active
         # on a subKSP the context is available.
         dm = self.snes.getDM()
-        dmhooks.set_appctx(dm, self._ctx)
-        self.set_from_options(self.snes)
+        with dmhooks.appctx(dm, self._ctx):
+            self.set_from_options(self.snes)
 
     def solve(self, bounds=None):
         """Solve the variational problem.
@@ -203,7 +203,6 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         """
         # Make sure appcontext is attached to the DM before we solve.
         dm = self.snes.getDM()
-        dmhooks.set_appctx(dm, self._ctx)
         # Apply the boundary conditions to the initial guess.
         for bc in self._problem.bcs:
             bc.apply(self._problem.u)
@@ -215,10 +214,11 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         work = self._work
         # Ensure options database has full set of options (so monitors work right)
         with self.inserted_options():
-            with self._problem.u.dat.vec as u:
-                u.copy(work)
-                self.snes.solve(None, work)
-                work.copy(u)
+            with dmhooks.appctx(dm, self._ctx):
+                with self._problem.u.dat.vec as u:
+                    u.copy(work)
+                    self.snes.solve(None, work)
+                    work.copy(u)
 
         solving_utils.check_snes_convergence(self.snes)
 

--- a/tests/regression/test_appctx_cleanup.py
+++ b/tests/regression/test_appctx_cleanup.py
@@ -1,0 +1,57 @@
+import numpy
+from firedrake import *
+
+
+class NonePC(PCBase):
+    def initialize(self, pc):
+        V = dmhooks.get_function_space(pc.getDM())
+        self.uh = Function(V)
+        u = TrialFunction(V)
+        v = TestFunction(V)
+        problem = LinearVariationalProblem(u*v*dx, 2*v*dx, self.uh)
+        self.solver = LinearVariationalSolver(problem)
+
+    def update(self, pc):
+        pass
+
+    def apply(self, pc, x, y):
+        x.copy(y)
+        self.solver.solve()
+        assert numpy.allclose(self.uh.dat.data_ro, 2.0)
+
+    def applyTranspose(self, pc, x, y):
+        x.copy(y)
+
+
+def test_appctx_cleanup():
+    mesh = UnitSquareMesh(1, 1)
+    mh = MeshHierarchy(mesh, 2)
+    mesh = mh[-1]
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = u*v*dx
+    L = v*dx
+
+    uh = Function(V)
+
+    solve(a == L, uh, solver_parameters={
+        "mat_type": "matfree",
+        "ksp_type": "cg",
+        "pc_type": "mg",
+        "mg_levels": {
+            "pc_type": "python",
+            "pc_python_type": "test_appctx_cleanup.NonePC",
+        },
+        "mg_coarse_pc_type": "python",
+        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+        "mg_coarse_assembled_pc_type": "lu",
+    })
+
+    while hasattr(V, "_coarse"):
+        assert dmhooks.get_appctx(V.dm) is None
+        V = V._coarse
+
+    assert numpy.allclose(uh.dat.data_ro, 1.0)


### PR DESCRIPTION
This manages the application context on a DM as a stack.

This way we can nest variational solvers inside other ones (e.g. if we do something fancy in a multigrid cycle).