### PR TITLE
Modify logic for binary operations on Slate tensors

### DIFF
--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -757,7 +757,8 @@ class Add(BinaryOp):
             raise ValueError("Illegal op on a %s-tensor with a %s-tensor."
                              % (A.shape, B.shape))
 
-        assert A.arg_function_spaces() == B.arg_function_spaces(), (
+        assert all([space_equivalence(fsA, fsB) for fsA, fsB in
+                    zip(A.arg_function_spaces(), B.arg_function_spaces())]), (
             "Function spaces associated with operands must match."
         )
 
@@ -796,7 +797,10 @@ class Mul(BinaryOp):
             raise ValueError("Illegal op on a %s-tensor with a %s-tensor."
                              % (A.shape, B.shape))
 
-        assert A.arg_function_spaces()[-1] == B.arg_function_spaces()[0], (
+        fsA = A.arg_function_spaces()[-1]
+        fsB = B.arg_function_spaces()[0]
+
+        assert space_equivalence(fsA, fsB), (
             "Cannot perform argument contraction over middle indices. "
             "They must be in the same function space."
         )
@@ -819,6 +823,24 @@ class Mul(BinaryOp):
         from multiplying two tensors A and B.
         """
         return self._args
+
+
+def space_equivalence(A, B):
+    """Checks that two function spaces are equivalent.
+
+    :arg A: A function space.
+    :arg B: Another function space.
+
+    Returns `True` if they have matching meshes, elements, and rank. Otherwise,
+    `False` is returned.
+    """
+
+    equiv = False
+    assert A.mesh() == B.mesh(), "Mismatching meshes!"
+    if A.rank == B.rank and A.ufl_element() == B.ufl_element():
+        equiv = True
+
+    return equiv
 
 
 # Establishes levels of precedence for Slate tensors

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -835,12 +835,7 @@ def space_equivalence(A, B):
     `False` is returned.
     """
 
-    equiv = False
-    assert A.mesh() == B.mesh(), "Mismatching meshes!"
-    if A.rank == B.rank and A.ufl_element() == B.ufl_element():
-        equiv = True
-
-    return equiv
+    return A.mesh() == B.mesh() and A.ufl_element() == B.ufl_element()
 
 
 # Establishes levels of precedence for Slate tensors


### PR DESCRIPTION
I ran into this problem while working on some HDG stuff. There are instances when using `tensor` blocking and multiplying against an `AssembledVector`, for example, causes a `ValueError` because the contracted spaces are not the "same."

This occurs because calling `block` on a tensor reconstructs function spaces such that they agree with the argument indices of the underlying UFL form, or other Slate objects. (Similar to what is done when you call the form splitter). Blocking does not carry over the information that a particular function space is an indexed subspace of a mixed space. Therefore, I run into instances where I hit my own error-checking when performing a Slate mat-vec, even though it mathematically makes sense.

This reproduces the error:
```python
from firedrake import *


mesh = UnitIcosahedralSphereMesh(3)

V = VectorFunctionSpace(mesh, "DG", 1)
U = FunctionSpace(mesh, "DG", 1)
T = FunctionSpace(mesh, "DGT", 1)
W = V * U * T

w, psi, gammar = TestFunctions(W)
u, phi, lambdar = TrialFunctions(W)

a = inner(w, u)*dx + inner(psi, phi)*dx + gammar('+')*lambdar('+')*dS

A = Tensor(a)

w = Function(W)
_, _, lambda_hyb = w.split()

A02 = A.block((0, 2))

# Slate coefficient vector for lambda.
# Note: same function space as the trial space for A02 (but is indexed)
Lambda = AssembledVector(lambda_hyb)
foo = A02 * Lambda
```

I'm not sure how to correct this without modifying the current logic for binary operations on Slate expressions. It wasn't invasive and this change fixes the issue. I'm open to suggestions.