### PR TITLE
Fix `DirichletBC.reconstruct`

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -319,6 +319,8 @@ class DirichletBC(BCBase):
            V.parent == fs.parent and \
            V.index == fs.index and \
            V.component == fs.component and \
+           (V.parent is None or V.parent.parent == fs.parent.parent) and \
+           (V.parent is None or V.parent.index == fs.parent.index) and \
            g == self._original_arg and \
            sub_domain == self.sub_domain and method == self.method:
             return self

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -318,7 +318,6 @@ class DirichletBC(BCBase):
         if V == fs and \
            V.parent == fs.parent and \
            V.index == fs.index and \
-           V.component == fs.component and \
            (V.parent is None or V.parent.parent == fs.parent.parent) and \
            (V.parent is None or V.parent.index == fs.parent.index) and \
            g == self._original_arg and \

--- a/tests/equation_bcs/test_bcs.py
+++ b/tests/equation_bcs/test_bcs.py
@@ -1,0 +1,64 @@
+import pytest
+
+from firedrake import *
+
+
+@pytest.mark.parallel
+def test_bc_on_sub_sub_domain():
+
+    # Solve a vector poisson problem
+
+    mesh = UnitSquareMesh(32, 32)
+
+    V = VectorFunctionSpace(mesh, "CG", 4)
+    VV = MixedFunctionSpace([V, V])
+
+    x, y = SpatialCoordinate(mesh)
+
+    f = Function(V)
+    f.interpolate(as_vector([-8.0 * pi * pi * cos(x * pi * 2) * cos(y * pi * 2),
+                             -8.0 * pi * pi * cos(x * pi * 2) * cos(y * pi * 2)]))
+
+    # interpolate the exact solution on gg[i][j]
+    gg = [[None, None], [None, None]]
+    for i in [0, 1]:
+        for j in [0, 1]:
+            gg[i][j] = Function(VV.sub(i).sub(j))
+            gg[i][j].interpolate(cos(2 * pi * x) * cos(2 * pi * y))
+
+    uu = Function(VV)
+    vv = TestFunction(VV)
+
+    F = 0
+    for u, v in zip(split(uu), split(vv)):
+        F += (- inner(grad(u), grad(v)) - dot(f, v)) * dx
+
+    bcs = [DirichletBC(VV.sub(0).sub(0), gg[0][0], 1),
+           DirichletBC(VV.sub(0).sub(1), gg[0][1], 2),
+           DirichletBC(VV.sub(1).sub(0), gg[1][0], 3),
+           DirichletBC(VV.sub(1).sub(1), gg[1][1], "on_boundary")]
+
+    parameters = {
+        "mat_type": "matfree",
+        "snes_max_it": 1,
+        "ksp_type": "gmres",
+        "ksp_rtol": 1.e-10,
+        "ksp_atol": 1.e-10,
+        "ksp_max_it": 200000,
+        "pc_type": "fieldsplit",
+        "pc_fieldsplit_type": "schur",
+        "pc_fieldsplit_schur_fact_type": "full",
+        "fieldsplit_0_ksp_type": "gmres",
+        "fieldsplit_0_ksp_rtol": 1.e-12,
+        "fieldsplit_1_ksp_type": "gmres",
+        "fieldsplit_1_ksp_rtol": 1.e-12,
+    }
+
+    solve(F == 0, uu, bcs=bcs, solver_parameters=parameters)
+
+    # interpolate the exact solution on f
+    f.interpolate(as_vector([cos(2 * pi * x) * cos(2 * pi * y),
+                             cos(2 * pi * x) * cos(2 * pi * y)]))
+
+    assert(sqrt(assemble(dot(uu.split()[0] - f, uu.split()[0] - f) * dx)) < 4.3e-07)
+    assert(sqrt(assemble(dot(uu.split()[1] - f, uu.split()[1] - f) * dx)) < 1.5e-07)

--- a/tests/equation_bcs/test_bcs.py
+++ b/tests/equation_bcs/test_bcs.py
@@ -1,16 +1,13 @@
-import pytest
-
 from firedrake import *
 
 
-@pytest.mark.parallel
 def test_bc_on_sub_sub_domain():
 
     # Solve a vector poisson problem
 
-    mesh = UnitSquareMesh(32, 32)
+    mesh = UnitSquareMesh(500, 500)
 
-    V = VectorFunctionSpace(mesh, "CG", 4)
+    V = VectorFunctionSpace(mesh, "CG", 1)
     VV = MixedFunctionSpace([V, V])
 
     x, y = SpatialCoordinate(mesh)
@@ -38,21 +35,15 @@ def test_bc_on_sub_sub_domain():
            DirichletBC(VV.sub(1).sub(0), gg[1][0], 3),
            DirichletBC(VV.sub(1).sub(1), gg[1][1], "on_boundary")]
 
-    parameters = {
-        "mat_type": "matfree",
-        "snes_max_it": 1,
-        "ksp_type": "gmres",
-        "ksp_rtol": 1.e-10,
-        "ksp_atol": 1.e-10,
-        "ksp_max_it": 200000,
-        "pc_type": "fieldsplit",
-        "pc_fieldsplit_type": "schur",
-        "pc_fieldsplit_schur_fact_type": "full",
-        "fieldsplit_0_ksp_type": "gmres",
-        "fieldsplit_0_ksp_rtol": 1.e-12,
-        "fieldsplit_1_ksp_type": "gmres",
-        "fieldsplit_1_ksp_rtol": 1.e-12,
-    }
+    parameters = {"mat_type": "matfree",
+                  "snes_type": "ksponly",
+                  "ksp_type": "preonly",
+                  "pc_type": "fieldsplit",
+                  "pc_fieldsplit_type": "additive",
+                  "fieldsplit_ksp_type": "preonly",
+                  "fieldsplit_pc_type": "python",
+                  "fieldsplit_pc_python_type": "firedrake.AssembledPC",
+                  "fieldsplit_assembled_pc_type": "lu"}
 
     solve(F == 0, uu, bcs=bcs, solver_parameters=parameters)
 
@@ -60,5 +51,5 @@ def test_bc_on_sub_sub_domain():
     f.interpolate(as_vector([cos(2 * pi * x) * cos(2 * pi * y),
                              cos(2 * pi * x) * cos(2 * pi * y)]))
 
-    assert(sqrt(assemble(dot(uu.split()[0] - f, uu.split()[0] - f) * dx)) < 4.3e-07)
-    assert(sqrt(assemble(dot(uu.split()[1] - f, uu.split()[1] - f) * dx)) < 1.5e-07)
+    assert(sqrt(assemble(dot(uu.split()[0] - f, uu.split()[0] - f) * dx)) < 4.0e-05)
+    assert(sqrt(assemble(dot(uu.split()[1] - f, uu.split()[1] - f) * dx)) < 4.0e-05)


### PR DESCRIPTION
This PR fixes issue #1467 regarding application of Dirichlet BCs on V.sub(i).sub(j), by fixing `DirichletBC.reconstruct` method that was returning `self` where it should not.

A relevant test has also been added.

