### PR TITLE
docker: Install sudo in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
                  cmake gfortran git libblas-dev liblapack-dev \
                  libmpich-dev libtool mercurial mpich\
                  python3-dev python3-pip python3-tk python3-venv \
-                 zlib1g-dev libboost-dev \
+                 zlib1g-dev libboost-dev sudo \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Allows user to install packages with apt.

C.f. https://bitbucket.org/dolfin-adjoint/pyadjoint/commits/bb089b31bf37c6f073199c9cccbf9f6a6ade1097#comment-7278552

I don't know what needs to happen to rebuild the images.