### PR TITLE
Add newlines to fix some interpolation docs

### DIFF
--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -68,17 +68,20 @@ following line creates an interpolator which will interpolate the
 current value of `expression` into the space `V`:
 
 .. code-block:: python
+
    interpolator = Interpolator(expression, V)
 
 If `expression` does not contain a :py:func:`~ufl.TestFunction` then
 the interpolation can be performed with:
 
 .. code-block:: python
+
    f = interpolator.interpolate()
 
 Alternatively, one can use the interpolator to set the value of an existing :py:class:`~.Function`:
 
 .. code-block:: python
+
    f = Function(V)
    interpolator.interpolate(output=f)
 
@@ -86,7 +89,8 @@ If `expression` does not contain a :py:func:`~ufl.TestFunction` then
 the interpolator acts to interpolate :py:class:`~.Function`\s in the
 test space to those in the target space. For example:
 
-.. code-bloc:: python
+.. code-block:: python
+
    w = TestFunction(W)
    interpolator = Interpolator(w, V)
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -26,7 +26,9 @@ def interpolate(expr, V, subset=None, access=op2.WRITE):
     :kwarg access: The access descriptor for combining updates to shared dofs.
     Returns a new :class:`.Function` in the space ``V`` (or ``V`` if
     it was a Function).
+
     .. note::
+
        If you find interpolating the same expression again and again
        (for example in a time loop) you may find you get better
        performance by using an :class:`Interpolator` instead.
@@ -45,7 +47,9 @@ class Interpolator(object):
         re-evaluated on each call.
     This object can be used to carry out the same interpolation
     multiple times (for example in a timestepping loop).
+
     .. note::
+
        The :class:`Interpolator` holds a reference to the provided
        arguments (such that they won't be collected until the
        :class:`Interpolator` is also collected).


### PR DESCRIPTION
Some of the docs for the new interpolator object aren't appearing correctly on the Firedrake website because restructured text is finnicky. Adds some newlines.