### PR TITLE
PATCH: pass MPI communicator to pyop2 compilation routine

### DIFF
--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -457,7 +457,7 @@ PetscErrorCode ComputeJacobian(PC pc,
 """.format(struct_decl, pyop2_call), struct
 
 
-def load_c_function(code, name):
+def load_c_function(code, name, comm):
     cppargs = ["-I%s/include" % d for d in get_petsc_dir()]
     ldargs = (["-L%s/lib" % d for d in get_petsc_dir()]
               + ["-Wl,-rpath,%s/lib" % d for d in get_petsc_dir()]
@@ -466,7 +466,8 @@ def load_c_function(code, name):
                 argtypes=[ctypes.c_voidp, ctypes.c_int, ctypes.c_voidp,
                           ctypes.c_voidp, ctypes.c_voidp, ctypes.c_int,
                           ctypes.c_voidp, ctypes.c_voidp, ctypes.c_voidp],
-                restype=ctypes.c_int, cppargs=cppargs, ldargs=ldargs)
+                restype=ctypes.c_int, cppargs=cppargs, ldargs=ldargs,
+                comm=comm)
 
 
 def make_c_arguments(form, kernel, state, get_map, require_state=False,
@@ -697,7 +698,7 @@ class PatchBase(PCSNESBase):
         Jop_data_args, Jop_map_args = make_c_arguments(J, Jcell_kernel, Jstate,
                                                        operator.methodcaller("cell_node_map"))
         code, Struct = make_jacobian_wrapper(Jop_data_args, Jop_map_args)
-        Jop_function = load_c_function(code, "ComputeJacobian")
+        Jop_function = load_c_function(code, "ComputeJacobian", obj.comm)
         Jop_struct = make_c_struct(Jop_data_args, Jop_map_args, Jcell_kernel.funptr, Struct)
 
         Jhas_int_facet_kernel = False
@@ -708,7 +709,7 @@ class PatchBase(PCSNESBase):
                                                                        operator.methodcaller("interior_facet_node_map"),
                                                                        require_facet_number=True)
             code, Struct = make_jacobian_wrapper(facet_Jop_data_args, facet_Jop_map_args)
-            facet_Jop_function = load_c_function(code, "ComputeJacobian")
+            facet_Jop_function = load_c_function(code, "ComputeJacobian", obj.comm)
             point2facet = J.ufl_domain().interior_facets.point2facetnumber.ctypes.data
             facet_Jop_struct = make_c_struct(facet_Jop_data_args, facet_Jop_map_args,
                                              Jint_facet_kernel.funptr, Struct,
@@ -727,7 +728,7 @@ class PatchBase(PCSNESBase):
                                                            require_state=True)
 
             code, Struct = make_residual_wrapper(Fop_data_args, Fop_map_args)
-            Fop_function = load_c_function(code, "ComputeResidual")
+            Fop_function = load_c_function(code, "ComputeResidual", obj.comm)
             Fop_struct = make_c_struct(Fop_data_args, Fop_map_args, Fcell_kernel.funptr, Struct)
 
             Fhas_int_facet_kernel = False
@@ -740,7 +741,7 @@ class PatchBase(PCSNESBase):
                                                                            require_state=True,
                                                                            require_facet_number=True)
                 code, Struct = make_jacobian_wrapper(facet_Fop_data_args, facet_Fop_map_args)
-                facet_Fop_function = load_c_function(code, "ComputeResidual")
+                facet_Fop_function = load_c_function(code, "ComputeResidual", obj.comm)
                 point2facet = F.ufl_domain().interior_facets.point2facetnumber.ctypes.data
                 facet_Fop_struct = make_c_struct(facet_Fop_data_args, facet_Fop_map_args,
                                                  Fint_facet_kernel.funptr, Struct,


### PR DESCRIPTION
Fixes deadlocks in PCPATCH when not using MPI_COMM_WORLD.