### PR TITLE
Matrix-free support for operators assembled from Slate

### DIFF
--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -6,6 +6,8 @@ from firedrake.formmanipulation import ExtractSubBlock
 
 from firedrake.petsc import PETSc
 
+from firedrake.slate import slate
+
 
 __all__ = ("ImplicitMatrixContext", )
 
@@ -76,7 +78,7 @@ class ImplicitMatrixContext(object):
     def __init__(self, a, row_bcs=[], col_bcs=[],
                  fc_params=None, appctx=None):
         self.a = a
-        self.aT = adjoint(a)
+        self.aT = _adjoint(a)
         self.fc_params = fc_params
         self.appctx = appctx
 
@@ -109,8 +111,8 @@ class ImplicitMatrixContext(object):
 
         self.block_size = (test_vec.getBlockSize(), trial_vec.getBlockSize())
 
-        self.action = action(self.a, self._x)
-        self.actionT = action(self.aT, self._y)
+        self.action = _action(self.a, self._x)
+        self.actionT = _action(self.aT, self._y)
 
         from firedrake.assemble import create_assembly_callable
         self._assemble_action = create_assembly_callable(self.action, tensor=self._y,
@@ -271,3 +273,21 @@ class ImplicitMatrixContext(object):
         submat.setUp()
 
         return submat
+
+
+def _adjoint(a):
+    """Adjoint of a form (or the transpose of a Slate expression)."""
+    if isinstance(a, slate.TensorBase):
+        return a.T
+    else:
+        return adjoint(a)
+
+
+def _action(a, x):
+    """The action of a bilinear form on a coefficient (or a matrix-vector
+    product for Slate expressions.
+    """
+    if isinstance(a, slate.TensorBase):
+        return a * slate.AssembledVector(x)
+    else:
+        return action(a, x)

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -171,7 +171,8 @@ class HybridizationPC(PCBase):
                 measures.append(ds)
             else:
                 measures.extend((ds(sd) for sd in sorted(neumann_subdomains)))
-                dirichlet_subdomains = set(mesh.exterior_facets.unique_markers) - neumann_subdomains
+                markers = [int(x) for x in mesh.exterior_facets.unique_markers]
+                dirichlet_subdomains = set(markers) - neumann_subdomains
                 trace_subdomains.extend(sorted(dirichlet_subdomains))
 
             for measure in measures:

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -200,7 +200,7 @@ class HybridizationPC(PCBase):
             tensor=self.schur_rhs,
             form_compiler_parameters=self.ctx.fc_params)
 
-        mat_type = PETSc.Options().getString(prefix + "S_mat_type", "aij")
+        mat_type = PETSc.Options().getString(prefix + "mat_type", "aij")
 
         schur_comp = K * Atilde.inv * K.T
         self.S = allocate_matrix(schur_comp, bcs=trace_bcs,

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -199,13 +199,17 @@ class HybridizationPC(PCBase):
             tensor=self.schur_rhs,
             form_compiler_parameters=self.ctx.fc_params)
 
+        mat_type = PETSc.Options().getString(prefix + "S_mat_type", "aij")
+
         schur_comp = K * Atilde.inv * K.T
         self.S = allocate_matrix(schur_comp, bcs=trace_bcs,
-                                 form_compiler_parameters=self.ctx.fc_params)
+                                 form_compiler_parameters=self.ctx.fc_params,
+                                 mat_type=mat_type)
         self._assemble_S = create_assembly_callable(schur_comp,
                                                     tensor=self.S,
                                                     bcs=trace_bcs,
-                                                    form_compiler_parameters=self.ctx.fc_params)
+                                                    form_compiler_parameters=self.ctx.fc_params,
+                                                    mat_type=mat_type)
 
         self._assemble_S()
         self.S.force_evaluation()

--- a/tests/slate/test_darcy_hybridized_mixed.py
+++ b/tests/slate/test_darcy_hybridized_mixed.py
@@ -63,3 +63,8 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
 
     assert sigma_err < 1e-8
     assert u_err < 1e-8
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_darcy_hybridized_mixed.py
+++ b/tests/slate/test_darcy_hybridized_mixed.py
@@ -63,8 +63,3 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
 
     assert sigma_err < 1e-8
     assert u_err < 1e-8
-
-
-if __name__ == '__main__':
-    import os
-    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_matrix_free_hybridization.py
+++ b/tests/slate/test_matrix_free_hybridization.py
@@ -1,0 +1,57 @@
+from firedrake import *
+import pytest
+
+
+def test_matrix_free_hybridization():
+    # Create a mesh
+    mesh = UnitSquareMesh(6, 6)
+    U = FunctionSpace(mesh, "RT", 1)
+    V = FunctionSpace(mesh, "DG", 0)
+    W = U * V
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+
+    # Define the source function
+    f = Function(V)
+    x, y = SpatialCoordinate(mesh)
+    f.interpolate((1+8*pi*pi)*sin(x*pi*2)*sin(y*pi*2))
+
+    # Define the variational forms
+    a = (dot(sigma, tau) - div(tau) * u + u * v + v * div(sigma)) * dx
+    L = f * v * dx
+
+    # Compare hybridized solution with non-hybridized
+    w = Function(W)
+
+    matfree_params = {'mat_type': 'matfree',
+                      'ksp_type': 'preonly',
+                      'pc_type': 'python',
+                      'pc_python_type': 'firedrake.HybridizationPC',
+                      'hybridization': {'ksp_type': 'cg',
+                                        'ksp_rtol': 1e-8,
+                                        'S_mat_type': 'matfree'}}
+    solve(a == L, w, solver_parameters=matfree_params)
+    sigma_h, u_h = w.split()
+
+    w2 = Function(W)
+    aij_params = {'mat_type': 'matfree',
+                  'ksp_type': 'preonly',
+                  'pc_type': 'python',
+                  'pc_python_type': 'firedrake.HybridizationPC',
+                  'hybridization': {'ksp_type': 'cg',
+                                    'ksp_rtol': 1e-8,
+                                    'S_mat_type': 'aij'}}
+    solve(a == L, w2, solver_parameters=aij_params)
+    _sigma, _u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, _sigma)
+    u_err = errornorm(u_h, _u)
+
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_matrix_free_hybridization.py
+++ b/tests/slate/test_matrix_free_hybridization.py
@@ -1,5 +1,4 @@
 from firedrake import *
-import pytest
 
 
 def test_matrix_free_hybridization():
@@ -56,8 +55,3 @@ def test_matrix_free_hybridization():
 
     assert sigma_err < 1e-8
     assert u_err < 1e-8
-
-
-if __name__ == '__main__':
-    import os
-    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_matrix_free_hybridization.py
+++ b/tests/slate/test_matrix_free_hybridization.py
@@ -32,8 +32,9 @@ def test_matrix_free_hybridization():
                       'pc_type': 'python',
                       'pc_python_type': 'firedrake.HybridizationPC',
                       'hybridization': {'ksp_type': 'cg',
+                                        'pc_type': 'none',
                                         'ksp_rtol': 1e-8,
-                                        'S_mat_type': 'matfree'}}
+                                        'mat_type': 'matfree'}}
     solve(a == L, w, bcs=bcs, solver_parameters=matfree_params)
     sigma_h, u_h = w.split()
 
@@ -43,8 +44,9 @@ def test_matrix_free_hybridization():
                   'pc_type': 'python',
                   'pc_python_type': 'firedrake.HybridizationPC',
                   'hybridization': {'ksp_type': 'cg',
+                                    'pc_type': 'none',
                                     'ksp_rtol': 1e-8,
-                                    'S_mat_type': 'aij'}}
+                                    'mat_type': 'aij'}}
     solve(a == L, w2, bcs=bcs, solver_parameters=aij_params)
     _sigma, _u = w2.split()
 


### PR DESCRIPTION
This adapts the `ImplicitMatrixContext` to support taking actions of Slate expressions on vectors. That way, we can solve the trace systems in hybridized solvers in a matrix-free manner.