### PR TITLE
Add firedrake removal instructions

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -6,7 +6,7 @@ Firedrake is installed using its install script::
   curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
   python3 firedrake-install
 
-Running ``firedrake-install`` with no arguments will install firedrake in
+Running ``firedrake-install`` with no arguments will install Firedrake in
 a python venv_ created in a ``firedrake`` subdirectory of the
 current directory. Run::
 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -146,17 +146,18 @@ Paraview_.  On Ubuntu and similar systems, you can obtain Paraview by
 installing the ``paraview`` package.  On Mac OS, the easiest approach
 is to download a binary from the `paraview website <Paraview_>`_.
 
+
+Removing Firedrake
+------------------
+Firedrake and its dependencies can be removed by deleting the Firedrake
+install directory. This is usually the ``firedrake`` subdirectory 
+created after having run ``firedrake-install``. Note that this will not 
+undo the installation of any system packages which are Firedrake
+dependencies: removing these might affect subsequently installed 
+packages for which these are also dependencies.
+
 .. _Paraview: http://www.paraview.org
 .. _venv: https://docs.python.org/3/tutorial/venv.html
 .. _homebrew: https://brew.sh/
 .. _anaconda: https://www.continuum.io/downloads
 .. _PETSc: https://www.mcs.anl.gov/petsc/
-
-Removing firedrake
-------------------
-Firedrake and its dependencies can be removed by deleting the firedrake 
-install directory. This is usually the ``firedrake`` subdirectory 
-created after having run ``firedrake-install``. Note that this will not 
-undo the installation of any system packages which are firedrake 
-dependencies: removing these might affect subsequently installed 
-packages for which these are also dependencies.

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -151,3 +151,12 @@ is to download a binary from the `paraview website <Paraview_>`_.
 .. _homebrew: https://brew.sh/
 .. _anaconda: https://www.continuum.io/downloads
 .. _PETSc: https://www.mcs.anl.gov/petsc/
+
+Removing firedrake
+------------------
+Firedrake and its dependencies can be removed by deleting the firedrake 
+install directory. This is usually the ``firedrake`` subdirectory 
+created after having run ``firedrake-install``. Note that this will not 
+undo the installation of any system packages which are firedrake 
+dependencies: removing these might affect subsequently installed 
+packages for which these are also dependencies.


### PR DESCRIPTION
Adds basic instructions for removing firedrake by deleting the install directory to the https://www.firedrakeproject.org/download.html page.

Note that I assume the user knows where their firedrake installation is. I believe this to be reasonable given the context of the rest of the download page.