### PR TITLE
mesh: Allow a local partition to have no cells

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -406,8 +406,10 @@ class MeshTopology(object):
             # it, we grow the halo.
             partitioner = plex.getPartitioner()
             if IntType.itemsize == 8:
-                # Default to Parmetis on 64bit ints (Chaco is 32 bit int only)
-                partitioner.setType(partitioner.Type.PARMETIS)
+                # Default to PTSCOTCH on 64bit ints (Chaco is 32 bit int only)
+                partitioner.setType(partitioner.Type.PTSCOTCH)
+            else:
+                partitioner.setType(partitioner.Type.CHACO)
             try:
                 sizes, points = distribute
                 partitioner.setType(partitioner.Type.SHELL)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -407,7 +407,11 @@ class MeshTopology(object):
             partitioner = plex.getPartitioner()
             if IntType.itemsize == 8:
                 # Default to PTSCOTCH on 64bit ints (Chaco is 32 bit int only)
-                partitioner.setType(partitioner.Type.PTSCOTCH)
+                from firedrake_configuration import get_config
+                if get_config().get("options", {}).get("with_parmetis", False):
+                    partitioner.setType(partitioner.Type.PARMETIS)
+                else:
+                    partitioner.setType(partitioner.Type.PTSCOTCH)
             else:
                 partitioner.setType(partitioner.Type.CHACO)
             try:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -52,8 +52,7 @@ class FiredrakeConfiguration(dict):
 
     _persistent_options = ["package_manager",
                            "minimal_petsc", "mpicc", "mpicxx", "mpif90", "mpiexec", "disable_ssh",
-                           "honour_petsc_dir",
-                           "show_petsc_configure_options",
+                           "honour_petsc_dir", "with_parmetis",
                            "slepc", "packages", "honour_pythonpath",
                            "petsc_int_type", "cache_dir"]
 
@@ -199,8 +198,11 @@ honoured.""",
                         help="Do not attempt to use ssh to clone git repositories: fall immediately back to https.")
     parser.add_argument("--no-package-manager", action='store_false', dest="package_manager",
                         help="Do not attempt to use apt or homebrew to install operating system packages on which we depend.")
-    parser.add_argument("--minimal-petsc", action="store_true",
-                        help="Minimise the set of petsc dependencies installed. This creates faster build times (useful for build testing).")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--minimal-petsc", action="store_true",
+                       help="Minimise the set of petsc dependencies installed. This creates faster build times (useful for build testing).")
+    group.add_argument("--with-parmetis", action="store_true",
+                       help="Install PETSc with ParMETIS? (Non-free license, see http://glaros.dtc.umn.edu/gkhome/metis/parmetis/download)")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--honour-petsc-dir", action="store_true",
                        help="Usually it is best to let Firedrake build its own PETSc. If you wish to use another PETSc, set PETSC_DIR and pass this option.")
@@ -234,7 +236,7 @@ honoured.""",
                         action="store", default=None,
                         help="MPI launcher (default is 'mpiexec')")
     parser.add_argument("--show-petsc-configure-options", action="store_true",
-                        help="Print out the configure options passed to PETSc")
+                        help="Print out the configure options passed to PETSc and exit")
     parser.add_argument("--venv-name", default="firedrake",
                         type=str, action="store",
                         help="Name of the venv to create (default is 'firedrake')")
@@ -438,24 +440,55 @@ petsc_opts = "--download-eigen=%s/src/eigen-3.3.3.tgz " % firedrake_env
 
 petsc_opts += "--with-fortran-bindings=0 "
 
-if options["minimal_petsc"]:
-    if options["petsc_int_type"] == "int64":
-        petsc_opts += """--download-metis --download-parmetis --download-hdf5 --download-hypre --with-64-bit-indices"""
-    else:
-        petsc_opts += """--download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre --download-mumps --download-hdf5"""
+petsc_options = {"--with-fortran-bindings=0",
+                 "--download-eigen=%s/src/eigen-3.3.3.tgz " % firedrake_env,
+                 # File format
+                 "--download-hdf5",
+                 # AMG
+                 "--download-hypre",
+                 # Sparse direct solver
+                 "--download-superlu_dist",
+                 # Parallel mesh partitioner
+                 "--download-ptscotch",
+                 # For superlu_dist amongst others.
+                 "--with-cxx-dialect=C++11"}
+
+if not options["minimal_petsc"]:
+    petsc_options.add("--with-zlib")
+    # File formats
+    petsc_options.add("--download-netcdf")
+    petsc_options.add("--download-pnetcdf")
+    petsc_options.add("--download-exodusii")
+    # Sparse direct solvers
+    petsc_options.add("--download-suitesparse")
+    petsc_options.add("--download-pastix")
+    # Serial mesh partitioner
+    petsc_options.add("--download-metis")
+    if options["with_parmetis"]:
+        # Non-free license.
+        petsc_options.add("--download-parmetis")
+
+if options["petsc_int_type"] == "int32":
+    # Sparse direct solver
+    petsc_options.add("--download-scalapack")  # Needed for mumps
+    petsc_options.add("--download-mumps")
+    # Serial mesh partitioner
+    petsc_options.add("--download-chaco")
+    if not options["minimal_petsc"]:
+        # AMG
+        petsc_options.add("--download-ml")
+        # Mesh adaptivity (needs metis, but not parmetis)
+        petsc_options.add("--download-pragmatic")
 else:
-    if options["petsc_int_type"] == "int64":
-        petsc_opts += """--download-metis --download-parmetis --download-hypre --with-zlib --download-netcdf --download-pnetcdf --download-hdf5 --download-exodusii --with-64-bit-indices"""
-    else:
-        petsc_opts += """--download-chaco --download-metis --download-parmetis --download-scalapack --download-hypre --download-mumps --with-zlib --download-netcdf --download-hdf5 --download-pnetcdf --download-exodusii"""
+    petsc_options.add("--with-64-bit-indices")
 
 
 if "PETSC_CONFIGURE_OPTIONS" not in os.environ:
-    os.environ["PETSC_CONFIGURE_OPTIONS"] = petsc_opts
+    os.environ["PETSC_CONFIGURE_OPTIONS"] = " ".join(sorted(petsc_options))
 else:
-    for opt in petsc_opts.split():
-        if opt not in os.environ["PETSC_CONFIGURE_OPTIONS"]:
-            os.environ["PETSC_CONFIGURE_OPTIONS"] += " " + opt
+    all_opts = petsc_options | set(os.environ["PETSC_CONFIGURE_OPTIONS"].split())
+    os.environ["PETSC_CONFIGURE_OPTIONS"] = " ".join(sorted(all_opts))
+
 
 if mode == "update" and petsc_int_type_changed:
     log.warning("""Force rebuilding all packages because PETSc int type changed""")
@@ -978,23 +1011,6 @@ def build_update_script():
     check_call(["chmod", "a+x", "../bin/firedrake-update"])
 
 
-if options["show_petsc_configure_options"]:
-    log.info("******************************************\n")
-    log.info("Building PETSc with the following options:\n")
-    log.info("******************************************\n")
-    log.info("%s\n\n" % os.environ["PETSC_CONFIGURE_OPTIONS"])
-
-if args.rebuild_script:
-    os.chdir(os.path.dirname(os.path.realpath(__file__)) + ("/../.."))
-
-    build_update_script()
-
-    log.info("Successfully rebuilt firedrake-update.\n")
-
-    log.info("To upgrade firedrake, run firedrake-update")
-    sys.exit(0)
-
-
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
 If you really want to use your own PETSc build, please run again with the
@@ -1015,6 +1031,25 @@ if "SLEPC_DIR" in os.environ and not args.honour_petsc_dir and options["slepc"]:
     quit("""The SLEPC_DIR environment variable is set.  If you want to use
 your own SLEPc version, you must also build your own PETSc and run
 with --honour-petsc-dir.""")
+
+
+if args.show_petsc_configure_options and not args.honour_petsc_dir:
+    log.info("*********************************************")
+    log.info("Would build PETSc with the following options:")
+    log.info("*********************************************\n")
+    log.info("\n".join(os.environ["PETSC_CONFIGURE_OPTIONS"].split()))
+    sys.exit(0)
+
+if args.rebuild_script:
+    os.chdir(os.path.dirname(os.path.realpath(__file__)) + ("/../.."))
+
+    build_update_script()
+
+    log.info("Successfully rebuilt firedrake-update.\n")
+
+    log.info("To upgrade firedrake, run firedrake-update")
+    sys.exit(0)
+
 
 log.debug("*** Current environment (output of 'env') ***")
 log.debug(check_output(["env"]))

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1097,6 +1097,8 @@ if mode == "install" or not args.update_script:
             apt_packages = ["build-essential",
                             "autoconf",
                             "automake",
+                            "bison",  # for ptscotch
+                            "flex",   # for ptscotch
                             "cmake",
                             "gfortran",
                             "git",


### PR DESCRIPTION
PETSc has changed the default partitioner to Parmetis, which produces
slightly worse partitions for small meshes. As a result, sometimes in
the tests we get meshes with no local cells.