### PR TITLE
plotting functions on surface meshes

### DIFF
--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -200,6 +200,19 @@ def tricontour(function, *args, **kwargs):
     return _plot_2d_field("tricontour", function, *args, **kwargs)
 
 
+def tripcolor(function, *args, **kwargs):
+    r"""Create a pseudo-color plot of a 2D Firedrake :class:`~.Function`
+
+    If the input function is a vector field, the magnitude will be plotted.
+
+    :arg function: the function to plot
+    :arg args: same as for matplotlib :func:`tripcolor <matplotlib.pyplot.tripcolor>`
+    :arg kwargs: same as for matplotlib
+    :return: matplotlib :class:`PolyCollection <matplotlib.collections.PolyCollection>` object
+    """
+    return _plot_2d_field("tripcolor", function, *args, **kwargs)
+
+
 def trisurf(function, *args, **kwargs):
     r"""Create a 3D surface plot of a 2D Firedrake :class:`~.Function`
 
@@ -232,19 +245,6 @@ def trisurf(function, *args, **kwargs):
     _kwargs.update(kwargs)
 
     return axes.plot_trisurf(triangulation, vals, *args, **_kwargs)
-
-
-def tripcolor(function, *args, **kwargs):
-    r"""Create a pseudo-color plot of a 2D Firedrake :class:`~.Function`
-
-    If the input function is a vector field, the magnitude will be plotted.
-
-    :arg function: the function to plot
-    :arg args: same as for matplotlib :func:`tripcolor <matplotlib.pyplot.tripcolor>`
-    :arg kwargs: same as for matplotlib
-    :return: matplotlib :class:`PolyCollection <matplotlib.collections.PolyCollection>` object
-    """
-    return _plot_2d_field("tripcolor", function, *args, **kwargs)
 
 
 def quiver(function, **kwargs):

--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -249,9 +249,13 @@ def trisurf(function, *args, **kwargs):
         figure = plt.figure()
         axes = figure.add_subplot(projection='3d')
 
+    _kwargs = {"antialiased": False, "edgecolor": "none",
+               "cmap": plt.rcParams["image.cmap"]}
+    _kwargs.update(kwargs)
+
     mesh = function.ufl_domain()
     if mesh.geometric_dimension() == 3:
-        return _trisurf_3d(axes, function, *args, **kwargs)
+        return _trisurf_3d(axes, function, *args, **_kwargs)
 
     if len(function.ufl_shape) == 1:
         element = function.ufl_element().sub_elements()[0]
@@ -263,11 +267,7 @@ def trisurf(function, *args, **kwargs):
                                                                num_sample_points)
     x, y = coords[:, 0], coords[:, 1]
     triangulation = matplotlib.tri.Triangulation(x, y, triangles=triangles)
-
-    _kwargs = {"antialiased": False, "edgecolor": "none", "shade": False,
-               "cmap": plt.rcParams["image.cmap"]}
-    _kwargs.update(kwargs)
-
+    _kwargs.update({"shade": False})
     return axes.plot_trisurf(triangulation, vals, *args, **_kwargs)
 
 

--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -228,8 +228,7 @@ def _trisurf_3d(axes, function, *args, vmin=None, vmax=None, norm=None, **kwargs
         collection.set_norm(norm)
 
     axes.add_collection(collection)
-    # TODO: see what the has_data thing does from MPL
-    axes.auto_scale_xyz(coords[:, 0], coords[:, 1], coords[:, 2])
+    _autoscale_view(axes, coords)
 
     return collection
 

--- a/tests/output/test_plotting.py
+++ b/tests/output/test_plotting.py
@@ -168,7 +168,7 @@ def test_triplot_3d():
     assert len(legend.get_texts()) == 6
 
 
-def test_3d_surface_plot():
+def test_trisurf():
     mesh = UnitSquareMesh(10, 10)
     V = FunctionSpace(mesh, "CG", 2)
     f = Function(V)
@@ -178,5 +178,31 @@ def test_3d_surface_plot():
     fig = plt.figure()
     axes = fig.add_subplot(projection='3d')
     assert isinstance(axes, Axes3D)
+    collection = trisurf(f, axes=axes)
+    assert collection is not None
+
+
+def test_trisurf3d():
+    mesh = UnitIcosahedralSphereMesh(2)
+    V = FunctionSpace(mesh, "CG", 2)
+    f = Function(V)
+    x = SpatialCoordinate(mesh)
+    f.interpolate(x[0] * x[1] * x[2])
+
+    fig = plt.figure()
+    axes = fig.add_subplot(projection='3d')
+    collection = trisurf(f, axes=axes)
+    assert collection is not None
+
+
+def test_trisurf3d_quad():
+    mesh = UnitCubedSphereMesh(2)
+    V = FunctionSpace(mesh, "CG", 2)
+    f = Function(V)
+    x = SpatialCoordinate(mesh)
+    f.interpolate(x[0] * x[1] * x[2])
+
+    fig = plt.figure()
+    axes = fig.add_subplot(projection='3d')
     collection = trisurf(f, axes=axes)
     assert collection is not None


### PR DESCRIPTION
This PR makes it possible to plot functions defined on surfaces embedded into 3D using matplotlib. This required a minor change to the internal plotting API. But the only thing users will see is that now they can call `trisurf` for functions defined on the surface of a sphere, torus, etc.