### PR TITLE
When splitting a SNESContext by field, add a _parent attribute to keep a reference to the parent

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -236,6 +236,8 @@ class _SNESContext(object):
             new_problem._constant_jacobian = problem._constant_jacobian
             splits.append(type(self)(new_problem, mat_type=self.mat_type, pmat_type=self.pmat_type,
                                      appctx=self.appctx))
+            splits[-1]._parent = self
+
         return self._splits.setdefault(tuple(fields), splits)
 
     @staticmethod

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -139,6 +139,8 @@ class _SNESContext(object):
         self._nullspace_T = None
         self._near_nullspace = None
 
+        self._parent = None
+
     def set_function(self, snes):
         r"""Set the residual evaluation function"""
         with self._F.dat.vec_wo as v:


### PR DESCRIPTION
I am solving a non-Newtonian Stokes problem. The viscosity is a function of the velocity. I would like to assemble the inverse-viscosity-weighted pressure mass matrix to use as a Schur complement approximation in a fieldsplit preconditioner. However, when I implement the `AuxiliaryOperatorPC` for the pressure mass matrix and fetch the SNESContext from the PC object, it only has the current pressure state, and keeps no reference to the parent velocity-pressure context. (This could be fixed by setting an appctx, but it's ugly.)

This pull request modifies the `_SNESContext.split()` method, so that the contexts created by the split keep a reference to the parent context. This enables the assembly of the required operator.