### PR TITLE
Fix/min max reduction

### DIFF
--- a/firedrake/halo.py
+++ b/firedrake/halo.py
@@ -1,6 +1,8 @@
 from pyop2 import op2
 from pyop2 import utils
 from mpi4py import MPI
+import numpy
+from functools import partial
 
 from firedrake.petsc import PETSc
 import firedrake.dmplex as dmplex
@@ -13,7 +15,10 @@ def _get_mtype(dat):
     """Get an MPI datatype corresponding to a Dat.
 
     This builds (if necessary a contiguous derived datatype of the
-    correct size)."""
+    correct size).
+
+    Also returns if it is a builtin type.
+    """
     key = (dat.dtype, dat.cdim)
     try:
         return _MPI_types[key]
@@ -28,11 +33,51 @@ def _get_mtype(dat):
             raise RuntimeError("Unknown base type %r", dat.dtype)
         if dat.cdim == 1:
             typ = btype
+            builtin = True
         else:
             typ = btype.Create_contiguous(dat.cdim)
             typ.Commit()
-        _MPI_types[key] = typ
-        return typ
+            builtin = False
+        return _MPI_types.setdefault(key, (typ, builtin))
+
+
+_numpy_types = {}
+
+
+def _get_dtype(datatype):
+    """Get a numpy datatype corresponding to an MPI datatype.
+
+    Only works for contiguous datatypes."""
+    try:
+        # possibly unsafe if handles are recycled, but OK, because we
+        # hold on to the contig types
+        return _numpy_types[datatype.py2f()]
+    except KeyError:
+        base, combiner, _ = datatype.decode()
+        if combiner != "CONTIGUOUS":
+            raise RuntimeError("Can only handle contiguous types")
+        try:
+            tdict = MPI.__TypeDict__
+        except AttributeError:
+            tdict = MPI._typedict
+
+        tdict = dict((v.py2f(), k) for k, v in tdict.items())
+        try:
+            base = tdict[base.py2f()]
+        except KeyError:
+            raise RuntimeError("Unhandled base datatype %r", base)
+        return _numpy_types.setdefault(datatype.py2f(), base)
+
+
+def reduction_op(op, invec, inoutvec, datatype):
+    dtype = _get_dtype(datatype)
+    invec = numpy.frombuffer(invec, dtype=dtype)
+    inoutvec = numpy.frombuffer(inoutvec, dtype=dtype)
+    inoutvec[:] = op(invec, inoutvec)
+
+
+_contig_min_op = MPI.Op.Create(partial(reduction_op, numpy.minimum), commute=True)
+_contig_max_op = MPI.Op.Create(partial(reduction_op, numpy.maximum), commute=True)
 
 
 class Halo(op2.Halo):
@@ -83,32 +128,38 @@ class Halo(op2.Halo):
         assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
         if self.comm.size == 1:
             return
-        mtype = _get_mtype(dat)
+        mtype, _ = _get_mtype(dat)
         dmplex.halo_begin(self.sf, dat, mtype, False)
 
     def global_to_local_end(self, dat, insert_mode):
         assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
         if self.comm.size == 1:
             return
-        mtype = _get_mtype(dat)
+        mtype, _ = _get_mtype(dat)
         dmplex.halo_end(self.sf, dat, mtype, False)
 
     def local_to_global_begin(self, dat, insert_mode):
         assert insert_mode in {op2.INC, op2.MIN, op2.MAX}, "%s LtoG not supported" % insert_mode
         if self.comm.size == 1:
             return
-        mtype = _get_mtype(dat)
-        op = {op2.INC: MPI.SUM,
-              op2.MIN: MPI.MIN,
-              op2.MAX: MPI.MAX}[insert_mode]
+        mtype, builtin = _get_mtype(dat)
+        op = {(False, op2.INC): MPI.SUM,
+              (True, op2.INC): MPI.SUM,
+              (False, op2.MIN): _contig_min_op,
+              (True, op2.MIN): MPI.MIN,
+              (False, op2.MAX): _contig_max_op,
+              (True, op2.MAX): MPI.MAX}[(builtin, insert_mode)]
         dmplex.halo_begin(self.sf, dat, mtype, True, op=op)
 
     def local_to_global_end(self, dat, insert_mode):
         assert insert_mode in {op2.INC, op2.MIN, op2.MAX}, "%s LtoG not supported" % insert_mode
         if self.comm.size == 1:
             return
-        mtype = _get_mtype(dat)
-        op = {op2.INC: MPI.SUM,
-              op2.MIN: MPI.MIN,
-              op2.MAX: MPI.MAX}[insert_mode]
+        mtype, builtin = _get_mtype(dat)
+        op = {(False, op2.INC): MPI.SUM,
+              (True, op2.INC): MPI.SUM,
+              (False, op2.MIN): _contig_min_op,
+              (True, op2.MIN): MPI.MIN,
+              (False, op2.MAX): _contig_max_op,
+              (True, op2.MAX): MPI.MAX}[(builtin, insert_mode)]
         dmplex.halo_end(self.sf, dat, mtype, True, op=op)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1079,7 +1079,7 @@ values from f.)"""
         """Spatial index to quickly find which cell contains a given point."""
 
         from firedrake import function, functionspace
-        from firedrake.parloops import par_loop, READ, RW
+        from firedrake.parloops import par_loop, READ, MIN, MAX
 
         gdim = self.ufl_cell().geometric_dimension()
         if gdim <= 1:
@@ -1106,8 +1106,8 @@ values from f.)"""
         """
         par_loop((domain, instructions), ufl.dx,
                  {'f': (self.coordinates, READ),
-                  'f_min': (coords_min, RW),
-                  'f_max': (coords_max, RW)},
+                  'f_min': (coords_min, MIN),
+                  'f_max': (coords_max, MAX)},
                  is_loopy_kernel=True)
 
         # Reorder bounding boxes according to the cell indices we use

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -214,7 +214,10 @@ each supermesh cell.
     }
     int supermesh_kernel(double* simplex_A, double* simplex_B, double* simplices_C, double* nodes_A, double* nodes_B, double* M_SS, double* outptr)
     {
-        int d = %(dim)s;
+#define d %(dim)s
+#define num_nodes_A %(num_nodes_A)s
+#define num_nodes_B %(num_nodes_B)s
+
         double simplex_ref_measure;
         PrintInfo("simplex_A coordinates\\n");
         print_coordinates(simplex_A, d);
@@ -224,9 +227,6 @@ each supermesh cell.
 
         if (d == 2) simplex_ref_measure = 0.5;
         else if (d == 3) simplex_ref_measure = 1.0/6;
-
-        int num_nodes_A = %(num_nodes_A)s;
-        int num_nodes_B = %(num_nodes_B)s;
 
         double R_AS[num_nodes_A][num_nodes_A];
         double R_BS[num_nodes_B][num_nodes_B];
@@ -243,8 +243,8 @@ each supermesh cell.
         // would like to do this
         //double MAB[%(num_nodes_A)s][%(num_nodes_B)s] = (double (*)[%(num_nodes_B)s])outptr;
         // but have to do this instead because we don't grok C
-        double (*MAB)[%(num_nodes_A)s] = (double (*)[%(num_nodes_A)s])outptr;
-        double (*MSS)[%(num_nodes_A)s] = (double (*)[%(num_nodes_A)s])M_SS; // note the underscore
+        double (*MAB)[num_nodes_A] = (double (*)[num_nodes_A])outptr;
+        double (*MSS)[num_nodes_A] = (double (*)[num_nodes_A])M_SS; // note the underscore
 
         for ( int i = 0; i < num_nodes_B; i++ ) {
             for (int j = 0; j < num_nodes_A; j++) {
@@ -265,7 +265,7 @@ each supermesh cell.
             double physical_nodes_A[num_nodes_A][d];
             for(int n=0; n < num_nodes_A; n++) {
                 double* reference_node_location = &nodes_A[n*d];
-                double* physical_node_location = &physical_nodes_A[n];
+                double* physical_node_location = physical_nodes_A[n];
                 for (int j=0; j < d; j++) physical_node_location[j] = 0.0;
                 pyop2_kernel_evaluate_kernel_S(physical_node_location, simplex_S, reference_node_location);
                 PrintInfo("\\tNode ");
@@ -278,7 +278,7 @@ each supermesh cell.
             double physical_nodes_B[num_nodes_B][d];
             for(int n=0; n < num_nodes_B; n++) {
                 double* reference_node_location = &nodes_B[n*d];
-                double* physical_node_location = &physical_nodes_B[n];
+                double* physical_node_location = physical_nodes_B[n];
                 for (int j=0; j < d; j++) physical_node_location[j] = 0.0;
                 pyop2_kernel_evaluate_kernel_S(physical_node_location, simplex_S, reference_node_location);
                 PrintInfo("\\tNode ");


### PR DESCRIPTION
Uses the correct access descriptors for building the spatial index bounding boxes. This then necessitates a change in the reduction op we're using for halo exchange: For MIN/MAX with non builtin datatypes, PetscSF doesn't support the combination, so we must define a custom reduction op that operates on the full contiguous type.

Then also fix a bug in the supermesh mass matrix assembly that exhibited on my new skylake box.