### PR TITLE
A preconditioner for explicitly specifiying the form to use as approximate Schur complements

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -122,6 +122,9 @@ def coarsen_bc(bc, self, coefficient_mapping=None):
 @coarsen.register(firedrake.functionspaceimpl.FunctionSpace)
 @coarsen.register(firedrake.functionspaceimpl.WithGeometry)
 def coarsen_function_space(V, self, coefficient_mapping=None):
+    if hasattr(V, "_coarse"):
+        return V._coarse
+    fine = V
     indices = []
     while True:
         if V.index is not None:
@@ -138,6 +141,8 @@ def coarsen_function_space(V, self, coefficient_mapping=None):
     V = firedrake.FunctionSpace(mesh, V.ufl_element())
     for i in reversed(indices):
         V = V.sub(i)
+    V._fine = fine
+    fine._coarse = V
     return V
 
 

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -79,7 +79,7 @@ class AssembledPC(PCBase):
         self._assemble_P()
         self.P.force_evaluation()
 
-    def form(self, test, trial, pc):
+    def form(self, pc, test, trial):
         _, P = pc.getOperators()
         assert P.type == "python"
         context = P.getPythonContext()

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -1,6 +1,7 @@
 import abc
 
 from firedrake.preconditioners.base import PCBase
+from firedrake.functionspace import FunctionSpace, MixedFunctionSpace
 from firedrake.petsc import PETSc
 from firedrake.ufl_expr import TestFunction, TrialFunction
 from firedrake.dmhooks import get_function_space
@@ -29,6 +30,10 @@ class AssembledPC(PCBase):
         fcp = appctx.get("form_compiler_parameters")
 
         V = get_function_space(pc.getDM())
+        if len(V) == 1:
+            V = FunctionSpace(V.mesh(), V.ufl_element())
+        else:
+            V = MixedFunctionSpace([V_ for V_ in V])
         test = TestFunction(V)
         trial = TrialFunction(V)
 

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -116,7 +116,7 @@ class ExplicitSchurPC(AssembledPC):
 
         :arg trial: a `TrialFunction` on this `FunctionSpace`.
 
-        This method should return `(a, bcs)`, where `a` is a bilinear `Form`
+        :returns `(a, bcs)`, where `a` is a bilinear `Form`
         and `bcs` is a list of `DirichletBC` boundary conditions (possibly `None`).
         """
         raise NotImplementedError

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -181,7 +181,7 @@ class _SNESContext(object):
             J = replace(J, {problem.u: u})
             if problem.Jp is not None:
                 Jp = splitter.split(problem.Jp, argument_indices=(field, field))
-                Jp = replace(Jp, {problem.u: subu})
+                Jp = replace(Jp, {problem.u: u})
             else:
                 Jp = None
             bcs = []

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -96,6 +96,7 @@ class _SNESContext(object):
         # context we could just require the user to pass in the
         # full state on the outside.
         appctx.setdefault("state", self._x)
+        appctx.setdefault("form_compiler_parameters", self.fcp)
 
         self.appctx = appctx
         self.matfree = matfree


### PR DESCRIPTION
This adds an `ExplicitSchurPC` that gives users a hook to specify a bilinear form to be used to assemble a Schur complement approximation.

It's driven by subclassing `ExplicitSchurPC` and overriding the `form` method to supply the form and boundary conditions.

Under the hood, it's just a subclass of `AssembledPC` that gets the form from its `form` method instead of the Python context. Some small refactoring of `AssembledPC` was necessary to make this possible.

To see how this can be used, I changed the Stokes fieldsplit solve in the geometric multigrid demo. I verified that it gives exactly the same results as the old code, up to roundoff errors (KSP residual norm  `1.576276679138e-05` at iteration 22 vs `1.576276688964e-05` with the old code).