### PR TITLE
preconditioners: don't require python pmat by default

### DIFF
--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -18,8 +18,6 @@ class AssembledPC(PCBase):
 
     _prefix = "assembled_"
 
-    needs_python_pmat = False
-
     def initialize(self, pc):
         from firedrake.assemble import allocate_matrix, create_assembly_callable
 

--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -68,7 +68,7 @@ class PCBase(PCSNESBase):
     needs_python_amat = False
     """Set this to True if the A matrix needs to be Python (matfree)."""
 
-    needs_python_pmat = True
+    needs_python_pmat = False
     """Set this to False if the P matrix needs to be Python (matfree).
 
     If the preconditioner also works with assembled matrices, then use False here.
@@ -96,10 +96,11 @@ class PCBase(PCSNESBase):
         Atype = A.getType()
         Ptype = P.getType()
 
+        pcname = type(self).__module__ + "." + type(self).__name__
         if self.needs_python_amat and Atype != PETSc.Mat.Type.PYTHON:
-            raise ValueError("PC needs amat to have type python, but it is %s" % Atype)
+            raise ValueError("PC '%s' needs amat to have type python, but it is %s" % (pcname, Atype))
         if self.needs_python_pmat and Ptype != PETSc.Mat.Type.PYTHON:
-            raise ValueError("PC needs pmat to have type python, but it is %s" % Ptype)
+            raise ValueError("PC '%s' needs pmat to have type python, but it is %s" % (pcname, Ptype))
 
         super().setUp(pc)
 

--- a/firedrake/preconditioners/low_order.py
+++ b/firedrake/preconditioners/low_order.py
@@ -108,6 +108,8 @@ def restriction_matrix(Pk, P1, Pk_bcs, P1_bcs):
 
 class P1PC(PCBase):
 
+    needs_python_pmat = True
+
     def initialize(self, pc):
         _, P = pc.getOperators()
         assert P.type == "python"

--- a/firedrake/preconditioners/massinv.py
+++ b/firedrake/preconditioners/massinv.py
@@ -6,6 +6,8 @@ __all__ = ("MassInvPC", )
 
 class MassInvPC(PCBase):
 
+    needs_python_pmat = True
+
     """A matrix free operator that inverts the mass matrix in the provided space.
 
     Internally this creates a PETSc KSP object that can be controlled
@@ -19,8 +21,6 @@ class MassInvPC(PCBase):
     """
     def initialize(self, pc):
         from firedrake import TrialFunction, TestFunction, dx, assemble, inner, parameters
-        if pc.getType() != "python":
-            raise ValueError("Expecting PC type python")
         prefix = pc.getOptionsPrefix()
         options_prefix = prefix + "Mp_"
         # we assume P has things stuffed inside of it

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -375,8 +375,6 @@ class PlaneSmoother(object):
 
 class PatchBase(PCSNESBase):
 
-    needs_python_pmat = False
-
     def initialize(self, obj):
 
         if isinstance(obj, PETSc.PC):
@@ -558,7 +556,6 @@ class PatchBase(PCSNESBase):
 
 
 class PatchPC(PCBase, PatchBase):
-    needs_python_pmat = False
 
     def configure_patch(self, patch, pc):
         (A, P) = pc.getOperators()

--- a/firedrake/preconditioners/pcd.py
+++ b/firedrake/preconditioners/pcd.py
@@ -5,6 +5,9 @@ __all__ = ("PCDPC", )
 
 
 class PCDPC(PCBase):
+
+    needs_python_pmat = True
+
     r"""A Pressure-Convection-Diffusion preconditioner for Navier-Stokes.
 
     This preconditioner approximates the inverse of the pressure schur

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -14,6 +14,9 @@ __all__ = ['HybridizationPC']
 
 
 class HybridizationPC(SCBase):
+
+    needs_python_pmat = True
+
     """A Slate-based python preconditioner that solves a
     mixed H(div)-conforming problem using hybridization.
     Currently, this preconditioner supports the hybridization

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -9,6 +9,9 @@ __all__ = ['SCPC']
 
 
 class SCPC(SCBase):
+
+    needs_python_pmat = True
+
     """A Slate-based python preconditioner implementation of
     static condensation for problems with up to three fields.
     """

--- a/tests/regression/test_custom_pc_python_pmat.py
+++ b/tests/regression/test_custom_pc_python_pmat.py
@@ -1,0 +1,54 @@
+from firedrake import *
+from firedrake.petsc import PETSc
+import pytest
+import numpy
+
+
+class MyPC(PCBase):
+
+    needs_python_pmat = True
+
+    def initialize(self, pc):
+        pass
+
+    def update(self, pc):
+        pass
+
+    def apply(self, pc, x, y):
+        x.copy(y)
+
+    def applyTranspose(self, pc, x, y):
+        x.copy(y)
+
+
+class AnyPC(MyPC):
+
+    needs_python_pmat = False
+
+
+def test_python_pc_valueerror():
+    mesh = UnitTriangleMesh()
+    V = FunctionSpace(mesh, "DG", 0)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    A = assemble(u*v*dx).M.handle
+    pc = PETSc.PC().create(comm=mesh.comm)
+    pc.setType(pc.Type.PYTHON)
+    pc.setOperators(A, A)
+    obj = MyPC()
+    with pytest.raises(ValueError):
+        obj.setUp(pc)
+
+
+def test_any_pc_fine():
+    mesh = UnitTriangleMesh()
+    V = FunctionSpace(mesh, "DG", 0)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    uh = Function(V)
+
+    solve(u*v*dx == v*dx, uh,
+          solver_parameters={"pc_type": "python",
+                             "pc_python_type": __name__ + "." + "AnyPC"})
+    assert numpy.allclose(uh.dat.data_ro, 1)


### PR DESCRIPTION
Results in confusing user errors when they implement something that
should work.

Additionally, report the name of the PC in the error message to make
things easier to track down.