### PR TITLE
pythonocc needs swig, too

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1149,6 +1149,7 @@ if mode == "install" or not args.update_script:
 
             if args.opencascade:
                 apt_packages.append("liboce-ocaf-dev")
+                apt_packages.append("swig")
 
             missing_packages = [p for p in apt_packages if not apt_check(p)]
             if missing_packages:


### PR DESCRIPTION
I had a PhD student whose `--opencascade` installation failed because he didn't have swig on his machine. This branch fixes the problem.