### PR TITLE
Slate patch: fix assignments for local vector temporaries

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -339,11 +339,11 @@ def coefficient_temporaries(builder, declared_temps):
             c_shape = cinfo.shape
             vector = cinfo.vector
             function = vector._function
+            t = cinfo.local_temp
 
             if vector not in declared_temps:
                 # Declare and initialize coefficient temporary
                 c_type = eigen_matrixbase_type(shape=c_shape)
-                t = ast.Symbol("VT%d" % len(declared_temps))
                 statements.append(ast.Decl(c_type, t))
                 declared_temps[vector] = t
 

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -4,7 +4,7 @@ from coffee import base as ast
 from collections import OrderedDict, Counter, namedtuple
 from functools import singledispatch
 
-from firedrake.slate.slac.utils import (traverse_dags, eigen_tensor, Transformer)
+from firedrake.slate.slac.utils import traverse_dags, eigen_tensor, Transformer
 from firedrake.utils import cached_property
 
 from tsfc.finatinterface import create_element
@@ -17,7 +17,8 @@ CoefficientInfo = namedtuple("CoefficientInfo",
                              ["space_index",
                               "offset_index",
                               "shape",
-                              "vector"])
+                              "vector",
+                              "local_temp"])
 CoefficientInfo.__doc__ = """\
 Context information for creating coefficient temporaries.
 
@@ -28,6 +29,9 @@ Context information for creating coefficient temporaries.
               the coefficient temporary.
 :param vector: The :class:`slate.AssembledVector` containing the
                relevant data to be placed into the temporary.
+:param local_temp: The local temporary for the coefficient vector.
+                   If the coefficient comes from a mixed space, then
+                   local temporaries may be shared by multiple vectors.
 """
 
 
@@ -112,12 +116,16 @@ class LocalKernelBuilder(object):
                     else:
                         shapes = [dimension(function.ufl_element())]
 
+                    # Local temporary
+                    local_temp = ast.Symbol("VecTemp%d" % len(seen_coeff))
+
                     offset = 0
                     for i, shape in enumerate(shapes):
                         cinfo = CoefficientInfo(space_index=i,
                                                 offset_index=offset,
                                                 shape=(sum(shapes), ),
-                                                vector=tensor)
+                                                vector=tensor,
+                                                local_temp=local_temp)
                         coeff_vecs.setdefault(shape, []).append(cinfo)
                         offset += shape
 

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -30,8 +30,6 @@ Context information for creating coefficient temporaries.
 :param vector: The :class:`slate.AssembledVector` containing the
                relevant data to be placed into the temporary.
 :param local_temp: The local temporary for the coefficient vector.
-                   If the coefficient comes from a mixed space, then
-                   local temporaries may be shared by multiple vectors.
 """
 
 

--- a/tests/slate/test_variational_prb.py
+++ b/tests/slate/test_variational_prb.py
@@ -1,0 +1,88 @@
+import pytest
+import numpy as np
+from firedrake import *
+
+
+@pytest.mark.parametrize('degree', range(1, 4))
+def test_lvp_equiv_hdg(degree):
+    """Runs an HDG problem and checks that passing
+    a Slate-defined problem into a variational problem
+    produces the same result for the traces as solving
+    the whole system using built-in and tested solvers
+    and preconditioners.
+    """
+
+    mesh = UnitSquareMesh(5, 5)
+    x = SpatialCoordinate(mesh)
+    n = FacetNormal(mesh)
+
+    U = VectorFunctionSpace(mesh, "DG", degree)
+    V = FunctionSpace(mesh, "DG", degree)
+    T = FunctionSpace(mesh, "HDiv Trace", degree)
+
+    W = U * V * T
+    s = Function(W)
+    q, u, uhat = TrialFunctions(W)
+    v, w, mu = TestFunctions(W)
+
+    f = Function(V).interpolate(-div(grad(sin(pi*x[0])*sin(pi*x[1]))))
+
+    tau = Constant(1)
+    qhat = q + tau*(u - uhat)*n
+
+    a = ((dot(v, q) - div(v)*u)*dx
+         + uhat('+')*jump(v, n=n)*dS
+         + uhat*dot(v, n)*ds
+         - dot(grad(w), q)*dx
+         + jump(qhat, n=n)*w('+')*dS
+         + dot(qhat, n)*w*ds
+         + mu('+')*jump(qhat, n=n)*dS
+         + mu*uhat*ds)
+
+    L = w*f*dx
+
+    params = {'mat_type': 'matfree',
+              'pmat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.SCPC',
+              'pc_sc_eliminate_fields': '0, 1',
+              'condensed_field': {'ksp_type': 'preonly',
+                                  'pc_type': 'lu',
+                                  'pc_factor_mat_solver_type': 'mumps'}}
+    ref_problem = LinearVariationalProblem(a, L, s)
+    ref_solver = LinearVariationalSolver(ref_problem, solver_parameters=params)
+    ref_solver.solve()
+
+    _, __, uhat_ref = s.split()
+
+    # Now using Slate expressions only
+    _O = Tensor(a)
+    O = _O.blocks
+
+    M = O[:2, :2]
+    K = O[:2, 2]
+    Q = O[2, :2]
+    J = O[2, 2]
+
+    S = J - Q * M.inv * K
+    l = assemble(L)
+    _R = AssembledVector(l)
+    R = _R.blocks
+    v1v2 = R[:2]
+    v3 = R[2]
+    r_lambda = v3 - Q * M.inv * v1v2
+
+    t = Function(T)
+    lvp = LinearVariationalProblem(S, r_lambda, t)
+    solver = LinearVariationalSolver(lvp, solver_parameters={'ksp_type': 'preonly',
+                                                             'pc_type': 'lu',
+                                                             'pc_factor_mat_solver_type': 'mumps'})
+    solver.solve()
+
+    assert np.allclose(uhat_ref.dat.data, t.dat.data, rtol=1.E-12)
+
+
+if __name__ == '__main__':
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/slate/test_variational_prb.py
+++ b/tests/slate/test_variational_prb.py
@@ -3,7 +3,7 @@ import numpy as np
 from firedrake import *
 
 
-@pytest.mark.parametrize('degree', range(1, 4))
+@pytest.mark.parametrize('degree', [1, 2])
 def test_lvp_equiv_hdg(degree):
     """Runs an HDG problem and checks that passing
     a Slate-defined problem into a variational problem
@@ -81,8 +81,3 @@ def test_lvp_equiv_hdg(degree):
     solver.solve()
 
     assert np.allclose(uhat_ref.dat.data, t.dat.data, rtol=1.E-12)
-
-
-if __name__ == '__main__':
-    import os
-    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
This small patch fixes a problem where some local temporaries for firedrake `Coefficient`s where not being assigned in the correct outer dof-extent loops in Slate-generated kernels.