### PR TITLE
Add option to create "new versions" of existing zenodo releases

### DIFF
--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -105,6 +105,8 @@ parser.add_argument("--title", "-t", action="store", nargs=1,
                     help="""Short description of the reason for this release.  Will be formatted as 'Software used in "TITLE"'""")
 parser.add_argument("--info-file", action="store", nargs=1,
                     help="""File containing additional information to be added to the Zenodo meta-record (e.g. dois linking to your simulation code).  Will be uploaded to Zenodo using the provided name.""")
+parser.add_argument("--new-version-of", action="store", nargs=1,
+                    help="Is this release a new version of a previous release (e.g. round two of a paper). If so, provide the DOI of the meta-release this is a new version of.")
 parser.add_argument("--honour-petsc-dir", action="store_true",
                     help="Does your firedrake use a self-built PETSc?")
 
@@ -123,6 +125,17 @@ parser.add_argument("--log", action='store_true',
                     help="Produce a verbose log of the release process in firedrake-zenodo.log. If you have problem running this script, please include this log in any bug report you file.")
 
 args = parser.parse_args()
+
+if args.new_version_of:
+    doi, = args.new_version_of
+    new_version_of = doi[len("10.5281/zenodo."):]
+    record = requests.get("https://zenodo.org/api/records/{}".format(new_version_of))
+    if record.status_code >= 400:
+        raise ValueError("Provided new version DOI, but could not find record {}".format(record.json()))
+    if doi != record.json()["doi"]:
+        raise ValueError("Provided DOI {} does not match DOI of record {}".format(doi, record.json()["doi"]))
+else:
+    new_version_of = None
 
 # Set up logging
 if args.log:
@@ -170,18 +183,31 @@ def check_output(args):
         raise
 
 
+class directory(object):
+    """Context manager that executes body in a given directory"""
+    def __init__(self, d):
+        self.d = os.path.abspath(d)
+
+    def __enter__(self):
+        self.olddir = os.path.abspath(os.getcwd())
+        os.chdir(self.d)
+
+    def __exit__(self, *args):
+        os.chdir(self.olddir)
+
+
 def collect_repo_shas():
     shas = {}
 
     for component in components:
         try:
-            os.chdir(src + "/" + component)
-            try:
-                check_call(["git", "diff-index", "--quiet", "HEAD"])
-            except subprocess.CalledProcessError:
-                log.error("Component %s has uncommitted changes, cannot create release" % component)
-                sys.exit(0)
-            shas[component] = check_output(["git", "rev-parse", "HEAD"]).strip()
+            with directory(os.path.join(src, component)):
+                try:
+                    check_call(["git", "diff-index", "--quiet", "HEAD"])
+                except subprocess.CalledProcessError:
+                    log.error("Component %s has uncommitted changes, cannot create release" % component)
+                    sys.exit(0)
+                shas[component] = check_output(["git", "rev-parse", "HEAD"]).strip()
         except (subprocess.CalledProcessError, OSError):
             if component in optional_components:
                 log.warning("Failed to retrieve git hash for optional "
@@ -371,14 +397,17 @@ See <a href="https://www.firedrakeproject.org/download.html">firedrakeproject.or
     return data
 
 
-def create_metarecord(tag, title, components, info_file=None):
+def create_metarecord(tag, title, components, info_file=None, update_record=None):
     """Create meta-record.
 
     :arg tag: The tag to create the record for.
     :arg title: The title of the record.
     :arg components: The components to include in the record.
     :arg info_file: optional (filename, contents) pair of any additional
-        (user-provided) information, will be uploaded using the provided filename."""
+        (user-provided) information, will be uploaded using the provided filename.
+
+    :arg update_record: Zenodo record this metarelease updates (use,
+        for example, for version two of a paper with newer components, or similar)."""
     # First check that we don't have a matching tag already.
     response = requests.get("https://zenodo.org/api/records",
                             params={"q": "creators.name:firedrake-zenodo AND version:{}".format(tag)})
@@ -424,13 +453,37 @@ def create_metarecord(tag, title, components, info_file=None):
 variable FIREDRAKE_ZENODO_TOKEN to a Zenodo personal access token
 with deposit:write scope.""")
         sys.exit(1)
-    empty = requests.post(base_url, params=authentication_params, json={})
-    if empty.status_code >= 400:
-        raise ValueError("Unable to create deposition {}".format(empty.json()))
-    empty = empty.json()
-    doi = empty["metadata"]["prereserve_doi"]["doi"]
 
-    depo_id = empty["id"]
+    if update_record is not None:
+        base = requests.get("{url}/{id}".format(url=base_url, id=update_record),
+                            params=authentication_params)
+        if base.status_code >= 400:
+            raise ValueError("Unable to find existing deposition {}\n{}".format(update_record, base.json()))
+        empty = requests.post("{url}/{id}/actions/newversion".format(url=base_url, id=update_record),
+                              params=authentication_params)
+        if empty.status_code >= 400:
+            raise ValueError("Unable to create new version {}".format(empty.json()))
+        # Delete carried-over files, we will replace them below
+        files = requests.get("{url}/files".format(url=empty.json()["links"]["latest_draft"]),
+                             params=authentication_params)
+        if files.status_code >= 400:
+            raise ValueError("Unable to retrieve list of files {}".format(files.json()))
+        for f in files.json():
+            s = requests.delete(f["links"]["self"], params=authentication_params)
+            if s.status_code >= 400:
+                raise ValueError("Unable to remove file {}".format(f))
+    else:
+        empty = requests.post(base_url, params=authentication_params, json={})
+        if empty.status_code >= 400:
+            raise ValueError("Unable to create deposition {}".format(empty.json()))
+    empty = empty.json()
+    depo_url = empty["links"]["latest_draft"]
+
+    info = requests.get(depo_url, params=authentication_params)
+    if info.status_code >= 400:
+        raise ValueError("Unable to get information about newly created deposition")
+    doi = info.json()["metadata"]["prereserve_doi"]["doi"]
+
     metadata = {
         "metadata": {
             "title": "Software used in '{}'".format(title),
@@ -444,13 +497,13 @@ with deposit:write scope.""")
             "description": create_description(matching_records, title, doi),
         }
     }
-    depo = requests.put("{url}/{id}".format(url=base_url, id=depo_id),
+    depo = requests.put("{url}".format(url=depo_url),
                         params=authentication_params, json=metadata)
     if depo.status_code >= 400:
         raise ValueError("Unable to add metadata to deposition {}".format(depo.json()))
 
     components = create_json(matching_records, title)
-    upload = requests.post("{url}/{id}/files".format(url=base_url, id=depo_id),
+    upload = requests.post("{url}/files".format(url=depo_url),
                            files={"file": ("components.json", components, "application/json")},
                            params=authentication_params)
     if upload.status_code >= 400:
@@ -471,7 +524,7 @@ with deposit:write scope.""")
             params = (filename, contents, content_type, {"Content-Encoding": encoding})
         else:
             params = (filename, contents, content_type)
-        upload = requests.post("{url}/{id}/files".format(url=base_url, id=depo_id),
+        upload = requests.post("{url}/files".format(url=depo_url),
                                files={"file": params},
                                params=authentication_params)
         if upload.status_code >= 400:
@@ -480,7 +533,7 @@ with deposit:write scope.""")
         if checksum != upload.json()["checksum"]:
             raise ValueError("User file '{}' failed checksum verification".format(filename))
 
-    publish = requests.post("{url}/{id}/actions/publish".format(url=base_url, id=depo_id),
+    publish = requests.post("{url}/actions/publish".format(url=depo_url),
                             params=authentication_params)
     if publish.status_code >= 400:
         raise ValueError("Unable to publish deposition {}".format(publish.json()))
@@ -570,7 +623,8 @@ if args.meta_release:
     title = data["title"]
     components = data["components"]
     info_file = decode_info_file(data["info_file"])
-    record = create_metarecord(tag, title, components, info_file)
+    new_version_of = data["new_version_of"]
+    record = create_metarecord(tag, title, components, info_file, update_record=new_version_of)
     record = record.json()
     log.info("Created Zenodo meta-release.")
     log.info("DOI is {}".format(record["doi"]))
@@ -599,6 +653,9 @@ if args.title:
 
 if args.info_file:
     shas["metarelease_info_file"] = encode_info_file(args.info_file[0])
+
+if args.new_version_of:
+    shas["new_version_of"] = new_version_of
 
 # Override hashes with any read from the command line.
 for component in components:
@@ -692,10 +749,11 @@ with open(meta_file, "w") as f:
     data = {"tag": tag,
             "title": shas["title"],
             "components": sorted(set(shas) & set(components)),
-            "info_file": shas.get("metarelease_info_file", None)}
+            "info_file": shas.get("metarelease_info_file", None),
+            "new_version_of": shas.get("new_version_of", None)}
     f.write(json.dumps(data))
 
 log.info("Releases complete. The release tag is %s" % tag)
 log.info("Now, you need to create the meta-release")
-log.info("Run 'firedrake-zenodo --create-meta-release %s' to do this" % meta_file)
+log.info("Run 'firedrake-zenodo --create-meta-release %s' to do this" % os.path.abspath(meta_file))
 log.info("It is best to wait a short while to ensure that Zenodo is up to date")


### PR DESCRIPTION
Often when archiving a release for a paper, when the reviews come
back, we need to make minor changes in the archived code, or rerun
experiments with a new version of Firedrake. This change makes that
workflow nicer in the zenodo archiving by allowing one to specify that
this release corresponds to a new version of an existing DOI.

Example: https://zenodo.org/record/3234784

Usage:

   firedrake-zenodo --new-version-of existing-zenodo-doi
   
Everything else flows through unchanged.

I think this is nice because, like when you update the paper on arxiv,
it is easy to see previous versions, the same is now also true of the
archived software.