### PR TITLE
replace git-core by git

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1005,7 +1005,7 @@ if mode == "install" or not args.update_script:
                             "automake",
                             "cmake",
                             "gfortran",
-                            "git-core",
+                            "git",
                             "libblas-dev",
                             "liblapack-dev",
                             "libopenmpi-dev",


### PR DESCRIPTION
Fixing #1240 (AFAIK `git-core` was a dummy package for `git` for a long time, and now doesn't exist at all)