### PR TITLE
Extract eigen include dir from PETSc conf

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -240,8 +240,6 @@ def generate_kernel_ast(builder, statements, declared_temps):
                         return include_dir
         except FileNotFoundError:
             raise FileNotFoundError("Could not find %s/lib/petsc/conf/petscvariables." % PETSC_ARCH if PETSC_ARCH else PETSC_DIR)
-
-        file.close()
         raise ValueError(""" Could not find Eigen configuration in %s/lib/petsc/conf/petscvariables.
                              Check PETSc was built with the correct options.""" % PETSC_ARCH)
 

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -232,8 +232,8 @@ def generate_kernel_ast(builder, statements, declared_temps):
 
     def extract_eigen_include_dir(PETSC_DIR, PETSC_ARCH):
         try:
-            with open(os.path.join(PETSC_ARCH, "lib/petsc/conf/petscvariables") if PETSC_ARCH
-                      else os.path.join(PETSC_DIR, "lib/petsc/conf/petscvariables")) as file:
+            with open(os.path.join(PETSC_ARCH, "lib", "petsc", "conf", "petscvariables") if PETSC_ARCH
+                      else os.path.join(PETSC_DIR, "lib", "petsc", "conf", "petscvariables")) as file:
                 for line in file:
                     if line.find("EIGEN_INCLUDE") == 0:
                         include_dir = line[18:].rstrip()

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -48,13 +48,12 @@ __all__ = ['compile_expression']
 try:
     PETSC_DIR, PETSC_ARCH = get_petsc_dir()
 except ValueError:
-    PETSC_DIR = get_petsc_dir()
+    PETSC_DIR, = get_petsc_dir()
     PETSC_ARCH = None
 
 EIGEN_INCLUDE_DIR = None
 if COMM_WORLD.rank == 0:
-    with open(os.path.join(PETSC_ARCH, "lib", "petsc", "conf", "petscvariables") if PETSC_ARCH
-              else os.path.join(PETSC_DIR, "lib", "petsc", "conf", "petscvariables")) as file:
+    with open(os.path.join(PETSC_ARCH or PETSC_DIR, "lib", "petsc", "conf", "petscvariables")) as file:
         for line in file:
             if line.find("EIGEN_INCLUDE") == 0:
                 EIGEN_INCLUDE_DIR = line[18:].rstrip()

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -239,7 +239,7 @@ def generate_kernel_ast(builder, statements, declared_temps):
                         include_dir = line[18:].rstrip()
                         return include_dir
         except FileNotFoundError:
-            raise FileNotFoundError("Could not find $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/petscvariables, where $PETSC_DIR/$PETSC_ARCH=%s." % PETSC_ARCH)
+            raise FileNotFoundError("Could not find %s/lib/petsc/conf/petscvariables." % PETSC_ARCH if PETSC_ARCH else PETSC_DIR)
 
         file.close()
         raise ValueError(""" Could not find Eigen configuration in %s/lib/petsc/conf/petscvariables.

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -18,6 +18,7 @@ from coffee import base as ast
 
 import time
 from hashlib import md5
+import os.path
 
 from firedrake_citations import Citations
 from firedrake.tsfc_interface import SplitKernel, KernelInfo, TSFCKernel
@@ -231,7 +232,8 @@ def generate_kernel_ast(builder, statements, declared_temps):
 
     def extract_eigen_include_dir(PETSC_DIR, PETSC_ARCH):
         try:
-            with open("%s/lib/petsc/conf/petscvariables" % PETSC_ARCH if PETSC_ARCH else PETSC_DIR) as file:
+            with open(os.path.join(PETSC_ARCH, "lib/petsc/conf/petscvariables") if PETSC_ARCH
+                      else os.path.join(PETSC_DIR, "lib/petsc/conf/petscvariables")) as file:
                 for line in file:
                     if line.find("EIGEN_INCLUDE") == 0:
                         include_dir = line[18:].rstrip()

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -53,14 +53,14 @@ except ValueError:
 
 EIGEN_INCLUDE_DIR = None
 if COMM_WORLD.rank == 0:
-    with open(os.path.join(PETSC_ARCH or PETSC_DIR, "lib", "petsc", "conf", "petscvariables")) as file:
+    filepath = os.path.join(PETSC_ARCH or PETSC_DIR, "lib", "petsc", "conf", "petscvariables")
+    with open(filepath) as file:
         for line in file:
             if line.find("EIGEN_INCLUDE") == 0:
                 EIGEN_INCLUDE_DIR = line[18:].rstrip()
                 break
     if EIGEN_INCLUDE_DIR is None:
-        raise ValueError(""" Could not find Eigen configuration in %s/lib/petsc/conf/petscvariables.
-                             Check if PETSc was built with the correct options.""" % PETSC_ARCH)
+        raise ValueError(""" Could not find Eigen configuration in %s. Did you build PETSc with Eigen?""" % PETSC_ARCH or PETSC_DIR)
 EIGEN_INCLUDE_DIR = COMM_WORLD.bcast(EIGEN_INCLUDE_DIR, root=0)
 
 cell_to_facets_dtype = np.dtype(np.int8)
@@ -241,7 +241,7 @@ def generate_kernel_ast(builder, statements, declared_temps):
 
     # Now we wrap up the kernel ast as a PyOP2 kernel and include the
     # Eigen header files
-    include_dirs = builder.include_dirs
+    include_dirs = list(builder.include_dirs)
     include_dirs.append(EIGEN_INCLUDE_DIR)
     op2kernel = op2.Kernel(kernel_ast,
                            macro_kernel_name,


### PR DESCRIPTION
Draft fix for #1436.

I'm not very happy with it yet but at least we've got a base to discuss.

Needed improvement:
  - I assume that $PETSC_ARCH is set, which pyOP2 doesn't seem to. I'm not too sure why.

Possible improvements:
  - using Python (multiline) regexps would shorten the patch but may be overkill.