### PR TITLE
Let the user control the colour of the mesh in plotting

### DIFF
--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -147,11 +147,15 @@ def plot_mesh(mesh, axes=None, surface=False, **kwargs):
         # Pad 1D array with zeros
         coords = np.dstack((coords, np.zeros_like(coords))).reshape(-1, 2)
     vertices = coords[values[:, idx]]
+
+    # need to pop the colors before we pass kwargs to figure
+    colors = kwargs.pop("colors", None)
+
     if axes is None:
         figure = plt.figure()
         axes = figure.add_subplot(111, projection=projection, **kwargs)
 
-    lines = Lines(vertices)
+    lines = Lines(vertices, colors=colors)
 
     if gdim == 3:
         axes.add_collection3d(lines)


### PR DESCRIPTION
This enables

`plot(mesh, colors=colors)`

where colors is passed to `matplotlib.collections.LineCollection`. (For example, `colors=[(0, 0, 0, 1)]` will plot the mesh edges in black.)