### PR TITLE
Fix adding subplots for matplotlib<3.1

### DIFF
--- a/docs/notebooks/09-hybridisation.ipynb
+++ b/docs/notebooks/09-hybridisation.ipynb
@@ -960,7 +960,7 @@
    ],
    "source": [
     "fig = plt.figure()\n",
-    "axes = fig.add_subplot(projection='3d')\n",
+    "axes = fig.add_subplot(111, projection='3d')\n",
     "triplot(mesh, axes=axes);"
    ]
   },

--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -77,9 +77,9 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     if axes is None:
         figure = plt.figure()
         if gdim == 3:
-            axes = figure.add_subplot(projection='3d')
+            axes = figure.add_subplot(111, projection='3d')
         else:
-            axes = figure.add_subplot()
+            axes = figure.add_subplot(111)
 
     coordinates = mesh.coordinates
     element = coordinates.function_space().ufl_element()
@@ -155,7 +155,7 @@ def _plot_2d_field(method_name, function, *args, **kwargs):
     axes = kwargs.pop("axes", None)
     if axes is None:
         figure = plt.figure()
-        axes = figure.add_subplot()
+        axes = figure.add_subplot(111)
 
     if len(function.ufl_shape) == 1:
         mesh = function.ufl_domain()
@@ -246,7 +246,7 @@ def trisurf(function, *args, **kwargs):
     axes = kwargs.pop("axes", None)
     if axes is None:
         figure = plt.figure()
-        axes = figure.add_subplot(projection='3d')
+        axes = figure.add_subplot(111, projection='3d')
 
     _kwargs = {"antialiased": False, "edgecolor": "none",
                "cmap": plt.rcParams["image.cmap"]}
@@ -283,7 +283,7 @@ def quiver(function, **kwargs):
     axes = kwargs.pop("axes", None)
     if axes is None:
         figure = plt.figure()
-        axes = figure.add_subplot()
+        axes = figure.add_subplot(111)
 
     coords = function.ufl_domain().coordinates.dat.data_ro
     V = function.ufl_domain().coordinates.function_space()
@@ -315,7 +315,7 @@ def plot(function, *args, bezier=False, num_sample_points=10, **kwargs):
     axes = kwargs.pop("axes", None)
     if axes is None:
         figure = plt.figure()
-        axes = figure.add_subplot()
+        axes = figure.add_subplot(111)
 
     if function.ufl_element().degree() < 4:
         return _bezier_plot(function, axes, **kwargs)

--- a/tests/output/test_plotting.py
+++ b/tests/output/test_plotting.py
@@ -176,7 +176,7 @@ def test_trisurf():
     f.interpolate(x[0] ** 2 + x[1] ** 2)
 
     fig = plt.figure()
-    axes = fig.add_subplot(projection='3d')
+    axes = fig.add_subplot(111, projection='3d')
     assert isinstance(axes, Axes3D)
     collection = trisurf(f, axes=axes)
     assert collection is not None
@@ -190,7 +190,7 @@ def test_trisurf3d():
     f.interpolate(x[0] * x[1] * x[2])
 
     fig = plt.figure()
-    axes = fig.add_subplot(projection='3d')
+    axes = fig.add_subplot(111, projection='3d')
     collection = trisurf(f, axes=axes)
     assert collection is not None
 
@@ -203,6 +203,6 @@ def test_trisurf3d_quad():
     f.interpolate(x[0] * x[1] * x[2])
 
     fig = plt.figure()
-    axes = fig.add_subplot(projection='3d')
+    axes = fig.add_subplot(111, projection='3d')
     collection = trisurf(f, axes=axes)
     assert collection is not None


### PR DESCRIPTION
In older versions of matplotlib, calling `add_subplot` without an explicit position argument returns `None` rather than assuming the position is `111`. The newer versions of matplotlib only support python-3.6 and above, so someone using python-3.5 will be stuck with the older matplotlib.