### PR TITLE
Add instructions for dealing with hanging parallel tests

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -61,9 +61,6 @@ hosts database at ``/etc/hosts`` to include the entries::
 where ``LOCALHOSTNAME`` is the name returned by running the `hostname` 
 command. Should the local host name change, this may require updating.
 
-Note also that there is currently an issue with the test harness on MacOS
-which causes the parallel tests to fail. Firedrake will still work in
-parallel, it is only the test system which is affected.
 
 System requirements
 -------------------

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -49,17 +49,19 @@ venv_ as above and then run::
   cd firedrake/src/firedrake
   make alltest
 
-Note that there is a known issue where parallel tests hang without 
-failing. This is particularly a problem on MacOS and is due to the 
-version of MPICH installed with Firedrake failing to resolve the 
-local host at ip address ``127.0.0.1``. To resolve this issue modify the 
-hosts database at ``/etc/hosts`` to include the entries::
+.. note::
 
-  127.0.0.1       LOCALHOSTNAME.local
-  127.0.0.1       LOCALHOSTNAME
+  There is a known issue which causes parallel tests to hang without 
+  failing. This is particularly a problem on MacOS and is due to the 
+  version of MPICH installed with Firedrake failing to resolve the 
+  local host at ip address ``127.0.0.1``. To resolve this issue modify 
+  the hosts database at ``/etc/hosts`` to include the entries::
 
-where ``LOCALHOSTNAME`` is the name returned by running the `hostname` 
-command. Should the local host name change, this may require updating.
+    127.0.0.1       LOCALHOSTNAME.local
+    127.0.0.1       LOCALHOSTNAME
+
+  where ``LOCALHOSTNAME`` is the name returned by running the `hostname` 
+  command. Should the local host name change, this may require updating.
 
 
 System requirements

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -49,7 +49,19 @@ venv_ as above and then run::
   cd firedrake/src/firedrake
   make alltest
 
-Note that there is currently an issue with the test harness on MacOS
+Note that there is a known issue where parallel tests hang without 
+failing. This is particularly a problem on MacOS and is due to the 
+version of MPICH installed with Firedrake failing to resolve the 
+local host at ip address ``127.0.0.1``. To resolve this issue modify the 
+hosts database at ``/etc/hosts`` to include the entries::
+
+  127.0.0.1       LOCALHOSTNAME.local
+  127.0.0.1       LOCALHOSTNAME
+
+where ``LOCALHOSTNAME`` is the name returned by running the `hostname` 
+command. Should the local host name change, this may require updating.
+
+Note also that there is currently an issue with the test harness on MacOS
 which causes the parallel tests to fail. Firedrake will still work in
 parallel, it is only the test system which is affected.
 


### PR DESCRIPTION
This adds instructions for dealing with hanging parallel tests, as observed by me on MacOS. I have also removed the warning about failing parallel tests that @wence- says is outdated.

Note that I have written the suggested file modification in the same style as commands to run. If you are aware of a more appropriate way of displaying the suggested modification please do say.