### PR TITLE
zenodo: don't create multiple releases on same commit

### DIFF
--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -12,6 +12,7 @@ import time
 import requests
 import base64
 import mimetypes
+import datetime
 
 
 descriptions = OrderedDict([
@@ -703,9 +704,9 @@ fd = gh.repository("firedrakeproject", "firedrake")
 tag = time.strftime("Firedrake_%Y%m%d", time.localtime())
 index = -1
 
-for r in fd.releases():
-    if r.tag_name.startswith(tag):
-        newindex = int(r.tag_name.split(".")[1])
+for r in fd.tags():
+    if r.name.startswith(tag):
+        newindex = int(r.name.split(".")[1])
         index = max(index, newindex)
 tag += "." + str(index + 1)
 
@@ -722,7 +723,7 @@ for component in components:
         shas[component] = commit.sha
 
     except KeyError:
-        log.warn("No commit specified for %s. No release will be created for this component." % component)
+        log.warning("No commit specified for %s. No release will be created for this component." % component)
 
 # Now create releases.
 message = """This release is specifically created to document the version of
@@ -735,14 +736,31 @@ https://www.firedrakeproject.org/citing.html"""
 for component in (set(shas) & set(components)):
     log.info("Releasing %s" % component)
     repo = gh.repository(projects[component], component)
+    releases = repo.releases()
+    just_tag = False
+    date = datetime.datetime.utcnow().replace(microsecond=0, tzinfo=datetime.timezone.utc).isoformat()
+    tagger = {"name": "firedrake-zenodo",
+              "email": "firedrake@imperial.ac.uk",
+              "date": date}
 
-    repo.create_release(
-        tag_name=tag,
-        target_commitish=shas[component],
-        name=descriptions[component],
-        body=message.format(component=component),
-        draft=False,
-        prerelease=True)
+    for release in releases:
+        if release.target_commitish == shas[component]:
+            just_tag = True
+            break
+    if just_tag:
+        repo.create_tag(tag,
+                        message=descriptions[component],
+                        sha=shas[component],
+                        obj_type="tree",
+                        tagger=tagger)
+    else:
+        repo.create_release(
+            tag_name=tag,
+            target_commitish=shas[component],
+            name=descriptions[component],
+            body=message.format(component=component),
+            draft=False,
+            prerelease=True)
 
 meta_file = "firedrake-meta-release.json"
 with open(meta_file, "w") as f:


### PR DESCRIPTION
GitHub have removed the ability to create a release for a given commit
if there is already a release referencing that commit. So check for
that case, and if it happens, just create a normal tag instead.

This works fine because the resolution of tags to commits and hence
zenodo releases in create_metarecord walks through tags, not releases.