### PR TITLE
Custom grid transfer

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -194,6 +194,11 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         self._setup = False
 
     def set_transfer_operators(self, contextmanager):
+        """Set a context manager which manages which grid transfer operators should be used.
+
+        :arg contextmanager: an instance of :class:`~.dmhooks.transfer_operators`.
+        :raises RuntimeError: if called after calling solve.
+        """
         if self._setup:
             raise RuntimeError("Cannot set transfer operators after solve")
         self._transfer_operators = contextmanager

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -189,6 +189,15 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         with dmhooks.appctx(dm, self._ctx):
             self.set_from_options(self.snes)
 
+        # Used for custom grid transfer.
+        self._transfer_operators = None
+        self._setup = False
+
+    def set_transfer_operators(self, contextmanager):
+        if self._setup:
+            raise RuntimeError("Cannot set transfer operators after solve")
+        self._transfer_operators = contextmanager
+
     def solve(self, bounds=None):
         """Solve the variational problem.
 
@@ -213,13 +222,17 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
                 self.snes.setVariableBounds(lb, ub)
         work = self._work
         # Ensure options database has full set of options (so monitors work right)
-        with self.inserted_options():
-            with dmhooks.appctx(dm, self._ctx):
-                with self._problem.u.dat.vec as u:
-                    u.copy(work)
+        with self.inserted_options(), dmhooks.appctx(dm, self._ctx):
+            with self._problem.u.dat.vec as u:
+                u.copy(work)
+                if self._transfer_operators is not None:
+                    with self._transfer_operators:
+                        self.snes.solve(None, work)
+                else:
                     self.snes.solve(None, work)
-                    work.copy(u)
+                work.copy(u)
 
+        self._setup = True
         solving_utils.check_snes_convergence(self.snes)
 
 

--- a/tests/multigrid/test_custom_transfer.py
+++ b/tests/multigrid/test_custom_transfer.py
@@ -1,3 +1,4 @@
+import pytest
 from firedrake import *
 
 
@@ -31,5 +32,39 @@ def test_repeated_custom_transfer():
     uh.assign(0)
 
     solve(a == L, uh, solver_parameters=options)
+
+    assert count == 1
+
+
+def test_custom_transfer_setting():
+    mesh = UnitIntervalMesh(2)
+    mh = MeshHierarchy(mesh, 1)
+    mesh = mh[-1]
+    count = 0
+
+    def myprolong(coarse, fine):
+        nonlocal count
+        prolong(coarse, fine)
+        count += 1
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = u*v*dx
+    L = v*dx
+
+    uh = Function(V)
+    options = {"ksp_type": "preonly",
+               "pc_type": "mg"}
+
+    problem = LinearVariationalProblem(a, L, uh)
+    solver = LinearVariationalSolver(problem, solver_parameters=options)
+    solver.set_transfer_operators(dmhooks.transfer_operators(V, prolong=myprolong))
+
+    solver.solve()
+
+    with pytest.raises(RuntimeError):
+        solver.set_transfer_operators(dmhooks.transfer_operators(V, prolong=myprolong))
 
     assert count == 1

--- a/tests/multigrid/test_custom_transfer.py
+++ b/tests/multigrid/test_custom_transfer.py
@@ -1,0 +1,35 @@
+from firedrake import *
+
+
+def test_repeated_custom_transfer():
+    mesh = UnitIntervalMesh(2)
+    mh = MeshHierarchy(mesh, 1)
+    mesh = mh[-1]
+    count = 0
+
+    def myprolong(coarse, fine):
+        nonlocal count
+        prolong(coarse, fine)
+        count += 1
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = u*v*dx
+    L = v*dx
+
+    uh = Function(V)
+    options = {"ksp_type": "preonly",
+               "pc_type": "mg"}
+
+    with dmhooks.transfer_operators(V, prolong=myprolong):
+        solve(a == L, uh, solver_parameters=options)
+
+    assert count == 1
+
+    uh.assign(0)
+
+    solve(a == L, uh, solver_parameters=options)
+
+    assert count == 1


### PR DESCRIPTION
Allow user to provide custom grid transfer operators.

Done with a context manager around `solve`.  One can attach this context manager to a solver object (not possible after solve has been called).