### PR TITLE
Slate unary precedence

### DIFF
--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -87,7 +87,7 @@ class TensorBase(object, metaclass=ABCMeta):
                 data = (type(op).__name__, )
             else:
                 raise ValueError("Unhandled type %r" % type(op))
-            hashdata.append(data)
+            hashdata.append(data + (op.prec, ))
         hashdata = "".join("%s" % (s, ) for s in hashdata)
         return hashlib.sha512(hashdata.encode("utf-8")).hexdigest()
 
@@ -1044,9 +1044,9 @@ def space_equivalence(A, B):
 # Establishes levels of precedence for Slate tensors
 precedences = [
     [AssembledVector, Block, Factorization, Tensor],
-    [UnaryOp],
     [Add],
-    [Mul, Solve]
+    [Mul, Solve],
+    [UnaryOp],
 ]
 
 # Here we establish the precedence class attribute for a given

--- a/tests/slate/test_unaryop_precedence.py
+++ b/tests/slate/test_unaryop_precedence.py
@@ -1,9 +1,7 @@
-import pytest
 from firedrake import *
 import numpy
 
 
-@pytest.mark.xfail(reason="Unary minus has wrong precedence")
 def test_unary_minus():
     mesh = UnitSquareMesh(1, 1)
 

--- a/tests/slate/test_unaryop_precedence.py
+++ b/tests/slate/test_unaryop_precedence.py
@@ -1,0 +1,28 @@
+import pytest
+from firedrake import *
+import numpy
+
+
+@pytest.mark.xfail(reason="Unary minus has wrong precedence")
+def test_unary_minus():
+    mesh = UnitSquareMesh(1, 1)
+
+    V = FunctionSpace(mesh, "CG", 1)
+
+    uh = Function(V)
+
+    v = TestFunction(V)
+
+    u = TrialFunction(V)
+
+    A = Tensor(u*v*dx)
+
+    B = Tensor(uh*v*dx)
+
+    uh.assign(1)
+
+    expr = action(A, uh) - B
+
+    assert numpy.allclose(norm(assemble(expr)), 0)
+
+    assert numpy.allclose(norm(assemble(-expr)), 0)


### PR DESCRIPTION
Unary minus previously bound too tightly, with the result that:

```python
expr = Tensor(a) + Tensor(b)
nexpr = -expr
```

Would compile the former to:
```python
T4 += A + B
```
but the latter to:
```python
T4 += -A + B
```

Rather than:
```python
T4 += -(A + B)
```