### PR TITLE
Non nested MG

### DIFF
--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -174,7 +174,7 @@ def pop_transfer_operators(dm, match=None):
             if transfer == match:
                 stack.pop()
             else:
-                print("Mismatch, not popping")
+                pass
         else:
             stack.pop()
 
@@ -228,6 +228,63 @@ class transfer_operators(object):
             pop_transfer_operators(V.dm, match=self.transfer)
             V = V._fine
         pop_transfer_operators(self.V.dm, match=self.transfer)
+
+
+def push_ctx_coarsener(dm, coarsen):
+    stack = dm.getAttr("__ctx_coarsen__")
+    if stack is None:
+        stack = []
+        dm.setAttr("__ctx_coarsen__", stack)
+    stack.append(coarsen)
+
+
+def pop_ctx_coarsener(dm, match):
+    stack = dm.getAttr("__ctx_coarsen__")
+    if stack:
+        if match is not None:
+            coarsen = stack[-1]
+            if coarsen == match:
+                stack.pop()
+            else:
+                pass
+        else:
+            stack.pop()
+
+
+def get_ctx_coarsener(dm):
+    from firedrake.mg.ufl_utils import coarsen as symbolic_coarsen
+    stack = dm.getAttr("__ctx_coarsen__")
+    if stack:
+        coarsen = stack[-1]
+    else:
+        coarsen = symbolic_coarsen
+
+    return coarsen
+
+
+class ctx_coarsener(object):
+    def __init__(self, V, coarsen=None):
+        from firedrake.mg.ufl_utils import coarsen as symbolic_coarsen
+        self.V = V
+        if coarsen is None:
+            coarsen = symbolic_coarsen
+        self.coarsen = coarsen
+
+    def __enter__(self):
+        push_ctx_coarsener(self.V.dm, self.coarsen)
+        V = self.V
+        while hasattr(V, "_coarse"):
+            V = V._coarse
+            push_ctx_coarsener(V.dm, self.coarsen)
+
+    def __exit__(self, typ, value, traceback):
+        V = self.V
+        while hasattr(V, "_coarse"):
+            V = V._coarse
+        while hasattr(V, "_fine"):
+            pop_ctx_coarsener(V.dm, self.coarsen)
+            V = V._fine
+        pop_ctx_coarsener(V.dm, self.coarsen)
 
 
 def create_matrix(dm):
@@ -329,7 +386,6 @@ def coarsen(dm, comm):
     DM (if found on the input DM).
     """
     from firedrake.mg.utils import get_level
-    from firedrake.mg.ufl_utils import coarsen
     V = get_function_space(dm)
     if V is None:
         raise RuntimeError("No functionspace found on DM")
@@ -339,11 +395,14 @@ def coarsen(dm, comm):
     if hasattr(V, "_coarse"):
         cdm = V._coarse.dm
     else:
-        V._coarse = firedrake.FunctionSpace(hierarchy[level - 1], V.ufl_element())
+        coarsen = get_ctx_coarsener(dm)
+        V._coarse = coarsen(V)
         cdm = V._coarse.dm
 
     transfer = get_transfer_operators(dm)
     push_transfer_operators(cdm, *transfer)
+    coarsen = get_ctx_coarsener(dm)
+    push_ctx_coarsener(cdm, coarsen)
     ctx = get_appctx(dm)
     if ctx is not None:
         push_appctx(cdm, coarsen(ctx))

--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -396,7 +396,7 @@ def coarsen(dm, comm):
         cdm = V._coarse.dm
     else:
         coarsen = get_ctx_coarsener(dm)
-        V._coarse = coarsen(V)
+        V._coarse = coarsen(V, coarsen)
         cdm = V._coarse.dm
 
     transfer = get_transfer_operators(dm)
@@ -405,7 +405,7 @@ def coarsen(dm, comm):
     push_ctx_coarsener(cdm, coarsen)
     ctx = get_appctx(dm)
     if ctx is not None:
-        push_appctx(cdm, coarsen(ctx))
+        push_appctx(cdm, coarsen(ctx, coarsen))
         # Necessary for MG inside a fieldsplit in a SNES.
         cdm.setKSPComputeOperators(firedrake.solving_utils._SNESContext.compute_operators)
     V._coarse._fine = V

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -7,7 +7,7 @@ from . import impl
 from .utils import set_level
 
 
-__all__ = ["MeshHierarchy", "ExtrudedMeshHierarchy"]
+__all__ = ["MeshHierarchy", "ExtrudedMeshHierarchy", "NonNestedHierarchy"]
 
 
 class HierarchyBase(object):
@@ -150,3 +150,7 @@ def ExtrudedMeshHierarchy(base_hierarchy, layers, kernel=None, layer_height=None
     return HierarchyBase(meshes,
                          base_hierarchy.coarse_to_fine_cells,
                          base_hierarchy.fine_to_coarse_cells)
+
+
+def NonNestedHierarchy(*meshes):
+    return HierarchyBase(meshes, [None for _ in meshes], [None for _ in meshes])

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -1,7 +1,7 @@
-
 import ufl
 
 from firedrake import dmhooks
+from firedrake import slate
 from firedrake import solving_utils
 from firedrake import ufl_expr
 from firedrake import utils
@@ -40,8 +40,8 @@ class NonlinearVariationalProblem(object):
         self.bcs = solving._extract_bcs(bcs)
 
         # Argument checking
-        if not isinstance(self.F, ufl.Form):
-            raise TypeError("Provided residual is a '%s', not a Form" % type(self.F).__name__)
+        if not isinstance(self.F, (ufl.Form, slate.slate.TensorBase)):
+            raise TypeError("Provided residual is a '%s', not a Form or Slate Tensor" % type(self.F).__name__)
         if len(self.F.arguments()) != 1:
             raise ValueError("Provided residual is not a linear form")
         if not isinstance(self.u, function.Function):
@@ -51,12 +51,12 @@ class NonlinearVariationalProblem(object):
         # the Jacobian from the residual.
         self.J = J or ufl_expr.derivative(F, u)
 
-        if not isinstance(self.J, ufl.Form):
-            raise TypeError("Provided Jacobian is a '%s', not a Form" % type(self.J).__name__)
+        if not isinstance(self.J, (ufl.Form, slate.slate.TensorBase)):
+            raise TypeError("Provided Jacobian is a '%s', not a Form or Slate Tensor" % type(self.J).__name__)
         if len(self.J.arguments()) != 2:
             raise ValueError("Provided Jacobian is not a bilinear form")
-        if self.Jp is not None and not isinstance(self.Jp, ufl.Form):
-            raise TypeError("Provided preconditioner is a '%s', not a Form" % type(self.Jp).__name__)
+        if self.Jp is not None and not isinstance(self.Jp, (ufl.Form, slate.slate.TensorBase)):
+            raise TypeError("Provided preconditioner is a '%s', not a Form or Slate Tensor" % type(self.Jp).__name__)
         if self.Jp is not None and len(self.Jp.arguments()) != 2:
             raise ValueError("Provided preconditioner is not a bilinear form")
 
@@ -266,12 +266,12 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
         # In the linear case, the Jacobian is the equation LHS.
         J = a
         # Jacobian is checked in superclass, but let's check L here.
-        if not isinstance(L, ufl.Form):
-            raise TypeError("Provided RHS is a '%s', not a Form" % type(L).__name__)
+        if not isinstance(L, (ufl.Form, slate.slate.TensorBase)):
+            raise TypeError("Provided RHS is a '%s', not a Form or Slate Tensor" % type(L).__name__)
         if len(L.arguments()) != 1:
             raise ValueError("Provided RHS is not a linear form")
 
-        F = ufl.action(J, u) - L
+        F = ufl_expr.action(J, u) - L
 
         super(LinearVariationalProblem, self).__init__(F, u, bcs, J, aP,
                                                        form_compiler_parameters=form_compiler_parameters)

--- a/tests/multigrid/test_non_nested.py
+++ b/tests/multigrid/test_non_nested.py
@@ -1,0 +1,40 @@
+from firedrake import *
+from firedrake.mg.ufl_utils import coarsen as symbolic_coarsen
+from functools import singledispatch
+
+
+def test_coarsen_callback():
+    mesh = UnitSquareMesh(4, 4)
+    mh = MeshHierarchy(mesh, 1)
+    mesh = mh[-1]
+
+    V = FunctionSpace(mesh, "CG", 3)
+
+    u = TrialFunction(V)
+
+    v = TestFunction(V)
+
+    a = dot(grad(u), grad(v))*dx + u*v*dx
+
+    L = Constant(1)*v*dx
+
+    @singledispatch
+    def coarsen(expr, self, coefficient_mapping=None):
+        return symbolic_coarsen(expr, self, coefficient_mapping=coefficient_mapping)
+
+    @coarsen.register(functionspaceimpl.FunctionSpace)
+    @coarsen.register(functionspaceimpl.WithGeometry)
+    def coarsen_fs(V, self, coefficient_mapping=None):
+        mesh = self(V.ufl_domain(), self)
+        return FunctionSpace(mesh, "CG", 1)
+
+    uh = Function(V)
+    lvp = LinearVariationalProblem(a, L, uh)
+    lvs = LinearVariationalSolver(lvp, solver_parameters={"ksp_type": "cg",
+                                                          "pc_type": "mg"})
+    with dmhooks.ctx_coarsener(V, coarsen):
+        lvs.solve()
+
+    Ac, _ = lvs.snes.ksp.pc.getMGCoarseSolve().getOperators()
+
+    assert Ac.getSize() == (25, 25)


### PR DESCRIPTION
Nascent support for non-nested MG

Provide callbacks for the user to be able to say how to coarsen variational problems in non-nested hierarchies (we're using this for Gopalakrishnan & Tan (2009) style Trace -> P1 multigrid).

You glue together meshes by saying `mh = NonNestedHierarchy(mesh1, mesh2, mesh3, ...)`

No support for grid transfer is provided (you need to do that yourself!).

Also all definition of variational problems using Slate tensor (rather than just forms).