### PR TITLE
wence/feature/assemble diagonal

### DIFF
--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -117,7 +117,7 @@ class ExtractSubBlock(MultiFunction):
 SplitForm = collections.namedtuple("SplitForm", ["indices", "form"])
 
 
-def split_form(form):
+def split_form(form, diagonal=False):
     """Split a form into a tuple of sub-forms defined on the component spaces.
 
     Each entry is a :class:`SplitForm` tuple of the indices into the
@@ -149,8 +149,15 @@ def split_form(form):
     args = form.arguments()
     shape = tuple(len(a.function_space()) for a in args)
     forms = []
+    if diagonal:
+        assert len(shape) == 2
     for idx in numpy.ndindex(shape):
         f = splitter.split(form, idx)
         if len(f.integrals()) > 0:
+            if diagonal:
+                i, j = idx
+                if i != j:
+                    continue
+                idx = (i, )
             forms.append(SplitForm(indices=idx, form=f))
     return tuple(forms)

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -122,3 +122,24 @@ def test_assemble_mat_with_tensor(mesh):
     M = assemble(Constant(2)*a, M)
     # Make sure we get the result of the last assembly
     assert np.allclose(M.M.values, 2*assemble(a).M.values, rtol=1e-14)
+
+
+def test_assemble_diagonal(mesh):
+    V = FunctionSpace(mesh, "P", 3)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = inner(u, v)*dx
+    M = assemble(a, mat_type="aij")
+    Mdiag = assemble(a, diagonal=True)
+    assert np.allclose(M.petscmat.getDiagonal().array_r, Mdiag.dat.data_ro)
+
+
+def test_assemble_diagonal_bcs(mesh):
+    V = FunctionSpace(mesh, "P", 3)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    bc = DirichletBC(V, 0, (1, 4))
+    a = inner(grad(u), grad(v))*dx
+    M = assemble(a, mat_type="aij", bcs=bc)
+    Mdiag = assemble(a, bcs=bc, diagonal=True)
+    assert np.allclose(M.petscmat.getDiagonal().array_r, Mdiag.dat.data_ro)


### PR DESCRIPTION
Allows assembly of the diagonal of an element tensor. Useful for matrix-free multigrid. Needs firedrakeproject/tsfc#200. Hooks up `getDiagonal` for `matfree` matrices so that one can do:
```
-pc_type mg
-mat_type matfree
-mg_levels_pc_type jacobi
``` 

@sv2518 this may be relevant eventually.