### PR TITLE
import: Fix logic for setting PETSc keys in os.environ

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -10,7 +10,7 @@ if "PETSC_DIR" in os.environ and not config["options"]["honour_petsc_dir"]:
 elif "PETSC_DIR" not in os.environ and config["options"]["honour_petsc_dir"]:
     raise ImportError("Firedrake was installed with --honour-petsc-dir, but PETSC_DIR is not set.\n"
                       "Please set PETSC_DIR (and PETSC_ARCH) before using Firedrake.")
-else:  # Using our own PETSC.
+elif not config["options"]["honour_petsc_dir"]:  # Using our own PETSC.
     os.environ["PETSC_DIR"] = os.path.join(os.environ["VIRTUAL_ENV"], "src", "petsc")
     os.environ["PETSC_ARCH"] = "default"
 del os, sys, config


### PR DESCRIPTION
If the user had passed `--honour-petsc-dir` and correctly set up the environment variables, we would just overwrite them.