### PR TITLE
Fixup firedrake-zenodo to work with github3 1.0.0+

### DIFF
--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -243,7 +243,7 @@ fd = gh.repository("firedrakeproject", "firedrake")
 tag = time.strftime("Firedrake_%Y%m%d", time.localtime())
 index = -1
 
-for r in fd.iter_releases():
+for r in fd.releases():
     if r.tag_name.startswith(tag):
         newindex = int(r.tag_name.split(".")[1])
         index = max(index, newindex)


### PR DESCRIPTION
Per renaming at https://github3py.readthedocs.io/en/1.0.0/project_changelog.html

I guess this will break people with github3.py below 1.0.0.  But only developers should be making releases, so this is less important(?)