### PR TITLE
PETSc install options

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -508,7 +508,7 @@ else:
     # Download mpich if the user does not tell us about an MPI.
     petsc_options.add("--download-mpich")
 
-petsc_options |= set(os.environ.get("PETSC_CONFIGURE_OPTIONS", "").split())
+petsc_options = list(petsc_options) + os.environ.get("PETSC_CONFIGURE_OPTIONS", "").split()
 
 if mode == "update" and petsc_int_type_changed:
     log.warning("""Force rebuilding all packages because PETSc int type changed""")


### PR DESCRIPTION
This PR changes the install options behavior so that user selected options come last. The motivation for this was that setting 

`export PETSC_CONFIGURE_OPTIONS="--download-netcdf=https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz"`

resulted in 

```
2020-01-31 11:01:28,061 DEBUG  Running command './configure PETSC_DIR=/home/wechsung/bin/firedrake-thesis/src/petsc PETSC_ARCH=default --download-pnetcdf --with-fc=mpif90.mpich --with-fortran-bindings=0 --download-netcdf=https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz --download-pastix --with-cc=mpicc.mpich --with-shared-libraries=1 --download-hdf5 --download-eigen=/home/wechsung/bin/firedrake-thesis/src/eigen-3.3.3.tgz  --download-scalapack --download-superlu_dist --with-zlib --download-netcdf --download-exodusii --download-metis --with-cxx=mpicxx.mpich --download-ptscotch --download-mumps --with-c2html=0 --download-superlu --download-ml --with-debugging=0 --with-mpiexec=mpiexec.mpich --with-cxx-dialect=C++11 --download-chaco --download-hypre --download-suitesparse'
```

note that the second appearance of ` --download-netcdf` overwrites the user specified option.