### PR TITLE
Fix SNESPATCH after refactoring of PCSNESBase

### DIFF
--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -7,16 +7,6 @@ __all__ = ("PCBase", "SNESBase", "PCSNESBase")
 
 
 class PCSNESBase(object, metaclass=abc.ABCMeta):
-
-    needs_python_amat = False
-    """Set this to True if the A matrix needs to be Python (matfree)."""
-
-    needs_python_pmat = True
-    """Set this to False if the P matrix needs to be Python (matfree).
-
-    If the preconditioner also works with assembled matrices, then use False here.
-    """
-
     def __init__(self):
         """Create a PC context suitable for PETSc.
 
@@ -48,14 +38,6 @@ class PCSNESBase(object, metaclass=abc.ABCMeta):
 
         Subclasses should probably not override this and instead
         implement :meth:`update` and :meth:`initialize`."""
-        A, P = pc.getOperators()
-        Atype = A.getType()
-        Ptype = P.getType()
-
-        if self.needs_python_amat and Atype != PETSc.Mat.Type.PYTHON:
-            raise ValueError("PC needs amat to have type python, but it is %s" % Atype)
-        if self.needs_python_pmat and Ptype != PETSc.Mat.Type.PYTHON:
-            raise ValueError("PC needs pmat to have type python, but it is %s" % Ptype)
 
         if self.initialized:
             self.update(pc)
@@ -83,6 +65,16 @@ class PCBase(PCSNESBase):
     _asciiname = "preconditioner"
     _objectname = "pc"
 
+    needs_python_amat = False
+    """Set this to True if the A matrix needs to be Python (matfree)."""
+
+    needs_python_pmat = True
+    """Set this to False if the P matrix needs to be Python (matfree).
+
+    If the preconditioner also works with assembled matrices, then use False here.
+    """
+
+
     @abc.abstractmethod
     def apply(self, pc, X, Y):
         """Apply the preconditioner to X, putting the result in Y.
@@ -100,6 +92,17 @@ class PCBase(PCSNESBase):
         """
         pass
 
+    def setUp(self, pc):
+        A, P = pc.getOperators()
+        Atype = A.getType()
+        Ptype = P.getType()
+
+        if self.needs_python_amat and Atype != PETSc.Mat.Type.PYTHON:
+            raise ValueError("PC needs amat to have type python, but it is %s" % Atype)
+        if self.needs_python_pmat and Ptype != PETSc.Mat.Type.PYTHON:
+            raise ValueError("PC needs pmat to have type python, but it is %s" % Ptype)
+
+        super().setUp(pc)
 
 class SNESBase(PCSNESBase):
 

--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -74,7 +74,6 @@ class PCBase(PCSNESBase):
     If the preconditioner also works with assembled matrices, then use False here.
     """
 
-
     @abc.abstractmethod
     def apply(self, pc, X, Y):
         """Apply the preconditioner to X, putting the result in Y.
@@ -103,6 +102,7 @@ class PCBase(PCSNESBase):
             raise ValueError("PC needs pmat to have type python, but it is %s" % Ptype)
 
         super().setUp(pc)
+
 
 class SNESBase(PCSNESBase):
 

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -558,6 +558,8 @@ class PatchBase(PCSNESBase):
 
 
 class PatchPC(PCBase, PatchBase):
+    needs_python_pmat = False
+
     def configure_patch(self, patch, pc):
         (A, P) = pc.getOperators()
         patch.setOperators(A, P)

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -478,7 +478,7 @@ class PatchBase(PCSNESBase):
             mat.assemble()
         patch.setPatchComputeOperator(Jop)
 
-        if hasattr(ctx, "F"):
+        if hasattr(ctx, "F") and isinstance(obj, PETSc.SNES):
             F = ctx.F
             Fstate = ctx._problem.u
             Ffunptr, Fkinfo = residual_funptr(F, Fstate)


### PR DESCRIPTION
Some refactoring of `PCBase` and `SNESBase` caused `SNESPATCH` to break. The `tests/regression/test_fas_snespatch.py` test is currently broken in master with

```
Traceback (most recent call last):
  File "libpetsc4py/libpetsc4py.pyx", line 1888, in libpetsc4py.SNESSetUp_Python
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20190126/src/firedrake/firedrake/preconditioners/base.py", line 51, in setUp
    A, P = pc.getOperators()
AttributeError: 'petsc4py.PETSc.SNES' object has no attribute 'getOperators'
```
Apologies for this. This patch fixes this error, by moving the PC-specific code from `PCSNESBase` to `PCBase`.
