### PR TITLE
Monkeypatch UFL so that users never put literals in their forms

### DIFF
--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -247,3 +247,8 @@ def FacetNormal(mesh):
     """
     mesh.init()
     return ufl.FacetNormal(mesh)
+
+
+for cls in [ufl.classes.IntValue, ufl.classes.FloatValue, ufl.classes.ComplexValue]:
+    # Make sure users never put literals in their forms.
+    setattr(cls, "__new__", lambda cls, value: firedrake.Constant(value))


### PR DESCRIPTION
Doesn't fix the slow "rebuilding form" issues, but does at least make sure that they don't recompile when they change `t`.