### PR TITLE
finalise delayed-bcs deprecation

### DIFF
--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -179,29 +179,11 @@ not supply them in solve call):
    b = assemble(L)
    solve(A, x, b)
 
-alternately, we can supply boundary conditions in
-:py:func:`~firedrake.solving.solve` as before:
+.. warning::
 
-.. code-block:: python
-
-  A = assemble(a)
-  b = assemble(L)
-  solve(A, x, b, bcs=[bc1, bc2])
-
-If boundary conditions have been supplied both in the assemble and
-solve calls, then those provided for the solve take precedence, for
-example, in the following, the system is solved only applying ``bc1``:
-
-.. code-block:: python
-
-  A = assemble(a, bcs=[bc1, bc2])
-  b = assemble(L)
-  solve(A, x, b, bcs=[bc1])
-
-Note that after the call to solve, ``A`` will be an assembled system
-with only ``bc1`` applied, hence subsequent calls to ``solve`` that do
-not change the boundary conditions again will not require a further
-re-assembly.
+   It is no longer possible to apply or change boundary
+   conditions after assembling the matrix ``A``; pass any
+   necessary boundary conditions to :py:func:`~.assemble`.
 
 Specifying solution methods
 ---------------------------

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -175,7 +175,6 @@ def _la_solve(A, x, b, **kwargs):
     :arg A: the assembled bilinear form, a :class:`.Matrix`.
     :arg x: the :class:`.Function` to write the solution into.
     :arg b: the :class:`.Function` defining the right hand side values.
-    :kwarg bcs: an optional list of :class:`.DirichletBC`\s and/or :class:`.EquationBC`\s to apply.
     :kwarg solver_parameters: optional solver parameters.
     :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
          :class:`.MixedVectorSpaceBasis`) spanning the null space of
@@ -192,17 +191,15 @@ def _la_solve(A, x, b, **kwargs):
 
     .. note::
 
-        Any boundary conditions passed in as an argument here override the
-        boundary conditions set when the bilinear form was assembled.
-        That is, in the following example:
+        This function no longer accepts :class:`.DirichletBC`\s or
+        :class:`.EquationBC`\s as arguments.
+        Any boundary conditions must be applied when assembling the
+        bilinear form as:
 
         .. code-block:: python
 
            A = assemble(a, bcs=[bc1])
-           solve(A, x, b, bcs=[bc2])
-
-        the boundary conditions in `bc2` will be applied to the problem
-        while `bc1` will be ignored.
+           solve(A, x, b)
 
     Example usage:
 
@@ -213,11 +210,9 @@ def _la_solve(A, x, b, **kwargs):
     bcs, solver_parameters, nullspace, nullspace_T, near_nullspace, \
         options_prefix = _extract_linear_solver_args(A, x, b, **kwargs)
 
-    for bc in _extract_bcs(bcs):
-        if not bc.is_linear:
-            raise RuntimeError("EquationBCs must also be linear when solving linear system.")
     if bcs is not None:
-        A.bcs = bcs
+        raise RuntimeError("It is no longer possible to apply or change boundary conditions after assembling the matrix `A`; pass any necessary boundary conditions to `assemble` when assembling `A`.")
+
     solver = ls.LinearSolver(A, solver_parameters=solver_parameters,
                              nullspace=nullspace,
                              transpose_nullspace=nullspace_T,
@@ -226,7 +221,7 @@ def _la_solve(A, x, b, **kwargs):
     if isinstance(x, firedrake.Vector):
         x = x.function
     # linear MG doesn't need RHS, supply zero.
-    lvp = vs.LinearVariationalProblem(a=A.a, L=0, u=x, bcs=bcs)
+    lvp = vs.LinearVariationalProblem(a=A.a, L=0, u=x, bcs=A.bcs)
     mat_type = A.mat_type
     appctx = solver_parameters.get("appctx", {})
     ctx = solving_utils._SNESContext(lvp,

--- a/tests/regression/test_bcs.py
+++ b/tests/regression/test_bcs.py
@@ -194,31 +194,6 @@ def test_update_bc_constant(a, u, V, f):
     assert np.allclose(u.vector().array(), 7.0)
 
 
-@pytest.mark.parametrize("mat_type", ["aij", "matfree"])
-def test_preassembly_change_bcs(V, f, mat_type):
-    v = TestFunction(V)
-    u = TrialFunction(V)
-    a = dot(u, v)*dx
-    bc = DirichletBC(V, f, 1)
-
-    A = assemble(a, bcs=[bc], mat_type=mat_type)
-    L = dot(v, f)*dx
-    b = assemble(L)
-
-    y = Function(V)
-    y.assign(7)
-    bc1 = DirichletBC(V, y, 1)
-    u = Function(V)
-
-    solve(A, u, b)
-    assert np.allclose(u.vector().array(), 10.0)
-
-    u.assign(0)
-    b = assemble(dot(v, y)*dx)
-    solve(A, u, b, bcs=[bc1])
-    assert np.allclose(u.vector().array(), 7.0)
-
-
 def test_preassembly_doesnt_modify_assembled_rhs(V, f):
     v = TestFunction(V)
     u = TrialFunction(V)

--- a/tests/regression/test_matrix_free.py
+++ b/tests/regression/test_matrix_free.py
@@ -198,31 +198,6 @@ def test_fieldsplitting(mesh, preassembled, parameters):
         assert np.allclose(d, 0.0)
 
 
-def test_matrix_free_preassembly_change_bcs(mesh):
-    V = FunctionSpace(mesh, "CG", 1)
-    v = TestFunction(V)
-    u = TrialFunction(V)
-    a = u*v*dx
-    bc1 = DirichletBC(V, Constant(10), 1)
-
-    A = assemble(a, bcs=bc1, mat_type="matfree")
-    L = Constant(10)*v*dx
-
-    b = assemble(L)
-
-    bc2 = DirichletBC(V, Constant(6), 1)
-
-    u = Function(V)
-
-    solve(A, u, b)
-    assert np.allclose(u.vector().array(), 10.0)
-
-    u.assign(0)
-    b = assemble(Constant(6)*v*dx)
-    solve(A, u, b, bcs=bc2)
-    assert np.allclose(u.vector().array(), 6.0)
-
-
 @pytest.mark.parallel(nprocs=4)
 def test_matrix_free_split_communicators():
 


### PR DESCRIPTION
As a consequence of removing `thunk`, passing `bcs` to `solve(A, x, b)` with an assembled linear operator `A` does not make sense any more.  This PR makes the following changes:

-make `_la_solve` throw an error message when this happens
-remove relevant tests
-change documentation