### PR TITLE
Documentation dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         sh 'mkdir tmp'
         dir('tmp') {
           timestamps {
-            sh '../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --slope --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
+            sh '../scripts/firedrake-install --disable-ssh --minimal-petsc ${SLEPC} --slope --documentation-dependencies --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
           }
         }
       }
@@ -63,6 +63,18 @@ python -m pytest -n 4 --cov firedrake -v tests
             sh '''
 . ./firedrake/bin/activate
 cd firedrake/src/pyadjoint; python -m pytest -v tests/firedrake_adjoint
+'''
+          }
+        }
+      }
+    }
+    stage('Test build documentation'){
+      steps {
+        dir('tmp') {
+          timestamps {
+            sh '''
+. ./firedrake/bin/activate
+cd firedrake/src/firedrake/docs; make html
 '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,9 @@ cd firedrake/src/pyadjoint; python -m pytest -v tests/firedrake_adjoint
           timestamps {
             sh '''
 . ./firedrake/bin/activate
+echo $PATH
+echo $VIRTUAL_ENV
+ls $VIRTUAL_ENV/bin
 cd firedrake/src/firedrake/docs; make html
 '''
           }

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -138,20 +138,7 @@ Paraview_.  On Ubuntu and similar systems, you can obtain Paraview by
 installing the ``paraview`` package.  On Mac OS, the easiest approach
 is to download a binary from the `paraview website <Paraview_>`_.
 
-
-Documentation dependencies
---------------------------
-
-Building the documention requires Sphinx_ (including the Youtube and
-Bibtex plugins) and wget_.  In addition the Sphinx Youtube and bibtex
-plugins are required.  The former is available from
-`a fork of the sphinx-contrib repository
-<https://bitbucket.org/David_Ham/sphinx-contrib>`__, the latter is
-the python package ``sphinxcontrib-bibtex``.
-
 .. _Paraview: http://www.paraview.org
-.. _Sphinx: http://www.sphinx-doc.org/
-.. _wget: http://www.gnu.org/software/wget/
 .. _venv: https://docs.python.org/3/tutorial/venv.html
 .. _homebrew: https://brew.sh/
 .. _anaconda: https://www.continuum.io/downloads

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -902,7 +902,7 @@ def install_documentation_dependencies():
     log.info("Installing documentation dependencies")
     run_pip_install(["sphinx"])
     run_pip_install(["sphinxcontrib-bibtex"])
-    install("git+https://github.com/sphinx-contrib/youtube.git")
+    run_pip_install(["git+https://github.com/sphinx-contrib/youtube.git"])
 
 
 def clean_obsolete_packages():

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -241,6 +241,8 @@ honoured.""",
     parser.add_argument("--cache-dir", type=str,
                         action="store",
                         help="Directory to use for disk caches of compiled code (default is the .cache subdirectory of the Firedrake installation).")
+    parser.add_argument("--documentation-dependencies", action="store_true",
+                        help="Install the dependencies required to build the documentation")
 
     args = parser.parse_args()
 
@@ -309,6 +311,8 @@ else:
     parser.add_argument("--cache-dir", type=str,
                         action="store", default=config["options"].get("cache_dir", ""),
                         help="Directory to use for disk caches of compiled code (default is the .cache subdirectory of the Firedrake installation).")
+    parser.add_argument("--documentation-dependencies", action="store_true",
+                        help="Install the dependencies required to build the documentation")
 
     args = parser.parse_args()
 
@@ -892,6 +896,15 @@ def build_and_install_slope():
         log.info("No need to rebuild SLOPE")
 
 
+def install_documentation_dependencies():
+    """Just install the required dependencies. There are no provenance
+    issues here so no need to record this in the configuration dict."""
+    log.info("Installing documentation dependencies")
+    install("sphynx")
+    install("sphynxcontrib-bibtex")
+    install("git+https://github.com/sphinx-contrib/youtube.git")
+
+
 def clean_obsolete_packages():
     dirs = os.listdir(".")
     for package in old_git_packages:
@@ -1124,12 +1137,6 @@ if mode == "install":
         pass
     packages.remove("petsc4py")
     packages.remove("firedrake")
-    v = sys.version_info
-    if v.major <= 2:
-        easyinstall = open("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "r").readlines()
-        new_packages = [os.getcwd() + "/" + p + "\n" for p in packages]
-        open("../lib/python%d.%d/site-packages/easy-install.pth" % (v.major, v.minor), "w").writelines(
-            easyinstall[:1] + new_packages + easyinstall[1:])
 
     build_update_script()
 
@@ -1213,6 +1220,8 @@ if options["slepc"]:
     build_and_install_slepc()
 if options["slope"]:
     build_and_install_slope()
+if args.documentation_dependencies:
+    install_documentation_dependencies()
 
 try:
     import firedrake_configuration

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -900,8 +900,8 @@ def install_documentation_dependencies():
     """Just install the required dependencies. There are no provenance
     issues here so no need to record this in the configuration dict."""
     log.info("Installing documentation dependencies")
-    install("sphinx")
-    install("sphinxcontrib-bibtex")
+    run_pip_install(["sphinx"])
+    run_pip_install(["sphinxcontrib-bibtex"])
     install("git+https://github.com/sphinx-contrib/youtube.git")
 
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -900,9 +900,9 @@ def install_documentation_dependencies():
     """Just install the required dependencies. There are no provenance
     issues here so no need to record this in the configuration dict."""
     log.info("Installing documentation dependencies")
-    run_pip_install(["sphinx"])
-    run_pip_install(["sphinxcontrib-bibtex"])
-    run_pip_install(["git+https://github.com/sphinx-contrib/youtube.git"])
+    run_pip_install(["--ignore-installed", "sphinx"])
+    run_pip_install(["--ignore-installed", "sphinxcontrib-bibtex"])
+    run_pip_install(["--ignore-installed", "git+https://github.com/sphinx-contrib/youtube.git"])
 
 
 def clean_obsolete_packages():

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -900,8 +900,8 @@ def install_documentation_dependencies():
     """Just install the required dependencies. There are no provenance
     issues here so no need to record this in the configuration dict."""
     log.info("Installing documentation dependencies")
-    install("sphynx")
-    install("sphynxcontrib-bibtex")
+    install("sphinx")
+    install("sphinxcontrib-bibtex")
     install("git+https://github.com/sphinx-contrib/youtube.git")
 
 


### PR DESCRIPTION
Add a command line option to firedrake-install which downloads the dependencies needed to build the documentation. Replaces the current messy manual process.