### PR TITLE
Assembled pc mat prefix

### DIFF
--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -1,13 +1,11 @@
-import ufl
-
 from firedrake.exceptions import ConvergenceError
 import firedrake.function as function
 import firedrake.vector as vector
 import firedrake.matrix as matrix
 import firedrake.solving_utils as solving_utils
 from firedrake.petsc import PETSc
-from firedrake.slate import slate
 from firedrake.utils import cached_property
+from firedrake.ufl_expr import action
 
 
 __all__ = ["LinearSolver"]
@@ -116,10 +114,7 @@ class LinearSolver(solving_utils.ParametersMixin):
         from firedrake.assemble import create_assembly_callable
         u = function.Function(self.trial_space)
         b = function.Function(self.test_space)
-        if isinstance(self.A.a, slate.TensorBase):
-            expr = -self.A.a * slate.AssembledVector(u)
-        else:
-            expr = -ufl.action(self.A.a, u)
+        expr = -action(self.A.a, u)
         return u, create_assembly_callable(expr, tensor=b), b
 
     def _lifted(self, b):

--- a/firedrake/matrix.py
+++ b/firedrake/matrix.py
@@ -147,8 +147,10 @@ class Matrix(MatrixBase):
     def __init__(self, a, bcs, *args, **kwargs):
         # sets self._a and self._bcs
         super(Matrix, self).__init__(a, bcs)
+        options_prefix = kwargs.pop("options_prefix")
         self._M = op2.Mat(*args, **kwargs)
         self.petscmat = self._M.handle
+        self.petscmat.setOptionsPrefix(options_prefix)
         self._thunk = None
         self._assembled = False
 
@@ -271,6 +273,7 @@ class ImplicitMatrix(MatrixBase):
         # sets self._a and self._bcs
         super(ImplicitMatrix, self).__init__(a, bcs)
 
+        options_prefix = kwargs.pop("options_prefix")
         appctx = kwargs.get("appctx", {})
 
         from firedrake.matrix_free.operators import ImplicitMatrixContext
@@ -284,6 +287,7 @@ class ImplicitMatrix(MatrixBase):
         self.petscmat.setSizes((ctx.row_sizes, ctx.col_sizes),
                                bsize=ctx.block_size)
         self.petscmat.setPythonContext(ctx)
+        self.petscmat.setOptionsPrefix(options_prefix)
         self.petscmat.setUp()
         self.petscmat.assemble()
 

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -1,12 +1,7 @@
-
-from ufl import action
-
-from firedrake.ufl_expr import adjoint
+from firedrake.ufl_expr import adjoint, action
 from firedrake.formmanipulation import ExtractSubBlock
 
 from firedrake.petsc import PETSc
-
-from firedrake.slate import slate
 
 
 __all__ = ("ImplicitMatrixContext", )
@@ -78,7 +73,7 @@ class ImplicitMatrixContext(object):
     def __init__(self, a, row_bcs=[], col_bcs=[],
                  fc_params=None, appctx=None):
         self.a = a
-        self.aT = a.T if isinstance(self.a, slate.TensorBase) else adjoint(a)
+        self.aT = adjoint(a)
         self.fc_params = fc_params
         self.appctx = appctx
 
@@ -111,12 +106,8 @@ class ImplicitMatrixContext(object):
 
         self.block_size = (test_vec.getBlockSize(), trial_vec.getBlockSize())
 
-        if isinstance(self.a, slate.TensorBase):
-            self.action = self.a * slate.AssembledVector(self._x)
-            self.actionT = self.aT * slate.AssembledVector(self._y)
-        else:
-            self.action = action(self.a, self._x)
-            self.actionT = action(self.aT, self._y)
+        self.action = action(self.a, self._x)
+        self.actionT = action(self.aT, self._y)
 
         from firedrake.assemble import create_assembly_callable
         self._assemble_action = create_assembly_callable(self.action, tensor=self._y,

--- a/firedrake/slate/preconditioners.py
+++ b/firedrake/slate/preconditioners.py
@@ -205,7 +205,8 @@ class HybridizationPC(PCBase):
         schur_comp = K * Atilde.inv * K.T
         self.S = allocate_matrix(schur_comp, bcs=trace_bcs,
                                  form_compiler_parameters=self.ctx.fc_params,
-                                 mat_type=mat_type)
+                                 mat_type=mat_type,
+                                 options_prefix=prefix)
         self._assemble_S = create_assembly_callable(schur_comp,
                                                     tensor=self.S,
                                                     bcs=trace_bcs,

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -154,7 +154,8 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
                                          pmat_type=pmat_type,
                                          appctx=appctx,
                                          pre_jacobian_callback=pre_j_callback,
-                                         pre_function_callback=pre_f_callback)
+                                         pre_function_callback=pre_f_callback,
+                                         options_prefix=self.options_prefix)
 
         # No preconditioner by default for matrix-free
         if (problem.Jp is not None and pmatfree) or matfree:
@@ -173,7 +174,7 @@ class NonlinearVariationalSolver(solving_utils.ParametersMixin):
         self.snes.setDM(problem.dm)
 
         ctx.set_function(self.snes)
-        ctx.set_jacobian(self.snes, self.options_prefix)
+        ctx.set_jacobian(self.snes)
         ctx.set_nullspace(nullspace, problem.J.arguments()[0].function_space()._ises,
                           transpose=False, near=False)
         ctx.set_nullspace(nullspace_T, problem.J.arguments()[1].function_space()._ises,

--- a/tests/regression/test_matrix_prefix.py
+++ b/tests/regression/test_matrix_prefix.py
@@ -35,3 +35,43 @@ def test_matrix_prefix_solver(options_prefix):
         if pfx is None:
             pfx = ""
         assert pfx == solver.options_prefix
+
+
+@pytest.mark.parametrize("options_prefix",
+                         [None,
+                          "",
+                          "foo"])
+def test_matrix_prefix_solver_assembled_pc(options_prefix):
+    parameters = {
+        "mat_type": "matfree",
+        "ksp_type": "preonly",
+        "pc_type": "python",
+        "pc_python_type": "firedrake.AssembledPC",
+        "assembled": {
+            "pc_type": "lu",
+            "pc_factor_mat_solver_type": "mumps",
+            "mat_mumps_icntl_24": 1
+        }
+    }
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "P", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = u*v*dx
+    L = v*dx
+    uh = Function(V)
+
+    problem = LinearVariationalProblem(a, L, uh)
+    solver = LinearVariationalSolver(problem, solver_parameters=parameters,
+                                     options_prefix=options_prefix)
+    solver.solve()
+
+    pc = solver.snes.ksp.pc
+    assert pc.getType() == "python"
+    python = pc.getPythonContext()
+    assert isinstance(python, AssembledPC)
+    assembled = python.pc
+    factor = assembled.getFactorMatrix()
+    assert factor.getType() == "mumps"
+    assert factor.getMumpsIcntl(24) == 1


### PR DESCRIPTION
Some small changes in slate (@thomasgibson) to make action and adjoint UFL/slate agnostic.

As well, allow assembling matrices with an options prefix (and use that feature everywhere).  This ensures that the right thing happens with solvers that use (say) mumps and want to control the mumps options (which are bound to the matrix, not the solver).