### PR TITLE
Work around homebrew linker issues.

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1078,6 +1078,10 @@ def create_compiler_env(cc, cxx, f90):
         env["MPICC"] = cc
         env["MPI_C_COMPILER"] = cc
         env["CC"] = cc
+        # Work around homebrew adding /usr/local/lib to the library search path.
+        env["CFLAGS"] = " ".join((os.environ.get("CFLAGS", ""),
+                                  "-L" + os.path.join(*get_petsc_dir(), "lib"),
+                                  "-I" + os.path.join(*get_petsc_dir(), "include")))
     if cxx:
         env["MPICXX"] = cxx
         env["MPI_CXX_COMPILER"] = cxx


### PR DESCRIPTION
Homebrew configures Python to add -L/usr/local/lib to the C compiler flags.
Because mpicc sees this as a user configuration, this means that any MPI library
installed by a homebrew will be used in preference to the one associated with
mpicc. This causes build fails if the user has installed open-mpi.

This change manually adds the petsc lib directory to CFLAGS. This will be checked
before /usr/local/lib and hence a petsc installed mpi will be preferred over a
homebrew installed one.