### PR TITLE
pass solver_parameters etc to NonlinearVariationalSolver

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -104,7 +104,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         self.solver_params = solver_params.copy()
         self.solver_kwargs = solver_kwargs
 
-        super().__init__(lhs, rhs, func, bcs, **kwargs)
+        super().__init__(lhs, rhs, func, bcs, **{**solver_kwargs, **kwargs})
 
         if self.problem_J is not None:
             for coeff in self.problem_J.coefficients():


### PR DESCRIPTION
This fixes https://github.com/dolfin-adjoint/pyadjoint/issues/6 

I have also pushed a test to https://github.com/florianwechsung/pyadjoint/tree/fw/options-nlvs.
Since this fails with the current firedrake, I suggest I open a PR on the pyadjoint side once this is merged here. Or is there a better way?