### PR TITLE
test against numbers.Integral instead of int.

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -7,6 +7,7 @@ import weakref
 from collections import OrderedDict, defaultdict
 from ufl.classes import ReferenceGrad
 import enum
+import numbers
 
 from pyop2.datatypes import IntType
 from pyop2 import op2
@@ -175,7 +176,7 @@ class _Facets(object):
             (or ``None``, for an empty subset).
         """
         valid_markers = set([unmarked]).union(self.unique_markers)
-        markers = as_tuple(markers, int)
+        markers = as_tuple(markers, numbers.Integral)
         if self.markers is None and valid_markers.intersection(markers):
             return self._null_subset
         try:

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -1,4 +1,5 @@
 import ufl
+import numbers
 import numpy as np
 
 from firedrake.slate.static_condensation.sc_base import SCBase
@@ -155,7 +156,7 @@ class HybridizationPC(SCBase):
                 if isinstance(subdom, str):
                     neumann_subdomains |= set([subdom])
                 else:
-                    neumann_subdomains |= set(as_tuple(subdom, int))
+                    neumann_subdomains |= set(as_tuple(subdom, numbers.Integral))
 
             # separate out the top and bottom bcs
             extruded_neumann_subdomains = neumann_subdomains & {"top", "bottom"}


### PR DESCRIPTION
Subdomain markers can be any sort of integer, they don't have to be an int.