### PR TITLE
dmhooks: Fix movement of transfer operators

### DIFF
--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -413,6 +413,12 @@ def coarsen(dm, comm):
     coarsen = get_ctx_coarsener(dm)
     Vc = coarsen(V, coarsen)
     cdm = Vc.dm
+    transfer = get_transfer_operators(dm)
+    push_transfer_operators(cdm, *transfer)
+    if len(V) > 1:
+        for V_, Vc_ in zip(V, Vc):
+            transfer = get_transfer_operators(V_.dm)
+            push_transfer_operators(Vc_.dm, *transfer)
     push_ctx_coarsener(cdm, coarsen)
     ctx = get_appctx(dm)
     if ctx is not None:

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -138,16 +138,7 @@ def coarsen_function_space(V, self, coefficient_mapping=None):
 
     mesh = self(V.mesh(), self)
 
-    Vf = V
     V = firedrake.FunctionSpace(mesh, V.ufl_element())
-
-    from firedrake.dmhooks import get_transfer_operators, push_transfer_operators
-    transfer = get_transfer_operators(Vf.dm)
-    push_transfer_operators(V.dm, *transfer)
-    if len(V) > 1:
-        for V_, Vc_ in zip(Vf, V):
-            transfer = get_transfer_operators(V_.dm)
-            push_transfer_operators(Vc_.dm, *transfer)
 
     for i in reversed(indices):
         V = V.sub(i)

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -214,7 +214,7 @@ class NonlinearVariationalSolver(OptionsManager):
         # DM with an app context in place so that if the DM is active
         # on a subKSP the context is available.
         dm = self.snes.getDM()
-        with dmhooks.appctx(dm, self._ctx):
+        with dmhooks.cleanup(dm), dmhooks.appctx(dm, self._ctx):
             self.set_from_options(self.snes)
 
         # Used for custom grid transfer.
@@ -258,7 +258,9 @@ class NonlinearVariationalSolver(OptionsManager):
             with ExitStack() as stack:
                 # Ensure options database has full set of options (so monitors
                 # work right)
-                for ctx in chain((self.inserted_options(), dmhooks.appctx(dm, self._ctx)),
+                for ctx in chain((dmhooks.cleanup(dm),
+                                  self.inserted_options(),
+                                  dmhooks.appctx(dm, self._ctx)),
                                  self._transfer_operators):
                     stack.enter_context(ctx)
                 self.snes.solve(None, work)


### PR DESCRIPTION
Move them when coarsening the DM, not the function space. Avoids
leaving cycles around that the GC can't collect.