### PR TITLE
Fix obscure bug with solve(A, x, b) if A had multiple DirichletBCs ap…

### DIFF
--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -319,7 +319,8 @@ class FunctionSpace(object):
         # FIXME: Think harder about equality
         return self.mesh() is other.mesh() and \
             self.dof_dset is other.dof_dset and \
-            self.ufl_element() == other.ufl_element()
+            self.ufl_element() == other.ufl_element() and \
+            self.component == other.component
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/firedrake/matrix.py
+++ b/firedrake/matrix.py
@@ -100,7 +100,7 @@ class MatrixBase(object, metaclass=abc.ABCMeta):
         new_bcs = [bc]
         for existing_bc in self._bcs:
             # New BC doesn't override existing one, so keep it.
-            if bc.sub_domain != existing_bc.sub_domain:
+            if bc.sub_domain != existing_bc.sub_domain or bc.function_space() != existing_bc.function_space():
                 new_bcs.append(existing_bc)
         self._bcs = new_bcs
 

--- a/tests/regression/test_la_solve_bcs.py
+++ b/tests/regression/test_la_solve_bcs.py
@@ -1,5 +1,6 @@
 from firedrake import *
 
+
 def test_la_solve_bcs():
     mesh = UnitSquareMesh(10, 10)
     V = VectorFunctionSpace(mesh, "CG", 1)
@@ -8,7 +9,7 @@ def test_la_solve_bcs():
 
     bcs = []
     for i in [0, 1]:
-        bc = DirichletBC(V.sub(i), 0, "on_boundary") # different components
+        bc = DirichletBC(V.sub(i), 0, "on_boundary")  # different components
         bcs.insert(0, bc)
         bc.apply(A)
 

--- a/tests/regression/test_la_solve_bcs.py
+++ b/tests/regression/test_la_solve_bcs.py
@@ -1,0 +1,15 @@
+from firedrake import *
+
+def test_la_solve_bcs():
+    mesh = UnitSquareMesh(10, 10)
+    V = VectorFunctionSpace(mesh, "CG", 1)
+
+    A = assemble(inner(grad(TrialFunction(V)), grad(TestFunction(V)))*dx)
+
+    bcs = []
+    for i in [0, 1]:
+        bc = DirichletBC(V.sub(i), 0, "on_boundary") # different components
+        bcs.insert(0, bc)
+        bc.apply(A)
+
+    assert A.bcs == bcs


### PR DESCRIPTION
As bc.apply(A) was called in turn, each bc would replace the previous ones,
rather than appending to A.bcs, if they applied to different components of the solution space.