### PR TITLE
Test case for NaNs in Conditionals

### DIFF
--- a/tests/regression/test_conditional.py
+++ b/tests/regression/test_conditional.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import ufl
 from firedrake import *
 
 
@@ -22,3 +23,41 @@ def test_conditional(ncell):
         expect[i, i] = 1.0/ncell
 
     assert np.allclose(A, expect)
+
+
+def test_conditional_nan():
+    # Test case courtesy of Marco Morandini:
+    # https://github.com/firedrakeproject/tsfc/issues/183
+
+    def crossTensor(V):
+        return as_tensor([
+            [0.0, V[2], -V[1]],
+            [-V[2], 0.0, V[0]],
+            [V[1], -V[0], 0.0]])
+
+    def coefa(phi2):
+        return conditional(le(phi2, 1.e-6),
+                           phi2,
+                           sin(phi2)/phi2)
+
+    def RotDiffTensor(phi):
+        PhiCross = crossTensor(phi)
+        phi2 = dot(phi, phi)
+        a = coefa(phi2)
+        return PhiCross * a
+
+    mesh = UnitIntervalMesh(8)
+    V = VectorFunctionSpace(mesh, "CG", 1, dim=3)
+    u_phi = Function(V)
+    v_phi = TestFunction(V)
+
+    Gamma = RotDiffTensor(u_phi)
+
+    beta = dot(Gamma, grad(u_phi))
+    delta_beta = ufl.derivative(beta, u_phi, v_phi)
+
+    L = inner(delta_beta, grad(u_phi)) * dx
+    result = assemble(L).dat.data
+
+    # Check whether there are any NaNs in the result
+    assert not np.isnan(result).any()


### PR DESCRIPTION
To protect against regressions on firedrakeproject/tsfc#183.

Should also mention that it requires firedrakeproject/tsfc#186.