### PR TITLE
Add split option to compile_form

### DIFF
--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -135,7 +135,7 @@ SplitKernel = collections.namedtuple("SplitKernel", ["indices",
                                                      "kinfo"])
 
 
-def compile_form(form, name, parameters=None, inverse=False):
+def compile_form(form, name, parameters=None, inverse=False, split=True):
     """Compile a form using TSFC.
 
     :arg form: the :class:`~ufl.classes.Form` to compile.
@@ -145,6 +145,7 @@ def compile_form(form, name, parameters=None, inverse=False):
          ``form_compiler`` slot of the Firedrake
          :data:`~.parameters` dictionary (which see).
     :arg inverse: If True then assemble the inverse of the local tensor.
+    :arg split: If ``False``, then don't split mixed forms.
 
     Returns a tuple of tuples of
     (index, integral type, subdomain id, coordinates, coefficients, needs_orientations, :class:`Kernels <pyop2.op2.Kernel>`).
@@ -172,20 +173,26 @@ def compile_form(form, name, parameters=None, inverse=False):
 
     # We stash the compiled kernels on the form so we don't have to recompile
     # if we assemble the same form again with the same optimisations
-    if "firedrake_kernels" in form._cache:
-        # Save both kernels and TSFC params so we can tell if this
-        # cached version is valid (the TSFC parameters might have changed)
-        kernels, coffee_params, old_name, params = form._cache["firedrake_kernels"]
-        if coffee_params == default_parameters["coffee"] and \
-           name == old_name and \
-           params == parameters:
-            return kernels
+    cache = form._cache.setdefault("firedrake_kernels", {})
+
+    def tuplify(params):
+        return tuple((k, params[k]) for k in sorted(params))
+
+    key = (tuplify(default_parameters["coffee"]), name, tuplify(parameters), split)
+    try:
+        val = cache[key]
+    except KeyError:
+        pass
 
     kernels = []
     # A map from all form coefficients to their number.
     coefficient_numbers = dict((c, n)
                                for (n, c) in enumerate(form.coefficients()))
-    for idx, f in split_form(form):
+    if split:
+        iterable = split_form(form)
+    else:
+        iterable = ([(0, )*len(form.arguments()), form], )
+    for idx, f in iterable:
         f = _real_mangle(f)
         # Map local coefficient numbers (as seen inside the
         # compiler) to the global coefficient numbers
@@ -196,9 +203,7 @@ def compile_form(form, name, parameters=None, inverse=False):
         for kinfo in kinfos:
             kernels.append(SplitKernel(idx, kinfo))
     kernels = tuple(kernels)
-    form._cache["firedrake_kernels"] = (kernels, default_parameters["coffee"].copy(),
-                                        name, parameters)
-    return kernels
+    return cache.setdefault(key, kernels)
 
 
 def _real_mangle(form):


### PR DESCRIPTION
By default, `compile_form` splits mixed forms.  In the patch code, we assemble mixed systems directly, but still want all the caching magic to happen for us.  So provide option not to split such forms (TSFC handles them fine).