### PR TITLE
Fix MeshTopology geometric dimension

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1193,7 +1193,7 @@ values from f.)"""
 
         if self.ufl_cell() not in (ufl.Cell('triangle', 3),
                                    ufl.Cell("quadrilateral", 3),
-                                   ufl.TensorProductCell(ufl.Cell('interval'), ufl.Cell('interval'),
+                                   ufl.TensorProductCell(ufl.Cell('interval', geometric_dimension=2), ufl.Cell('interval'),
                                                          geometric_dimension=3)):
             raise NotImplementedError('Only implemented for triangles and quadrilaterals embedded in 3d')
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -424,7 +424,9 @@ class MeshTopology(object):
             partitioner.setFromOptions()
             plex.distribute(overlap=0)
 
-        dim = plex.getDimension()
+        tdim = plex.getDimension()
+        # assume the embedding space is the same as the geometric space
+        gdim = plex.getCoordinateDim()
 
         # Allow empty local meshes on a process
         cStart, cEnd = plex.getHeightStratum(0)  # cells
@@ -437,7 +439,7 @@ class MeshTopology(object):
         nfacets = self.comm.allreduce(nfacets, op=MPI.MAX)
 
         self._grown_halos = False
-        self._ufl_cell = ufl.Cell(_cells[dim][nfacets])
+        self._ufl_cell = ufl.Cell(_cells[tdim][nfacets], geometric_dimension=gdim)
 
         # A set of weakrefs to meshes that are explicitly labelled as being
         # parallel-compatible for interpolation/projection/supermeshing
@@ -470,7 +472,7 @@ class MeshTopology(object):
                                                                  reordering)
 
                 # Derive a cell numbering from the Plex renumbering
-                entity_dofs = np.zeros(dim+1, dtype=IntType)
+                entity_dofs = np.zeros(tdim+1, dtype=IntType)
                 entity_dofs[-1] = 1
 
                 self._cell_numbering = self.create_section(entity_dofs)


### PR DESCRIPTION
Adds the cell geometric dimension to the `ufl_cell` created when creating a `MeshTopology` object. Otherwise the `MeshTopology`'s `ufl_cell` field defaults to the same topological dimension as geometric dimension.

This is necessary to ensure correct creation of `CoordinatelessFunction`s on the mesh topology: UFL uses the UFL cell's geometric dimension information when creating a `CoordinatelessFunction` (rather than looking at the `dim` parameter added when creating the `FunctionSpace` for the `CoordinatelessFunction`). See `ufl.Coefficient.__init__(self, function_space.ufl_element())` on line 62 of `function.py`.