### PR TITLE
When coarsening a SNESContext, coarsen its nullspaces too.

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -216,7 +216,9 @@ def coarsen_nlvp(problem, self, coefficient_mapping=None):
 @coarsen.register(firedrake.VectorSpaceBasis)
 def coarsen_vectorspacebasis(basis, self, coefficient_mapping=None):
     coarse_vecs = [self(vec, self, coefficient_mapping=coefficient_mapping) for vec in basis._vecs]
-    return firedrake.VectorSpaceBasis(coarse_vecs, constant=basis._constant)
+    vsb = firedrake.VectorSpaceBasis(coarse_vecs, constant=basis._constant)
+    vsb.orthonormalize()
+    return vsb
 
 
 @coarsen.register(firedrake.MixedVectorSpaceBasis)
@@ -227,11 +229,10 @@ def coarsen_mixedvectorspacebasis(mspbasis, self, coefficient_mapping=None):
     for basis in mspbasis._bases:
         if isinstance(basis, firedrake.VectorSpaceBasis):
             coarse_bases.append(self(basis, self, coefficient_mapping=coefficient_mapping))
-            continue
-        if basis.index is not None:
+        elif basis.index is not None:
             coarse_bases.append(coarse_V.sub(basis.index))
-            continue
-        raise RuntimeError("MixedVectorSpaceBasis can only contain vector space bases or indexed function spaces")
+        else:
+            raise RuntimeError("MixedVectorSpaceBasis can only contain vector space bases or indexed function spaces")
 
     return firedrake.MixedVectorSpaceBasis(coarse_V, coarse_bases)
 
@@ -265,15 +266,13 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
     coarse._fine = context
     context._coarse = coarse
 
-    if context._nullspace:
-        coarse._nullspace = self(context._nullspace, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=False)
-    if context._nullspace_T:
-        coarse._nullspace_T = self(context._nullspace_T, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._nullspace_T, problem.J.arguments()[0].function_space()._ises, transpose=True, near=False)
-    if context._near_nullspace:
-        coarse._near_nullspace = self(context._near_nullspace, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._near_nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=True)
+    ises = problem.J.arguments()[0].function_space()._ises
+    coarse._nullspace = self(context._nullspace, self, coefficient_mapping=coefficient_mapping)
+    coarse.set_nullspace(coarse._nullspace, ises, transpose=False, near=False)
+    coarse._nullspace_T = self(context._nullspace_T, self, coefficient_mapping=coefficient_mapping)
+    coarse.set_nullspace(coarse._nullspace_T, ises, transpose=True, near=False)
+    coarse._near_nullspace = self(context._near_nullspace, self, coefficient_mapping=coefficient_mapping)
+    coarse.set_nullspace(coarse._near_nullspace, ises, transpose=False, near=True)
 
     return coarse
 

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -213,6 +213,29 @@ def coarsen_nlvp(problem, self, coefficient_mapping=None):
     return problem
 
 
+@coarsen.register(firedrake.VectorSpaceBasis)
+def coarsen_vectorspacebasis(basis, self, coefficient_mapping=None):
+    coarse_vecs = [self(vec, self, coefficient_mapping=coefficient_mapping) for vec in basis._vecs]
+    return firedrake.VectorSpaceBasis(coarse_vecs, constant=basis._constant)
+
+
+@coarsen.register(firedrake.MixedVectorSpaceBasis)
+def coarsen_mixedvectorspacebasis(mspbasis, self, coefficient_mapping=None):
+    coarse_V = self(mspbasis._function_space, self, coefficient_mapping=coefficient_mapping)
+    coarse_bases = []
+
+    for basis in mspbasis._bases:
+        if isinstance(basis, firedrake.VectorSpaceBasis):
+            coarse_bases.append(self(basis, self, coefficient_mapping=coefficient_mapping))
+            continue
+        if basis.index is not None:
+            coarse_bases.append(coarse_V.sub(basis.index))
+            continue
+        raise RuntimeError("MixedVectorSpaceBasis can only contain vector space bases or indexed function spaces")
+
+    return firedrake.MixedVectorSpaceBasis(coarse_V, coarse_bases)
+
+
 @coarsen.register(firedrake.solving_utils._SNESContext)
 def coarsen_snescontext(context, self, coefficient_mapping=None):
     if coefficient_mapping is None:
@@ -241,6 +264,17 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
                            appctx=new_appctx)
     coarse._fine = context
     context._coarse = coarse
+
+    if context._nullspace:
+        coarse._nullspace = self(context._nullspace, self, coefficient_mapping=coefficient_mapping)
+        coarse.set_nullspace(coarse._nullspace, transpose=False, near=False)
+    if context._nullspace_T:
+        coarse._nullspace_T = self(context._nullspace_T, self, coefficient_mapping=coefficient_mapping)
+        coarse.set_nullspace(coarse._nullspace_T, transpose=True, near=False)
+    if context._near_nullspace:
+        coarse._near_nullspace = self(context._near_nullspace, self, coefficient_mapping=coefficient_mapping)
+        coarse.set_nullspace(coarse._near_nullspace, transpose=False, near=True)
+
     return coarse
 
 

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -267,13 +267,13 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
 
     if context._nullspace:
         coarse._nullspace = self(context._nullspace, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._nullspace, transpose=False, near=False)
+        coarse.set_nullspace(coarse._nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=False)
     if context._nullspace_T:
         coarse._nullspace_T = self(context._nullspace_T, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._nullspace_T, transpose=True, near=False)
+        coarse.set_nullspace(coarse._nullspace_T, problem.J.arguments()[0].function_space()._ises, transpose=True, near=False)
     if context._near_nullspace:
         coarse._near_nullspace = self(context._near_nullspace, self, coefficient_mapping=coefficient_mapping)
-        coarse.set_nullspace(coarse._near_nullspace, transpose=False, near=True)
+        coarse.set_nullspace(coarse._near_nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=True)
 
     return coarse
 

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -306,12 +306,10 @@ class _SNESContext(object):
             ctx._assemble_pjac()
             ctx._pjac.force_evaluation()
 
-        if ctx._nullspace:
-            ctx.set_nullspace(ctx._nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=False)
-        if ctx._nullspace_T:
-            ctx.set_nullspace(ctx._nullspace_T, problem.J.arguments()[0].function_space()._ises, transpose=True, near=False)
-        if ctx._near_nullspace:
-            ctx.set_nullspace(ctx._near_nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=True)
+        ises = problem.J.arguments()[0].function_space()._ises
+        ctx.set_nullspace(ctx._nullspace, ises, transpose=False, near=False)
+        ctx.set_nullspace(ctx._nullspace_T, ises, transpose=True, near=False)
+        ctx.set_nullspace(ctx._near_nullspace, ises, transpose=False, near=True)
 
     @staticmethod
     def compute_operators(ksp, J, P):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -300,10 +300,18 @@ class _SNESContext(object):
 
         ctx._assemble_jac()
         ctx._jac.force_evaluation()
+
         if ctx.Jp is not None:
             assert P.handle == ctx._pjac.petscmat.handle
             ctx._assemble_pjac()
             ctx._pjac.force_evaluation()
+
+        if ctx._nullspace:
+            ctx.set_nullspace(ctx._nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=False)
+        if ctx._nullspace_T:
+            ctx.set_nullspace(ctx._nullspace_T, problem.J.arguments()[0].function_space()._ises, transpose=True, near=False)
+        if ctx._near_nullspace:
+            ctx.set_nullspace(ctx._near_nullspace, problem.J.arguments()[0].function_space()._ises, transpose=False, near=True)
 
     @staticmethod
     def compute_operators(ksp, J, P):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -126,6 +126,10 @@ class _SNESContext(object):
         self._coarse = None
         self._fine = None
 
+        self._nullspace = None
+        self._nullspace_T = None
+        self._near_nullspace = None
+
     def set_function(self, snes):
         r"""Set the residual evaluation function"""
         with self._F.dat.vec_wo as v:

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -183,6 +183,9 @@ class NonlinearVariationalSolver(OptionsManager):
                           transpose=True, near=False)
         ctx.set_nullspace(near_nullspace, problem.J.arguments()[0].function_space()._ises,
                           transpose=False, near=True)
+        ctx._nullspace = nullspace
+        ctx._nullspace_T = nullspace_T
+        ctx._near_nullspace = near_nullspace
 
         # Set from options now, so that people who want to noodle with
         # the snes object directly (mostly Patrick), can.  We need the

--- a/tests/regression/test_coarse_nullspace.py
+++ b/tests/regression/test_coarse_nullspace.py
@@ -1,5 +1,6 @@
 from firedrake import *
 
+
 def test_coarse_nullspace():
     base = UnitSquareMesh(10, 10)
     mh = MeshHierarchy(base, 1)
@@ -35,6 +36,7 @@ def test_coarse_nullspace():
     vecs = nsp.getVecs()
     assert len(vecs) == 1
     assert abs(vecs[0].dot(vecs[0]) - 1) < 1.0e-12
+
 
 if __name__ == "__main__":
     test_coarse_nullspace()

--- a/tests/regression/test_coarse_nullspace.py
+++ b/tests/regression/test_coarse_nullspace.py
@@ -36,7 +36,3 @@ def test_coarse_nullspace():
     vecs = nsp.getVecs()
     assert len(vecs) == 1
     assert abs(vecs[0].dot(vecs[0]) - 1) < 1.0e-12
-
-
-if __name__ == "__main__":
-    test_coarse_nullspace()

--- a/tests/regression/test_coarse_nullspace.py
+++ b/tests/regression/test_coarse_nullspace.py
@@ -1,0 +1,40 @@
+from firedrake import *
+
+def test_coarse_nullspace():
+    base = UnitSquareMesh(10, 10)
+    mh = MeshHierarchy(base, 1)
+    V = FunctionSpace(mh[-1], "CG", 1)
+    w = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = inner(grad(w), grad(v))*dx
+    f = Constant(0)
+    F = inner(f, v)*dx
+    one = Function(V)
+    one.interpolate(Constant(1))
+    nsp = VectorSpaceBasis([one])
+
+    sp = {"ksp_type": "cg",
+          "ksp_monitor_true_residual": None,
+          "pc_type": "mg",
+          "mg_coarse_ksp_type": "richardson",
+          "mg_coarse_pc_type": "gamg"}
+
+    u = Function(V)
+    with u.dat.vec_wo as x:
+        x.setRandom()
+
+    problem = LinearVariationalProblem(a, F, u)
+    solver = LinearVariationalSolver(problem, solver_parameters=sp, nullspace=nsp)
+    solver.solve()
+
+    coarseksp = solver.snes.ksp.pc.getMGCoarseSolve()
+    (cA, cP) = coarseksp.getOperators()
+    nsp = cA.getNullSpace()
+    assert nsp is not None
+    vecs = nsp.getVecs()
+    assert len(vecs) == 1
+    assert abs(vecs[0].dot(vecs[0]) - 1) < 1.0e-12
+
+if __name__ == "__main__":
+    test_coarse_nullspace()


### PR DESCRIPTION
At the moment, when using geometric multigrid the fine grid knows about the nullspace, but coarser grids don't. With this patch, the nullspaces are coarsened when a `SNESContext` is coarsened, and the coarsened nullspaces are applied to the coarsened Jacobians.