### PR TITLE
Make ImplicitMatrix behave more like an assembled Matrix

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -94,6 +94,20 @@ class DirichletBC(object):
                 self._original_arg = self.function_arg
         return self._function_arg
 
+    def reconstruct(self, *, V=None, g=None, sub_domain=None, method=None):
+        if V is None:
+            V = self.function_space()
+        if g is None:
+            g = self._original_arg
+        if sub_domain is None:
+            sub_domain = self.sub_domain
+        if method is None:
+            method = self.method
+        if V == self.function_space() and g == self._original_arg and \
+           sub_domain == self.sub_domain and method == self.method:
+            return self
+        return type(self)(V, g, sub_domain, method=method)
+
     @function_arg.setter
     def function_arg(self, g):
         '''Set the value of this boundary condition.'''

--- a/tests/regression/test_bcs.py
+++ b/tests/regression/test_bcs.py
@@ -242,13 +242,14 @@ def test_update_bc_constant(a, u, V, f):
     assert np.allclose(u.vector().array(), 7.0)
 
 
-def test_preassembly_change_bcs(V, f):
+@pytest.mark.parametrize("mat_type", ["aij", "matfree"])
+def test_preassembly_change_bcs(V, f, mat_type):
     v = TestFunction(V)
     u = TrialFunction(V)
     a = dot(u, v)*dx
     bc = DirichletBC(V, f, 1)
 
-    A = assemble(a, bcs=[bc])
+    A = assemble(a, bcs=[bc], mat_type=mat_type)
     L = dot(v, f)*dx
     b = assemble(L)
 

--- a/tests/regression/test_matrix.py
+++ b/tests/regression/test_matrix.py
@@ -18,6 +18,11 @@ def a(V):
     return u*v*dx
 
 
+@pytest.fixture(params=["nest", "aij", "matfree"])
+def mat_type(request):
+    return request.param
+
+
 def test_assemble_returns_matrix(a):
     A = assemble(a)
 
@@ -72,9 +77,9 @@ def test_adding_bcs(a, V):
     assert set(A.bcs) == set([bc2, bc3])
 
 
-def test_assemble_with_bcs(a, V):
+def test_assemble_with_bcs(a, V, mat_type):
     bc1 = DirichletBC(V, 0, 1)
-    A = assemble(a, bcs=[bc1])
+    A = assemble(a, bcs=[bc1], mat_type=mat_type)
 
     A.assemble()
     assert A.assembled
@@ -121,9 +126,9 @@ def test_assemble_with_bcs_then_not(a, V):
     assert (Anobcs != Abcs).any()
 
 
-def test_assemble_with_bcs_multiple_subdomains(a, V):
+def test_assemble_with_bcs_multiple_subdomains(a, V, mat_type):
     bc1 = DirichletBC(V, 0, [1, 2])
-    A = assemble(a, bcs=[bc1])
+    A = assemble(a, bcs=[bc1], mat_type=mat_type)
     assert not A.assembled
     assert A._needs_reassembly
     A.assemble()


### PR DESCRIPTION
Mimic the logic involving tracking boundary condition state, so that
we can:

   A = assemble(a, mat_type="matfree")
   bc.apply(A)

and have the correct boundary conditions on A.