### PR TITLE
slate: Add approximate flop counts to kernels

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -226,6 +226,7 @@ def generate_kernel_ast(builder, statements, declared_temps):
                            headers=['#include <Eigen/Dense>',
                                     '#define restrict __restrict'])
 
+    op2kernel.num_flops = builder.expression_flops + builder.terminal_flops
     # Send back a "TSFC-like" SplitKernel object with an
     # index and KernelInfo
     kinfo = KernelInfo(kernel=op2kernel,


### PR DESCRIPTION
A slate expression has a flop count consisting of the flops to
assemble the terminal data (approximately determined from the TSFC
kernels), and the flops to compute the expression on assembled data.
This latter is just matrix algebra, so easy to do.

@rckirby use this to get flops counts for slate kernels doing static condensation.