### PR TITLE
Enable the use of MG etc for the algebraic solve interface. Fixes #1256.

### DIFF
--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -223,12 +223,8 @@ def _la_solve(A, x, b, **kwargs):
                              near_nullspace=near_nullspace,
                              options_prefix=options_prefix)
 
-    from firedrake import dx, inner, Constant
-    v = ufl.algorithms.extract_arguments(A.a)[0]
-    L = inner(Constant(ufl.zero(v.ufl_shape)), v)*dx # linear MG doesn't need RHS form,
-                                                     # supply zero
-
-    lvp = vs.LinearVariationalProblem(a=A.a, L=L, u=x, bcs=bcs)
+    # linear MG doesn't need RHS, supply zero.
+    lvp = vs.LinearVariationalProblem(a=A.a, L=0, u=x, bcs=bcs)
     mat_type = solver_parameters.get("mat_type")
     appctx = solver_parameters.get("appctx", {})
     ctx = solving_utils._SNESContext(lvp,

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -266,12 +266,14 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
         # In the linear case, the Jacobian is the equation LHS.
         J = a
         # Jacobian is checked in superclass, but let's check L here.
-        if not isinstance(L, (ufl.Form, slate.slate.TensorBase)):
-            raise TypeError("Provided RHS is a '%s', not a Form or Slate Tensor" % type(L).__name__)
-        if len(L.arguments()) != 1:
-            raise ValueError("Provided RHS is not a linear form")
-
-        F = ufl_expr.action(J, u) - L
+        if L is 0:
+            F = ufl_expr.action(J, u)
+        else:
+            if not isinstance(L, (ufl.Form, slate.slate.TensorBase)):
+                raise TypeError("Provided RHS is a '%s', not a Form or Slate Tensor" % type(L).__name__)
+            if len(L.arguments()) != 1:
+                raise ValueError("Provided RHS is not a linear form")
+            F = ufl_expr.action(J, u) - L
 
         super(LinearVariationalProblem, self).__init__(F, u, bcs, J, aP,
                                                        form_compiler_parameters=form_compiler_parameters)


### PR DESCRIPTION
Enable the use of sophisticated solvers via DM contexts with the algebraic solve interface `solve(A, u, b)`.

Fixes firedrake #1256 and dolfin-adjoint #59 (https://bitbucket.org/dolfin-adjoint/pyadjoint/issues/59/cannot-use-firedrake-mg-firedrake_adjoint).