### PR TITLE
Fix webpage typo

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ Features:
   for high order elements, and vectorisation.
 * Geometric multigrid.
 * Customisable operator preconditioners.
-* Support for hydridisation, and HDG methods.
+* Support for static condensation, hybridisation, and HDG methods.
 
 
 .. only:: html


### PR DESCRIPTION
This fixes a minor typo in the "Features" list on the main webpage. "hydridisation" is now "hybridisation". I also decided to throw in "static condensation" since people have used it without hybridisation in mind.