### PR TITLE
Slate support for Argyris, Morley, Hermite, and Bell

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -206,6 +206,12 @@ def generate_kernel_ast(builder, statements, declared_temps):
     if builder.needs_mesh_layers:
         args.append(ast.Decl("int", builder.mesh_layer_sym))
 
+    # Cell size information
+    if builder.needs_cell_sizes:
+        args.append(ast.Decl(SCALAR_TYPE, builder.cell_size_sym,
+                             pointers=[("restrict",)],
+                             qualifiers=["const"]))
+
     # Macro kernel
     macro_kernel_name = "compile_slate"
     stmts = ast.Block(statements)

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -263,7 +263,7 @@ class LocalKernelBuilder(object):
                                  "exterior_facet_vert"]:
                     args.append(ast.FlatBlock("&%s" % self.it_sym))
 
-                if needs_cell_sizes:
+                if kinfo.needs_cell_sizes:
                     args.append(self.cell_size_sym)
 
                 # Assembly calls within the macro kernel

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -52,6 +52,7 @@ class LocalKernelBuilder(object):
     cell_facet_sym = ast.Symbol("cell_facets")
     it_sym = ast.Symbol("i0")
     mesh_layer_sym = ast.Symbol("layer")
+    cell_size_sym = ast.Symbol("cell_sizes")
 
     # Supported integral types
     supported_integral_types = [
@@ -248,6 +249,7 @@ class LocalKernelBuilder(object):
                 indices = split_kernel.indices
                 kinfo = split_kernel.kinfo
                 kint_type = kinfo.integral_type
+                needs_cell_sizes = needs_cell_sizes or kinfo.needs_cell_sizes
 
                 args = [c for i in kinfo.coefficient_map
                         for c in self.coefficient(local_coefficients[i])]
@@ -260,6 +262,9 @@ class LocalKernelBuilder(object):
                                  "interior_facet_vert",
                                  "exterior_facet_vert"]:
                     args.append(ast.FlatBlock("&%s" % self.it_sym))
+
+                if needs_cell_sizes:
+                    args.append(self.cell_size_sym)
 
                 # Assembly calls within the macro kernel
                 tensor = eigen_tensor(exp, self.temps[exp], indices)
@@ -285,7 +290,6 @@ class LocalKernelBuilder(object):
                 templated_subkernels.append(kast)
                 include_dirs.extend(kinfo.kernel._include_dirs)
                 oriented = oriented or kinfo.oriented
-                needs_cell_sizes = needs_cell_sizes or kinfo.needs_cell_sizes
 
         # Add subdomain call to assembly dict
         assembly_calls.update(subdomain_calls)

--- a/tests/slate/test_zany_element_tensors.py
+++ b/tests/slate/test_zany_element_tensors.py
@@ -1,0 +1,44 @@
+import pytest
+import numpy as np
+from firedrake import *
+
+
+@pytest.fixture(scope='module')
+def mesh(request):
+    return UnitSquareMesh(2, 2)
+
+
+@pytest.fixture(scope='module', params=['M2', 'H3', 'B5', 'A5'])
+def function_space(request, mesh):
+    """Generates zany function spaces for testing SLATE tensor assembly."""
+    A5 = FunctionSpace(mesh, "Argyris", 5)
+    B5 = FunctionSpace(mesh, "Bell", 5)
+    H3 = FunctionSpace(mesh, "Hermite", 3)
+    M2 = FunctionSpace(mesh, "Morley", 2)
+    return {'A5': A5,
+            'B5': B5,
+            'H3': H3,
+            'M2': M2}[request.param]
+
+
+@pytest.fixture
+def mass(function_space):
+    """Generate a generic zany mass form."""
+    u = TrialFunction(function_space)
+    v = TestFunction(function_space)
+    return inner(u, v) * dx
+
+
+@pytest.fixture
+def mass_matrix(mass):
+    return Tensor(mass)
+
+
+def test_assemble_zany_tensor(mass_matrix):
+    M = assemble(mass_matrix)
+    assert np.allclose(M.M.values, assemble(mass_matrix.form).M.values, rtol=1e-14)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_zany_element_tensors.py
+++ b/tests/slate/test_zany_element_tensors.py
@@ -8,17 +8,15 @@ def mesh(request):
     return UnitSquareMesh(2, 2)
 
 
-@pytest.fixture(scope='module', params=['M2', 'H3', 'B5', 'A5'])
+@pytest.fixture(scope='module',
+                params=[("Morley", 2),
+                        ("Hermite", 3),
+                        ("Bell", 5),
+                        ("Argyris", 5)],
+                ids=['M2', 'H3', 'B5', 'A5'])
 def function_space(request, mesh):
     """Generates zany function spaces for testing SLATE tensor assembly."""
-    A5 = FunctionSpace(mesh, "Argyris", 5)
-    B5 = FunctionSpace(mesh, "Bell", 5)
-    H3 = FunctionSpace(mesh, "Hermite", 3)
-    M2 = FunctionSpace(mesh, "Morley", 2)
-    return {'A5': A5,
-            'B5': B5,
-            'H3': H3,
-            'M2': M2}[request.param]
+    return FunctionSpace(mesh, *request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
Addresses an issue raised by @pefarrell in #1310. This PR makes sure the `cell_size` argument is handled correctly in the Slate compiler.