### PR TITLE
Make indexing Slate Tensor blocks much less ugly

### DIFF
--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -58,10 +58,11 @@ class BlockIndexer(object):
        This class is not intended for user instatiation.
     """
 
-    __slots__ = ['tensor']
+    __slots__ = ['tensor', 'block_cache']
 
     def __init__(self, tensor):
         self.tensor = tensor
+        self.block_cache = {}
 
     def __getitem__(self, key):
 
@@ -78,7 +79,14 @@ class BlockIndexer(object):
         blocks = tuple(range(n)[k] if isinstance(k, slice) else k
                        for k, n in zip(key, self.tensor.shape))
 
-        return Block(tensor=self.tensor, indices=blocks)
+        # Avoid repeated instantiation of an equivalent block
+        try:
+            block = self.block_cache[blocks]
+        except KeyError:
+            block = Block(tensor=self.tensor, indices=blocks)
+            self.block_cache[blocks] = block
+
+        return block
 
 
 class TensorBase(object, metaclass=ABCMeta):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -67,12 +67,12 @@ class BlockIndexer(object):
 
         key = list(as_tuple(key))
 
-        if len(key) != self.tensor.rank:
-            raise ValueError("Attempting to index a rank-%s tensor with %s indices."
-                             % (self.tensor.rank, len(key)))
-
         # Make indexing with too few indices legal.
         key += [slice(None) for i in range(self.tensor.rank - len(key))]
+
+        if len(key) > self.tensor.rank:
+            raise ValueError("Attempting to index a rank-%s tensor with %s indices."
+                             % (self.tensor.rank, len(key)))
 
         # Convert slice indices to tuple of indices.
         blocks = tuple(range(n)[k] if isinstance(k, slice) else k
@@ -458,6 +458,9 @@ class Block(TensorBase):
     def __new__(cls, tensor, indices):
         if not isinstance(tensor, TensorBase):
             raise TypeError("Can only extract blocks of Slate tensors.")
+
+        if len(indices) != tensor.rank:
+            raise ValueError("Length of indices must be equal to the tensor rank.")
 
         if not all(0 <= i < len(arg.function_space())
                    for arg, idx in zip(tensor.arguments(), indices) for i in as_tuple(idx)):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -57,23 +57,24 @@ class BlockIndexer(object):
 
        This class is not intended for user instatiation.
     """
-    def __init__(self, tensor):
-        self.tensor = tensor
 
     __slots__ = ['tensor']
 
+    def __init__(self, tensor):
+        self.tensor = tensor
+
     def __getitem__(self, key):
 
-       key = list(key)
+        key = list(as_tuple(key))
 
-       # Make indexing with too few indices legal.
-       key += [slice(None) for i in range(self.tensor.rank - len(key))]
+        # Make indexing with too few indices legal.
+        key += [slice(None) for i in range(self.tensor.rank - len(key))]
 
-       # Convert slice indices to lists of indices.
-       blocks =  list(range(n)[k] if isinstance(k, slice) else k
-                      for k, n in zip(key, tensor.shape))
+        # Convert slice indices to tuple of indices.
+        blocks = tuple(range(n)[k] if isinstance(k, slice) else k
+                       for k, n in zip(key, self.tensor.shape))
 
-       return Block(tensor=tensor, indices=blocks)
+        return Block(tensor=self.tensor, indices=blocks)
 
 
 class TensorBase(object, metaclass=ABCMeta):
@@ -207,7 +208,7 @@ class TensorBase(object, metaclass=ABCMeta):
         """
         return Solve(self, B, decomposition=decomposition)
 
-    @property
+    @cached_property
     def block(self):
         """Return a block of the tensor defined on the component spaces
         described by indices.

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -67,6 +67,10 @@ class BlockIndexer(object):
 
         key = list(as_tuple(key))
 
+        if len(key) != self.tensor.rank:
+            raise ValueError("Attempting to index a rank-%s tensor with %s indices."
+                             % (self.tensor.rank, len(key)))
+
         # Make indexing with too few indices legal.
         key += [slice(None) for i in range(self.tensor.rank - len(key))]
 
@@ -454,9 +458,6 @@ class Block(TensorBase):
     def __new__(cls, tensor, indices):
         if not isinstance(tensor, TensorBase):
             raise TypeError("Can only extract blocks of Slate tensors.")
-
-        if len(indices) != tensor.rank:
-            raise ValueError("Length of indices must be equal to the tensor rank.")
 
         if not all(0 <= i < len(arg.function_space())
                    for arg, idx in zip(tensor.arguments(), indices) for i in as_tuple(idx)):

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -186,7 +186,7 @@ def test_vector_subblocks(mesh):
     K = Tensor(inner(u, v)*dx + inner(phi, psi)*dx + inner(eta, nu)*dx)
     F = Tensor(inner(q, v)*dx + inner(p, psi)*dx + inner(r, nu)*dx)
     E = K.inv * F
-    items = [(E.block((0,)), q), (E.block((1,)), p), (E.block((2,)), r)]
+    items = [(E.block[0], q), (E.block[1], p), (E.block[2], r)]
 
     for tensor, ref in items:
         assert np.allclose(assemble(tensor).dat.data, ref.dat.data, rtol=1e-14)
@@ -211,24 +211,24 @@ def test_matrix_subblocks(mesh):
     # Test individual blocks
     indices = [(0, 0), (0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2)]
     refs = dict(split_form(A.form))
-    for idx in indices:
-        ref = assemble(refs[idx]).M.values
-        block = A.block(idx)
+    for x, y in indices:
+        ref = assemble(refs[x, y]).M.values
+        block = A.block[x, y]
         assert np.allclose(assemble(block).M.values, ref, rtol=1e-14)
 
     # Mixed blocks
-    A0101 = A.block(((0, 1), (0, 1)))
-    A1212 = A.block(((1, 2), (1, 2)))
+    A0101 = A.block[:2, :2]
+    A1212 = A.block[1:3, 1:3]
 
     # Block of blocks
-    A0101_00 = A0101.block((0, 0))
-    A0101_11 = A0101.block((1, 1))
-    A0101_01 = A0101.block((0, 1))
-    A0101_10 = A0101.block((1, 0))
-    A1212_00 = A1212.block((0, 0))
-    A1212_11 = A1212.block((1, 1))
-    A1212_01 = A1212.block((0, 1))
-    A1212_10 = A1212.block((1, 0))
+    A0101_00 = A0101.block[0, 0]
+    A0101_11 = A0101.block[1, 1]
+    A0101_01 = A0101.block[0, 1]
+    A0101_10 = A0101.block[1, 0]
+    A1212_00 = A1212.block[0, 0]
+    A1212_11 = A1212.block[1, 1]
+    A1212_01 = A1212.block[0, 1]
+    A1212_10 = A1212.block[1, 0]
 
     items = [(A0101_00, refs[(0, 0)]),
              (A0101_11, refs[(1, 1)]),

--- a/tests/slate/test_slate_infrastructure.py
+++ b/tests/slate/test_slate_infrastructure.py
@@ -221,33 +221,33 @@ def test_blocks(zero_rank_tensor, mixed_matrix, mixed_vector):
     a = M.form
     L = F.form
     splitter = ExtractSubBlock()
-    M00 = M.block((0, 0))
-    M11 = M.block((1, 1))
-    M22 = M.block((2, 2))
-    M0101 = M.block(((0, 1), (0, 1)))
-    M012 = M.block(((0, 1), (2,)))
-    M201 = M.block((((2,), (0, 1))))
-    F0 = F.block((0,))
-    F1 = F.block((1,))
-    F2 = F.block((2,))
-    F01 = F.block(((0, 1),))
-    F12 = F.block(((1, 2),))
+    M00 = M.block[0, 0]
+    M11 = M.block[1, 1]
+    M22 = M.block[2, 2]
+    M0101 = M.block[:2, :2]
+    M012 = M.block[:2, 2]
+    M201 = M.block[2, :2]
+    F0 = F.block[0]
+    F1 = F.block[1]
+    F2 = F.block[2]
+    F01 = F.block[:2]
+    F12 = F.block[1:3]
 
     # Test index checking
     with pytest.raises(ValueError):
-        S.block((0,))
+        S.block[0]
 
     with pytest.raises(ValueError):
-        F.block((0, 1))
+        F.block[0, 1]
 
     with pytest.raises(ValueError):
-        M.block(((0, 1, 2, 3), 0))
+        M.block[0:5, 2]
 
     with pytest.raises(ValueError):
-        M.block((3, 3))
+        M.block[3, 3]
 
     with pytest.raises(ValueError):
-        F.block((3,))
+        F.block[3]
 
     # Check Tensor is (not) mixed where appropriate
     assert not M00.is_mixed
@@ -263,13 +263,13 @@ def test_blocks(zero_rank_tensor, mixed_matrix, mixed_vector):
     assert F12.is_mixed
 
     # Taking blocks of non-mixed block (or scalars) should induce a no-op
-    assert S.block(()) == S
-    assert M00.block((0, 0)) == M00
-    assert M11.block((0, 0)) == M11
-    assert M22.block((0, 0)) == M22
-    assert F0.block((0,)) == F0
-    assert F1.block((0,)) == F1
-    assert F2.block((0,)) == F2
+    assert S.block[None] == S   # This is silly, but it's technically a no-op
+    assert M00.block[0, 0] == M00
+    assert M11.block[0, 0] == M11
+    assert M22.block[0, 0] == M22
+    assert F0.block[0] == F0
+    assert F1.block[0] == F1
+    assert F2.block[0] == F2
 
     # Test arguments
     assert M00.arguments() == splitter.split(a, (0, 0)).arguments()


### PR DESCRIPTION
This is a short change to the code which is intended to make indexing slate tensor blocks work like proper python indexing rather than requiring lots of nested lists. For example `A.block(((0, 1), (0, 1)))` now becomes `A.block[:2, :2]`. Consequential changes to tests and demos are still needed.