### PR TITLE
tests: Fix pytest cleanup failure in output tests

### DIFF
--- a/tests/output/conftest.py
+++ b/tests/output/conftest.py
@@ -1,0 +1,16 @@
+from firedrake import COMM_WORLD
+import tempfile
+import pytest
+
+
+@pytest.fixture
+def dumpdir():
+    comm = COMM_WORLD
+    if comm.rank == 0:
+        tmp = tempfile.TemporaryDirectory()
+        yield comm.bcast(tmp.name, root=0)
+        comm.barrier()
+        tmp.cleanup()
+    else:
+        yield comm.bcast(None, root=0)
+        comm.barrier()

--- a/tests/output/test_config_exist.py
+++ b/tests/output/test_config_exist.py
@@ -1,5 +1,3 @@
-
-
 def test_config_exist():
     import firedrake_configuration
     config = firedrake_configuration.get_config()

--- a/tests/output/test_dumb_checkpoint.py
+++ b/tests/output/test_dumb_checkpoint.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from firedrake import *
 import numpy as np
 
@@ -21,8 +22,8 @@ def fs(request):
 
 
 @pytest.fixture
-def dumpfile(tmpdir):
-    return str(tmpdir.join("dump"))
+def dumpfile(dumpdir):
+    return os.path.join(dumpdir, "dump")
 
 
 @pytest.fixture(scope="module")
@@ -158,8 +159,3 @@ def test_new_file_valueerror(f, dumpfile):
         chk.store(f)
         with pytest.raises(ValueError):
             chk.new_file()
-
-
-if __name__ == "__main__":
-    import os
-    pytest.main(os.path.abspath(__file__))

--- a/tests/output/test_hdf5file_checkpoint.py
+++ b/tests/output/test_hdf5file_checkpoint.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from firedrake import *
 import numpy as np
 from mpi4py import MPI
@@ -23,8 +24,8 @@ def fs(request):
 
 
 @pytest.fixture
-def dumpfile(tmpdir):
-    return str(tmpdir.join("dump.h5"))
+def dumpfile(dumpdir):
+    return os.path.join(dumpdir, "dump")
 
 
 @pytest.fixture(scope="module")
@@ -128,8 +129,3 @@ def test_multiple_timestamps(f, dumpfile):
         timestamps = h5.get_timestamps()
 
         assert np.allclose(timestamps, [0.1, 0.2])
-
-
-if __name__ == "__main__":
-    import os
-    pytest.main(os.path.abspath(__file__))

--- a/tests/output/test_pvd_output.py
+++ b/tests/output/test_pvd_output.py
@@ -19,8 +19,9 @@ def mesh(request):
 
 
 @pytest.fixture
-def pvd(tmpdir):
-    return File(str(tmpdir.join("foo.pvd")))
+def pvd(dumpdir):
+    f = join(dumpdir, "foo.pvd")
+    return File(f)
 
 
 def test_can_save_coordinates(mesh, pvd):
@@ -161,8 +162,3 @@ def test_restart_shorten(mesh, tmpdir):
     for i, ds in enumerate(datasets):
         assert ds.attrib["timestep"] == "%d" % i
         assert ds.attrib["file"] == "restart_%d.vtu" % i
-
-
-if __name__ == "__main__":
-    import os
-    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Seems like the tmpdir fixture doesn't like the parallel run we were
doing. So fabricate our own.