### PR TITLE
This fixes the problem Gusto is having with creating a MixedFunctionS…

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1479,6 +1479,8 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
     helement = mesh._coordinates.ufl_element().sub_elements()[0]
     if extrusion_type == 'radial_hedgehog':
         helement = helement.reconstruct(family="DG", variant="equispaced")
+    elif extrusion_type == 'uniform':
+        helement = helement.reconstruct(cell=topology.ufl_cell().sub_cells()[0])
     velement = ufl.FiniteElement("Lagrange", ufl.interval, 1)
     element = ufl.TensorProductElement(helement, velement)
 


### PR DESCRIPTION
Further to the discussion on Slack, this fixes the problem Gusto is having with creating a `MixedFunctionSpace` on an `ExtrudedMesh` based on a `PeriodicIntervalMesh`.

The problem arose from a recent change to the `ExtrudedMesh` class which now creates the `TensorProductElement` using `helement=mesh._coordinates.ufl_element().sub_elements()[0]`. Previously just `hfamily` and `hdegree` were taken from `mesh._coordinates.ufl_element()` and passed into `VectorFunctionSpace` which then created the `TensorProductElement` using `topology.ufl_cell()` to provide the cell.

My 'fix' is to reconstruct `helement`, passing in `cell=topology.ufl_cell()`.

I am not sure what's the right thing to do for radial or custom extrusion.

I would like to add a test for this - I can't see that any of the extruded tests use a periodic mesh. Should I add a new test in the extruded directory?