### PR TITLE
Fix mixed Poisson Demo

### DIFF
--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -118,8 +118,8 @@ bilinear and linear forms of the variational problem are defined as: ::
 The strongly enforced boundary conditions on the BDM space on the top and
 bottom of the domain are declared as: ::
 
-  bc0 = DirichletBC(W.sub(0), as_vector([0.0, -sin(5*x)]), 1)
-  bc1 = DirichletBC(W.sub(0), as_vector([0.0, sin(5*y)]), 2)
+  bc0 = DirichletBC(W.sub(0), as_vector([0.0, -sin(5*x)]), 3)
+  bc1 = DirichletBC(W.sub(0), as_vector([0.0, sin(5*x)]), 4)
 
 Note that it is necessary to apply these boundary conditions to the first
 subspace of the mixed function space using ``W.sub(0)``. This way the


### PR DESCRIPTION
This fixes a typo in the BCs for the mixed Poisson demo, as well as the boundary edges to which the BCs are applied (to become consistent with the problem statement).

Does this demo also need a better description of how the vector function given for the BC relates to the scalar function that prescribes the BC in the problem description?