### PR TITLE
Smaclachlan/embedded error message

### DIFF
--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -22,7 +22,7 @@ def check_arguments(coarse, fine):
         raise ValueError("Can't transfer between functions from different hierarchies")
     if coarse.ufl_shape != fine.ufl_shape:
         raise ValueError("Mismatching function space shapes")
-    if coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native:
+    if (not isinstance(coarse.ufl_element(),firedrake.MixedElement) and not isinstance(fine.ufl_element(),firedrake.MixedElement)) and (coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native):
         raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedDGTransfer instead")
 
 

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -22,7 +22,7 @@ def check_arguments(coarse, fine):
         raise ValueError("Can't transfer between functions from different hierarchies")
     if coarse.ufl_shape != fine.ufl_shape:
         raise ValueError("Mismatching function space shapes")
-    if coarse.ufl_element().family() not in native:
+    if coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native:
         raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedProlongation instead")
 
 def prolong(coarse, fine):

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -7,7 +7,9 @@ from . import kernels
 
 __all__ = ["prolong", "restrict", "inject"]
 
+
 native = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
+
 
 def check_arguments(coarse, fine):
     cfs = coarse.function_space()
@@ -24,6 +26,7 @@ def check_arguments(coarse, fine):
         raise ValueError("Mismatching function space shapes")
     if coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native:
         raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedProlongation instead")
+
 
 def prolong(coarse, fine):
     check_arguments(coarse, fine)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -7,6 +7,7 @@ from . import kernels
 
 __all__ = ["prolong", "restrict", "inject"]
 
+native = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
 
 def check_arguments(coarse, fine):
     cfs = coarse.function_space()
@@ -21,7 +22,8 @@ def check_arguments(coarse, fine):
         raise ValueError("Can't transfer between functions from different hierarchies")
     if coarse.ufl_shape != fine.ufl_shape:
         raise ValueError("Mismatching function space shapes")
-
+    if coarse.ufl_element().family() not in native:
+        raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedProlongation instead")
 
 def prolong(coarse, fine):
     check_arguments(coarse, fine)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -8,10 +8,8 @@ from . import kernels
 __all__ = ["prolong", "restrict", "inject"]
 
 
-native = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
-
-
 def check_arguments(coarse, fine):
+    from .embedded import native
     cfs = coarse.function_space()
     ffs = fine.function_space()
     hierarchy, lvl = utils.get_level(cfs.mesh())
@@ -25,7 +23,7 @@ def check_arguments(coarse, fine):
     if coarse.ufl_shape != fine.ufl_shape:
         raise ValueError("Mismatching function space shapes")
     if coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native:
-        raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedProlongation instead")
+        raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedDGTransfer instead")
 
 
 def prolong(coarse, fine):

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -22,7 +22,7 @@ def check_arguments(coarse, fine):
         raise ValueError("Can't transfer between functions from different hierarchies")
     if coarse.ufl_shape != fine.ufl_shape:
         raise ValueError("Mismatching function space shapes")
-    if (not isinstance(coarse.ufl_element(),firedrake.MixedElement) and not isinstance(fine.ufl_element(),firedrake.MixedElement)) and (coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native):
+    if (not isinstance(coarse.ufl_element(), firedrake.MixedElement) and not isinstance(fine.ufl_element(), firedrake.MixedElement)) and (coarse.ufl_element().family() not in native or fine.ufl_element().family() not in native):
         raise ValueError("Function space doesn't allow native transfer operators, consider using EmbeddedDGTransfer instead")
 
 


### PR DESCRIPTION
Adding a check when inject/restrict/prolong are called to throw a better error message when no native operators are available.

Note: this duplicates "native" as is also set in embedded.py.  Should this list be stored in just one place?