### PR TITLE
Import petsc check

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -1,3 +1,15 @@
+import firedrake_configuration
+import os
+import sys
+config = firedrake_configuration.get_config()
+if "PETSC_DIR" in os.environ and not config["options"]["honour_petsc_dir"]:
+    raise ImportError("PETSC_DIR is set, but you did not install with --honour-petsc-dir.\n"
+                      "Please unset PETSC_DIR (and PETSC_ARCH) before using Firedrake.")
+elif "PETSC_DIR" not in os.environ and config["options"]["honour_petsc_dir"]:
+    raise ImportError("Firedrake was installed with --honour-petsc-dir, but PETSC_DIR is not set.\n"
+                      "Please set PETSC_DIR (and PETSC_ARCH) before using Firedrake.")
+del os, sys, config
+
 # Ensure petsc is initialised by us before anything else gets in there.
 import firedrake.petsc as petsc
 del petsc
@@ -23,7 +35,6 @@ except AttributeError:
 del ufl
 from ufl import *
 # Set up the cache directories before importing PyOP2.
-import firedrake_configuration
 firedrake_configuration.setup_cache_dirs()
 
 from firedrake_citations import Citations    # noqa: F401

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -57,6 +57,7 @@ class FiredrakeConfiguration(dict):
 
     _persistent_options = ["package_manager",
                            "minimal_petsc", "mpicc", "mpicxx", "mpif90", "disable_ssh",
+                           "honour_petsc_dir",
                            "show_petsc_configure_options", "adjoint",
                            "slepc", "slope", "packages", "honour_pythonpath",
                            "petsc_int_type", "cache_dir"]
@@ -208,6 +209,7 @@ else:
                         help="Install SLEPc along with PETSc")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--honour-petsc-dir", action="store_true",
+                       default=config["options"].get("honour_petsc_dir", False),
                        help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
     group.add_argument("--petsc-int-type", choices=["int32", "int64"],
                        default="int32", type=str,


### PR DESCRIPTION
Raise `ImportError` during firedrake import if PETSC_DIR is set and firedrake was not installed with `--honour-petsc-dir` (and vice versa).

Thanks to @bueler for the suggestion and motivating example.