### PR TITLE
Ensure that PeriodicIntervalMesh coordinate function space has an int…

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -507,7 +507,8 @@ cells in each direction are not currently supported")
 
     m = TorusMesh(nx, ny, 1.0, 0.5, quadrilateral=quadrilateral, reorder=reorder, distribution_parameters=distribution_parameters, comm=comm)
     coord_family = 'DQ' if quadrilateral else 'DG'
-    coord_fs = VectorFunctionSpace(m, FiniteElement(coord_family, m.ufl_cell(), 1, variant="equispaced"), dim=2)
+    cell = 'quadrilateral' if quadrilateral else 'triangle'
+    coord_fs = VectorFunctionSpace(m, FiniteElement(coord_family, cell, 1, variant="equispaced"), dim=2)
     old_coordinates = m.coordinates
     new_coordinates = Function(coord_fs)
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -6,7 +6,7 @@ from pyop2.mpi import COMM_WORLD
 from pyop2.datatypes import IntType
 
 from firedrake import VectorFunctionSpace, Function, Constant, \
-    par_loop, dx, WRITE, READ, interpolate, FiniteElement
+    par_loop, dx, WRITE, READ, interpolate, FiniteElement, interval
 from firedrake.cython import dmplex
 from firedrake import mesh
 from firedrake import function
@@ -105,7 +105,7 @@ def PeriodicIntervalMesh(ncells, length, distribution_parameters=None, comm=COMM
 cells are not currently supported")
 
     m = CircleManifoldMesh(ncells, distribution_parameters=distribution_parameters, comm=comm)
-    coord_fs = VectorFunctionSpace(m, FiniteElement('DG', m.ufl_cell(), 1, variant="equispaced"), dim=1)
+    coord_fs = VectorFunctionSpace(m, FiniteElement('DG', interval, 1, variant="equispaced"), dim=1)
     old_coordinates = m.coordinates
     new_coordinates = Function(coord_fs)
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -1414,7 +1414,8 @@ cells in each direction are not currently supported")
                      distribution_parameters=distribution_parameters,
                      diagonal=diagonal, comm=comm)
     coord_family = 'DQ' if quadrilateral else 'DG'
-    coord_fs = VectorFunctionSpace(m, FiniteElement(coord_family, m.ufl_cell(), 1, variant="equispaced"), dim=2)
+    cell = 'quadrilateral' if quadrilateral else 'triangle'
+    coord_fs = VectorFunctionSpace(m, FiniteElement(coord_family, cell, 1, variant="equispaced"), dim=2)
     old_coordinates = m.coordinates
     new_coordinates = Function(coord_fs)
 

--- a/tests/extrusion/test_mixed_periodic.py
+++ b/tests/extrusion/test_mixed_periodic.py
@@ -1,0 +1,20 @@
+from firedrake import *
+import pytest
+
+
+@pytest.fixture(params=["interval", "square", "quad-square"])
+def base_mesh(request):
+    if request.param == "interval":
+        return PeriodicUnitIntervalMesh(4)
+    elif request.param == "square":
+        return PeriodicUnitSquareMesh(4, 4)
+    elif request.param == "quad-square":
+        return PeriodicUnitSquareMesh(4, 4, quadrilateral=True)
+
+
+def test_mixed_periodic(base_mesh):
+    mesh = ExtrudedMesh(base_mesh, layers=4, layer_height=0.25)
+    V1 = FunctionSpace(mesh, "DG", 1)
+    V2 = FunctionSpace(mesh, "CG", 2)
+    V2_broken = FunctionSpace(mesh, BrokenElement(V2.ufl_element()))
+    W = MixedFunctionSpace((V1, V2_broken))

--- a/tests/extrusion/test_mixed_periodic.py
+++ b/tests/extrusion/test_mixed_periodic.py
@@ -2,10 +2,13 @@ from firedrake import *
 import pytest
 
 
-@pytest.fixture(params=["interval", "square", "quad-square"])
+@pytest.fixture(params=["interval", "square-x-periodic", "square",
+                        "quad-square"])
 def base_mesh(request):
     if request.param == "interval":
         return PeriodicUnitIntervalMesh(4)
+    elif request.param == "square-x-periodic":
+        return PeriodicUnitSquareMesh(4, 4, direction="x")
     elif request.param == "square":
         return PeriodicUnitSquareMesh(4, 4)
     elif request.param == "quad-square":

--- a/tests/extrusion/test_mixed_periodic.py
+++ b/tests/extrusion/test_mixed_periodic.py
@@ -20,4 +20,4 @@ def test_mixed_periodic(base_mesh):
     V1 = FunctionSpace(mesh, "DG", 1)
     V2 = FunctionSpace(mesh, "CG", 2)
     V2_broken = FunctionSpace(mesh, BrokenElement(V2.ufl_element()))
-    W = MixedFunctionSpace((V1, V2_broken))
+    MixedFunctionSpace((V1, V2_broken))


### PR DESCRIPTION
…erval cell, rather than the 2D interval left over from CircleManifoldMesh and add a test. Note: test is broken in 2D

Weird thing: `error("Sub elements must live on the same cell.")` in the UFL MixedElement class is only triggered in the very special case demonstrated in the test - i.e. when a function space created using a `BrokenElement` is passed in to `MixedFunctionSpace`.

I'm not sure what to do with the 2D case - is there an equivalent of `interval`?