### PR TITLE
Tsslac

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ Tianjiao Sun
 Florian Wechsung
 Fangyi Zhou
 Cyrus Cheng
+Sophia Vorderwuelbecke

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -626,7 +626,7 @@ def dg_injection_kernel(Vf, Vc, ncell):
     u = TrialFunction(Vc)
     v = TestFunction(Vc)
     expr = Tensor(ufl.inner(u, v)*ufl.dx).inv * AssembledVector(ufl.Coefficient(Vc))
-    Ainv, = compile_expression(expr)
+    Ainv, = compile_expression(expr, coffee=True)
     Ainv = Ainv.kinfo.kernel
     A = ast.Symbol(local_tensor.sym.symbol)
     R = ast.Symbol("R")

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -113,6 +113,26 @@ def compile_expression(slate_expr, tsfc_parameters=None, coffee=False):
         return cache.setdefault(key, kernel)
 
 
+def get_temp_info(loopy_kernel):
+    """Get information about temporaries in loopy kernel.
+
+    Returns memory in bytes and number of temporaries.
+    """
+    mems = [temp.nbytes for temp in loopy_kernel.temporary_variables.values()]
+    mem_total = sum(mems)
+    num_temps = len(loopy_kernel.temporary_variables)
+
+    # Get number of temporaries of different shapes
+    shapes = {}
+    for temp in loopy_kernel.temporary_variables.values():
+        shape = temp.shape
+        if temp.storage_shape is not None:
+            shape = temp.storage_shape
+
+        shapes[len(shape)] = shapes.get(len(shape), 0) + 1
+    return mem_total, num_temps, mems, shapes
+
+
 def generate_loopy_kernel(slate_expr, tsfc_parameters=None):
     cpu_time = time.time()
     if len(slate_expr.ufl_domains()) > 1:

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -22,8 +22,8 @@ import os.path
 
 from firedrake_citations import Citations
 from firedrake.tsfc_interface import SplitKernel, KernelInfo, TSFCKernel
-from firedrake.slate.slac.kernel_builder import LocalKernelBuilder
-from firedrake.slate.slac.utils import topological_sort
+from firedrake.slate.slac.kernel_builder import LocalLoopyKernelBuilder, LocalKernelBuilder
+from firedrake.slate.slac.utils import topological_sort, slate_to_gem, merge_loopy
 from firedrake import op2
 from firedrake.logging import logger
 from firedrake.parameters import parameters
@@ -36,10 +36,14 @@ from itertools import chain
 from pyop2.utils import get_petsc_dir, as_tuple
 from pyop2.datatypes import as_cstr
 from pyop2.mpi import COMM_WORLD
+from pyop2.codegen.rep2loopy import solve_fn_lookup, inv_fn_lookup
 
 import firedrake.slate.slate as slate
 import numpy as np
-
+import loopy
+import gem
+from gem import indices as make_indices
+from tsfc.loopy import generate as generate_loopy
 
 __all__ = ['compile_expression']
 
@@ -106,6 +110,47 @@ def compile_expression(slate_expr, tsfc_parameters=None, coffee=False):
     except KeyError:
         kernel = SlateKernel(slate_expr, tsfc_parameters, coffee).split_kernel
         return cache.setdefault(key, kernel)
+
+
+def generate_loopy_kernel(slate_expr, tsfc_parameters=None):
+    cpu_time = time.time()
+    if len(slate_expr.ufl_domains()) > 1:
+        raise NotImplementedError("Multiple domains not implemented.")
+
+    Citations().register("Gibson2018")
+
+    # Create a loopy builder for the Slate expression,
+    # e.g. contains the loopy kernels coming from TSFC
+    gem_expr, var2terminal = slate_to_gem(slate_expr)
+    slate_loopy = gem_to_loopy(gem_expr)
+    builder = LocalLoopyKernelBuilder(expression=slate_expr,
+                                      tsfc_parameters=tsfc_parameters)
+    loopy_merged = merge_loopy(slate_loopy, builder, var2terminal)
+
+    loopy_merged = loopy.register_function_id_to_in_knl_callable_mapper(loopy_merged, inv_fn_lookup)
+    loopy_merged = loopy.register_function_id_to_in_knl_callable_mapper(loopy_merged, solve_fn_lookup)
+
+    # WORKAROUND: Generate code directly from the loopy kernel here,
+    # then attach code as a c-string to the op2kernel
+    code = loopy.generate_code_v2(loopy_merged).device_code()
+    code.replace('void slate_kernel', 'static void slate_kernel')
+    loopykernel = op2.Kernel(code, loopy_merged.name, ldargs=["-llapack"])
+
+    kinfo = KernelInfo(kernel=loopykernel,
+                       integral_type="cell",  # slate can only do things as contributions to the cell integrals
+                       oriented=builder.bag.needs_cell_orientations,
+                       subdomain_id="otherwise",
+                       domain_number=0,
+                       coefficient_map=tuple(range(len(slate_expr.coefficients()))),
+                       needs_cell_facets=builder.bag.needs_cell_facets,
+                       pass_layer_arg=builder.bag.needs_mesh_layers,
+                       needs_cell_sizes=builder.bag.needs_cell_sizes)
+
+    # Cache the resulting kernel
+    # Slate kernels are never split, so indicate that with None in the index slot.
+    idx = tuple([None]*slate_expr.rank)
+    logger.info(GREEN % "compile_slate_expression finished in %g seconds.", time.time() - cpu_time)
+    return (SplitKernel(idx, kinfo),)
 
 
 def generate_kernel(slate_expr, tsfc_parameters=None):

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -29,7 +29,7 @@ particular integral type.
                      provided by TSFC."""
 
 
-def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None):
+def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None, coffee=True):
     """Compiles the TSFC form associated with a Slate :class:`Tensor`
     object. This function will return a :class:`ContextKernel`
     which stores information about the original tensor, integral types

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -66,9 +66,9 @@ def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None, coffee=True
                                parameters=tsfc_parameters,
                                coffee=True)
         cxt_k = ContextKernel(tensor=tensor,
-                              coefficients=form.coefficients(),
-                              original_integral_type=orig_it_type,
-                              tsfc_kernels=kernels)
+                            coefficients=form.coefficients(),
+                            original_integral_type=orig_it_type,
+                            tsfc_kernels=kernels)
         cxt_kernels.append(cxt_k)
 
     cxt_kernels = tuple(cxt_kernels)

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -64,12 +64,13 @@ def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None, coffee=True
         kernels = tsfc_compile(form,
                                subkernel_prefix,
                                parameters=tsfc_parameters,
-                               coffee=True)
-        cxt_k = ContextKernel(tensor=tensor,
-                            coefficients=form.coefficients(),
-                            original_integral_type=orig_it_type,
-                            tsfc_kernels=kernels)
-        cxt_kernels.append(cxt_k)
+                               coffee=coffee, split=False)
+        if kernels:
+            cxt_k = ContextKernel(tensor=tensor,
+                                  coefficients=form.coefficients(),
+                                  original_integral_type=orig_it_type,
+                                  tsfc_kernels=kernels)
+            cxt_kernels.append(cxt_k)
 
     cxt_kernels = tuple(cxt_kernels)
 

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -318,22 +318,41 @@ def topological_sort(exprs):
     return schedule
 
 
-def traverse_dags(exprs):
-    """Traverses a set of DAGs and returns each node.
+def merge_loopy(slate_loopy, builder, var2terminal):
+    """ Merges tsfc loopy kernels and slate loopy kernel into a wrapper kernel."""
+    from firedrake.slate.slac.kernel_builder import SlateWrapperBag
+    coeffs = builder.collect_coefficients()
+    builder.bag = SlateWrapperBag(coeffs)
 
-    :arg exprs: An iterable of Slate expressions.
-    """
-    seen = set()
-    container = []
-    for tensor in exprs:
-        if tensor not in seen:
-            seen.add(tensor)
-            container.append(tensor)
-    while container:
-        tensor = container.pop()
-        yield tensor
+    # In the initialisation the loopy tensors for the terminals are generated
+    # Those are the needed again for generating the TSFC calls
+    inits, tensor2temp = builder.initialise_terminals(var2terminal, builder.bag.coefficients)
+    terminal_tensors = list(filter(lambda x: isinstance(x, sl.Tensor), var2terminal.values()))
+    tsfc_calls, tsfc_kernels = zip(*itertools.chain.from_iterable(
+                                   (builder.generate_tsfc_calls(terminal, tensor2temp[terminal])
+                                    for terminal in terminal_tensors)))
 
-        for operand in tensor.operands:
-            if operand not in seen:
-                seen.add(operand)
-                container.append(operand)
+    # Construct args
+    args = slate_loopy.args.copy() + builder.generate_wrapper_kernel_args(tensor2temp, tsfc_kernels)
+
+    # Munge instructions
+    insns = inits
+    insns.extend(tsfc_calls)
+    insns += builder.slate_call(slate_loopy)
+
+    # Inames come from initialisations + loopyfying kernel args and lhs
+    domains = builder.bag.index_creator.domains
+
+    # Generates the loopy wrapper kernel
+    slate_wrapper = lp.make_function(domains, insns, args, name="slate_wrapper",
+                                     seq_dependencies=True, target=lp.CTarget())
+
+    # Generate program from kernel, so that one can register and inline kernels
+    prg = make_program(slate_wrapper)
+    for tsfc_loopy in tsfc_kernels:
+        prg = register_callable_kernel(prg, tsfc_loopy)
+        prg = inline_callable_kernel(prg, tsfc_loopy.name)
+    prg = register_callable_kernel(prg, slate_loopy)
+    prg = inline_callable_kernel(prg, slate_loopy.name)
+
+    return prg


### PR DESCRIPTION
Hi all. With this PR I intend to share the code for tsslac. Tsslac is the compiler, which translates Slate to loopy with an intermediate representation in gem. I am sharing the code to get feedback on code that is working, but is improvable.

Now I just want to briefly explain the flow of the program to make reviewing hopefully a bit easier. The relevant code is in `slac/compiler.py`, `slac/utils.py` and `slac/kernel_builder.py.`
A slate expression is coming into the compiler. The following steps are taken from there.

1)	Stage 1: A `SlateTranslator` takes the `LocalLoopyKernelBuilder` and Slate expression and **translates the expression into gem**.
2)	Stage 2a: The gem expression is **translated to loopy** with the following steps
a.	A function from Tsfc’s `impero_utils` compiles gem to impero_c.
b.	Tsfc’s `generate_loopy` compiles impero_c to a loopy kernel.
3)	Stage 2b: The outer loopy kernel containing the instructions for the Slate operations and the inner loopy kernel containing the assembly of Terminals are **merged**. The Kernel builder does all the data management in its _setup method.
a.	First the temporaries for the terminals have to initialized.
b.	They are followed by the `CallInstruction` for the TSFC kernel.	
c.	The TSFC kernel is registered and inlined.
d.	Slate instructions start after the inlined TSFC kernel.
4)	Stage 2c: Solve and Inverse have been translated into **loopy `Callables`** and are later on replaced by C functions containing Lapack calls (`getrf`/`getri`/`gesv`) for factorisation/inverse/solve. The functions need to be registered.

### MOST IMPORTANT PART OF THE PR COMMENT STARTS HERE 
Things I would like to encourage discussion about:

- [x] Can the Slate to gem translation be simplified? -> I changed the translation from Slate Tensors such that they become a construct which has a shape. Now, all the pulling up with the former `get_tensor_withnewidx`is not necessary anymore.
- [x] What is causing the trouble for hdg methods? -> Coefficient order in pyop2 did not fit to coefficient order in tsslac
- [x] The loopy kernel generation introduces sequential dependencies between all instructions, how do we prevent this to do efficient vectorisation later on? -> I will deal with this when tsslac landed
- [x] Only save loopy indices in builder and for initialisations in utils. 
- [x] Refactor KernelBuilder and change the order of when things are done, e.g. postpone TSFC call generation to gem to loopy stage. 
- [x] Postpone index naming from gem to loopy stage. 
- [x] Can the dealing with coefficients be simplified? 
- [x] Make a wrapper loopy rather than extending the Slate kernel
- [x] Variable layers -> **not in this PR**
- [ ] 	Slate `Factorization` nodes are simply dropped at the moment. The LAPACK functions do PartialPivLU. (How) do we feed this information through to loopy?

Additional notes
- [x] If carrying coffee to its grave, multigrid test needs to be made loopy compatible. -> We don't expunge coffee for now.
- [x] In which part of Firedrake do the Callables belong into? They are currently in the slack/compiler.py but should probably go into the Firedrake loopy branch? -> put them into pyop2 see https://github.com/OP2/PyOP2/pull/581
- [x] Do I need to make this complex safe? -> **no**
- [x] I still need to fix the pickling for the Solve and InvCallables.
- [x] I need to make things work with new petscblaslapack.h 

