### PR TITLE
some fixes for bcs on components of vector spaces

### DIFF
--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -159,12 +159,19 @@ def bcdofs(bc, ghost=True):
 
         Z = Z.sub(idx)
 
-    bs = Z.value_size
+    if Z.parent is not None and isinstance(Z.parent.ufl_element(), VectorElement):
+        bs = Z.parent.value_size
+        start = 0
+        stop = 1
+    else:
+        bs = Z.value_size
+        start = 0
+        stop = bs
     nodes = bc.nodes
     if not ghost:
         nodes = nodes[nodes < Z.dof_dset.size]
 
-    return numpy.concatenate([nodes*bs + j for j in range(bs)]) + offset
+    return numpy.concatenate([nodes*bs + j for j in range(start, stop)]) + offset
 
 
 def select_entity(p, dm=None, exclude=None):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -6,6 +6,7 @@ from firedrake.exceptions import ConvergenceError
 from firedrake.petsc import PETSc
 from firedrake.formmanipulation import ExtractSubBlock
 from firedrake.utils import cached_property
+from ufl import VectorElement
 
 
 def _make_reasons(reasons):
@@ -210,8 +211,12 @@ class _SNESContext(object):
                 Jp = None
             bcs = []
             for bc in problem.bcs:
-                index = bc.function_space().index
-                cmpt = bc.function_space().component
+                Vbc = bc.function_space()
+                if Vbc.parent is not None and isinstance(Vbc.parent.ufl_element(), VectorElement):
+                    index = Vbc.parent.index
+                else:
+                    index = Vbc.index
+                cmpt = Vbc.component
                 # TODO: need to test this logic
                 if index in field:
                     if len(field) == 1:


### PR DESCRIPTION
in patchpc we got the wrong dofs for bcs associated with components of vector spaces and in fieldsplit we would forget such bcs