### PR TITLE
I had cached wheel problems for islpy after reinstalling firedrake. 

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -12,7 +12,7 @@ from collections import OrderedDict
 import atexit
 
 # Packages which we wish to ensure are always recompiled
-wheel_blacklist = ["mpi4py", "randomgen"]
+wheel_blacklist = ["mpi4py", "randomgen", "islpy"]
 
 # Firedrake application installation shortcuts.
 firedrake_apps = {


### PR DESCRIPTION
I suggest to resolve this issue by installing islpy with --no-binary.