### PR TITLE
Fix R.dim to be a method for consistency with other function spaces

### DIFF
--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -839,7 +839,6 @@ class RealFunctionSpace(FunctionSpace):
     """
 
     finat_element = None
-    dim = 1
     rank = 0
     shape = ()
     value_size = 1
@@ -900,3 +899,6 @@ class RealFunctionSpace(FunctionSpace):
     def top_nodes(self):
         ":class:`RealFunctionSpace` objects have no bottom nodes."
         return None
+
+    def dim(self):
+        return 1


### PR DESCRIPTION
Consider

```
from firedrake import *

mesh = UnitSquareMesh(10, 10)

Vele = VectorElement("CG", mesh.ufl_cell(), 2, dim=3)
Qele = FiniteElement("DG", mesh.ufl_cell(), 0)
Rele = FiniteElement("R",  mesh.ufl_cell(), 0)
Zele = MixedElement([Vele, Qele, Rele])
Z = FunctionSpace(mesh, Zele)

print(Z.sub(0).dim())
print(Z.sub(1).dim())
print(Z.sub(2).dim())
```
prints

```
1323
200
Traceback (most recent call last):
  File "wtf.py", line 13, in <module>
    print(Z.sub(2).dim())
TypeError: 'int' object is not callable
```

This branch fixes this.