### PR TITLE
add mesh of the unit disk to utility meshes

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -675,8 +675,6 @@ def UnitDiskMesh(refinement_level=0, distribution_parameters=None, comm=COMM_WOR
     # mark boundary facets
     plex.createLabel(dmplex.FACE_SETS_LABEL)
     plex.markBoundaryFaces("boundary_faces")
-    coords = plex.getCoordinates()
-    coord_sec = plex.getCoordinateSection()
     if plex.getStratumSize("boundary_faces", 1) > 0:
         boundary_faces = plex.getStratumIS("boundary_faces", 1).getIndices()
         for face in boundary_faces:

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -644,7 +644,7 @@ def CircleManifoldMesh(ncells, radius=1, distribution_parameters=None, comm=COMM
     return m
 
 
-def UnitDiskMesh(refinement_level=0, distribution_parameters=None, comm=COMM_WORLD):
+def UnitDiskMesh(refinement_level=0, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a mesh of the unit disk in 2D
 
     :kwarg refinement_level: optional number of refinements (0 is a diamond)
@@ -691,7 +691,7 @@ def UnitDiskMesh(refinement_level=0, distribution_parameters=None, comm=COMM_WOR
             t = np.max(np.abs(x)) / norm
             x[:] *= t
 
-    m = mesh.Mesh(plex, dim=2, reorder=False, distribution_parameters=distribution_parameters)
+    m = mesh.Mesh(plex, dim=2, reorder=reorder, distribution_parameters=distribution_parameters)
     return m
 
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -19,7 +19,7 @@ __all__ = ['IntervalMesh', 'UnitIntervalMesh',
            'RectangleMesh', 'SquareMesh', 'UnitSquareMesh',
            'PeriodicRectangleMesh', 'PeriodicSquareMesh',
            'PeriodicUnitSquareMesh',
-           'CircleManifoldMesh',
+           'CircleManifoldMesh', 'UnitDiskMesh',
            'UnitTetrahedronMesh',
            'BoxMesh', 'CubeMesh', 'UnitCubeMesh',
            'IcosahedralSphereMesh', 'UnitIcosahedralSphereMesh',
@@ -641,6 +641,59 @@ def CircleManifoldMesh(ncells, radius=1, distribution_parameters=None, comm=COMM
     plex = mesh._from_cell_list(1, cells, vertices, comm)
     m = mesh.Mesh(plex, dim=2, reorder=False, distribution_parameters=distribution_parameters)
     m._radius = radius
+    return m
+
+
+def UnitDiskMesh(refinement_level=0, distribution_parameters=None, comm=COMM_WORLD):
+    """Generate a mesh of the unit disk in 2D
+
+    :kwarg refinement_level: optional number of refinements (0 is a diamond)
+    :kwarg reorder: (optional), should the mesh be reordered?
+    :kwarg comm: Optional communicator to build the mesh on (defaults to
+        COMM_WORLD)."""
+    vertices = np.array([[0, 0],
+                         [1, 0],
+                         [1, 1],
+                         [0, 1],
+                         [-1, 1],
+                         [-1, 0],
+                         [-1, -1],
+                         [0, -1],
+                         [1, -1]], dtype=np.double)
+
+    cells = np.array([[0, 1, 2],
+                      [0, 2, 3],
+                      [0, 3, 4],
+                      [0, 4, 5],
+                      [0, 5, 6],
+                      [0, 6, 7],
+                      [0, 7, 8],
+                      [0, 8, 1]], np.int32)
+
+    plex = mesh._from_cell_list(2, cells, vertices, comm)
+
+    # mark boundary facets
+    plex.createLabel(dmplex.FACE_SETS_LABEL)
+    plex.markBoundaryFaces("boundary_faces")
+    coords = plex.getCoordinates()
+    coord_sec = plex.getCoordinateSection()
+    if plex.getStratumSize("boundary_faces", 1) > 0:
+        boundary_faces = plex.getStratumIS("boundary_faces", 1).getIndices()
+        for face in boundary_faces:
+            plex.setLabelValue(dmplex.FACE_SETS_LABEL, face, 1)
+
+    plex.setRefinementUniform(True)
+    for i in range(refinement_level):
+        plex = plex.refine()
+
+    coords = plex.getCoordinatesLocal().array.reshape(-1, 2)
+    for x in coords:
+        norm = np.sqrt(np.dot(x, x))
+        if norm > 1. / (1 << (refinement_level + 1)):
+            t = np.max(np.abs(x)) / norm
+            x[:] *= t
+
+    m = mesh.Mesh(plex, dim=2, reorder=False, distribution_parameters=distribution_parameters)
     return m
 
 

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -44,6 +44,7 @@ def test_periodic_interval():
 def test_unit_square():
     assert abs(integrate_one(UnitSquareMesh(3, 3)) - 1) < 1e-3
 
+
 def test_unit_disk():
     assert abs(integrate_one(UnitDiskMesh(5)) - np.pi) < 1e-3
 

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -44,6 +44,9 @@ def test_periodic_interval():
 def test_unit_square():
     assert abs(integrate_one(UnitSquareMesh(3, 3)) - 1) < 1e-3
 
+def test_unit_disk():
+    assert abs(integrate_one(UnitDiskMesh(5)) - np.pi) < 1e-3
+
 
 def test_rectangle():
     assert abs(integrate_one(RectangleMesh(3, 3, 10, 2)) - 20) < 1e-3


### PR DESCRIPTION
This PR adds a mesh of the unit disk by mapping from the rectangle [-1, 1] x [-1, 1]. The minimum and maximum angles are around pi / 6.75 and pi / 2.5 respectively, and the ratio of the largest triangle area to the smallest approaches 2.

I haven't added the option for higher-degree coordinate spaces like for the icosahedral sphere mesh, but I can do that if need be.