### PR TITLE
mg: Fix coarsening of boundary data inside context coarsening

### DIFF
--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -263,8 +263,10 @@ get_appctx = partial(get_attr, "__appctx__")
 def get_transfer_operators(dm):
     appctx = get_appctx(dm)
     if appctx is None:
-        # We're not in a solve, so all we can do is use the defaults.
-        transfer = firedrake
+        # We're not in a solve, so all we can do is make a new one (not cached)
+        transfer = firedrake.TransferManager()
+        firedrake.warning("Creating new TransferManager to transfer data to coarse grids")
+        firedrake.warning("This might be slow (you probably want to save it on an appctx)")
     else:
         transfer = appctx.transfer_manager
     return (transfer.prolong, transfer.restrict, transfer.inject)

--- a/tests/multigrid/test_transfer_manager.py
+++ b/tests/multigrid/test_transfer_manager.py
@@ -1,0 +1,42 @@
+import pytest
+import numpy
+from firedrake import *
+from firedrake.mg.ufl_utils import coarsen
+
+
+@pytest.mark.parametrize("sub", (True, False), ids=["Z.sub(0)", "V"])
+def test_transfer_manager_inside_coarsen(sub):
+    mesh = UnitSquareMesh(1, 1)
+    mh = MeshHierarchy(mesh, 1)
+    mesh = mh[-1]
+    V = FunctionSpace(mesh, "N1curl", 2)
+    Q = FunctionSpace(mesh, "P", 1)
+    Z = V*Q
+    x, y = SpatialCoordinate(mesh)
+
+    if sub:
+        bc_space = Z.sub(0)
+    else:
+        bc_space = V
+    bcdata = project(as_vector([-y, x]), bc_space)
+
+    bc = DirichletBC(Z.sub(0), bcdata, "on_boundary")
+
+    u = Function(Z)
+
+    v = TestFunction(Z)
+
+    F = inner(u, v)*dx
+
+    problem = NonlinearVariationalProblem(F, u, bcs=bc)
+    solver = NonlinearVariationalSolver(problem)
+
+    with dmhooks.add_hooks(Z.dm, solver, appctx=solver._ctx):
+        cctx = coarsen(solver._ctx, coarsen)
+
+    bc, = cctx._problem.bcs
+    V = bc.function_space()
+    mesh = V.ufl_domain()
+    x, y = SpatialCoordinate(mesh)
+    expect = project(as_vector([-y, x]), V)
+    assert numpy.allclose(bc.function_arg.dat.data_ro, expect.dat.data_ro)


### PR DESCRIPTION
The transfer manager lives on a parent DM, not the current one if
we're coarsening a split function. To alleviate this, attempt to find
the parent DM (and hence the appctx), otherwise just make a new
(throwaway) TransferManager and warn that we did so.