### PR TITLE
update LinearVariationalProblem docstring

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -276,7 +276,7 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
         r"""
         :param a: the bilinear form
         :param L: the linear form
-        :param u: the :class:`.Function` to solve for
+        :param u: the :class:`.Function` to which the solution will be assigned
         :param bcs: the boundary conditions (optional)
         :param aP: an optional operator to assemble to precondition
                  the system (if not provided a preconditioner may be


### PR DESCRIPTION
Clarifies that the `u` parameter is where the solution is assigned when the problem is solved, as opposed to being the function within the input forms for which a solution is sought. (The solution is sought for whatever the `TrialFunction` is in the bilinear form)

This change has been made after getting confused whilst following the "DG advection equation with upwinding" example.