### PR TITLE
Call expand_derivatives before splitting a form in ExtractSubBlock.

### DIFF
--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -4,6 +4,7 @@ import collections
 
 from ufl import as_vector
 from ufl.classes import Zero
+from ufl.algorithms import expand_derivatives
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.corealg.map_dag import MultiFunction
 
@@ -26,6 +27,7 @@ class ExtractSubBlock(MultiFunction):
 
         Returns a new :class:`ufl.classes.Form` on the selected subspace.
         """
+        form = expand_derivatives(form)
         args = form.arguments()
         self._arg_cache = {}
         self.blocks = dict(zip((0, 1), argument_indices))


### PR DESCRIPTION
It appears that `ExtractSubBlock.split` and `ufl.algorithms.expand_derivatives` don't commute. Sometimes when a form with an unexpanded derivative is split, UFL later crashes when trying to expand it. The original, unexpanded form in question is

```
{ d/dfj { d/dfj { 0.5 * ((grad([w_{14}[1], w_{14}[2]])) : (grad([w_{14}[1], w_{14}[2]]))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_{14}[3] * (conj((div([w_{14}[1], w_{14}[2]])))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { 0.5 * 2500.0 * (-1 + 1.1 / (0.1 + w_{14}[0])) * (([w_{14}[1], w_{14}[2]]) : ([w_{14}[1], w_{14}[2]])) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_{14}[4] * (conj((0.3333333333333333 + -1 * w_{14}[0]))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_0 * ln(w_{14}[0] + -1 * w_{67}) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_0 * ln(w_{68} + -1 * w_{14}[0]) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_0,)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*(v_1,)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
Unexpanded form: { 0.5 * (sum_{i_{621}} sum_{i_{620}} (([{ A | A_{i_{624}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[1, i_{624}] }, { A | A_{i_{625}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[2, i_{625}] }])[i_{620}, i_{621}] * (conj((([{ A | A_{i_{624}} = ({ A | A_{i_{627}, i_{626}} = I[4, i_{627}] * (grad(v_0))[i_{626}] })[1, i_{624}] }, { A | A_{i_{625}} = ({ A | A_{i_{627}, i_{626}} = I[4, i_{627}] * (grad(v_0))[i_{626}] })[2, i_{625}] }])[i_{620}, i_{621}]))) + ([{ A | A_{i_{624}} = ({ A | A_{i_{627}, i_{626}} = I[4, i_{627}] * (grad(v_0))[i_{626}] })[1, i_{624}] }, { A | A_{i_{625}} = ({ A | A_{i_{627}, i_{626}} = I[4, i_{627}] * (grad(v_0))[i_{626}] })[2, i_{625}] }])[i_{620}, i_{621}] * (conj((([{ A | A_{i_{624}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[1, i_{624}] }, { A | A_{i_{625}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[2, i_{625}] }])[i_{620}, i_{621}]))))  ) } * dx(<Mesh #1>[everywhere], {})
  +  { -1 * (([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[3] * (conj((sum_{i_{622}} ([{ A | A_{i_{628}} = ({ A | A_{i_{632}, i_{631}} = I[4, i_{632}] * (grad(v_0))[i_{631}] })[1, i_{628}] }, { A | A_{i_{629}} = ({ A | A_{i_{632}, i_{631}} = I[4, i_{632}] * (grad(v_0))[i_{631}] })[2, i_{629}] }])[i_{622}, i_{622}] ))) + ([0, 0, 0, 0, v_0])[3] * (conj((sum_{i_{622}} ([{ A | A_{i_{628}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[1, i_{628}] }, { A | A_{i_{629}} = (grad([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}]))[2, i_{629}] }])[i_{622}, i_{622}] )))) } * dx(<Mesh #1>[everywhere], {})
  +  { 0.5 * 2500.0 * (-1 + 1.1 / (0.1 + ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0])) * (sum_{i_{623}} (([([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[1], ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[2]])[i_{623}] * (conj((([([0, 0, 0, 0, v_0])[1], ([0, 0, 0, 0, v_0])[2]])[i_{623}]))) + ([([0, 0, 0, 0, v_0])[1], ([0, 0, 0, 0, v_0])[2]])[i_{623}] * (conj((([([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[1], ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[2]])[i_{623}])))) ) + 0.5 * 2500.0 * -1 * ([0, 0, 0, 0, v_0])[0] * 1.1 / (0.1 + ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0]) / (0.1 + ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0]) * (sum_{i_{623}} ([([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[1], ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[2]])[i_{623}] * (conj((([([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[1], ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[2]])[i_{623}]))) ) } * dx(<Mesh #1>[everywhere], {})
  +  { -1 * (([0, 0, 0, 0, v_0])[4] * (conj((0.3333333333333333 + -1 * ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0]))) + ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[4] * (conj((-1 * ([0, 0, 0, 0, v_0])[0])))) } * dx(<Mesh #1>[everywhere], {})
  +  { -1 * w_0 * ([0, 0, 0, 0, v_0])[0] / (([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0] + -1 * w_{67}) } * dx(<Mesh #1>[everywhere], {})
  +  { -1 * w_0 * -1 * ([0, 0, 0, 0, v_0])[0] / (w_{68} + -1 * ([w_{73}, w_{74}[0], w_{74}[1], w_{75}, w_{240}])[0]) } * dx(<Mesh #1>[everywhere], {})
Unexpanded form: { d/dfj { d/dfj { 0.5 * ((grad([w_{14}[1], w_{14}[2]])) : (grad([w_{14}[1], w_{14}[2]]))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_{14}[3] * (conj((div([w_{14}[1], w_{14}[2]])))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { 0.5 * 2500.0 * (-1 + 1.1 / (0.1 + w_{14}[0])) * (([w_{14}[1], w_{14}[2]]) : ([w_{14}[1], w_{14}[2]])) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_{14}[4] * (conj((0.3333333333333333 + -1 * w_{14}[0]))) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_0 * ln(w_{14}[0] + -1 * w_{67}) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
  +  { d/dfj { d/dfj { -1 * w_0 * ln(w_{68} + -1 * w_{14}[0]) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_0[0], v_0[1], v_0[2], v_0[3], v_0[4]],)), and coefficient derivatives ExprMapping(*()) }, with fh=ExprList(*(w_{14},)), dfh/dfj = ExprList(*([v_1[0], v_1[1], v_1[2], v_1[3], v_1[4]],)), and coefficient derivatives ExprMapping(*()) } * dx(<Mesh #1>[everywhere], {})
```

and the error message is

```
UFL:ERROR Expecting gradient of a FormArgument, not <ListTensor id=139633817089920>
Traceback (most recent call last):
  File "libpetsc4py/libpetsc4py.pyx", line 712, in libpetsc4py.MatCreateSubMatrix_Python
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/firedrake/firedrake/matrix_free/operators.py", line 269, in createSubMatrix
    appctx=self.appctx)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/firedrake/firedrake/matrix_free/operators.py", line 84, in __init__
    self.aT = adjoint(a)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/firedrake/firedrake/ufl_expr.py", line 231, in adjoint
    return ufl.adjoint(form, reordered_arguments)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/formoperators.py", line 142, in adjoint
    form = expand_derivatives(form)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/ad.py", line 45, in expand_derivatives
    form = apply_derivatives(form)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/apply_derivatives.py", line 1095, in apply_derivatives
    return map_integrand_dags(rules, expression)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/map_integrands.py", line 58, in map_integrand_dags
    form, only_integral_type)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/map_integrands.py", line 39, in map_integrands
    for itg in form.integrals()]
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/map_integrands.py", line 39, in <listcomp>
    for itg in form.integrals()]
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/map_integrands.py", line 46, in map_integrands
    return itg.reconstruct(function(itg.integrand()))
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/map_integrands.py", line 57, in <lambda>
    return map_integrands(lambda expr: map_expr_dag(function, expr, compress),
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/corealg/map_dag.py", line 37, in map_expr_dag
    result, = map_expr_dags(function, [expression], compress=compress)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/corealg/map_dag.py", line 86, in map_expr_dags
    r = handlers[v._ufl_typecode_](v, *[vcache[u] for u in v.ufl_operands])
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/apply_derivatives.py", line 1057, in coefficient_derivative
    return map_expr_dag(rules, f)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/corealg/map_dag.py", line 37, in map_expr_dag
    result, = map_expr_dags(function, [expression], compress=compress)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/corealg/map_dag.py", line 84, in map_expr_dags
    r = handlers[v._ufl_typecode_](v)
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/algorithms/apply_derivatives.py", line 891, in grad
    error("Expecting gradient of a FormArgument, not %s" % ufl_err_str(o))
  File "/mnt/ntfs/data/install-scripts/firedrake/firedrake-dev-20190428-mpich/src/ufl/ufl/log.py", line 172, in error
    raise self._exception_type(self._format_raw(*message))
ufl.log.UFLException: Expecting gradient of a FormArgument, not <ListTensor id=139633817089920>
```

This patch fixes the problem by always calling `expand_derivatives` before splitting the form.