### PR TITLE
Fixes for 3 small bugs found in install/update

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -902,7 +902,7 @@ def build_and_install_libsupermesh():
                             "-DMPI_C_COMPILER=" + cc,
                             "-DMPI_CXX_COMPILER=" + cxx,
                             "-DMPI_Fortran_COMPILER=" + f90,
-                            "-DCMAKE_Fortran_COMPILER" + f90])
+                            "-DCMAKE_Fortran_COMPILER=" + f90])
                 check_call(["make"])
                 check_call(["make", "install"])
     else:
@@ -925,7 +925,7 @@ def build_and_install_pythonocc():
                             "-DMPI_C_COMPILER=" + cc,
                             "-DMPI_CXX_COMPILER=" + cxx,
                             "-DMPI_Fortran_COMPILER=" + f90,
-                            "-DCMAKE_Fortran_COMPILER" + f90])
+                            "-DCMAKE_Fortran_COMPILER=" + f90])
                 check_call(["make", "install"])
     else:
         log.info("No need to rebuild pythonocc-core")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -502,6 +502,9 @@ else:
 
 if options.get("mpiexec") is not None:
     petsc_options.add("--with-mpiexec={}".format(options["mpiexec"]))
+    petsc_options.add("--with-cc={}".format(options["mpicc"]))
+    petsc_options.add("--with-cxx={}".format(options["mpicxx"]))
+    petsc_options.add("--with-fc={}".format(options["mpif90"]))
 else:
     # Download mpich if the user does not tell us about an MPI.
     petsc_options.add("--download-mpich")
@@ -898,7 +901,8 @@ def build_and_install_libsupermesh():
                             "-DCMAKE_INSTALL_PREFIX=" + firedrake_env,
                             "-DMPI_C_COMPILER=" + cc,
                             "-DMPI_CXX_COMPILER=" + cxx,
-                            "-DMPI_Fortran_COMPILER=" + f90])
+                            "-DMPI_Fortran_COMPILER=" + f90,
+                            "-DCMAKE_Fortran_COMPILER" + f90])
                 check_call(["make"])
                 check_call(["make", "install"])
     else:
@@ -920,7 +924,8 @@ def build_and_install_pythonocc():
                             "-DPYTHON_EXECUTABLE=" + python[0],
                             "-DMPI_C_COMPILER=" + cc,
                             "-DMPI_CXX_COMPILER=" + cxx,
-                            "-DMPI_Fortran_COMPILER=" + f90])
+                            "-DMPI_Fortran_COMPILER=" + f90,
+                            "-DCMAKE_Fortran_COMPILER" + f90])
                 check_call(["make", "install"])
     else:
         log.info("No need to rebuild pythonocc-core")
@@ -1250,7 +1255,7 @@ for opt in ["mpicc", "mpicxx", "mpif90"]:
     os.symlink(src, dest)
 
 if options.get("mpiexec"):
-    mpiexec_loc = shutil.which(args.mpiexec)
+    mpiexec_loc = shutil.which(options.get("mpiexec"))
 else:
     mpiexec_loc = os.path.join(petsc_dir, petsc_arch, "bin", "mpiexec")
 mpiexecf = os.path.join(firedrake_env, "bin", "mpiexec")


### PR DESCRIPTION
Found 2 bugs in install when using `icc`:

- PETSc uses wrong compilers sometimes in it's own build procedure
- Old versions of CMake don't correctly detect FORTRAN compiler

Found one bug in update:

- `mpiexec` is using value from `args` but I think this needs to be read from `options` instead, this bug will only occur on update.

See inline comments for details