### PR TITLE
adjoint: cache mesh coordinate space

### DIFF
--- a/firedrake/adjoint/mesh.py
+++ b/firedrake/adjoint/mesh.py
@@ -8,6 +8,7 @@ class MeshGeometryMixin(OverloadedType):
         def wrapper(self, *args, **kwargs):
             OverloadedType.__init__(self, *args, **kwargs)
             init(self, *args, **kwargs)
+            self._ad_coordinate_space = None
         return wrapper
 
     @no_annotations
@@ -38,3 +39,8 @@ class MeshGeometryMixin(OverloadedType):
             f._ad_outputs = [self]
             return f
         return _coordinates_function
+
+    def _ad_function_space(self):
+        if self._ad_coordinate_space is None:
+            self._ad_coordinate_space = self.coordinates.function_space().ufl_function_space()
+        return self._ad_coordinate_space


### PR DESCRIPTION
Cache for mesh coordinate space used in pyadjoint.
This change is required for firedrake to work with the following pull request in pyadjoint:
https://bitbucket.org/dolfin-adjoint/pyadjoint/pull-requests/102/merge-all-assemblys-of-second-order/diff
