### PR TITLE
Paraviewfix

### DIFF
--- a/docs/source/visualisation.rst
+++ b/docs/source/visualisation.rst
@@ -145,7 +145,7 @@ This approximation can be controlled in at least two ways:
    curved geometry. Further, the Nonlinear Subdivision Level can also be
    changed after applying filters such as Extract Surface.
 2. The Tessellate_ filter can be applied to unstructured grid data
-   and has two parameters: Chord Error, Maximum Number of Subdivisions,
+   and has three parameters: Chord Error, Maximum Number of Subdivisions,
    and Field Error. Tessellation_ is the process of approximating a higher
    order geometry via subdividing cells into smaller linear cells. Chord Error
    is a tessellation error metric, the distance between the midpoint of any

--- a/firedrake/paraview_reordering.py
+++ b/firedrake/paraview_reordering.py
@@ -46,6 +46,8 @@ def invert(list1, list2):
                 return idx
         raise ValueError("Unable to establish permutation between Paraview basis and given element's basis.")
     perm = [find_same(x, list2) for x in list1]
+    if len(set(perm)) != len(perm):
+        raise ValueError("Unable to establish permutation between Paraview basis and given element's basis.")
     return perm
 
 

--- a/firedrake/paraview_reordering.py
+++ b/firedrake/paraview_reordering.py
@@ -2,6 +2,7 @@ from tsfc.fiatinterface import create_element
 import numpy as np
 from pyop2.utils import as_tuple
 import importlib
+import functools
 """
 This requires an explentation.
 Vtk has some .so deps that might not be present (e.g. libsm.so (X11 Sessions))
@@ -39,13 +40,13 @@ def invert(list1, list2):
     """
     if len(list1) != len(list2):
         raise ValueError("Dimension of Paraview basis and Element basis unequal.")
-    N = len(list1)
-    pt1, o1 = zip(*sorted(zip(map(tuple, list1), range(N))))
-    pt2, o2 = zip(*sorted(zip(map(tuple, list2), range(N))))
-    if not np.allclose(pt1, pt2):
+    def find_same(val, lst, tol=0.00000001):
+        for (idx, x) in enumerate(lst):
+            if np.linalg.norm(val - x) < tol:
+                return idx
         raise ValueError("Unable to establish permutation between Paraview basis and given element's basis.")
-
-    return np.asarray(o2)[np.argsort(o1)]
+    perm = [find_same(x, list2) for x in list1]
+    return perm
 
 
 # The following functions wrap around functions provided by vtk (pip install vtk).

--- a/firedrake/paraview_reordering.py
+++ b/firedrake/paraview_reordering.py
@@ -2,7 +2,6 @@ from tsfc.fiatinterface import create_element
 import numpy as np
 from pyop2.utils import as_tuple
 import importlib
-import functools
 """
 This requires an explentation.
 Vtk has some .so deps that might not be present (e.g. libsm.so (X11 Sessions))
@@ -40,6 +39,7 @@ def invert(list1, list2):
     """
     if len(list1) != len(list2):
         raise ValueError("Dimension of Paraview basis and Element basis unequal.")
+
     def find_same(val, lst, tol=0.00000001):
         for (idx, x) in enumerate(lst):
             if np.linalg.norm(val - x) < tol:


### PR DESCRIPTION
This pull fixes two problems in the current vis system:

1.  The old invert function is not robust enough so a simpler scheme is used. Credit to @florianwechsung  for stumbling upon this.
2.  There was a minor typo in the docs.

In the course of fixing this, I found that if I make vector data with Firedrake and then attempt to view it with Paraview, Paraview segfaults. I'm looking into this...