### PR TITLE
replace VIRTUAL_ENV with sys.prefix

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -3,7 +3,7 @@ import os
 import sys
 config = firedrake_configuration.get_config()
 if "PETSC_DIR" in os.environ and not config["options"]["honour_petsc_dir"]:
-    if os.environ["PETSC_DIR"] != os.path.join(os.environ["VIRTUAL_ENV"], "src", "petsc")\
+    if os.environ["PETSC_DIR"] != os.path.join(sys.prefix, "src", "petsc")\
        or os.environ["PETSC_ARCH"] != "default":
         raise ImportError("PETSC_DIR is set, but you did not install with --honour-petsc-dir.\n"
                           "Please unset PETSC_DIR (and PETSC_ARCH) before using Firedrake.")
@@ -11,7 +11,7 @@ elif "PETSC_DIR" not in os.environ and config["options"]["honour_petsc_dir"]:
     raise ImportError("Firedrake was installed with --honour-petsc-dir, but PETSC_DIR is not set.\n"
                       "Please set PETSC_DIR (and PETSC_ARCH) before using Firedrake.")
 elif not config["options"]["honour_petsc_dir"]:  # Using our own PETSC.
-    os.environ["PETSC_DIR"] = os.path.join(os.environ["VIRTUAL_ENV"], "src", "petsc")
+    os.environ["PETSC_DIR"] = os.path.join(sys.prefix, "src", "petsc")
     os.environ["PETSC_ARCH"] = "default"
 del os, sys, config
 

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -1,7 +1,7 @@
 # Code for projections and other fun stuff involving supermeshes.
 import firedrake
 import ctypes
-import os
+import sys
 from firedrake.cython.supermeshimpl import assemble_mixed_mass_matrix as ammm, intersection_finder
 from firedrake.mg.utils import get_level
 from firedrake.petsc import PETSc

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -358,7 +358,7 @@ each supermesh cell.
         "dim": dim
     }
 
-    dirs = get_petsc_dir() + (os.environ["VIRTUAL_ENV"], )
+    dirs = get_petsc_dir() + (sys.prefix, )
     includes = ["-I%s/include" % d for d in dirs]
     libs = ["-L%s/lib" % d for d in dirs]
     libs = libs + ["-Wl,-rpath,%s/lib" % d for d in dirs] + ["-lpetsc", "-lsupermesh"]


### PR DESCRIPTION
Relying on the `VIRTUAL_ENV` environment variable is unsafe because users can validly run in the venv just by explicitly calling executables from the venv bin directory. In that use case the environment is unaltered. sys.prefix, however, will still point to the venv.