### PR TITLE
Allow transfer managers to be set from options

### DIFF
--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -260,7 +260,7 @@ pop_appctx = partial(pop_attr, "__appctx__")
 get_appctx = partial(get_attr, "__appctx__")
 
 
-def get_transfer_operators(dm):
+def get_transfer_manager(dm):
     appctx = get_appctx(dm)
     if appctx is None:
         # We're not in a solve, so all we can do is make a new one (not cached)
@@ -269,7 +269,7 @@ def get_transfer_operators(dm):
         firedrake.warning("This might be slow (you probably want to save it on an appctx)")
     else:
         transfer = appctx.transfer_manager
-    return (transfer.prolong, transfer.restrict, transfer.inject)
+    return transfer
 
 
 push_ctx_coarsener = partial(push_attr, "__ctx_coarsener__")

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -31,8 +31,8 @@ def prolong(coarse, fine):
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
         for in_, out in zip(coarse.split(), fine.split()):
-            myprolong, _, _ = firedrake.dmhooks.get_transfer_operators(in_.function_space().dm)
-            myprolong(in_, out)
+            manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
+            manager.prolong(in_, out)
         return fine
 
     if Vc.ufl_element().family() == "Real" or Vf.ufl_element().family() == "Real":
@@ -91,8 +91,8 @@ def restrict(fine_dual, coarse_dual):
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
         for in_, out in zip(fine_dual.split(), coarse_dual.split()):
-            _, myrestrict, _ = firedrake.dmhooks.get_transfer_operators(in_.function_space().dm)
-            myrestrict(in_, out)
+            manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
+            manager.restrict(in_, out)
         return coarse_dual
 
     if Vc.ufl_element().family() == "Real" or Vf.ufl_element().family() == "Real":
@@ -152,8 +152,8 @@ def inject(fine, coarse):
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
         for in_, out in zip(fine.split(), coarse.split()):
-            _, _, myinject = firedrake.dmhooks.get_transfer_operators(in_.function_space().dm)
-            myinject(in_, out)
+            manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
+            manager.inject(in_, out)
         return
 
     if Vc.ufl_element().family() == "Real" or Vf.ufl_element().family() == "Real":

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -281,7 +281,8 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
     # Otherwise they won't have the right transfer manager when they are
     # coarsened in turn
     from firedrake.dmhooks import get_appctx, push_appctx, pop_appctx, add_hook, get_parent
-    for val in coefficient_mapping.values():
+    from itertools import chain
+    for val in chain(coefficient_mapping.values(), (bc._original_val for bc in problem.bcs)):
         if isinstance(val, firedrake.function.Function):
             V = val.function_space()
             coarseneddm = V.dm

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -281,20 +281,13 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
     # Otherwise they won't have the right transfer manager when they are
     # coarsened in turn
     from firedrake.dmhooks import get_appctx, push_appctx, pop_appctx
-    from firedrake.dmhooks import add_hook, get_parent, SetupHooks, push_attr
+    from firedrake.dmhooks import add_hook, get_parent
     from itertools import chain
     for val in chain(coefficient_mapping.values(), (bc._original_val for bc in problem.bcs)):
         if isinstance(val, firedrake.function.Function):
             V = val.function_space()
             coarseneddm = V.dm
-            parentdm = get_parent(coarseneddm)
-
-            # Need to make sure parentdm has a __setup_hooks__,
-            # this can happen if e.g. a BC value is assigned on Z.sub(0)
-            stack = parentdm.getAttr("__setup_hooks__")
-            if stack is None:
-                hooks = SetupHooks()
-                push_attr("__setup_hooks__", parentdm, hooks)
+            parentdm = get_parent(context._problem.u.function_space().dm)
 
             # Now attach the hook to the parent DM
             if get_appctx(coarseneddm) is None:

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -82,7 +82,7 @@ class AssembledPC(PCBase):
         octx = get_appctx(dm)
         oproblem = octx._problem
         nproblem = NonlinearVariationalProblem(oproblem.F, oproblem.u, bcs, J=a, form_compiler_parameters=fcp)
-        self._ctx_ref = _SNESContext(nproblem, mat_type, mat_type, octx.appctx)
+        self._ctx_ref = _SNESContext(nproblem, mat_type, mat_type, octx.appctx, options_prefix=options_prefix)
 
         pc.setDM(dm)
         pc.setOptionsPrefix(options_prefix)

--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -60,7 +60,7 @@ class PCSNESBase(object, metaclass=abc.ABCMeta):
         return get_appctx(pc.getDM()).appctx
 
     @staticmethod
-    def new_snes_ctx(pc, op, bcs, mat_type, fcp=None):
+    def new_snes_ctx(pc, op, bcs, mat_type, fcp=None, options_prefix=None):
         """ Create a new SNES contex for nested preconditioning
         """
         from firedrake.variational_solver import NonlinearVariationalProblem
@@ -77,8 +77,7 @@ class PCSNESBase(object, metaclass=abc.ABCMeta):
                                             bcs=bcs,
                                             J=op,
                                             form_compiler_parameters=fcp)
-        nctx = _SNESContext(nprob, mat_type, mat_type, old_appctx)
-        return nctx
+        return _SNESContext(nprob, mat_type, mat_type, old_appctx, options_prefix=options_prefix)
 
 
 class PCBase(PCSNESBase):

--- a/firedrake/preconditioners/gtmg.py
+++ b/firedrake/preconditioners/gtmg.py
@@ -135,13 +135,6 @@ class GTMGPC(PCBase):
         pcmg.setMGInterpolation(1, interp_petscmat)
         pcmg.setOperators(A=fine_petscmat, P=fine_petscmat)
 
-        # Create new appctx
-        self._ctx_ref = self.new_snes_ctx(pc,
-                                          coarse_operator,
-                                          coarse_space_bcs,
-                                          coarse_mat_type,
-                                          fcp)
-
         coarse_solver = pcmg.getMGCoarseSolve()
         coarse_solver.setOperators(A=coarse_opmat, P=coarse_opmat)
         # coarse space dm
@@ -152,6 +145,15 @@ class GTMGPC(PCBase):
         pcmg.setFromOptions()
         self.pc = pcmg
         self._dm = coarse_dm
+
+        prefix = coarse_solver.getOptionsPrefix()
+        # Create new appctx
+        self._ctx_ref = self.new_snes_ctx(pc,
+                                          coarse_operator,
+                                          coarse_space_bcs,
+                                          coarse_mat_type,
+                                          fcp,
+                                          options_prefix=prefix)
 
         with dmhooks.add_hooks(coarse_dm, self,
                                appctx=self._ctx_ref,

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -235,7 +235,8 @@ class HybridizationPC(SCBase):
                                           schur_comp,
                                           trace_bcs,
                                           mat_type,
-                                          self.ctx.fc_params)
+                                          self.ctx.fc_params,
+                                          options_prefix=prefix)
 
         # dm associated with the trace problem
         trace_dm = TraceSpace.dm

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -162,7 +162,8 @@ class SCPC(SCBase):
                                           S_expr,
                                           bcs,
                                           mat_type,
-                                          self.cxt.fc_params)
+                                          self.cxt.fc_params,
+                                          options_prefix=prefix)
 
         # Push new context onto the dm associated with the condensed problem
         c_dm = Vc.dm

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -167,7 +167,6 @@ class _SNESContext(object):
         """
         if self._transfer_manager is None:
             opts = PETSc.Options()
-            assert self.options_prefix is not None
             prefix = self.options_prefix or ""
             if opts.hasName(prefix + "mg_transfer_manager"):
                 managername = opts[prefix + "mg_transfer_manager"]

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -153,8 +153,28 @@ class _SNESContext(object):
     @property
     def transfer_manager(self):
         if self._transfer_manager is None:
-            from firedrake import TransferManager
-            self._transfer_manager = TransferManager(use_averaging=True)
+            opts = PETSc.Options()
+            prefix = self.options_prefix or ""
+            if opts.hasName(prefix + "mg_transfer_manager"):
+                managername = opts[prefix + "mg_transfer_manager"]
+            elif opts.hasName(prefix + "fas_transfer_manager"):
+                managername = opts[prefix + "fas_transfer_manager"]
+            else:
+                managername = None
+
+            if managername is None:
+                from firedrake import TransferManager
+                transfer = TransferManager(use_averaging=True)
+            else:
+                (modname, objname) = managername.rsplit('.', 1)
+                mod = __import__(modname)
+                obj = getattr(mod, objname)
+                if isinstance(obj, type):
+                    transfer = obj()
+                else:
+                    transfer = obj
+
+            self._transfer_manager = transfer
         return self._transfer_manager
 
     @transfer_manager.setter
@@ -355,8 +375,8 @@ class _SNESContext(object):
 
         fine = ctx._fine
         if fine is not None:
-            _, _, inject = dmhooks.get_transfer_operators(fine._x.function_space().dm)
-            inject(fine._x, ctx._x)
+            manager = dmhooks.get_transfer_manager(fine._x.function_space().dm)
+            manager.inject(fine._x, ctx._x)
 
             for bc in itertools.chain(*ctx._problem.bcs):
                 if isinstance(bc, DirichletBC):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -152,8 +152,19 @@ class _SNESContext(object):
 
     @property
     def transfer_manager(self):
+        """This allows the transfer manager to be set from options, e.g.
+
+        solver_parameters = {"ksp_type": "cg",
+                             "pc_type": "mg",
+                             "mg_transfer_manager": __name__ + ".manager"}
+
+        The value for "mg_transfer_manager" can either be a specific instantiated
+        object, or a function or class name. In the latter case it will be invoked
+        with no arguments to instantiate the object.
+        """
         if self._transfer_manager is None:
             opts = PETSc.Options()
+            assert self.options_prefix is not None
             prefix = self.options_prefix or ""
             if opts.hasName(prefix + "mg_transfer_manager"):
                 managername = opts[prefix + "mg_transfer_manager"]

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -161,6 +161,9 @@ class _SNESContext(object):
         The value for "mg_transfer_manager" can either be a specific instantiated
         object, or a function or class name. In the latter case it will be invoked
         with no arguments to instantiate the object.
+
+        If "snes_type": "fas" is used, the relevant option is "fas_transfer_manager",
+        with the same semantics.
         """
         if self._transfer_manager is None:
             opts = PETSc.Options()

--- a/tests/multigrid/test_custom_transfer.py
+++ b/tests/multigrid/test_custom_transfer.py
@@ -38,6 +38,42 @@ def test_repeated_custom_transfer():
 
     assert count == 1
 
+optcount = 0
+class CountingTransferManager(TransferManager):
+    def prolong(self, *args, **kwargs):
+        global optcount
+        TransferManager.prolong(self, *args, **kwargs)
+        optcount += 1
+
+def test_repeated_custom_transfer_options():
+    mesh = UnitIntervalMesh(2)
+    mh = MeshHierarchy(mesh, 1)
+    mesh = mh[-1]
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    a = u*v*dx
+    L = v*dx
+
+    uh = Function(V)
+    options = {"ksp_type": "preonly",
+               "pc_type": "mg",
+               "mg_transfer_manager": __name__ + ".CountingTransferManager"}
+
+    problem = LinearVariationalProblem(a, L, uh)
+    solver = LinearVariationalSolver(problem, solver_parameters=options)
+    solver.solve()
+
+    global optcount
+    assert optcount == 1
+
+    uh.assign(0)
+
+    solve(a == L, uh, solver_parameters=options)
+
+    assert optcount == 2
 
 def test_multiple_custom_transfer_split():
     mesh = UnitIntervalMesh(2)

--- a/tests/multigrid/test_custom_transfer.py
+++ b/tests/multigrid/test_custom_transfer.py
@@ -38,12 +38,16 @@ def test_repeated_custom_transfer():
 
     assert count == 1
 
+
 optcount = 0
+
+
 class CountingTransferManager(TransferManager):
     def prolong(self, *args, **kwargs):
         global optcount
         TransferManager.prolong(self, *args, **kwargs)
         optcount += 1
+
 
 def test_repeated_custom_transfer_options():
     mesh = UnitIntervalMesh(2)
@@ -74,6 +78,7 @@ def test_repeated_custom_transfer_options():
     solve(a == L, uh, solver_parameters=options)
 
     assert optcount == 2
+
 
 def test_multiple_custom_transfer_split():
     mesh = UnitIntervalMesh(2)


### PR DESCRIPTION
The `SNESContext` now looks up the options dictionary with its options path to see if the user has specified a transfer manager there. This allows one to set e.g.

```
solver_parameters = {"ksp_type": "cg", "pc_type": "mg", "mg_transfer_manager": __name__ + ".manager"}
```

to use the object `manager` in the current module to govern intergrid transfers. One can also specify a class name or function and it will be constructed/called with no arguments to make a transfer manager.

This allows for the setting of transfer managers on auxiliary problems defined via `AuxiliaryOperatorPC` (before this PR there was no way for the user to specify that a custom transfer manager should be used).