### PR TITLE
Expose Eigen factorizations for local solves

### DIFF
--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -271,13 +271,13 @@ class HybridizationPC(PCBase):
         M = D - C * A.inv * B
         R = K_1.T - C * A.inv * K_0.T
         u_rec = M.solve(f - C * A.inv * g - R * lambdar,
-                        factor_type="PartialPivLU")
+                        decomposition="PartialPivLU")
         self._sub_unknown = create_assembly_callable(u_rec,
                                                      tensor=u,
                                                      form_compiler_parameters=self.ctx.fc_params)
 
         sigma_rec = A.solve(g - B * AssembledVector(u) - K_0.T * lambdar,
-                            factor_type="PartialPivLU")
+                            decomposition="PartialPivLU")
         self._elim_unknown = create_assembly_callable(sigma_rec,
                                                       tensor=sigma,
                                                       form_compiler_parameters=self.ctx.fc_params)

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -270,12 +270,14 @@ class HybridizationPC(PCBase):
 
         M = D - C * A.inv * B
         R = K_1.T - C * A.inv * K_0.T
-        u_rec = M.inv * (f - C * A.inv * g - R * lambdar)
+        u_rec = M.solve(f - C * A.inv * g - R * lambdar,
+                        factor_type="PartialPivLU")
         self._sub_unknown = create_assembly_callable(u_rec,
                                                      tensor=u,
                                                      form_compiler_parameters=self.ctx.fc_params)
 
-        sigma_rec = A.inv * (g - B * AssembledVector(u) - K_0.T * lambdar)
+        sigma_rec = A.solve(g - B * AssembledVector(u) - K_0.T * lambdar,
+                            factor_type="PartialPivLU")
         self._elim_unknown = create_assembly_callable(sigma_rec,
                                                       tensor=sigma,
                                                       form_compiler_parameters=self.ctx.fc_params)

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -48,8 +48,7 @@ def compile_expression(slate_expr, tsfc_parameters=None):
 
     :arg slate_expr: a :class:'TensorBase' expression.
     :arg tsfc_parameters: an optional `dict` of form compiler parameters to
-                          be passed onto TSFC during the compilation of
-                          ufl forms.
+        be passed onto TSFC during the compilation of ufl forms.
 
     Returns: A `tuple` containing a `SplitKernel(idx, kinfo)`
     """
@@ -116,11 +115,11 @@ def generate_kernel_ast(builder, statements, declared_temps):
     contained in the :class:`LocalKernelBuilder`.
 
     :arg builder: The :class:`LocalKernelBuilder` containing
-                  all relevant expression information.
+        all relevant expression information.
     :arg statements: A list of COFFEE objects containing all
-                     assembly calls and temporary declarations.
+        assembly calls and temporary declarations.
     :arg declared_temps: A `dict` containing all previously
-                         declared temporaries.
+        declared temporaries.
 
     Return: A `KernelInfo` object describing the complete AST.
     """
@@ -220,11 +219,10 @@ def declare_factorizations(builder, declared_temps):
     expression.
 
     :arg builder: The :class:`LocalKernelBuilder` containing
-                  all relevant expression information.
+        all relevant expression information.
     :arg declared_temps: A `dict` containing all previously
-                         declared temporaries. This dictionary
-                         is updated as auxiliary expressions
-                         are assigned temporaries.
+        declared temporaries. This dictionary is updated as
+        auxiliary expressions are assigned temporaries.
     """
 
     statements = [ast.FlatBlock("/* Matrix factorizations */\n")]
@@ -257,11 +255,10 @@ def auxiliary_temporaries(builder, declared_temps):
     by the :class:`LocalKernelBuilder`.
 
     :arg builder: The :class:`LocalKernelBuilder` containing
-                  all relevant expression information.
+        all relevant expression information.
     :arg declared_temps: A `dict` containing all previously
-                         declared temporaries. This dictionary
-                         is updated as auxiliary expressions
-                         are assigned temporaries.
+        declared temporaries. This dictionary is updated as
+        auxiliary expressions are assigned temporaries.
     """
     statements = [ast.FlatBlock("/* Auxiliary temporaries */\n")]
     results = []
@@ -299,10 +296,10 @@ def coefficient_temporaries(builder, declared_temps):
     coefficients to vector temporaries.
 
     :arg builder: The :class:`LocalKernelBuilder` containing
-                  all relevant expression information.
+        all relevant expression information.
     :arg declared_temps: A `dict` keeping track of all declared
-                         temporaries. This dictionary is updated
-                         as coefficients are assigned temporaries.
+        temporaries. This dictionary is updated as coefficients
+        are assigned temporaries.
 
     'AssembledVector's require creating coefficient temporaries to
     store data. The temporaries are created by inspecting the function
@@ -381,8 +378,7 @@ def tensor_assembly_calls(builder):
     finite element tensors.
 
     :arg builder: The :class:`LocalKernelBuilder` containing
-                  all relevant expression information and
-                  assembly calls.
+        all relevant expression information and assembly calls.
     """
     assembly_calls = builder.assembly_calls
     statements = [ast.FlatBlock("/* Assemble local tensors */\n")]
@@ -529,15 +525,15 @@ def slate_to_cpp(expr, temps, prec=None):
 
     :arg expr: a :class:`slate.TensorBase` expression.
     :arg temps: a `dict` of temporaries which map a given expression to its
-                corresponding representation as a `coffee.Symbol` object.
+        corresponding representation as a `coffee.Symbol` object.
     :arg prec: an argument dictating the order of precedence in the linear
-               algebra operations. This ensures that parentheticals are placed
-               appropriately and the order in which linear algebra operations
-               are performed are correct.
+        algebra operations. This ensures that parentheticals are placed
+        appropriately and the order in which linear algebra operations
+        are performed are correct.
 
-    Returns
-        This function returns a `string` which represents the C/C++ code
-        representation of the `slate.TensorBase` expr.
+    Returns:
+        a `string` which represents the C/C++ code representation of the
+        `slate.TensorBase` expr.
     """
     # If the tensor is terminal, it has already been declared.
     # Coefficients defined as AssembledVectors will have been declared
@@ -613,11 +609,12 @@ def eigen_matrixbase_type(shape):
     """Returns the Eigen::Matrix declaration of the tensor.
 
     :arg shape: a tuple of integers the denote the shape of the
-                :class:`slate.TensorBase` object.
+        :class:`slate.TensorBase` object.
 
-    Returns: Returns a string indicating the appropriate declaration of the
-             `slate.TensorBase` object in the appropriate Eigen C++ template
-             library syntax.
+    Returns:
+        a string indicating the appropriate declaration of the
+        `slate.TensorBase` object in the appropriate Eigen C++ template
+        library syntax.
     """
     if len(shape) == 0:
         rows = 1

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -547,6 +547,15 @@ def slate_to_cpp(expr, temps, prec=None):
 
         return parenthesize(result, expr.prec, prec)
 
+    elif isinstance(expr, slate.Solve):
+        A, B = expr.operands
+        factor_type = expr.factor_type
+        result = "(%s).%s().solve(%s)" % (slate_to_cpp(A, temps, expr.prec),
+                                          factor_type,
+                                          slate_to_cpp(B, temps, expr.prec))
+
+        return parenthesize(result, expr.prec, prec)
+
     else:
         raise NotImplementedError("Type %s not supported.", type(expr))
 

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -276,7 +276,6 @@ def auxiliary_temporaries(builder, declared_temps):
                 result = slate_to_cpp(exp, declared_temps)
                 tensor_type = eigen_matrixbase_type(shape=exp.shape)
                 statements.append(ast.Decl(tensor_type, t))
-                statements.append(ast.FlatBlock("%s.setZero();\n" % t))
                 results.append(ast.Assign(t, result))
 
             declared_temps[exp] = t
@@ -339,7 +338,6 @@ def coefficient_temporaries(builder, declared_temps):
                 c_type = eigen_matrixbase_type(shape=c_shape)
                 t = ast.Symbol("VT%d" % len(declared_temps))
                 statements.append(ast.Decl(c_type, t))
-                statements.append(ast.FlatBlock("%s.setZero();\n" % t))
                 declared_temps[vector] = t
 
             # Assigning coefficient values into temporary

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -120,11 +120,6 @@ class LocalKernelBuilder(object):
 
                     seen_coeff.add(function)
 
-            # Collect inverse for factorization
-            if isinstance(tensor, slate.Inverse) and tensor.shape > (4, 4):
-                factor_type = "PartialPivLU"
-                factor_mats.setdefault(factor_type, list()).append(tensor)
-
             # Collect matrices to factor for computing local solves
             if isinstance(tensor, slate.Solve):
                 Ainv, _ = tensor.operands
@@ -140,7 +135,8 @@ class LocalKernelBuilder(object):
         self.aux_exprs = [tensor for tensor in topological_sort(expression_dag)
                           if counter[tensor] > 1
                           and not isinstance(tensor, (slate.Tensor,
-                                                      slate.Negative))]
+                                                      slate.Negative))
+                          or isinstance(tensor, slate.Inverse)]
         self.factor_mats = factor_mats
 
         self.coefficient_vecs = coeff_vecs

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -135,8 +135,7 @@ class LocalKernelBuilder(object):
         self.aux_exprs = [tensor for tensor in topological_sort(expression_dag)
                           if counter[tensor] > 1
                           and not isinstance(tensor, (slate.Tensor,
-                                                      slate.Negative))
-                          or isinstance(tensor, slate.Inverse)]
+                                                      slate.Negative))]
         self.factor_mats = factor_mats
 
         self.coefficient_vecs = coeff_vecs

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -77,8 +77,7 @@ class LocalKernelBuilder(object):
 
         :arg expression: a :class:`TensorBase` object.
         :arg tsfc_parameters: an optional `dict` of parameters to provide to
-                              TSFC when constructing subkernels associated
-                              with the expression.
+            TSFC when constructing subkernels associated with the expression.
         """
         assert isinstance(expression, slate.TensorBase)
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -847,7 +847,7 @@ class Solve(BinaryOp):
     """
     """
 
-    def __new__(cls, A, B):
+    def __new__(cls, A, B, factor_type=None):
         assert A.rank == 2, "Operator must be a matrix."
 
         # Same rules for performing multiplication on Slate tensors

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -876,18 +876,18 @@ class Solve(BinaryOp):
         """Constructor for the Solve class."""
 
         # Partial pivoted LU is a stable default.
-        factor_type = factor_type or "partialPivLu"
+        factor_type = factor_type or "PartialPivLU"
 
         # These are the currently supported factorizations
         # in Eigen. This will change when the linear algebra
         # backend changes.
-        if factor_type not in ["partialPivLu", "fullPivLu",
-                               "householderQr", "colPivHouseholderQr",
-                               "fullPivHouseholderQr", "llt",
-                               "ldlt", "jacobiSvd"]:
+        if factor_type not in ["PartialPivLU", "FullPivLU",
+                               "HouseholderQR", "ColPivHouseholderQR",
+                               "FullPivHouseholderQR", "LLT",
+                               "LDLT", "JacobiSVD"]:
             raise ValueError("Factorization '%s' not supported" % factor_type)
 
-        super(Solve, self).__init__(A, B)
+        super(Solve, self).__init__(A.inv, B)
 
         self.factor_type = factor_type
 
@@ -897,8 +897,8 @@ class Solve(BinaryOp):
         """Returns a tuple of function spaces that the tensor
         is defined on.
         """
-        A, B = self.operands
-        return A.arg_function_spaces()[::-1][:-1] + B.arg_function_spaces()[1:]
+        Ainv, B = self.operands
+        return Ainv.arg_function_spaces()[:-1] + B.arg_function_spaces()[1:]
 
     def arguments(self):
         """Returns the arguments of a tensor resulting

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -844,7 +844,13 @@ class Mul(BinaryOp):
 
 
 class Solve(BinaryOp):
-    """
+    """Abstract Slate class describing a local linear system of equations,
+    with the possibility of multiple right-hand sides.
+
+    :arg A: The left-hand side operator.
+    :arg B: The right-hand side vector (or matrix).
+    :arg factor_type: A string denoting the type of factorization
+                      to be used.
     """
 
     def __new__(cls, A, B, factor_type=None):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -144,9 +144,17 @@ class TensorBase(object, metaclass=ABCMeta):
         return Transpose(self)
 
     def solve(self, B, factor_type=None):
-        """
-        """
+        """Solve a system of equations with
+        a specified right-hand side.
 
+        :arg B: a Slate expression. This can be either a
+            vector or a matrix.
+        :arg factor_type: A string describing the type of
+            factorization to use when inverting the local
+            systems. At the moment, these are determined by
+            what is available in Eigen. See the :class:`Solve`
+            documentation for details.
+        """
         return Solve(self, B, factor_type=factor_type)
 
     def block(self, arg_indices):
@@ -157,21 +165,20 @@ class TensorBase(object, metaclass=ABCMeta):
 
         .. code-block:: python
 
-            V = FunctionSpace(m, "CG", 1)
-            W = V * V * V
-            u, p, r = TrialFunctions(W)
-            w, q, s = TestFunctions(W)
-            A = Tensor(u*w*dx + p*q*dx + r*s*dx)
+           V = FunctionSpace(m, "CG", 1)
+           W = V * V * V
+           u, p, r = TrialFunctions(W)
+           w, q, s = TestFunctions(W)
+           A = Tensor(u*w*dx + p*q*dx + r*s*dx)
 
         The tensor `A` has 3x3 block structure. Providing argument indices
         (0, 0) will extract the block defined by the form `u*w*dx`:
         `Block(A, (0, 0))` See :class:`Block` for more information.
 
         :arg arg_indices: Indices describing the test and trial spaces to
-                          extract. This should be 0-, 1-, or 2-tuples whose
-                          length is the same as the rank of the tensor. Entries
-                          can be either an integer index or an iterable of
-                          indices.
+            extract. This should be 0-, 1-, or 2-tuples whose length is
+            the same as the rank of the tensor. Entries can be either an
+            integer index or an iterable of indices.
         """
         return Block(tensor=self, indices=arg_indices)
 
@@ -339,44 +346,44 @@ class Block(TensorBase):
 
     :arg tensor: A (mixed) tensor.
     :arg indices: Indices of the test and trial function
-                  spaces to extract. This should be a 0-,
-                  1-, or 2-tuple (whose length is equal
-                  to the rank of the tensor.) The entries
-                  should be an iterable of integer indices.
+        spaces to extract. This should be a 0-, 1-, or
+        2-tuple (whose length is equal to the rank of the
+        tensor.) The entries should be an iterable of integer
+        indices.
 
     For example, consider the mixed tensor defined by:
 
     .. code-block:: python
 
-        n = FacetNormal(m)
-        U = FunctionSpace(m, "DRT", 1)
-        V = FunctionSpace(m, "DG", 0)
-        M = FunctionSpace(m, "DGT", 0)
-        W = U * V * M
-        u, p, r = TrialFunctions(W)
-        w, q, s = TestFunctions(W)
-        A = Tensor(dot(u, w)*dx + p*div(w)*dx + r*dot(w, n)*dS
-                   + div(u)*q*dx + p*q*dx + r*s*ds)
+       n = FacetNormal(m)
+       U = FunctionSpace(m, "DRT", 1)
+       V = FunctionSpace(m, "DG", 0)
+       M = FunctionSpace(m, "DGT", 0)
+       W = U * V * M
+       u, p, r = TrialFunctions(W)
+       w, q, s = TestFunctions(W)
+       A = Tensor(dot(u, w)*dx + p*div(w)*dx + r*dot(w, n)*dS
+                  + div(u)*q*dx + p*q*dx + r*s*ds)
 
     This describes a block 3x3 mixed tensor of the form:
 
     .. math::
 
-        \begin{bmatrix}
+      \\begin{bmatrix}
             A & B & C \\
             D & E & F \\
             G & H & J
-        \end{bmatrix}
+      \\end{bmatrix}
 
     Providing the 2-tuple ((0, 1), (0, 1)) returns a tensor
     corresponding to the upper 2x2 block:
 
     .. math::
 
-        \begin{bmatrix}
+       \\begin{bmatrix}
             A & B \\
             D & E
-        \end{bmatrix}
+       \\end{bmatrix}
 
     More generally, argument indices of the form `(idr, idc)`
     produces a tensor of block-size `len(idr)` x `len(idc)`
@@ -565,7 +572,7 @@ class TensorOp(TensorBase):
     existing Slate tensors.
 
     :arg operands: an iterable of operands that are :class:`TensorBase`
-                   objects.
+        objects.
     """
 
     def __init__(self, *operands):
@@ -615,10 +622,10 @@ class UnaryOp(TensorOp):
     Tensor object.
 
     :arg A: a :class:`TensorBase` object. This can be a terminal tensor object
-            (:class:`Tensor`) or any derived expression resulting from any
-            number of linear algebra operations on `Tensor` objects. For
-            example, another instance of a `UnaryOp` object is an acceptable
-            input, or a `BinaryOp` object.
+        (:class:`Tensor`) or any derived expression resulting from any
+        number of linear algebra operations on `Tensor` objects. For
+        example, another instance of a `UnaryOp` object is an acceptable
+        input, or a `BinaryOp` object.
     """
 
     def __repr__(self):
@@ -721,10 +728,10 @@ class BinaryOp(TensorOp):
     Such operations take two operands and returns a tensor-valued expression.
 
     :arg A: a :class:`TensorBase` object. This can be a terminal tensor object
-            (:class:`Tensor`) or any derived expression resulting from any
-            number of linear algebra operations on `Tensor` objects. For
-            example, another instance of a `BinaryOp` object is an acceptable
-            input, or a `UnaryOp` object.
+        (:class:`Tensor`) or any derived expression resulting from any
+        number of linear algebra operations on `Tensor` objects. For
+        example, another instance of a `BinaryOp` object is an acceptable
+        input, or a `UnaryOp` object.
     :arg B: a :class:`TensorBase` object.
     """
 
@@ -845,12 +852,20 @@ class Mul(BinaryOp):
 
 class Solve(BinaryOp):
     """Abstract Slate class describing a local linear system of equations,
-    with the possibility of multiple right-hand sides.
+    with the possibility of multiple right-hand sides. The factorizations
+    available are the following:
+
+        (1) LU with full or partial pivoting ('FullPivLU' and 'PartialPivLU');
+        (2) QR using Householder reflectors ('HouseholderQR') with the option
+            to use column pivoting ('ColPivHouseholderQR') or full pivoting
+            ('FullPivHouseholderQR'); and
+        (3) Standard Cholesky ('LLT') and stabilized Cholesky factorizations
+            with pivoting ('LDLT').
 
     :arg A: The left-hand side operator.
     :arg B: The right-hand side vector (or matrix).
     :arg factor_type: A string denoting the type of factorization
-                      to be used.
+        to be used.
     """
 
     def __new__(cls, A, B, factor_type=None):
@@ -889,8 +904,7 @@ class Solve(BinaryOp):
         # backend changes.
         if factor_type not in ["PartialPivLU", "FullPivLU",
                                "HouseholderQR", "ColPivHouseholderQR",
-                               "FullPivHouseholderQR", "LLT",
-                               "LDLT", "JacobiSVD"]:
+                               "FullPivHouseholderQR", "LLT", "LDLT"]:
             raise ValueError("Factorization '%s' not supported" % factor_type)
 
         super(Solve, self).__init__(A.inv, B)

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -939,9 +939,9 @@ class Mul(BinaryOp):
 
 
 class Solve(BinaryOp):
-    """Abstract Slate class describing a local linear system of equations,
+    """Abstract Slate class describing a local linear system of equations.
     This object is a direct solver, utilizing the application of the inverse
-    of matrix decompositions.
+    of matrix in a decomposed form.
 
     :arg A: The left-hand side operator.
     :arg B: The right-hand side.

--- a/tests/slate/test_linear_algebra.py
+++ b/tests/slate/test_linear_algebra.py
@@ -102,8 +102,8 @@ def test_aggressive_unaryop_nesting():
     assert np.allclose(assemble(foo).dat.data, np.ones(V.node_count))
 
 
-@pytest.mark.parametrize("factor_type", ["PartialPivLU", "FullPivLU"])
-def test_local_solve(factor_type):
+@pytest.mark.parametrize("decomp", ["PartialPivLU", "FullPivLU"])
+def test_local_solve(decomp):
 
     V = FunctionSpace(UnitSquareMesh(3, 3), "DG", 3)
     f = Function(V).assign(1.0)
@@ -113,7 +113,7 @@ def test_local_solve(factor_type):
 
     A = Tensor(inner(v, u)*dx)
     b = Tensor(inner(v, f)*dx)
-    x = assemble(A.solve(b, factor_type=factor_type))
+    x = assemble(A.solve(b, decomposition=decomp))
 
     assert np.allclose(x.dat.data, f.dat.data, rtol=1.e-13)
 

--- a/tests/slate/test_linear_algebra.py
+++ b/tests/slate/test_linear_algebra.py
@@ -9,9 +9,10 @@ def mesh(request):
     return m
 
 
-def test_left_inverse(mesh):
+@pytest.mark.parametrize("degree", range(1, 4))
+def test_left_inverse(mesh, degree):
     """Tests the SLATE expression A.inv * A = I"""
-    V = FunctionSpace(mesh, "DG", 1)
+    V = FunctionSpace(mesh, "DG", degree)
     u = TrialFunction(V)
     v = TestFunction(V)
     form = u*v*dx
@@ -22,9 +23,10 @@ def test_left_inverse(mesh):
     assert (Result.M.values - np.identity(nnode) <= 1e-13).all()
 
 
-def test_right_inverse(mesh):
+@pytest.mark.parametrize("degree", range(1, 4))
+def test_right_inverse(mesh, degree):
     """Tests the SLATE expression A * A.inv = I"""
-    V = FunctionSpace(mesh, "DG", 1)
+    V = FunctionSpace(mesh, "DG", degree)
     u = TrialFunction(V)
     v = TestFunction(V)
     form = u*v*dx
@@ -82,7 +84,7 @@ def test_aggressive_unaryop_nesting():
     """Test Slate's ability to handle extremely
     nested expressions.
     """
-    V = FunctionSpace(UnitSquareMesh(1, 1), "DG", 1)
+    V = FunctionSpace(UnitSquareMesh(1, 1), "DG", 3)
     f = Function(V)
     g = Function(V)
     f.assign(1.0)
@@ -98,6 +100,22 @@ def test_aggressive_unaryop_nesting():
     # This is a very silly way to write the vector of ones
     foo = (B.T*A.inv).T*G + (-A.inv.T*B.T).inv*F + B.inv*(A.T).T*F
     assert np.allclose(assemble(foo).dat.data, np.ones(V.node_count))
+
+
+@pytest.mark.parametrize("factor_type", ["PartialPivLU", "FullPivLU"])
+def test_local_solve(factor_type):
+
+    V = FunctionSpace(UnitSquareMesh(3, 3), "DG", 3)
+    f = Function(V).assign(1.0)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    A = Tensor(inner(v, u)*dx)
+    b = Tensor(inner(v, f)*dx)
+    x = assemble(A.solve(b, factor_type=factor_type))
+
+    assert np.allclose(x.dat.data, f.dat.data, rtol=1.e-13)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR reworks the handling of matrix inverses and introduces a `Solve` node in Slate. Larger matrices will always have a factorization declared and used beforehand. This avoids explicitly storing the inverse and instead just applies the inverse of the defined factorization.