### PR TITLE
SIMD vectorization with loopy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         sh 'mkdir tmp'
         dir('tmp') {
           timestamps {
-            sh '../scripts/firedrake-install --package-branch firedrake tsfc2loopy --package-branch tsfc tsfc2loopy --package-branch PyOP2 kaushik --package-branch loopy firedrake --disable-ssh --minimal-petsc ${SLEPC} --slope --documentation-dependencies --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
+            sh '../scripts/firedrake-install --package-branch firedrake tsfc2loopy --package-branch tsfc tsfc2loopy --package-branch PyOP2 vector --package-branch loopy cvec --disable-ssh --minimal-petsc ${SLEPC} --slope --documentation-dependencies --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         sh 'mkdir tmp'
         dir('tmp') {
           timestamps {
-            sh '../scripts/firedrake-install --package-branch firedrake tsfc2loopy --package-branch tsfc tsfc2loopy --package-branch PyOP2 vector --package-branch loopy cvec --disable-ssh --minimal-petsc ${SLEPC} --slope --documentation-dependencies --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
+            sh '../scripts/firedrake-install --package-branch firedrake tsfc2loopy --package-branch tsfc tsfc2loopy-vec --package-branch PyOP2 vector --package-branch loopy cvec --disable-ssh --minimal-petsc ${SLEPC} --slope --documentation-dependencies --install thetis --install gusto --install icepack --install pyadjoint ${PACKAGE_MANAGER} || (cat firedrake-install.log && /bin/false)'
           }
         }
       }


### PR DESCRIPTION
This PR switches on SIMD vectorization for loopy backend.

Branches required: `loopy/cvec`, `PyOP2/vector`, `tsfc/tsfc2loopy`

This passes all tests except with the following commits:
```
---------------------------------------------------------------------------
|Package             |Branch                        |Revision  |Modified  |
---------------------------------------------------------------------------
|COFFEE              |master                        |72a4464   |False     |
|FInAT               |master                        |fe06984   |False     |
|PyOP2               |vector                        |faf85eb5  |False     |
|fiat                |master                        |0964801   |False     |
|firedrake           |vectorization                 |879e7149  |False     |
|h5py                |firedrake                     |6768237   |False     |
|libspatialindex     |master                        |4768bf3   |True      |
|libsupermesh        |master                        |f51e59a   |False     |
|loopy               |cvec                          |0724d022  |False     |
|petsc               |firedrake                     |53ccc9989a|False     |
|petsc4py            |firedrake                     |6fe2748   |False     |
|pytools             |master                        |a0ea215   |False     |
|tsfc                |tsfc2loopy-vec                |8412037   |False     |
|ufl                 |master                        |7c42c33f  |False     |
---------------------------------------------------------------------------
```

Known limitations:
- Need to add some logic to determine SIMD width from CPU and compilers, currently this is hardcoded to 4.
https://github.com/OP2/PyOP2/blob/vector/pyop2/configuration.py#L81
- Need to turn off this check in loopy for extruded mesh (looks like the current check is too strict)
https://github.com/firedrakeproject/loopy/blob/cvec/loopy/check.py#L744
- Need to turn off this assertion, which creates ISL runtime error when splitting inames with slabs.
https://github.com/firedrakeproject/loopy/blob/cvec/loopy/transform/privatize.py#L169

Some discussion points:
- Vertex based limiter cannot vectorise easily because by running in batches, the cells do not see the update of the vertices of the other cells in the same batch. I switched off vectorisation for kernels with indirect args with accesses MIN, MAX or RW, but is there a more elegant way to treat this?
- Slabs (0, 1) seems to work just fine, but slabs (1, 1) might be preferred.
https://github.com/OP2/PyOP2/blob/vector/pyop2/sequential.py#L85
- Maybe we should just switch off vectorization for all function calls, instead of checking the list
https://github.com/firedrakeproject/loopy/blob/cvec/loopy/preprocess.py#L2119
- We should be able to do better with vectorizing conditionals (using predicates?)
https://github.com/firedrakeproject/loopy/blob/cvec/loopy/preprocess.py#L2179