### PR TITLE
Install script updates

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -245,6 +245,8 @@ honoured.""",
                         help="MPI launcher. If not set, MPICH will be downloaded and used.")
     parser.add_argument("--show-petsc-configure-options", action="store_true",
                         help="Print out the configure options passed to PETSc and exit")
+    parser.add_argument("--show-package-manager-options", action="store_true",
+                        help="Print out the package manager used and packages installed/required.")
     parser.add_argument("--venv-name", default="firedrake",
                         type=str, action="store",
                         help="Name of the venv to create (default is 'firedrake')")
@@ -1125,6 +1127,70 @@ log.debug("\n\n")
 if mode == "install" or not args.update_script:
     # Check operating system.
     osname = platform.uname()[0]
+    required_packages = None
+    package_manager = None
+    if osname == "Darwin":
+        package_manager = "brew"
+        required_packages = ["gcc",
+                             "python3",
+                             "autoconf",
+                             "automake",
+                             "cmake",
+                             "libtool",
+                             "mercurial",
+                             "boost"]
+    elif osname == "Linux":
+        package_manager = "apt-get"
+        required_packages = ["build-essential",
+                             "autoconf",
+                             "automake",
+                             "bison",  # for ptscotch
+                             "flex",   # for ptscotch
+                             "cmake",
+                             "gfortran",
+                             "git",
+                             "libblas-dev",
+                             "liblapack-dev",
+                             "libtool",
+                             "mercurial",
+                             "mpich",
+                             "python3-dev",
+                             "python3-pip",
+                             "python3-tk",
+                             "python3-venv",
+                             "zlib1g-dev",
+                             "libboost-dev"]  # For ROL in pyadjoint
+        if args.opencascade:
+            required_packages.append("liboce-ocaf-dev")
+            required_packages.append("swig")
+    else:
+        log.warning("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
+
+    if args.show_package_manager_options:
+        log.info("\n************************************************")
+        log.info("The following dependencies need to be installed:")
+        log.info("************************************************\n")
+        log.info("* A C and C++ compiler (for example gcc/g++ or clang), GNU make")
+        log.info("* A Fortran compiler (for PETSc)")
+        log.info("* Blas and Lapack")
+        log.info("* Boost")
+        log.info("* Git, Mercurial")
+        log.info("* Python version >=3.5")
+        log.info("* The Python headers")
+        log.info("* autoconf, automake, libtool")
+        log.info("* CMake")
+        if osname == "Linux":
+            log.info("* zlib, bison, flex")
+        if package_manager:
+            log.info("\n********************************************")
+            log.info("The following %s packages are recommended:" % (package_manager))
+            log.info("********************************************\n")
+            log.info("\n".join(required_packages))
+            log.info("\nThey will be installed by %s unless --no-package-manager is used." % (package_manager))
+            if osname == "Darwin":
+                log.info("\nIn addition, the command line tools will be installed using xcode")
+        sys.exit(0)
+
     if osname == "Darwin":
         if options["package_manager"]:
 
@@ -1142,16 +1208,11 @@ if mode == "install" or not args.update_script:
 
             log.info("Installing required packages via homebrew. You can safely ignore warnings that packages are already installed")
             # Ensure a fortran compiler is available
-            brew_install("gcc")
-            brew_install("python3")
-            brew_install("autoconf")
-            brew_install("automake")
-            brew_install("cmake")
-            brew_install("libtool")
-            brew_install("mercurial")
-            brew_install("boost")
+            for package in required_packages:
+                brew_install(package)
         else:
             log.info("Xcode and homebrew installation disabled. Proceeding on the rash assumption that packaged dependencies are in place.")
+            log.info("Please use the --show_package_manager_options for more information.")
 
     elif osname == "Linux":
         # Check for apt.
@@ -1160,49 +1221,14 @@ if mode == "install" or not args.update_script:
                 raise InstallError
             check_call(["apt-get", "--version"])
 
-            apt_packages = ["build-essential",
-                            "autoconf",
-                            "automake",
-                            "bison",  # for ptscotch
-                            "flex",   # for ptscotch
-                            "cmake",
-                            "gfortran",
-                            "git",
-                            "libblas-dev",
-                            "liblapack-dev",
-                            "libtool",
-                            "mercurial",
-                            "mpich",
-                            "python3-dev",
-                            "python3-pip",
-                            "python3-tk",
-                            "python3-venv",
-                            "zlib1g-dev",
-                            "libboost-dev"]  # For ROL in pyadjoint
-
-            if args.opencascade:
-                apt_packages.append("liboce-ocaf-dev")
-                apt_packages.append("swig")
-
-            missing_packages = [p for p in apt_packages if not apt_check(p)]
+            missing_packages = [p for p in required_packages if not apt_check(p)]
             if missing_packages:
                 apt_install(missing_packages)
 
         except (subprocess.CalledProcessError, InstallError):
             log.info("apt-get not found or disabled. Proceeding on the rash assumption that your compiled dependencies are in place.")
-            log.info("If this is not the case, please install the following and try again:")
-            log.info("* A C and C++ compiler (for example gcc/g++ or clang), GNU make")
-            log.info("* A Fortran compiler (for PETSc)")
-            log.info("* Blas and Lapack")
-            log.info("* Git, Mercurial")
-            log.info("* Python version >=3.5")
-            log.info("* The Python headers")
-            log.info("* autoconf, automake, libtool")
-            log.info("* CMake")
-            log.info("* zlib")
+            log.info("Please use the --show_package_manager_options for more information.")
 
-    else:
-        log.warning("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
 
 if mode == "install":
     if os.path.exists(firedrake_env):

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1076,8 +1076,8 @@ if mode == "install" and args.show_petsc_configure_options:
     log.info("*********************************************")
     log.info("Would build PETSc with the following options:")
     log.info("*********************************************\n")
-    log.info("\n".join(os.environ["PETSC_CONFIGURE_OPTIONS"].split()))
-    log.info("\nEigen will be downloaded from https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz")
+    log.info("\n".join(petsc_options))
+    log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
     sys.exit(0)
 
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -245,7 +245,7 @@ honoured.""",
                         help="MPI launcher. If not set, MPICH will be downloaded and used.")
     parser.add_argument("--show-petsc-configure-options", action="store_true",
                         help="Print out the configure options passed to PETSc and exit")
-    parser.add_argument("--show-package-manager-options", action="store_true",
+    parser.add_argument("--show-dependencies", action="store_true",
                         help="Print out the package manager used and packages installed/required.")
     parser.add_argument("--venv-name", default="firedrake",
                         type=str, action="store",
@@ -1166,7 +1166,7 @@ if mode == "install" or not args.update_script:
     else:
         log.warning("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
 
-    if args.show_package_manager_options:
+    if args.show_dependencies:
         log.info("\n************************************************")
         log.info("The following dependencies need to be installed:")
         log.info("************************************************\n")
@@ -1212,7 +1212,7 @@ if mode == "install" or not args.update_script:
                 brew_install(package)
         else:
             log.info("Xcode and homebrew installation disabled. Proceeding on the rash assumption that packaged dependencies are in place.")
-            log.info("Please use the --show_package_manager_options for more information.")
+            log.info("Please use the --show-dependencies for more information.")
 
     elif osname == "Linux":
         # Check for apt.
@@ -1227,7 +1227,7 @@ if mode == "install" or not args.update_script:
 
         except (subprocess.CalledProcessError, InstallError):
             log.info("apt-get not found or disabled. Proceeding on the rash assumption that your compiled dependencies are in place.")
-            log.info("Please use the --show_package_manager_options for more information.")
+            log.info("Please use the --show-dependencies for more information.")
 
 
 if mode == "install":


### PR DESCRIPTION
This PR addresses two distinct issues with the install script:

1. Petsc build options display is fixed

2. A new option --show-depencies is added, that displays dependencies and the list packages installed by the script.
I had to reorganise slightly the dependencies installation loop. The list of dependencies should probably be double checked.

3. Not (yet) addressed: MPI now seems to be installed by PETSc : shouldn't it be removed from the dependencies list ? (and the apt package lists)