### PR TITLE
don't require the venv to be active

### DIFF
--- a/firedrake_configuration/__init__.py
+++ b/firedrake_configuration/__init__.py
@@ -6,10 +6,11 @@ itself is broken."""
 
 import json
 import os
+import sys
 
 # Attempt to read configuration from file.
 try:
-    with open(os.path.join(os.environ["VIRTUAL_ENV"],
+    with open(os.path.join(sys.prefix,
                            ".configuration.json"), "r") as f:
         _config = json.load(f)
 


### PR DESCRIPTION
Checking the environment isn't quite a safe way to know where the venv is. It's better to ask python.