### PR TITLE
fix expression dimension in test_slate_infrastructure.py

### DIFF
--- a/tests/slate/test_slate_infrastructure.py
+++ b/tests/slate/test_slate_infrastructure.py
@@ -1,6 +1,7 @@
 import pytest
 from firedrake import *
 from firedrake.formmanipulation import ExtractSubBlock
+import math
 
 
 @pytest.fixture(scope='module', params=[interval, triangle, quadrilateral])
@@ -58,7 +59,8 @@ def stiffness(function_space):
 @pytest.fixture
 def load(function_space):
     f = Function(function_space)
-    f.interpolate(Expression("cos(x[0]*pi*2)"))
+    x = SpatialCoordinate(function_space.mesh())
+    f.interpolate(cos(x[0])*math.pi*2)
     v = TestFunction(function_space)
     return Tensor(f * v * dx)
 
@@ -66,10 +68,11 @@ def load(function_space):
 @pytest.fixture
 def boundary_load(function_space):
     f = Function(function_space)
-    if function_space.mesh().cell_dimension == 1:
-        f.interpolate(Expression("cos(x[0]*pi*2)"))
+    x = SpatialCoordinate(function_space.mesh())
+    if function_space.mesh().cell_dimension() == 1:
+        f.interpolate(cos(x[0]*math.pi*2))
     else:
-        f.interpolate(Expression("cos(x[1]*pi*2)"))
+        f.interpolate(cos(x[1] * math.pi*2))
     v = TestFunction(function_space)
     return Tensor(f * v * ds)
 
@@ -77,10 +80,11 @@ def boundary_load(function_space):
 @pytest.fixture
 def zero_rank_tensor(function_space):
     c = Function(function_space)
-    if function_space.mesh().cell_dimension == 1:
-        c.interpolate(Expression("x[0]*x[0]"))
+    x = SpatialCoordinate(function_space.mesh())
+    if function_space.mesh().cell_dimension() == 1:
+        c.interpolate(x[0]*x[0])
     else:
-        c.interpolate(Expression("x[0]*x[1]"))
+        c.interpolate(x[0]*x[1])
     return Tensor(c * dx)
 
 

--- a/tests/slate/test_slate_infrastructure.py
+++ b/tests/slate/test_slate_infrastructure.py
@@ -66,7 +66,10 @@ def load(function_space):
 @pytest.fixture
 def boundary_load(function_space):
     f = Function(function_space)
-    f.interpolate(Expression("cos(x[1]*pi*2)"))
+    if function_space.mesh().cell_dimension == 1:
+        f.interpolate(Expression("cos(x[0]*pi*2)"))
+    else:
+        f.interpolate(Expression("cos(x[1]*pi*2)"))
     v = TestFunction(function_space)
     return Tensor(f * v * ds)
 
@@ -74,7 +77,10 @@ def boundary_load(function_space):
 @pytest.fixture
 def zero_rank_tensor(function_space):
     c = Function(function_space)
-    c.interpolate(Expression("x[0]*x[1]"))
+    if function_space.mesh().cell_dimension == 1:
+        c.interpolate(Expression("x[0]*x[0]"))
+    else:
+        c.interpolate(Expression("x[0]*x[1]"))
     return Tensor(c * dx)
 
 


### PR DESCRIPTION
When interpolating `"cos(x[1]*pi*2)"` in `boundary_load` on intervals, the generated code is
```
// ...
 static inline void expression_kernel (double  A[2] , double*  x_ )
{
  const double  X[2][2]  = {{1.0,-2.47782643405e-17},
  {-2.47782643405e-17,1.0}};
  double  x[1] ;
  const double  pi  = 3.141592653589793;
  {
    for (int  k  = 0; k < 2; k += 1)
    {   
      for (unsigned int  d  = 0; d < 1; d += 1)
      {
        x[d] = 0;   
        for (unsigned int  i  = 0; i < 2; i += 1)
        {
          x[d] += X[k][i] * x_[(i * 1) + d];
        }
      }
      A[k] = cos(x[1]*pi*2);
    }
  }
}
// ...
```
so we have a out of bound access at `x[1]`.

Another issue, apart from my fix may or may not make mathematical sense, is that we shouldn't actually generate code for this test. What I observe is, if I just run

> `py.test slate/test_slate_infrastructure.py::test_integral_information` 

no code is generated. But if I run

> `py.test slate/test_slate_infrastructure.py`

code for interpolation is generated at the test `slate/test_slate_infrastructure.py::test_integral_information[cg2-mesh2]`.

Presumably something triggered the evaluation of the queue, but I haven't figured out why. Can raise a separate issue if it is indeed problematic.