### PR TITLE
Ensure bcs cache key is consistent in parallel

### DIFF
--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -463,16 +463,19 @@ class FunctionSpaceData(object):
         entity_node_list = self.entity_node_lists[entity_set]
 
         if bcs is not None:
+            for bc in bcs:
+                fs = bc.function_space()
+                # Unwind proxies for ComponentFunctionSpace, but not
+                # IndexedFunctionSpace.
+                while fs.component is not None and fs.parent is not None:
+                    fs = fs.parent
+                if fs.topological != V:
+                    raise RuntimeError("DirichletBC defined on a different FunctionSpace!")
             # Separate explicit bcs (we just place negative entries in
             # the appropriate map values) from implicit ones (extruded
             # top and bottom) that require PyOP2 code gen.
-            explicit_bcs = [bc for bc in bcs if bc.sub_domain not in ['top', 'bottom']]
-            implicit_bcs = [(bc.sub_domain, bc.method) for bc in bcs if bc.sub_domain in ['top', 'bottom']]
-            if len(explicit_bcs) == 0:
-                # Implicit bcs are not part of the cache key for the
-                # map (they only change the generated PyOP2 code),
-                # hence rewrite bcs here.
-                bcs = ()
+            explicit_bcs = tuple(bc for bc in bcs if bc.sub_domain not in ['top', 'bottom'])
+            implicit_bcs = tuple((bc.sub_domain, bc.method) for bc in bcs if bc.sub_domain in ['top', 'bottom'])
             if len(implicit_bcs) == 0:
                 implicit_bcs = None
         else:
@@ -480,24 +483,20 @@ class FunctionSpaceData(object):
             # assembly, which uses a set to keep track of the bcs
             # applied to matrix hits the cache when that set is
             # empty.  tuple(set([])) == tuple().
-            bcs = ()
             implicit_bcs = None
+            explicit_bcs = ()
 
-        for bc in bcs:
-            fs = bc.function_space()
-            # Unwind proxies for ComponentFunctionSpace, but not
-            # IndexedFunctionSpace.
-            while fs.component is not None and fs.parent is not None:
-                fs = fs.parent
-            if fs.topological != V:
-                raise RuntimeError("DirichletBC defined on a different FunctionSpace!")
-        # Ensure bcs is a tuple in a canonical order for the hash key.
-        lbcs = tuple(sorted(bcs, key=lambda bc: bc.__hash__()))
+        # Boundary condition list *must* be collectively ordered already.
+        # Key is a sorted list of bc subdomain, bc method, bc component.
+        bc_key = []
+        for bc in explicit_bcs:
+            bc_key.append(bc.domain_args + (bc.method, ) + (bc.function_space().component, ))
+        bc_key = tuple(sorted(bc_key))
 
         cache = self.map_caches[entity_set]
         try:
             # Cache hit
-            val = cache[lbcs]
+            val = cache[bc_key]
             # In the implicit bc case, we decorate the cached map with
             # the list of implicit boundary conditions so PyOP2 knows
             # what to do.
@@ -507,15 +506,13 @@ class FunctionSpaceData(object):
         except KeyError:
             # Cache miss.
             # Any top and bottom bcs (for the extruded case) are handled elsewhere.
-            nodes = [bc.nodes for bc in lbcs if bc.sub_domain not in ['top', 'bottom']]
+            nodes = [bc.nodes for bc in explicit_bcs]
             decorate = any(bc.function_space().component is not None for
-                           bc in lbcs)
+                           bc in explicit_bcs)
             if nodes:
                 bcids = reduce(numpy.union1d, nodes)
                 negids = numpy.copy(bcids)
-                for bc in lbcs:
-                    if bc.sub_domain in ["top", "bottom"]:
-                        continue
+                for bc in explicit_bcs:
                     nbits = IntType.itemsize * 8 - 2
                     if decorate and bc.function_space().component is None:
                         # Some of the other entries will be marked
@@ -572,7 +569,7 @@ class FunctionSpaceData(object):
 
             if decorate:
                 val = op2.DecoratedMap(val, vector_index=True)
-            cache[lbcs] = val
+            cache[bc_key] = val
             if implicit_bcs:
                 return op2.DecoratedMap(val, implicit_bcs=implicit_bcs)
             return val

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -155,14 +155,14 @@ class HybridizationPC(PCBase):
 
             # separate out the top and bottom bcs
             extruded_neumann_subdomains = neumann_subdomains & {"top", "bottom"}
-            neumann_subdomains = neumann_subdomains.difference(extruded_neumann_subdomains)
+            neumann_subdomains = neumann_subdomains - extruded_neumann_subdomains
 
             integrand = gammar * ufl.dot(sigma, n)
             measures = []
             trace_subdomains = []
             if mesh.cell_set._extruded:
                 ds = ufl.ds_v
-                for subdomain in extruded_neumann_subdomains:
+                for subdomain in sorted(extruded_neumann_subdomains):
                     measures.append({"top": ufl.ds_t, "bottom": ufl.ds_b}[subdomain])
                 trace_subdomains.extend(sorted({"top", "bottom"} - extruded_neumann_subdomains))
             else:
@@ -170,7 +170,7 @@ class HybridizationPC(PCBase):
             if "on_boundary" in neumann_subdomains:
                 measures.append(ds)
             else:
-                measures.extend([ds(sd) for sd in neumann_subdomains])
+                measures.extend((ds(sd) for sd in sorted(neumann_subdomains)))
                 dirichlet_subdomains = set(mesh.exterior_facets.unique_markers) - neumann_subdomains
                 trace_subdomains.extend(sorted(dirichlet_subdomains))
 


### PR DESCRIPTION
Construct bc nodes currently requires a parallel communication
round (and is hence collective).    Ensure that we maintain the
correct ordering when running in parallel, by sorting the bcs to
access on a deterministic basis.  Fixes #1212.

A better mechanism would be to remove the requirement that
constructing boundary nodes requires synchronisation.  This would be
more work, however.