### PR TITLE
Deprecate options translation

### DIFF
--- a/demos/ma-demo/ma-demo.py.rst
+++ b/demos/ma-demo/ma-demo.py.rst
@@ -173,9 +173,9 @@ Finally, we'd like to see some output to check things are working, and
 to limit the KSP solver to 20 iterations. ::
 
   #
-     "ksp_monitor": True,
+     "ksp_monitor": None,
      "ksp_max_it": 20,
-     "snes_monitor": True
+     "snes_monitor": None
      }
 
 We then put all of these options into the iterative solver, ::

--- a/demos/matrix_free/navier_stokes.py.rst
+++ b/demos/matrix_free/navier_stokes.py.rst
@@ -53,7 +53,7 @@ in a ``try/except`` block. ::
 
   try:
       solve(F == 0, up, bcs=bcs, nullspace=nullspace,
-            solver_parameters={"snes_monitor": True,
+            solver_parameters={"snes_monitor": None,
                                "ksp_type": "gmres",
                                "mat_type": "aij",
                                "pc_type": "lu",
@@ -70,14 +70,14 @@ pressure Schur complement.  We'll need more solver parameters this
 time, so again we'll set those up in a dictionary. ::
 
   parameters = {"mat_type": "matfree",
-                "snes_monitor": True,
+                "snes_monitor": None,
 
 We'll use a non-stationary Krylov solve for the Schur complement, so
 we need to use a flexible Krylov method on the outside. ::
 
                "ksp_type": "fgmres",
-               "ksp_gmres_modifiedgramschmidt": True,
-               "ksp_monitor_true_residual": True,
+               "ksp_gmres_modifiedgramschmidt": None,
+               "ksp_monitor_true_residual": None,
 
 Now to configure the preconditioner::
 

--- a/demos/matrix_free/poisson.py.rst
+++ b/demos/matrix_free/poisson.py.rst
@@ -44,7 +44,7 @@ unassembled operator using the ``"mat_type"`` solver parameter.::
   solve(a == L, uu, bcs=bcs, solver_parameters={"mat_type": "matfree",
                                                 "ksp_type": "cg",
                                                 "pc_type": "none",
-                                                "ksp_monitor": True})
+                                                "ksp_monitor": None})
 
 Finally, we demonstrate the use of a :class:`.AssembledPC`
 preconditioner.  This uses matrix-free actions but preconditions the
@@ -54,7 +54,7 @@ operator.::
   uu.assign(0)
   solve(a == L, uu, bcs=bcs, solver_parameters={"mat_type": "matfree",
                                                 "ksp_type": "cg",
-                                                "ksp_monitor": True,
+                                                "ksp_monitor": None,
 
 To use the assembled matrix for the preconditioner we select a
 ``"python"`` type::

--- a/demos/matrix_free/rayleigh-benard.py.rst
+++ b/demos/matrix_free/rayleigh-benard.py.rst
@@ -79,7 +79,7 @@ errors if it is not available. ::
   try:
      solve(F == 0, upT, bcs=bcs, nullspace=nullspace,
            solver_parameters={"mat_type": "aij",
-                              "snes_monitor": True,
+                              "snes_monitor": None,
                               "ksp_type": "gmres",
                               "pc_type": "lu",
                               "pc_factor_mat_solver_type": "mumps"})
@@ -97,7 +97,7 @@ matrix-free actions for the coupled operator, and solve the linearised
 system with GMRES preconditioned with a multiplicative fieldsplit. ::
 
   parameters = {"mat_type": "matfree",
-                "snes_monitor": True,
+                "snes_monitor": None,
                 "ksp_type": "gmres",
                 "pc_type": "fieldsplit",
                 "pc_fieldsplit_type": "multiplicative",
@@ -152,7 +152,7 @@ of options and the key is `prepended` to all keys in the dictionary
 before passing to the solver. ::
 
   parameters = {"mat_type": "matfree",
-                "snes_monitor": True,
+                "snes_monitor": None,
 
 We'll use inexact GMRES solves to invert the Navier-Stokes block, so
 the preconditioner as a whole is not stationary, hence we need

--- a/demos/matrix_free/stokes.py.rst
+++ b/demos/matrix_free/stokes.py.rst
@@ -80,8 +80,8 @@ also monitor the convergence of the residual, and ask PETSc to view
 the configured Krylov solver object.::
 
       "ksp_type": "gmres",
-      "ksp_monitor_true_residual": True,
-      "ksp_view": True,
+      "ksp_monitor_true_residual": None,
+      "ksp_view": None,
       "pc_type": "fieldsplit",
       "pc_fieldsplit_type": "schur",
       "pc_fieldsplit_schur_fact_type": "diag",

--- a/demos/multigrid/geometric_multigrid.py.rst
+++ b/demos/multigrid/geometric_multigrid.py.rst
@@ -165,7 +165,7 @@ remembering to tell PETSc to use pivoting in the factorisation. ::
   solve(a == L, u, bcs=bcs, solver_parameters={"ksp_type": "preonly",
                                                "pc_type": "lu",
                                                "pc_factor_shift_type": "inblocks",
-                                               "ksp_monitor": True,
+                                               "ksp_monitor": None,
                                                "pmat_type": "aij"})
 
 Next we'll use a Schur complement solver, using geometric multigrid to
@@ -183,7 +183,7 @@ bilinear form to the solver ourselves: ::
 
   parameters = {
       "ksp_type": "gmres",
-      "ksp_monitor": True,
+      "ksp_monitor": None,
       "pc_type": "fieldsplit",
       "pc_fieldsplit_type": "schur",
       "pc_fieldsplit_schur_fact_type": "lower",
@@ -216,7 +216,7 @@ approximations.
 
   parameters = {
         "ksp_type": "gcr",
-        "ksp_monitor": True,
+        "ksp_monitor": None,
         "mat_type": "nest",
         "pc_type": "mg",
         "mg_coarse_ksp_type": "preonly",
@@ -237,12 +237,12 @@ approximations.
         "mg_levels_fieldsplit_0_ksp_type": "richardson",
         "mg_levels_fieldsplit_0_ksp_convergence_test": "skip",
         "mg_levels_fieldsplit_0_ksp_max_it": 2,
-        "mg_levels_fieldsplit_0_ksp_richardson_self_scale": True,
+        "mg_levels_fieldsplit_0_ksp_richardson_self_scale": None,
         "mg_levels_fieldsplit_0_pc_type": "bjacobi",
         "mg_levels_fieldsplit_0_sub_pc_type": "ilu",
         "mg_levels_fieldsplit_1_ksp_type": "richardson",
         "mg_levels_fieldsplit_1_ksp_convergence_test": "skip",
-        "mg_levels_fieldsplit_1_ksp_richardson_self_scale": True,
+        "mg_levels_fieldsplit_1_ksp_richardson_self_scale": None,
         "mg_levels_fieldsplit_1_ksp_max_it": 3,
         "mg_levels_fieldsplit_1_pc_type": "python",
         "mg_levels_fieldsplit_1_pc_python_type": "__main__.Mass",

--- a/docs/notebooks/example-elasticity.ipynb
+++ b/docs/notebooks/example-elasticity.ipynb
@@ -150,7 +150,7 @@
     "L = dot(f, v)*dx\n",
     "\n",
     "uh = Function(V)\n",
-    "solve(a == L, uh, bcs=bc, solver_parameters={\"ksp_monitor\": True})"
+    "solve(a == L, uh, bcs=bc, solver_parameters={\"ksp_monitor\": None})"
    ]
   },
   {
@@ -1095,7 +1095,7 @@
     "                                         \"ksp_max_it\": 100, \n",
     "                                         \"pc_type\": \"gamg\",\n",
     "                                         \"mat_type\": \"aij\",\n",
-    "                                         \"ksp_monitor\": True})"
+    "                                         \"ksp_monitor\": None})"
    ]
   },
   {
@@ -1170,7 +1170,7 @@
     "                                         \"ksp_max_it\": 100, \n",
     "                                         \"pc_type\": \"gamg\",\n",
     "                                         \"mat_type\": \"aij\",\n",
-    "                                         \"ksp_monitor\": True})"
+    "                                         \"ksp_monitor\": None})"
    ]
   },
   {

--- a/docs/notebooks/example-multigrid.ipynb
+++ b/docs/notebooks/example-multigrid.ipynb
@@ -229,7 +229,7 @@
     "solver = create_solver({\"ksp_type\": \"preonly\",\n",
     "                        \"pc_type\": \"lu\",\n",
     "                        \"pc_factor_shift_type\": \"inblocks\",\n",
-    "                        \"ksp_monitor\": True,\n",
+    "                        \"ksp_monitor\": None,\n",
     "                        \"pmat_type\": \"aij\"})\n",
     "solver.solve()"
    ]
@@ -1853,7 +1853,7 @@
    "source": [
     "parameters = {\n",
     "    \"ksp_type\": \"gmres\",\n",
-    "    \"ksp_monitor\": True,\n",
+    "    \"ksp_monitor\": None,\n",
     "    \"pc_type\": \"fieldsplit\",\n",
     "    \"pc_use_amat\": True,\n",
     "    \"pc_fieldsplit_type\": \"schur\",\n",
@@ -1887,7 +1887,7 @@
    "source": [
     "parameters = {\n",
     "      \"ksp_type\": \"fgmres\",\n",
-    "      \"ksp_monitor\": True,\n",
+    "      \"ksp_monitor\": None,\n",
     "      \"mat_type\": \"nest\",\n",
     "      \"pc_type\": \"mg\",\n",
     "      \"mg_coarse_ksp_type\": \"preonly\",\n",
@@ -2010,7 +2010,7 @@
    "source": [
     "parameters = {\n",
     "    \"ksp_type\": \"gmres\",\n",
-    "    \"ksp_monitor\": True,\n",
+    "    \"ksp_monitor\": None,\n",
     "    \"pc_type\": \"fieldsplit\",\n",
     "    \"pc_use_amat\": True,\n",
     "    \"pc_fieldsplit_type\": \"schur\",\n",

--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -776,13 +776,13 @@ view flag to the solve call.  For linear solves pass:
 
 .. code-block:: python
 
-   solver_parameters={'ksp_view': True}
+   solver_parameters={'ksp_view': None}
 
 For nonlinear solves use:
 
 .. code-block:: python
 
-   solver_parameters={'snes_view': True}
+   solver_parameters={'snes_view': None}
 
 PETSc will then print its view of the solver objects that Firedrake
 has constructed.  This is especially useful for debugging complicated
@@ -914,9 +914,9 @@ options are not being passed in correctly):
 
 .. code-block:: python
 
-   solver_parameters={'ksp_converged_reason': True,
-                      'ksp_monitor_true_residual': True,
-                      'ksp_view': True}
+   solver_parameters={'ksp_converged_reason': None,
+                      'ksp_monitor_true_residual': None,
+                      'ksp_view': None}
 
 If the problem is converging, but only slowly, it may be that it is
 badly conditioned.  If the problem is small, we can try using a direct
@@ -971,11 +971,11 @@ the correct options:
 
 .. code-block:: python
 
-   solver_parameters={'snes_monitor': True,
-                      'snes_view': True,
-                      'ksp_monitor_true_residual': True,
-                      'snes_converged_reason': True,
-                      'ksp_converged_reason': True}
+   solver_parameters={'snes_monitor': None,
+                      'snes_view': None,
+                      'ksp_monitor_true_residual': None,
+                      'snes_converged_reason': None,
+                      'ksp_converged_reason': None}
 
 If the linear solve fails to converge, debug the problem as above for
 linear systems.  If the linear solve converges but the outer Newton

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -193,12 +193,13 @@ class OptionsManager(object):
             for k, v in self.parameters.items():
                 key = self.options_prefix + k
                 if type(v) is bool:
-                    warning("""Firedrake will stop translating True/False options soon.\n"""
-                            """This is to allow controlling boolean options with a default value of True.\n"""
-                            """To obtain the old behaviour you should translate:\n"""
-                            """  {"option": True} => {"option": None}\n"""
-                            """and\n"""
-                            """  {"option": False} => {}\n""")
+                    if "monitor" in k or "view" in k:
+                        warning("""Firedrake will stop translating True/False options soon.\n"""
+                                """This is to allow controlling boolean options with a default value of True.\n"""
+                                """To obtain the old behaviour you should translate:\n"""
+                                """  {%r: True} => {"option": None}\n"""
+                                """and\n"""
+                                """  {%r: False} => {}\n""" % (k, k))
                     if v:
                         self.options_object[key] = None
                 else:

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -188,10 +188,17 @@ class OptionsManager(object):
     def inserted_options(self):
         """Context manager inside which the petsc options database
     contains the parameters from this object."""
+        from firedrake.logging import warning
         try:
             for k, v in self.parameters.items():
                 key = self.options_prefix + k
                 if type(v) is bool:
+                    warning("""Firedrake will stop translating True/False options soon.\n"""
+                            """This is to allow controlling boolean options with a default value of True.\n"""
+                            """To obtain the old behaviour you should translate:\n"""
+                            """  {"option": True} => {"option": None}\n"""
+                            """and\n"""
+                            """  {"option": False} => {}\n""")
                     if v:
                         self.options_object[key] = None
                 else:

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -107,12 +107,13 @@ class NonlinearVariationalSolver(OptionsManager):
 
             {'snes_type': 'ksponly'}
 
-        PETSc flag options should be specified with `bool` values.
+        PETSc flag options (where the presence of the option means something) should
+        be specified with ``None``.
         For example:
 
         .. code-block:: python
 
-            {'snes_monitor': True}
+            {'snes_monitor': None}
 
         To use the ``pre_jacobian_callback`` or ``pre_function_callback``
         functionality, the user-defined function must accept the current

--- a/tests/multigrid/test_nested_split.py
+++ b/tests/multigrid/test_nested_split.py
@@ -26,7 +26,7 @@ import pytest
                           {
                               # Newton
                               "snes_type": "newtonls",
-                              "snes_view": True,
+                              "snes_view": None,
                               "ksp_type": "cg",
                               # Same as before, just with a recursive split, so we need an aij matrix
                               "mat_type": "aij",

--- a/tests/regression/test_p1pc.py
+++ b/tests/regression/test_p1pc.py
@@ -62,7 +62,7 @@ def test_p_independence(mesh, expected):
                 "ksp_type": "preonly",
                 "pc_type": "cholesky",
             },
-            "ksp_monitor": True})
+            "ksp_monitor": None})
 
         solver.solve()
 

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -60,7 +60,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
     jacobi = LinearVariationalSolver(problem,
                                      solver_parameters={"ksp_type": "cg",
                                                         "pc_type": "sor" if multiplicative else "jacobi",
-                                                        "ksp_monitor": True,
+                                                        "ksp_monitor": None,
                                                         "mat_type": "aij"})
 
     jacobi.snes.ksp.setConvergenceHistory()
@@ -82,7 +82,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
                                                        "patch_pc_patch_symmetrise_sweep": multiplicative,
                                                        "patch_sub_ksp_type": "preonly",
                                                        "patch_sub_pc_type": "lu",
-                                                       "ksp_monitor": True})
+                                                       "ksp_monitor": None})
 
     patch.snes.ksp.setConvergenceHistory()
 

--- a/tests/regression/test_stokes_hdiv_parallel.py
+++ b/tests/regression/test_stokes_hdiv_parallel.py
@@ -86,7 +86,7 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
             "ksp_max_it": "30",
             "ksp_atol": "1.e-16",
             "ksp_rtol": "1.e-11",
-            "ksp_monitor_true_residual": True,
+            "ksp_monitor_true_residual": None,
             "pc_type": "fieldsplit",
             "pc_fieldsplit_type": "multiplicative",
 

--- a/tests/regression/test_stokes_mini.py
+++ b/tests/regression/test_stokes_mini.py
@@ -50,7 +50,7 @@ def run_stokes_mini(mat_type, n):
                              'fieldsplit_0_pc_type': 'redundant',
                              'fieldsplit_0_redundant_pc_type': 'lu',
                              'fieldsplit_1_pc_type': 'none',
-                             'ksp_monitor_true_residual': True,
+                             'ksp_monitor_true_residual': None,
                              'mat_type': mat_type})
 
     # We've set up Poiseuille flow, so we expect a parabolic velocity

--- a/tests/regression/test_vector_laplace_on_quadrilaterals.py
+++ b/tests/regression/test_vector_laplace_on_quadrilaterals.py
@@ -44,7 +44,7 @@ def vector_laplace(n, degree):
                              'pc_fieldsplit_type': 'additive',
                              'fieldsplit_0_pc_type': 'lu',
                              'fieldsplit_1_pc_type': 'lu',
-                             'ksp_monitor': True})
+                             'ksp_monitor': None})
 
     out_s, out_u = out.split()
 


### PR DESCRIPTION
It makes it difficult to switch off boolean options in the natural
way:
```
  {"pc_use_foo": False}
```
Presently does not work if the default value for "pc_use_foo" is
True (since our translation removes this option from the dictionary
entirely).

We can argue about when this should change, I vote for sooner rather than later.