### PR TITLE
include arxiv urls in bibtex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,8 @@ cd firedrake/src/pyadjoint; python -m pytest -v tests/firedrake_adjoint
 echo $PATH
 echo $VIRTUAL_ENV
 ls $VIRTUAL_ENV/bin
+firedrake-preprocess-bibtex --validate firedrake/src/firedrake/docs/source/_static/bibliography.bib
+firedrake-preprocess-bibtex --validate firedrake/src/firedrake/docs/source/_static/firedrake-apps.bib
 cd firedrake/src/firedrake/docs; make html
 '''
               }

--- a/docs/source/_static/bibliography.bib
+++ b/docs/source/_static/bibliography.bib
@@ -1,303 +1,312 @@
-@Article{Bercea2016,
-  author =       {Gheorghe{-}Teodor Bercea and Andrew T. T. McRae and
-                  David A. Ham and Lawrence Mitchell and Florian
-                  Rathgeber and Luigi Nardi and Fabio Luporini and
-                  Paul H. J. Kelly},
-  title =        {A structure-exploiting numbering algorithm for
-                  finite elements on extruded meshes, and its
-                  performance evaluation in Firedrake},
-  journal =      {Geoscientific Model Development},
-  year =         2016,
-  volume =       9,
-  number =       10,
-  pages =        {3803--3815},
-  doi =          {10.5194/gmd-9-3803-2016},
-  archiveprefix ={arXiv},
-  eprint =       {1604.05937},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1604.05937}
+@comment{
+ATTENTION: After editing this file ensure that the following command runs without error:
+
+firedrake-preprocess-bibtex bibliography.bib
+
 }
 
-@Misc{Gibson2018,
-  author =       {Thomas H. Gibson and Lawrence Mitchell and David A.
-                  Ham and Colin J. Cotter},
-  title =        {{Slate: extending Firedrake's domain-specific abstraction to 
-                  hybridized solvers for geoscience and beyond.}},
-  journal =      {Geoscientific model development.},
-  volume =       {13},
-  number =       {2},
-  pages =        {735--761},
-  year =         {2020},
-  publisher =    {Copernicus Publications},
-  doi =          {10.5194/gmd-13-735-2020},
-  archiveprefix ={arXiv},
-  eprint =       {1802.00303},
-  primaryclass = {cs.MS},
-  url =          {https://arxiv.org/abs/1802.00303}
+@article{Bercea2016,
+  archiveprefix = {arXiv},
+  author        = {Gheorghe{-}Teodor Bercea and Andrew T. T. McRae and
+David A. Ham and Lawrence Mitchell and Florian
+Rathgeber and Luigi Nardi and Fabio Luporini and
+Paul H. J. Kelly},
+  doi           = {10.5194/gmd-9-3803-2016},
+  eprint        = {1604.05937},
+  journal       = {Geoscientific Model Development},
+  number        = {10},
+  pages         = {3803--3815},
+  primaryclass  = {cs.MS},
+  title         = {A structure-exploiting numbering algorithm for
+finite elements on extruded meshes, and its
+performance evaluation in Firedrake},
+  url           = {http://arxiv.org/abs/1604.05937},
+  volume        = {9},
+  year          = {2016}
 }
 
-@Article{Ham2019,
-  author =       {David A. Ham and Lawrence Mitchell and Alberto
-                  Paganini and Florian Wechsung},
-  title =        {{Automated shape differentiation in the Unified Form
-                  Language}},
-  journal =      {Structural and Multidisciplinary Optimization},
-  publisher =    {Springer},
-  volume =       {60},
-  number =       {5},
-  pages =        {1813--1820},
-  year =         2019,
-  doi =          {10.1007/s00158-019-02281-z},
-  archiveprefix ={arXiv},
-  eprint =       {1808.08083},
-  primaryclass = {math.NA},
+@misc{Gibson2018,
+  archiveprefix = {arXiv},
+  author        = {Thomas H. Gibson and Lawrence Mitchell and David A.
+Ham and Colin J. Cotter},
+  doi           = {10.5194/gmd-13-735-2020},
+  eprint        = {1802.00303},
+  journal       = {Geoscientific model development.},
+  number        = {2},
+  pages         = {735--761},
+  primaryclass  = {cs.MS},
+  publisher     = {Copernicus Publications},
+  title         = {{Slate: extending Firedrake's domain-specific abstraction to 
+hybridized solvers for geoscience and beyond.}},
+  url           = {https://arxiv.org/abs/1802.00303},
+  volume        = {13},
+  year          = {2020}
 }
 
-@Article{Homolya2016,
-  author =       {Mikl\'os Homolya and David A. Ham},
-  title =        {A parallel edge orientation algorithm for
-                  quadrilateral meshes},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2016,
-  volume =       38,
-  number =       5,
-  pages =        {S48--S61},
-  doi =          {10.1137/15M1021325},
-  archiveprefix ={arXiv},
-  eprint =       {1505.03357},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1505.03357}
+@article{Ham2019,
+  archiveprefix = {arXiv},
+  author        = {David A. Ham and Lawrence Mitchell and Alberto
+Paganini and Florian Wechsung},
+  doi           = {10.1007/s00158-019-02281-z},
+  eprint        = {1808.08083},
+  journal       = {Structural and Multidisciplinary Optimization},
+  number        = {5},
+  pages         = {1813--1820},
+  primaryclass  = {math.NA},
+  publisher     = {Springer},
+  title         = {{Automated shape differentiation in the Unified Form
+Language}},
+  volume        = {60},
+  year          = {2019}
 }
 
-@Misc{Homolya2017a,
-  author =       {Mikl\'os Homolya and Robert C. Kirby and David A.
-                  Ham},
-  title =        {{Exposing and exploiting structure: optimal code
-                  generation for high-order finite element methods}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1711.02473},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1711.02473}
+@article{Homolya2016,
+  archiveprefix = {arXiv},
+  author        = {Mikl\'os Homolya and David A. Ham},
+  doi           = {10.1137/15M1021325},
+  eprint        = {1505.03357},
+  journal       = {SIAM Journal on Scientific Computing},
+  number        = {5},
+  pages         = {S48--S61},
+  primaryclass  = {cs.MS},
+  title         = {A parallel edge orientation algorithm for
+quadrilateral meshes},
+  url           = {http://arxiv.org/abs/1505.03357},
+  volume        = {38},
+  year          = {2016}
 }
 
-@Article{Homolya2018,
-  author =       {Homolya, M. and Mitchell, L. and Luporini, F. and
-                  Ham, D.},
-  title =        {TSFC: A Structure-Preserving Form Compiler},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2018,
-  volume =       40,
-  number =       3,
-  pages =        {C401-C428},
-  doi =          {10.1137/17M1130642},
-  url =          {https://doi.org/10.1137/17M1130642}
+@misc{Homolya2017a,
+  archiveprefix = {arXiv},
+  author        = {Mikl\'os Homolya and Robert C. Kirby and David A.
+Ham},
+  eprint        = {1711.02473},
+  primaryclass  = {cs.MS},
+  title         = {{Exposing and exploiting structure: optimal code
+generation for high-order finite element methods}},
+  url           = {http://arxiv.org/abs/1711.02473},
+  year          = {2017}
 }
 
-@Article{Kirby2017,
-  author =       {Robert C. Kirby and Lawrence Mitchell},
-  title =        {{Solver composition across the PDE/linear algebra
-                  barrier}},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2018,
-  volume =       40,
-  number =       1,
-  pages =        {C76-C98},
-  doi =          {10.1137/17M1133208},
-  archiveprefix ={arXiv},
-  eprint =       {1706.01346},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1706.01346}
+@article{Homolya2018,
+  author        = {Homolya, M. and Mitchell, L. and Luporini, F. and
+Ham, D.},
+  doi           = {10.1137/17M1130642},
+  journal       = {SIAM Journal on Scientific Computing},
+  number        = {3},
+  pages         = {C401-C428},
+  title         = {TSFC: A Structure-Preserving Form Compiler},
+  url           = {https://doi.org/10.1137/17M1130642},
+  volume        = {40},
+  year          = {2018}
 }
 
-@Misc{Kirby2018,
-  author =       {Robert C. Kirby and Lawrence Mitchell},
-  title =        {Code generation for generally mapped finite
-                  elements},
-  year =         2018,
-  archiveprefix ={arXiv},
-  eprint =       {1808.05513},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1808.05513}
+@article{Kirby2017,
+  archiveprefix = {arXiv},
+  author        = {Robert C. Kirby and Lawrence Mitchell},
+  doi           = {10.1137/17M1133208},
+  eprint        = {1706.01346},
+  journal       = {SIAM Journal on Scientific Computing},
+  number        = {1},
+  pages         = {C76-C98},
+  primaryclass  = {cs.MS},
+  title         = {{Solver composition across the PDE/linear algebra
+barrier}},
+  url           = {http://arxiv.org/abs/1706.01346},
+  volume        = {40},
+  year          = {2018}
 }
 
-@Article{Lange2016,
-  author =       {Michael Lange and Lawrence Mitchell and Matthew G.
-                  Knepley and Gerard J. Gorman},
-  title =        {Efficient mesh management in {Firedrake} using
-                  {PETSc-DMPlex}},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2016,
-  volume =       38,
-  number =       5,
-  pages =        {S143--S155},
-  doi =          {10.1137/15M1026092},
-  archiveprefix ={arXiv},
-  eprint =       {1506.07749},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1506.07749}
+@misc{Kirby2018,
+  archiveprefix = {arXiv},
+  author        = {Robert C. Kirby and Lawrence Mitchell},
+  eprint        = {1808.05513},
+  primaryclass  = {cs.MS},
+  title         = {Code generation for generally mapped finite
+elements},
+  url           = {http://arxiv.org/abs/1808.05513},
+  year          = {2018}
 }
 
-@Article{Luporini2015,
-  author =       {Fabio Luporini and Ana Lucia Varbanescu and Florian
-                  Rathgeber and Gheorghe-Teodor Bercea and J.
-                  Ramanujam and David A. Ham and Paul H. J. Kelly},
-  title =        {Cross-Loop Optimization of Arithmetic Intensity for
-                  Finite Element Local Assembly},
-  journal =      {ACM Transactions on Architecture and Code
-                  Optimization},
-  year =         2015,
-  volume =       11,
-  number =       4,
-  pages =        {57:1--57:25},
-  url =          {http://doi.acm.org/10.1145/2687415},
-  doi =          {10.1145/2687415},
+@article{Lange2016,
+  archiveprefix = {arXiv},
+  author        = {Michael Lange and Lawrence Mitchell and Matthew G.
+Knepley and Gerard J. Gorman},
+  doi           = {10.1137/15M1026092},
+  eprint        = {1506.07749},
+  journal       = {SIAM Journal on Scientific Computing},
+  number        = {5},
+  pages         = {S143--S155},
+  primaryclass  = {cs.MS},
+  title         = {Efficient mesh management in {Firedrake} using
+{PETSc-DMPlex}},
+  url           = {http://arxiv.org/abs/1506.07749},
+  volume        = {38},
+  year          = {2016}
 }
 
-@Article{Luporini2017,
-  author =       {Fabio Luporini and David A. Ham and Paul H. J.
-                  Kelly},
-  title =        {An algorithm for the optimization of finite element
-                  integration loops},
-  journal =      {ACM Transactions on Mathematical Software},
-  year =         2017,
-  volume =       44,
-  number =       1,
-  pages =        {3:1--3:26},
-  doi =          {10.1145/3054944},
-  archiveprefix ={arXiv},
-  eprint =       {1604.05872},
-  primaryclass = {cs.MS},
+@article{Luporini2015,
+  author        = {Fabio Luporini and Ana Lucia Varbanescu and Florian
+Rathgeber and Gheorghe-Teodor Bercea and J.
+Ramanujam and David A. Ham and Paul H. J. Kelly},
+  doi           = {10.1145/2687415},
+  journal       = {ACM Transactions on Architecture and Code
+Optimization},
+  number        = {4},
+  pages         = {57:1--57:25},
+  title         = {Cross-Loop Optimization of Arithmetic Intensity for
+Finite Element Local Assembly},
+  url           = {http://doi.acm.org/10.1145/2687415},
+  volume        = {11},
+  year          = {2015}
 }
 
-@Article{Markall2010,
-  author =       {Graham R. Markall and David A. Ham and Paul H. J.
-                  Kelly},
-  title =        {Towards generating optimised finite element solvers
-                  for GPUs from high-level specifications},
-  journal =      {Procedia Computer Science},
-  year =         2010,
-  volume =       1,
-  number =       1,
-  pages =        {1815--1823},
-  note =         {{ICCS} 2010},
-  doi =          {10.1016/j.procs.2010.04.203},
-  url =          {http://dx.doi.org/10.1016/j.procs.2010.04.203},
+@article{Luporini2017,
+  archiveprefix = {arXiv},
+  author        = {Fabio Luporini and David A. Ham and Paul H. J.
+Kelly},
+  doi           = {10.1145/3054944},
+  eprint        = {1604.05872},
+  journal       = {ACM Transactions on Mathematical Software},
+  number        = {1},
+  pages         = {3:1--3:26},
+  primaryclass  = {cs.MS},
+  title         = {An algorithm for the optimization of finite element
+integration loops},
+  volume        = {44},
+  year          = {2017}
 }
 
-@Article{Markall2012,
-  author =       {Graham R. Markall and A. Slemmer and David A. Ham
-                  and Paul H. J. Kelly and Chris D. Cantwell and
-                  Spencer J. Sherwin},
-  title =        {Finite element assembly strategies on multi- and
-                  many-core architectures},
-  journal =      {International Journal for Numerical Methods in
-                  Fluids},
-  year =         2013,
-  volume =       71,
-  pages =        {80--97},
-  doi =          {10.1002/fld.3648},
-  url =          {http://dx.doi.org/10.1002/fld.3648}
+@article{Markall2010,
+  author        = {Graham R. Markall and David A. Ham and Paul H. J.
+Kelly},
+  doi           = {10.1016/j.procs.2010.04.203},
+  journal       = {Procedia Computer Science},
+  note          = {{ICCS} 2010},
+  number        = {1},
+  pages         = {1815--1823},
+  title         = {Towards generating optimised finite element solvers
+for GPUs from high-level specifications},
+  url           = {http://dx.doi.org/10.1016/j.procs.2010.04.203},
+  volume        = {1},
+  year          = {2010}
 }
 
-@InProceedings{Markall2013,
-  author =       {Graham R. Markall and Florian Rathgeber and Lawrence
-                  Mitchell and Nicolas Loriant and Carlo Bertolli and
-                  David A. Ham and Paul H. J. Kelly},
-  title =        {Performance-Portable Finite Element Assembly Using
-                  PyOP2 and FEniCS},
-  booktitle =    {28th International Supercomputing Conference, ISC,
-                  Proceedings},
-  year =         2013,
-  editor =       {Kunkel, Julian Martin and Ludwig, Thomas and Meuer,
-                  Hans Werner},
-  volume =       7905,
-  series =       {Lecture Notes in Computer Science},
-  pages =        {279--289},
-  publisher =    {Springer},
-  doi =          {10.1007/978-3-642-38750-0_21},
-  url =          {http://dx.doi.org/10.1007/978-3-642-38750-0_21}
+@article{Markall2012,
+  author        = {Graham R. Markall and A. Slemmer and David A. Ham
+and Paul H. J. Kelly and Chris D. Cantwell and
+Spencer J. Sherwin},
+  doi           = {10.1002/fld.3648},
+  journal       = {International Journal for Numerical Methods in
+Fluids},
+  pages         = {80--97},
+  title         = {Finite element assembly strategies on multi- and
+many-core architectures},
+  url           = {http://dx.doi.org/10.1002/fld.3648},
+  volume        = {71},
+  year          = {2013}
 }
 
-@Article{McRae2016,
-  author =       {Andrew T. T. McRae and Gheorghe-Teodor Bercea and
-                  Lawrence Mitchell and David A. Ham and Colin J.
-                  Cotter},
-  title =        {Automated generation and symbolic manipulation of
-                  tensor product finite elements},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2016,
-  volume =       38,
-  number =       5,
-  pages =        {S25--S47},
-  doi =          {10.1137/15M1021167},
-  archiveprefix ={arXiv},
-  eprint =       {1411.2940},
-  primaryclass = {math.NA},
-  url =          {http://arxiv.org/abs/1411.2940}
+@inproceedings{Markall2013,
+  author        = {Graham R. Markall and Florian Rathgeber and Lawrence
+Mitchell and Nicolas Loriant and Carlo Bertolli and
+David A. Ham and Paul H. J. Kelly},
+  booktitle     = {28th International Supercomputing Conference, ISC,
+Proceedings},
+  doi           = {10.1007/978-3-642-38750-0_21},
+  editor        = {Kunkel, Julian Martin and Ludwig, Thomas and Meuer,
+Hans Werner},
+  pages         = {279--289},
+  publisher     = {Springer},
+  series        = {Lecture Notes in Computer Science},
+  title         = {Performance-Portable Finite Element Assembly Using
+PyOP2 and FEniCS},
+  url           = {http://dx.doi.org/10.1007/978-3-642-38750-0_21},
+  volume        = {7905},
+  year          = {2013}
 }
 
-@Article{Mitchell2016,
-  author =       {Lawrence Mitchell and Eike Hermann M\"uller},
-  title =        {High level implementation of geometric multigrid
-                  solvers for finite element problems: applications in
-                  atmospheric modelling},
-  journal =      {Journal of Computational Physics},
-  year =         2016,
-  volume =       327,
-  pages =        {1--18},
-  doi =          {10.1016/j.jcp.2016.09.037},
-  archiveprefix ={arXiv},
-  eprint =       {1605.00492},
-  primaryclass = {cs.MS},
-  url =          {http://arxiv.org/abs/1605.00492}
+@article{McRae2016,
+  archiveprefix = {arXiv},
+  author        = {Andrew T. T. McRae and Gheorghe-Teodor Bercea and
+Lawrence Mitchell and David A. Ham and Colin J.
+Cotter},
+  doi           = {10.1137/15M1021167},
+  eprint        = {1411.2940},
+  journal       = {SIAM Journal on Scientific Computing},
+  number        = {5},
+  pages         = {S25--S47},
+  primaryclass  = {math.NA},
+  title         = {Automated generation and symbolic manipulation of
+tensor product finite elements},
+  url           = {http://arxiv.org/abs/1411.2940},
+  volume        = {38},
+  year          = {2016}
 }
 
-@InProceedings{Rathgeber2012,
-  author =       {Florian Rathgeber and Graham R. Markall and Lawrence
-                  Mitchell and Nicolas Loriant and David A. Ham and
-                  Carlo Bertolli and Paul H. J. Kelly},
-  title =        {PyOP2: A High-Level Framework for
-                  Performance-Portable Simulations on Unstructured
-                  Meshes},
-  booktitle =    {High Performance Computing, Networking Storage and
-                  Analysis, SC Companion:},
-  year =         2012,
-  pages =        {1116-1123},
-  address =      {Los Alamitos, CA, USA},
-  publisher =    {IEEE Computer Society},
-  isbn =         {978-1-4673-3049-7},
-  doi =          {10.1109/SC.Companion.2012.134},
-  url =          {http://dx.doi.org/10.1109/SC.Companion.2012.134}
+@article{Mitchell2016,
+  archiveprefix = {arXiv},
+  author        = {Lawrence Mitchell and Eike Hermann M\"uller},
+  doi           = {10.1016/j.jcp.2016.09.037},
+  eprint        = {1605.00492},
+  journal       = {Journal of Computational Physics},
+  pages         = {1--18},
+  primaryclass  = {cs.MS},
+  title         = {High level implementation of geometric multigrid
+solvers for finite element problems: applications in
+atmospheric modelling},
+  url           = {http://arxiv.org/abs/1605.00492},
+  volume        = {327},
+  year          = {2016}
 }
 
-@Article{Rathgeber2016,
-  author =       {Rathgeber, Florian and Ham, David A. and Mitchell,
-                  Lawrence and Lange, Michael and Luporini, Fabio and
-                  Mcrae, Andrew T. T. and Bercea, Gheorghe-Teodor and
-                  Markall, Graham R. and Kelly, Paul H. J.},
-  title =        {Firedrake: Automating the Finite Element Method by
-                  Composing Abstractions},
-  journal =      {ACM Trans. Math. Softw.},
-  year =         2016,
-  volume =       43,
-  number =       3,
-  pages =        {24:1--24:27},
-  doi =          {10.1145/2998441},
-  archiveprefix ={arXiv},
-  eprint =       {1501.01809},
-  url =          {http://arxiv.org/abs/1501.01809},
-  primaryclass = {cs.MS}
+@inproceedings{Rathgeber2012,
+  address       = {Los Alamitos, CA, USA},
+  author        = {Florian Rathgeber and Graham R. Markall and Lawrence
+Mitchell and Nicolas Loriant and David A. Ham and
+Carlo Bertolli and Paul H. J. Kelly},
+  booktitle     = {High Performance Computing, Networking Storage and
+Analysis, SC Companion:},
+  doi           = {10.1109/SC.Companion.2012.134},
+  isbn          = {978-1-4673-3049-7},
+  pages         = {1116-1123},
+  publisher     = {IEEE Computer Society},
+  title         = {PyOP2: A High-Level Framework for
+Performance-Portable Simulations on Unstructured
+Meshes},
+  url           = {http://dx.doi.org/10.1109/SC.Companion.2012.134},
+  year          = {2012}
 }
 
-@Misc{Sun2019,
-  author =       {Tianjiao Sun and Lawrence Mitchell and Kaushik
-                  Kulkarni and Andreas Kl\"ockner and David A. Ham and
-                  Paul H. J. Kelly},
-  title =        {A study of vectorization for matrix-free finite
-                  element methods},
-  year =         2019,
-  archiveprefix ={arXiv},
-  eprint =       {1903.08243},
-  primaryclass = {cs.MS}
+@article{Rathgeber2016,
+  archiveprefix = {arXiv},
+  author        = {Rathgeber, Florian and Ham, David A. and Mitchell,
+Lawrence and Lange, Michael and Luporini, Fabio and
+Mcrae, Andrew T. T. and Bercea, Gheorghe-Teodor and
+Markall, Graham R. and Kelly, Paul H. J.},
+  doi           = {10.1145/2998441},
+  eprint        = {1501.01809},
+  journal       = {ACM Trans. Math. Softw.},
+  number        = {3},
+  pages         = {24:1--24:27},
+  primaryclass  = {cs.MS},
+  title         = {Firedrake: Automating the Finite Element Method by
+Composing Abstractions},
+  url           = {http://arxiv.org/abs/1501.01809},
+  volume        = {43},
+  year          = {2016}
 }
+
+@misc{Sun2019,
+  archiveprefix = {arXiv},
+  author        = {Tianjiao Sun and Lawrence Mitchell and Kaushik
+Kulkarni and Andreas Kl\"ockner and David A. Ham and
+Paul H. J. Kelly},
+  eprint        = {1903.08243},
+  primaryclass  = {cs.MS},
+  title         = {A study of vectorization for matrix-free finite
+element methods},
+  url           = {https://arxiv.org/abs/1903.08243},
+  year          = {2019}
+}
+

--- a/docs/source/_static/firedrake-apps.bib
+++ b/docs/source/_static/firedrake-apps.bib
@@ -1,29 +1,36 @@
+@comment{
+ATTENTION: After editing this file ensure that the following command runs without error:
+
+firedrake-preprocess-bibtex firedrake-apps.bib
+
+}
+
 @inproceedings{Andrej2018,
-  author    = {{Andrej}, J. and {Meurer}, T.},
-  booktitle = {2018 Annual American Control Conference (ACC)},
-  date      = {2018-06},
-  doi       = {10.23919/ACC.2018.8431201},
-  issn      = {2378-5861},
-  pages     = {2539--2544},
-  title     = {Flatness-based constrained optimal control of reaction-diffusion systems},
+  author       = {{Andrej}, J. and {Meurer}, T.},
+  booktitle    = {2018 Annual American Control Conference (ACC)},
+  date         = {2018-06},
+  doi          = {10.23919/ACC.2018.8431201},
+  issn         = {2378-5861},
+  pages        = {2539--2544},
+  title        = {Flatness-based constrained optimal control of reaction-diffusion systems}
 }
 
 @thesis{Andrej2019,
-  author   = {Andrej, Julian},
-  url      = {https://macau.uni-kiel.de/receive/diss_mods_00025104},
-  date     = {2019},
-  keywords = {finite element method; FEM; flatness-based control; optimal control; multiphysics; control theory},
-  title    = {Modeling and optimal control of multiphysics problems using the finite element method},
-  type     = {phdthesis},
+  author       = {Andrej, Julian},
+  date         = {2019},
+  keywords     = {finite element method; FEM; flatness-based control; optimal control; multiphysics; control theory},
+  title        = {Modeling and optimal control of multiphysics problems using the finite element method},
+  type         = {phdthesis},
+  url          = {https://macau.uni-kiel.de/receive/diss_mods_00025104}
 }
 
 @misc{Angeloudis2017,
-  author     = {Angeloudis, Athanasios and Piggott, Matthew D. and Kramer, Stephan C. and Avdis, Alexandros and Coles, Daniel and Christou, Marios},
-  date       = {2017},
-  doi        = {10.17605/osf.io/sjxf4},
-  eprint     = {sjxf4},
-  eprinttype = {EarthArXiv},
-  title      = {{Comparison of 0-D, 1-D and 2-D model capabilities for tidal range energy resource assessments}},
+  author       = {Angeloudis, Athanasios and Piggott, Matthew D. and Kramer, Stephan C. and Avdis, Alexandros and Coles, Daniel and Christou, Marios},
+  date         = {2017},
+  doi          = {10.17605/osf.io/sjxf4},
+  eprint       = {sjxf4},
+  eprinttype   = {EarthArXiv},
+  title        = {{Comparison of 0-D, 1-D and 2-D model capabilities for tidal range energy resource assessments}}
 }
 
 @article{Angeloudis2018,
@@ -34,16 +41,17 @@
   journaltitle = {Applied Energy},
   pages        = {680--690},
   title        = {Optimising tidal range power plant operation},
-  volume       = {212},
+  volume       = {212}
 }
 
 @inproceedings{Angeloudis2018a,
   author       = {Angeloudis, A and Hawkins, N and Kramer, SC and Piggott, MD},
-  organization = {CRC Press},
   booktitle    = {Advances in Renewable Energies Offshore: Proceedings of the 3rd International Conference on Renewable Energies Offshore (RENEW 2018), October 8-10, 2018, Lisbon, Portugal},
   date         = {2018},
+  doi          = {10.1201/9780429505324},
+  organization = {CRC Press},
   pages        = {159},
-  title        = {Comparison of twin-basin lagoon systems against conventional tidal power plant designs},
+  title        = {Comparison of twin-basin lagoon systems against conventional tidal power plant designs}
 }
 
 @article{Angeloudis2019,
@@ -54,126 +62,126 @@
   number       = {2},
   pages        = {45--54},
   title        = {Tidal range structure operation assessment and optimisation},
-  volume       = {29},
+  volume       = {29}
 }
 
 @article{Angeloudis2020,
-  author    = {Angeloudis, Athanasios and Kramer, Stephan C and Hawkins, Noah and Piggott, Matthew},
-  publisher = {EarthArXiv},
-  date      = {2020},
-  doi       = {10.31223/osf.io/ancu8},
-  title     = {On the potential of linked-basin tidal power plants: an operational and coastal modelling assessment},
+  author       = {Angeloudis, Athanasios and Kramer, Stephan C and Hawkins, Noah and Piggott, Matthew},
+  date         = {2020},
+  doi          = {10.31223/osf.io/ancu8},
+  publisher    = {EarthArXiv},
+  title        = {On the potential of linked-basin tidal power plants: an operational and coastal modelling assessment}
 }
 
 @article{Baker2020,
-  author    = {Baker, Amy L and Craighead, Robert M and Jarvis, Emma J and Stenton, Harriett C and Angeloudis, Athanasios and Mackie, Lucas and Avdis, Alexandros and Piggott, Matthew and Hill, Jon},
-  publisher = {EarthArXiv},
-  url       = {https://doi.org/10.31223/osf.io/vapmu},
-  date      = {2020},
-  doi       = {10.31223/osf.io/vapmu},
-  title     = {Modelling the ecological impacts of tidal energy barrages},
+  author       = {Baker, Amy L and Craighead, Robert M and Jarvis, Emma J and Stenton, Harriett C and Angeloudis, Athanasios and Mackie, Lucas and Avdis, Alexandros and Piggott, Matthew and Hill, Jon},
+  date         = {2020},
+  doi          = {10.31223/osf.io/vapmu},
+  publisher    = {EarthArXiv},
+  title        = {Modelling the ecological impacts of tidal energy barrages},
+  url          = {https://doi.org/10.31223/osf.io/vapmu}
 }
 
 @misc{Barral2016,
-  author      = {Barral, Nicolas and Knepley, Matthew G and Lange, Michael and Piggott, Matthew D and Gorman, Gerard J},
-  url         = {http://arxiv.org/abs/1610.09874},
-  date        = {2016},
-  eprint      = {1610.09874},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Anisotropic mesh adaptation in Firedrake with PETSc DMPlex}},
+  author       = {Barral, Nicolas and Knepley, Matthew G and Lange, Michael and Piggott, Matthew D and Gorman, Gerard J},
+  date         = {2016},
+  eprint       = {1610.09874},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Anisotropic mesh adaptation in Firedrake with PETSc DMPlex}},
+  url          = {http://arxiv.org/abs/1610.09874}
 }
 
 @misc{Bauer2018,
-  author      = {Bauer, Werner and Cotter, Colin J.},
-  url         = {https://arxiv.org/abs/1801.00691},
-  date        = {2018},
-  eprint      = {1801.00691},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Energy-enstrophy conserving compatible finite element schemes for the shallow water equations on rotating domains with boundaries}},
+  author       = {Bauer, Werner and Cotter, Colin J.},
+  date         = {2018},
+  eprint       = {1801.00691},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Energy-enstrophy conserving compatible finite element schemes for the shallow water equations on rotating domains with boundaries}},
+  url          = {https://arxiv.org/abs/1801.00691}
 }
 
 @misc{Bendall2017,
-  author      = {Bendall, Thomas M and Cotter, Colin J},
-  url         = {https://arxiv.org/abs/1710.04845},
-  date        = {2017},
-  eprint      = {1710.04845},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Statistical properties of an enstrophy conserving discretisation for the stochastic quasi-geostrophic equation}},
+  author       = {Bendall, Thomas M and Cotter, Colin J},
+  date         = {2017},
+  eprint       = {1710.04845},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Statistical properties of an enstrophy conserving discretisation for the stochastic quasi-geostrophic equation}},
+  url          = {https://arxiv.org/abs/1710.04845}
 }
 
 @article{Bendall2019,
   author       = {Bendall, Thomas M and Cotter, Colin J and Shipton, Jemma},
-  publisher    = {Elsevier},
   date         = {2019},
   doi          = {10.1016/j.jcp.2019.04.013},
   journaltitle = {Journal of Computational Physics},
   pages        = {342--358},
+  publisher    = {Elsevier},
   title        = {The `recovered space' advection scheme for lowest-order compatible finite element methods},
-  volume       = {390},
+  volume       = {390}
 }
 
 @misc{Bendall2019b,
-  author      = {Bendall, Thomas M. and Gibson, Thomas H. and Shipton, Jemma and Cotter, Colin J. and Shipway, Ben},
-  url         = {https://arxiv.org/abs/1910.01857},
-  date        = {2019},
-  eprint      = {1910.01857},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{A Compatible Finite Element Discretisation for the Moist Compressible Euler Equations}},
+  author       = {Bendall, Thomas M. and Gibson, Thomas H. and Shipton, Jemma and Cotter, Colin J. and Shipway, Ben},
+  date         = {2019},
+  eprint       = {1910.01857},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{A Compatible Finite Element Discretisation for the Moist Compressible Euler Equations}},
+  url          = {https://arxiv.org/abs/1910.01857}
 }
 
 @thesis{Betteridge2019,
-  author = {Betteridge, Jack},
-  date   = {2019},
-  file   = {https://people.bath.ac.uk/masigg/theses/Betteridge_thesis.pdf},
-  title  = {{Efficient elliptic solvers for higher order DG discretisations on modern architectures and applications in atmospheric modelling}},
-  type   = {phdthesis},
+  author       = {Betteridge, Jack},
+  date         = {2019},
+  title        = {{Efficient elliptic solvers for higher order DG discretisations on modern architectures and applications in atmospheric modelling}},
+  type         = {phdthesis},
+  url          = {https://people.bath.ac.uk/masigg/theses/Betteridge_thesis.pdf}
 }
 
 @misc{Bihlo2019,
-  author      = {Bihlo, Alex and Jackaman, James and Valiquette, Francis},
-  url         = {https://arxiv.org/abs/1907.00961},
-  date        = {2019},
-  eprint      = {1907.00961},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {On the development of symmetry-preserving finite element schemes for ordinary differential equations},
+  author       = {Bihlo, Alex and Jackaman, James and Valiquette, Francis},
+  date         = {2019},
+  eprint       = {1907.00961},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {On the development of symmetry-preserving finite element schemes for ordinary differential equations},
+  url          = {https://arxiv.org/abs/1907.00961}
 }
 
 @inproceedings{Bokhove2016,
-  author    = {Bokhove, Onno and Kalogirou, Anna},
-  editor    = {Bridges, Thomas J. and Groves, Mark D. and Nicholls, David P.},
-  publisher = {Cambridge University Press},
-  url       = {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf},
-  booktitle = {Lectures on the theory of water waves},
-  date      = {2016},
-  pages     = {226--260},
-  series    = {LMS Lecture Note Series},
-  title     = {Variational water wave modelling: from continuum to experiment},
-  volume    = {426},
+  author       = {Bokhove, Onno and Kalogirou, Anna},
+  booktitle    = {Lectures on the theory of water waves},
+  date         = {2016},
+  editor       = {Bridges, Thomas J. and Groves, Mark D. and Nicholls, David P.},
+  pages        = {226--260},
+  publisher    = {Cambridge University Press},
+  series       = {LMS Lecture Note Series},
+  title        = {Variational water wave modelling: from continuum to experiment},
+  url          = {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf},
+  volume       = {426}
 }
 
 @article{Braun2017,
   author       = {Braun, Moritz and Obodo, Kingsley O.},
-  url          = {http://www.sciencedirect.com/science/article/pii/S0898122116306745},
   date         = {2017},
   doi          = {10.1016/j.camwa.2016.12.003},
   issn         = {0898-1221},
   journaltitle = {Computers & Mathematics with Applications},
   title        = {Multi-domain muffin tin finite element density functional calculations for small molecules},
+  url          = {http://www.sciencedirect.com/science/article/pii/S0898122116306745}
 }
 
 @misc{Brugnoli2020,
-  author      = {Brugnoli, Andrea and Alazar, Daniel and Pommier-Budinger, Valérie and Matignon, Denis},
-  url         = {https://arxiv.org/abs/2002.12816},
-  date        = {2020},
-  eprint      = {2002.12816},
-  eprintclass = {physics.class-ph},
-  eprinttype  = {arXiv},
-  title       = {{Port-Hamiltonian flexible multibody dynamics}},
+  author       = {Brugnoli, Andrea and Alazar, Daniel and Pommier-Budinger, Valérie and Matignon, Denis},
+  date         = {2020},
+  eprint       = {2002.12816},
+  eprintclass  = {physics.class-ph},
+  eprinttype   = {arXiv},
+  title        = {{Port-Hamiltonian flexible multibody dynamics}},
+  url          = {https://arxiv.org/abs/2002.12816}
 }
 
 @article{Budd2018,
@@ -185,12 +193,11 @@
   journaltitle = {Journal of Computational Physics},
   pages        = {540--564},
   title        = {{The scaling and skewness of optimally transported meshes on the sphere}},
-  volume       = {375},
+  volume       = {375}
 }
 
 @article{Chang2017,
   author       = {Chang, J. and Nakshatrala, K.B. and Knepley, M.G. and Johnsson, L.},
-  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.4401},
   date         = {2017},
   doi          = {10.1002/cpe.4401},
   eprint       = {1705.03625},
@@ -200,7 +207,8 @@
   number       = {11},
   pages        = {e4401},
   title        = {A performance spectrum for parallel computational frameworks that solve PDEs},
-  volume       = {30},
+  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.4401},
+  volume       = {30}
 }
 
 @article{Chang2017a,
@@ -214,79 +222,79 @@
   journaltitle = {Computer Methods in Applied Mechanics and Engineering},
   pages        = {287--334},
   title        = {Variational inequality approach to enforcing the non-negative constraint for advection–diffusion equations},
-  volume       = {320},
+  volume       = {320}
 }
 
 @thesis{Chang2017b,
-  author      = {Chang, Justin},
-  institution = {University of Houston},
-  date        = {2017},
-  title       = {Structure-preserving high performance computational methods for transport in porous media},
-  type        = {phdthesis},
+  author       = {Chang, Justin},
+  date         = {2017},
+  institution  = {University of Houston},
+  title        = {Structure-preserving high performance computational methods for transport in porous media},
+  type         = {phdthesis},
+  url          = {https://hdl.handle.net/10657/4618}
 }
 
 @misc{Chang2018,
-  author      = {Chang, J. and Fabian, M. S. and Knepley, M. G. and Mills, R. T.},
-  url         = {https://arxiv.org/abs/1802.07832},
-  date        = {2018},
-  eprint      = {1802.07832},
-  eprintclass = {cs.MS},
-  eprinttype  = {arXiv},
-  title       = {{Comparative study of finite element methods using the Time-Accuracy-Size (TAS) spectrum analysis}},
+  author       = {Chang, J. and Fabian, M. S. and Knepley, M. G. and Mills, R. T.},
+  date         = {2018},
+  eprint       = {1802.07832},
+  eprintclass  = {cs.MS},
+  eprinttype   = {arXiv},
+  title        = {{Comparative study of finite element methods using the Time-Accuracy-Size (TAS) spectrum analysis}},
+  url          = {https://arxiv.org/abs/1802.07832}
 }
 
 @misc{Chaudhry2020,
-  author      = {Chaudhry, Jehanzeb Hameed and Olson, Luke N. and Sentz, Peter},
-  url         = {https://arxiv.org/abs/2003.04555},
-  date        = {2020},
-  eprint      = {2003.04555},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{A Least-Squares Finite Element Reduced Basis Method}},
+  author       = {Chaudhry, Jehanzeb Hameed and Olson, Luke N. and Sentz, Peter},
+  date         = {2020},
+  eprint       = {2003.04555},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{A Least-Squares Finite Element Reduced Basis Method}},
+  url          = {https://arxiv.org/abs/2003.04555}
 }
 
 @misc{Chiw2017,
-  author      = {Chiw, Charisee and Kindlmann, Gordon and Reppy, John},
-  url         = {https://arxiv.org/abs/1706.05718},
-  date        = {2017},
-  eprint      = {1706.05718},
-  eprintclass = {cs.HC},
-  eprinttype  = {arXiv},
-  title       = {{An exploiration to visualize finite element data with a DSL}},
+  author       = {Chiw, Charisee and Kindlmann, Gordon and Reppy, John},
+  date         = {2017},
+  eprint       = {1706.05718},
+  eprintclass  = {cs.HC},
+  eprinttype   = {arXiv},
+  title        = {{An exploiration to visualize finite element data with a DSL}},
+  url          = {https://arxiv.org/abs/1706.05718}
 }
 
 @misc{Collin2019,
-  author      = {Collin, Teodoro and Kindlmann, Gordon and Scott, L. Ridgway},
-  url         = {https://arxiv.org/abs/1911.00790},
-  date        = {2019},
-  eprint      = {1911.00790},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{An Adaptive Savitsky-Golay Filter for Smoothing Finite Element Computation}},
+  author       = {Collin, Teodoro and Kindlmann, Gordon and Scott, L. Ridgway},
+  date         = {2019},
+  eprint       = {1911.00790},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{An Adaptive Savitsky-Golay Filter for Smoothing Finite Element Computation}},
+  url          = {https://arxiv.org/abs/1911.00790}
 }
 
 @article{Cotter2014,
   author       = {Cotter, Colin J. and Kirby, Robert C.},
-  url          = {http://arxiv.org/abs/1410.0045},
   date         = {2015},
   doi          = {10.1007/s00211-015-0748-z},
   journaltitle = {Numerische Mathematik},
   pages        = {1--23},
   title        = {Mixed finite elements for global tide models},
+  url          = {http://arxiv.org/abs/1410.0045}
 }
 
 @misc{Cotter2015,
-  author     = {Cotter, Colin J. and Ham, David A. and McRae, Andrew T. T. and Mitchell, Lawrence and Natale, Andrea},
-  url        = {http://arxiv.org/abs/1410.3069},
-  date       = {2015},
-  eprint     = {1410.3069},
-  eprinttype = {arXiv},
-  title      = {On the shallow atmosphere approximation in finite element dynamical cores},
+  author       = {Cotter, Colin J. and Ham, David A. and McRae, Andrew T. T. and Mitchell, Lawrence and Natale, Andrea},
+  date         = {2015},
+  eprint       = {1410.3069},
+  eprinttype   = {arXiv},
+  title        = {On the shallow atmosphere approximation in finite element dynamical cores},
+  url          = {http://arxiv.org/abs/1410.3069}
 }
 
 @article{Cotter2016,
   author       = {Cotter, Colin J. and Kuzmin, Dmitri},
-  url          = {http://arxiv.org/abs/1509.04431},
   date         = {2016},
   doi          = {10.1016/j.jcp.2016.02.021},
   eprint       = {1509.04431},
@@ -295,7 +303,8 @@
   journaltitle = {Journal of Computational Physics},
   pages        = {363--373},
   title        = {Embedded discontinuous {Galerkin} transport schemes with localised limiters},
-  volume       = {311},
+  url          = {http://arxiv.org/abs/1509.04431},
+  volume       = {311}
 }
 
 @article{Cotter2018,
@@ -308,12 +317,11 @@
   issue        = {4},
   journaltitle = {Numerische Mathematik},
   title        = {{Mixed finite elements for global tide models with nonlinear damping}},
-  volume       = {140},
+  volume       = {140}
 }
 
 @article{Cotter2019,
   author       = {Cotter, Colin and Crisan, Dan and Holm, Darryl D and Pan, Wei and Shevchenko, Igor},
-  publisher    = {SIAM},
   date         = {2019},
   doi          = {10.1137/18M1167929},
   eprint       = {1801.09729},
@@ -322,36 +330,36 @@
   journaltitle = {Multiscale Modeling \& Simulation},
   number       = {1},
   pages        = {192--232},
+  publisher    = {SIAM},
   title        = {{Numerically Modeling Stochastic Lie Transport in Fluid Dynamics}},
-  volume       = {17},
+  volume       = {17}
 }
 
 @misc{Dokken2020,
-  author      = {Dokken, Jørgen S. and Mitusch, Sebastian K. and Funke, Simon W.},
-  url         = {https://arxiv.org/abs/2001.10058},
-  date        = {2020},
-  eprint      = {2001.10058},
-  eprintclass = {math.OC},
-  eprinttype  = {arXiv},
-  title       = {{Automatic shape derivatives for transient PDEs in FEniCS and Firedrake}},
+  author       = {Dokken, Jørgen S. and Mitusch, Sebastian K. and Funke, Simon W.},
+  date         = {2020},
+  eprint       = {2001.10058},
+  eprintclass  = {math.OC},
+  eprinttype   = {arXiv},
+  title        = {{Automatic shape derivatives for transient PDEs in FEniCS and Firedrake}},
+  url          = {https://arxiv.org/abs/2001.10058}
 }
 
 @article{Eldred2019,
   author       = {Eldred, Christopher and Dubos, Thomas and Kritsikis, Evaggelos},
-  publisher    = {Elsevier},
   date         = {2019},
   doi          = {10.1016/j.jcp.2018.10.038},
   eprint       = {hal-01847698},
   eprinttype   = {HAL},
   journaltitle = {Journal of Computational Physics},
   pages        = {1--31},
+  publisher    = {Elsevier},
   title        = {{A quasi-Hamiltonian discretization of the thermal shallow water equations}},
-  volume       = {379},
+  volume       = {379}
 }
 
 @article{Farrell2019,
   author       = {Farrell, Patrick E. and Mitchell, Lawrence and Wechsung, Florian},
-  url          = {https://arxiv.org/abs/1810.03315},
   date         = {2019},
   eprint       = {1810.03315},
   eprintclass  = {math.NA},
@@ -360,32 +368,32 @@
   journaltitle = {SIAM Journal on Scientific Computing},
   pages        = {A3073--A3096},
   title        = {{An augmented Lagrangian preconditioner for the 3D stationary incompressible Navier–-Stokes equations at high Reynolds number}},
-  volume       = {41},
+  url          = {https://arxiv.org/abs/1810.03315},
+  volume       = {41}
 }
 
 @misc{Farrell2019a,
-  author      = {Farrell, Patrick E. and Gazca-Orozco, Pablo Alexei and Süli, Endre},
-  url         = {https://arxiv.org/abs/1904.09136},
-  date        = {2019},
-  eprint      = {1904.09136},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Numerical Analysis of Unsteady Implicitly Constituted Incompressible Fluids: Three-Field Formulation}},
+  author       = {Farrell, Patrick E. and Gazca-Orozco, Pablo Alexei and Süli, Endre},
+  date         = {2019},
+  eprint       = {1904.09136},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Numerical Analysis of Unsteady Implicitly Constituted Incompressible Fluids: Three-Field Formulation}},
+  url          = {https://arxiv.org/abs/1904.09136}
 }
 
 @misc{Farrell2019b,
-  author      = {Farrell, Patrick E. and He, Yunhui and MacLachlan, Scott P.},
-  url         = {https://arxiv.org/abs/1908.09949},
-  date        = {2019},
-  eprint      = {1908.09949},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{A local Fourier analysis of additive Vanka relaxation for the Stokes equations}},
+  author       = {Farrell, Patrick E. and He, Yunhui and MacLachlan, Scott P.},
+  date         = {2019},
+  eprint       = {1908.09949},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{A local Fourier analysis of additive Vanka relaxation for the Stokes equations}},
+  url          = {https://arxiv.org/abs/1908.09949}
 }
 
 @article{Farrell2019c,
   author       = {Farrell, Patrick E. and Croci, Matteo and Surowiec, Thomas M.},
-  publisher    = {Taylor & Francis},
   date         = {2019},
   doi          = {10.1080/10556788.2019.1613655},
   eprint       = {1904.13299},
@@ -393,48 +401,49 @@
   eprinttype   = {arXiv},
   journaltitle = {Optimization Methods and Software},
   pages        = {1--24},
-  title        = {Deflation for semismooth equations},
+  publisher    = {Taylor & Francis},
+  title        = {Deflation for semismooth equations}
 }
 
 @misc{Farrell2019d,
-  author      = {Farrell, Patrick E. and Knepley, Matthew G. and Mitchell, Lawrence and Wechsung, Florian},
-  url         = {https://arxiv.org/abs/1912.08516},
-  date        = {2019},
-  eprint      = {1912.08516},
-  eprintclass = {cs.MS},
-  eprinttype  = {arXiv},
-  title       = {{PCPATCH: software for the topological construction of multigrid relaxation methods}},
+  author       = {Farrell, Patrick E. and Knepley, Matthew G. and Mitchell, Lawrence and Wechsung, Florian},
+  date         = {2019},
+  eprint       = {1912.08516},
+  eprintclass  = {cs.MS},
+  eprinttype   = {arXiv},
+  title        = {{PCPATCH: software for the topological construction of multigrid relaxation methods}},
+  url          = {https://arxiv.org/abs/1912.08516}
 }
 
 @article{Farrell2020a,
   author       = {Farrell, PE and Gazca-Orozco, PA and Süli, E},
-  publisher    = {SIAM},
   date         = {2020},
   doi          = {10.1137/19M125738X},
   journaltitle = {SIAM Journal on Numerical Analysis},
   number       = {1},
   pages        = {757--787},
+  publisher    = {SIAM},
   title        = {{Numerical Analysis of Unsteady Implicitly Constituted Incompressible Fluids: 3-Field Formulation}},
-  volume       = {58},
+  volume       = {58}
 }
 
 @misc{Farrell2020b,
-  author      = {Farrell, Patrick E. and Mitchell, Lawrence and Scott, L. Ridgway and Wechsung, Florian},
-  url         = {https://arxiv.org/abs/2002.02051},
-  date        = {2020},
-  eprint      = {2002.02051},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {Robust multigrid methods for nearly incompressible elasticity using macro elements},
+  author       = {Farrell, Patrick E. and Mitchell, Lawrence and Scott, L. Ridgway and Wechsung, Florian},
+  date         = {2020},
+  eprint       = {2002.02051},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {Robust multigrid methods for nearly incompressible elasticity using macro elements},
+  url          = {https://arxiv.org/abs/2002.02051}
 }
 
 @book{Gibson2019,
-  author    = {Gibson, Thomas H. and McRae, Andrew T.T. and Cotter, Colin J. and Mitchell, Lawrence and Ham, David A.},
-  publisher = {Springer International Publishing},
-  url       = {https://doi.org/10.1007/978-3-030-23957-2},
-  date      = {2019},
-  doi       = {10.1007/978-3-030-23957-2},
-  title     = {{Compatible Finite Element Methods for Geophysical Flows: automation and implementation using Firedrake}},
+  author       = {Gibson, Thomas H. and McRae, Andrew T.T. and Cotter, Colin J. and Mitchell, Lawrence and Ham, David A.},
+  date         = {2019},
+  doi          = {10.1007/978-3-030-23957-2},
+  publisher    = {Springer International Publishing},
+  title        = {{Compatible Finite Element Methods for Geophysical Flows: automation and implementation using Firedrake}},
+  url          = {https://doi.org/10.1007/978-3-030-23957-2}
 }
 
 @article{Gidel2017,
@@ -444,26 +453,26 @@
   journaltitle = {Nonlinear Processes in Geophysics},
   pages        = {43--60},
   title        = {Variational modelling of extreme waves through oblique interaction of solitary waves: application to {Mach} reflection},
-  volume       = {24},
+  volume       = {24}
 }
 
 @inproceedings{Gidel2017a,
-  author    = {Gidel, Floriane and Bokhove, Onno and Kelmanson, Mark},
-  booktitle = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
-  date      = {2017},
-  doi       = {10.1115/omae2017-61974},
-  pages     = {V001T01A053},
-  title     = {Driven nonlinear potential flow with wave breaking at shallow-water beaches},
+  author       = {Gidel, Floriane and Bokhove, Onno and Kelmanson, Mark},
+  booktitle    = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
+  date         = {2017},
+  doi          = {10.1115/omae2017-61974},
+  pages        = {V001T01A053},
+  title        = {Driven nonlinear potential flow with wave breaking at shallow-water beaches}
 }
 
 @misc{Gjerde2018,
-  author      = {Gjerde, Ingeborg G. and Kumar, Kundan and Nordbotten, Jan M. and Wohlmuth, Barbara},
-  url         = {https://arxiv.org/abs/1810.12979},
-  date        = {2018},
-  eprint      = {1810.12979},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {Splitting method for elliptic equations with line sources},
+  author       = {Gjerde, Ingeborg G. and Kumar, Kundan and Nordbotten, Jan M. and Wohlmuth, Barbara},
+  date         = {2018},
+  eprint       = {1810.12979},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {Splitting method for elliptic equations with line sources},
+  url          = {https://arxiv.org/abs/1810.12979}
 }
 
 @article{Harcourt2019,
@@ -476,41 +485,41 @@
   journaltitle = {Applied Energy},
   pages        = {873--884},
   title        = {Utilising the flexible generation potential of tidal range power plants to optimise economic value},
-  volume       = {237},
+  volume       = {237}
 }
 
 @article{He2020,
   author       = {He, Yunhui and MacLachlan, Scott},
-  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nla.2285},
   doi          = {10.1002/nla.2285},
   journaltitle = {Numerical Linear Algebra with Applications},
   keywords     = {finite-element method,higher-order elements,Jacobi iteration,local Fourier analysis,multigrid},
   pages        = {e2285},
   title        = {{Two-level Fourier analysis of multigrid for higher-order finite-element discretizations of the Laplacian}},
+  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nla.2285}
 }
 
 @article{Huber2020,
   author       = {Huber, Christian and Cano, Santiago and Teliban, Iulian and Schuschnigg, Stephan and Groenefeld, Martin and Suess, Dieter},
-  publisher    = {AIP Publishing},
-  url          = {http://dx.doi.org/10.1063/1.5139493},
   date         = {2020-02},
   doi          = {10.1063/1.5139493},
   issn         = {1089-7550},
   journaltitle = {Journal of Applied Physics},
   number       = {6},
   pages        = {063904},
+  publisher    = {AIP Publishing},
   title        = {{Polymer-bonded anisotropic SrFe12O19 filaments for fused filament fabrication}},
-  volume       = {127},
+  url          = {http://dx.doi.org/10.1063/1.5139493},
+  volume       = {127}
 }
 
 @misc{Iglesias2017,
-  author      = {Iglesias, José A. and Sturm, Kevin and Wechsung, Florian},
-  url         = {https://arxiv.org/abs/1710.06496},
-  date        = {2017},
-  eprint      = {1710.06496},
-  eprintclass = {math.OC},
-  eprinttype  = {arXiv},
-  title       = {Shape optimisation with nearly conformal transformations},
+  author       = {Iglesias, José A. and Sturm, Kevin and Wechsung, Florian},
+  date         = {2017},
+  eprint       = {1710.06496},
+  eprintclass  = {math.OC},
+  eprinttype   = {arXiv},
+  title        = {Shape optimisation with nearly conformal transformations},
+  url          = {https://arxiv.org/abs/1710.06496}
 }
 
 @article{Iglesias2018,
@@ -524,54 +533,53 @@
   number       = {6},
   pages        = {A3807--A3830},
   title        = {{Two-Dimensional Shape Optimization with Nearly Conformal Transformations}},
-  volume       = {40},
+  volume       = {40}
 }
 
 @misc{Jackaman2017,
-  author      = {Jackaman, James and Papamikos, Georgios and Pryor, Tristan},
-  url         = {https://arxiv.org/abs/1710.03527},
-  date        = {2017},
-  eprint      = {1710.03527},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{The design of conservative finite element discretisations for the vectorial modified KdV equation}},
+  author       = {Jackaman, James and Papamikos, Georgios and Pryor, Tristan},
+  date         = {2017},
+  eprint       = {1710.03527},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{The design of conservative finite element discretisations for the vectorial modified KdV equation}},
+  url          = {https://arxiv.org/abs/1710.03527}
 }
 
 @misc{Jackaman2018,
-  author      = {Jackaman, James and Pryor, Tristan},
-  url         = {https://arxiv.org/abs/1811.09999},
-  date        = {2018},
-  eprint      = {1811.09999},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Conservative Galerkin methods for dispersive Hamiltonian problems}},
+  author       = {Jackaman, James and Pryor, Tristan},
+  date         = {2018},
+  eprint       = {1811.09999},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Conservative Galerkin methods for dispersive Hamiltonian problems}},
+  url          = {https://arxiv.org/abs/1811.09999}
 }
 
 @article{Jacobs2015,
   author       = {Jacobs, Christian T. and Piggott, Matthew D.},
-  url          = {http://www.geosci-model-dev.net/8/533/2015/},
   date         = {2015},
   doi          = {10.5194/gmd-8-533-2015},
   journaltitle = {Geoscientific Model Development},
   number       = {3},
   pages        = {533--547},
   title        = {{Firedrake-Fluids} v0.1: numerical modelling of shallow water flows using an automated solution framework},
-  volume       = {8},
+  url          = {http://www.geosci-model-dev.net/8/533/2015/},
+  volume       = {8}
 }
 
 @misc{Joshaghani2018,
-  author      = {Joshaghani, M. S. and Joodat, S. H. S. and Nakshatrala, K. B.},
-  url         = {https://arxiv.org/abs/1805.01389},
-  date        = {2018},
-  eprint      = {1805.01389},
-  eprintclass = {cs.CE},
-  eprinttype  = {arXiv},
-  title       = {A stabilized mixed discontinuous Galerkin formulation for double porosity/permeability model},
+  author       = {Joshaghani, M. S. and Joodat, S. H. S. and Nakshatrala, K. B.},
+  date         = {2018},
+  eprint       = {1805.01389},
+  eprintclass  = {cs.CE},
+  eprinttype   = {arXiv},
+  title        = {A stabilized mixed discontinuous Galerkin formulation for double porosity/permeability model},
+  url          = {https://arxiv.org/abs/1805.01389}
 }
 
 @article{Joshaghani2019,
   author       = {Joshaghani, MS and Chang, J and Nakshatrala, KB and Knepley, Matthew G},
-  publisher    = {Elsevier},
   date         = {2019},
   doi          = {10.1016/j.jcp.2019.02.020},
   eprint       = {1808.08328},
@@ -579,68 +587,69 @@
   eprinttype   = {arXiv},
   journaltitle = {Journal of Computational Physics},
   pages        = {428--466},
+  publisher    = {Elsevier},
   title        = {Composable block solvers for the four-field double porosity/permeability model},
-  volume       = {386},
+  volume       = {386}
 }
 
 @article{Kalogirou2016,
   author       = {Kalogirou, Anna and Moulopoulou, Erietta E. and Bokhove, Onno},
-  url          = {http://www.sciencedirect.com/science/article/pii/S0307904X1630110X},
   date         = {2016},
   doi          = {10.1016/j.apm.2016.02.036},
   issn         = {0307-904X},
   journaltitle = {Applied Mathematical Modelling},
   pages        = {7493--7503},
   title        = {{Variational finite element methods for waves in a Hele–Shaw tank}},
+  url          = {http://www.sciencedirect.com/science/article/pii/S0307904X1630110X}
 }
 
 @inproceedings{Kalogirou2016a,
-  author    = {Kalogirou, Anna and Bokhove, Onno},
-  booktitle = {Proceedings of the ASME 2016 35th International Conference on Ocean, Offshore and Arctic Engineering},
-  date      = {2016},
-  doi       = {10.1115/OMAE2016-54937},
-  pages     = {V007T06A067},
-  title     = {Mathematical and numerical modelling of wave impact on wave-energy buoys},
+  author       = {Kalogirou, Anna and Bokhove, Onno},
+  booktitle    = {Proceedings of the ASME 2016 35th International Conference on Ocean, Offshore and Arctic Engineering},
+  date         = {2016},
+  doi          = {10.1115/OMAE2016-54937},
+  pages        = {V007T06A067},
+  title        = {Mathematical and numerical modelling of wave impact on wave-energy buoys}
 }
 
 @inproceedings{Kalogirou2017,
-  author    = {Kalogirou, Anna and Bokhove, Onno and Ham, David},
-  booktitle = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
-  date      = {2017},
-  doi       = {10.1115/omae2017-61966},
-  pages     = {V07AT06A060},
-  title     = {Modelling of Nonlinear Wave-Buoy Dynamics Using Constrained Variational Methods},
+  author       = {Kalogirou, Anna and Bokhove, Onno and Ham, David},
+  booktitle    = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
+  date         = {2017},
+  doi          = {10.1115/omae2017-61966},
+  pages        = {V07AT06A060},
+  title        = {Modelling of Nonlinear Wave-Buoy Dynamics Using Constrained Variational Methods}
 }
 
 @article{Karna2018,
   author       = {Kärnä, T. and Kramer, S. C. and Mitchell, L. and Ham, D. A. and Piggott, M. D. and Baptista, A. M.},
-  url          = {https://www.geosci-model-dev.net/11/4359/2018/},
   date         = {2018},
   doi          = {10.5194/gmd-11-4359-2018},
   journaltitle = {Geoscientific Model Development},
   number       = {11},
   pages        = {4359--4382},
   title        = {Thetis coastal ocean model: discontinuous Galerkin discretization for the three-dimensional hydrostatic equations},
-  volume       = {11},
+  url          = {https://www.geosci-model-dev.net/11/4359/2018/},
+  volume       = {11}
 }
 
 @thesis{Kater2019,
-  author      = {Kater, Andreas},
-  institution = {Christian-Albrechts Universität Kiel},
-  url         = {https://macau.uni-kiel.de/servlets/MCRFileNodeServlet/dissertation_derivate_00008486/kater_thesis.pdf},
-  date        = {2019},
-  title       = {Mathematical Modeling, Motion Planning and Control of Elastic Structures with Piezoelectric Elements},
-  type        = {phdthesis},
+  author       = {Kater, Andreas},
+  date         = {2019},
+  institution  = {Christian-Albrechts Universität Kiel},
+  title        = {Mathematical Modeling, Motion Planning and Control of Elastic Structures with Piezoelectric Elements},
+  type         = {phdthesis},
+  url          = {https://macau.uni-kiel.de/servlets/MCRFileNodeServlet/dissertation_derivate_00008486/kater_thesis.pdf}
 }
 
 @misc{Kawecki2017,
-  author      = {Kawecki, Ellya L.},
-  url         = {https://arxiv.org/abs/1711.01836},
-  date        = {2017},
-  eprint      = {1711.01836},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{A DGFEM for Uniformly Elliptic Two Dimensional Oblique Boundary Value Problems}},
+  author       = {Kawecki, Ellya L.},
+  date         = {2017},
+  eprint       = {1711.01836},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{A DGFEM for Uniformly Elliptic Two Dimensional Oblique Boundary Value Problems}},
+  url          = {https://arxiv.org/abs/1711.01836}
 }
 
 @article{Kawecki2019,
@@ -654,77 +663,77 @@
   number       = {5},
   pages        = {1717--1744},
   title        = {{A DGFEM for nondivergence form elliptic equations with Cordes coefficients on curved domains}},
-  volume       = {35},
+  volume       = {35}
 }
 
 @misc{Kawecki2019a,
-  author      = {Kawecki, Ellya L.},
-  url         = {https://arxiv.org/abs/1903.08735},
-  date        = {2019},
-  eprint      = {1903.08735},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Finite element theory on curved domains with applications to DGFEMs}},
+  author       = {Kawecki, Ellya L.},
+  date         = {2019},
+  eprint       = {1903.08735},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Finite element theory on curved domains with applications to DGFEMs}},
+  url          = {https://arxiv.org/abs/1903.08735}
 }
 
 @article{Kirby2020,
   author       = {Kirby, Robert C and Coogan, Peter},
-  publisher    = {Elsevier},
   date         = {2020},
   doi          = {10.1016/j.camwa.2019.11.011},
   journaltitle = {Computers \& Mathematics with Applications},
   number       = {8},
   pages        = {2458--2471},
+  publisher    = {Elsevier},
   title        = {{Optimal-order preconditioners for the Morse--Ingard equations}},
-  volume       = {79},
+  volume       = {79}
 }
 
 @inproceedings{Lange2015,
-  author      = {Lange, Michael and Knepley, Matthew G. and Gorman, Gerard J.},
-  location    = {Edinburgh, UK},
-  publisher   = {University of Edinburgh},
-  url         = {http://dl.acm.org/citation.cfm?id=2820083.2820097},
-  booktitle   = {Proceedings of the 3rd International Conference on Exascale Applications and Software},
-  date        = {2015},
-  eprint      = {1505.04633},
-  eprintclass = {cs.MS},
-  eprinttype  = {arXiv},
-  isbn        = {978-0-9926615-1-9},
-  pages       = {71--76},
-  series      = {EASC '15},
-  title       = {{Flexible, Scalable Mesh and Data Management Using PETSc DMPlex}},
+  author       = {Lange, Michael and Knepley, Matthew G. and Gorman, Gerard J.},
+  booktitle    = {Proceedings of the 3rd International Conference on Exascale Applications and Software},
+  date         = {2015},
+  eprint       = {1505.04633},
+  eprintclass  = {cs.MS},
+  eprinttype   = {arXiv},
+  isbn         = {978-0-9926615-1-9},
+  location     = {Edinburgh, UK},
+  pages        = {71--76},
+  publisher    = {University of Edinburgh},
+  series       = {EASC '15},
+  title        = {{Flexible, Scalable Mesh and Data Management Using PETSc DMPlex}},
+  url          = {http://dl.acm.org/citation.cfm?id=2820083.2820097}
 }
 
 @misc{Loe2019,
-  author      = {Loe, Jennifer A. and Thornquist, Heidi K. and Boman, Erik G.},
-  url         = {https://arxiv.org/abs/1907.00072},
-  date        = {2019},
-  eprint      = {1907.00072},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Polynomial Preconditioned GMRES to Reduce Communication in Parallel Computing}},
+  author       = {Loe, Jennifer A. and Thornquist, Heidi K. and Boman, Erik G.},
+  date         = {2019},
+  eprint       = {1907.00072},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Polynomial Preconditioned GMRES to Reduce Communication in Parallel Computing}},
+  url          = {https://arxiv.org/abs/1907.00072}
 }
 
 @article{Maddison2019,
   author       = {Maddison, James R and Goldberg, Daniel N and Goddard, Benjamin D},
-  publisher    = {SIAM},
   date         = {2019},
   doi          = {10.1137/18M1209465},
   journaltitle = {SIAM Journal on Scientific Computing},
   number       = {5},
   pages        = {C417--C445},
+  publisher    = {SIAM},
   title        = {{Automated Calculation of Higher Order Partial Differential Equation Constrained Derivative Information}},
-  volume       = {41},
+  volume       = {41}
 }
 
 @misc{Mapakshi2017,
-  author      = {Mapakshi, N. K. and Chang, J. and Nakshatrala, K. B.},
-  url         = {https://arxiv.org/abs/1710.02620},
-  date        = {2017},
-  eprint      = {1710.02620},
-  eprintclass = {cs.ME},
-  eprinttype  = {arXiv},
-  title       = {A scalable variational inequality approach for flow through porous media models with pressure-dependent viscosity},
+  author       = {Mapakshi, N. K. and Chang, J. and Nakshatrala, K. B.},
+  date         = {2017},
+  eprint       = {1710.02620},
+  eprintclass  = {cs.ME},
+  eprinttype   = {arXiv},
+  title        = {A scalable variational inequality approach for flow through porous media models with pressure-dependent viscosity},
+  url          = {https://arxiv.org/abs/1710.02620}
 }
 
 @article{McCormack2018,
@@ -734,12 +743,11 @@
   journaltitle = {Advances in Water Resources},
   pages        = {236--248},
   title        = {{Modeling the poroelastic response to megathrust earthquakes: A look at the 2012 Mw 7.6 Costa Rican event}},
-  volume       = {114},
+  volume       = {114}
 }
 
 @article{McRae2018,
   author       = {McRae, Andrew T. T. and Cotter, Colin J. and Budd, Chris J.},
-  url          = {http://arxiv.org/abs/1612.08077},
   date         = {2018},
   doi          = {10.1137/16M1109515},
   eprint       = {1612.08077},
@@ -749,12 +757,12 @@
   number       = {2},
   pages        = {A1121--A1148},
   title        = {{Optimal-Transport-Based Mesh Adaptivity on the Plane and Sphere Using Finite Elements}},
-  volume       = {40},
+  url          = {http://arxiv.org/abs/1612.08077},
+  volume       = {40}
 }
 
 @article{Natale2016,
   author       = {Natale, Andrea and Shipton, Jemma and Cotter, Colin J.},
-  url          = {http://arxiv.org/abs/1605.00551},
   date         = {2016},
   doi          = {10.1093/climsys/dzw005},
   eprint       = {1605.00551},
@@ -763,12 +771,12 @@
   issue        = {1},
   journaltitle = {Dynamics and Statistics of the Climate System},
   title        = {Compatible finite element spaces for geophysical fluid dynamics},
-  volume       = {1},
+  url          = {http://arxiv.org/abs/1605.00551},
+  volume       = {1}
 }
 
 @article{Natale2016a,
   author       = {Natale, Andrea and Cotter, Colin J.},
-  url          = {http://arxiv.org/abs/1611.02623},
   date         = {2017},
   doi          = {10.1002/qj.3063},
   eprint       = {1611.02623},
@@ -776,6 +784,7 @@
   eprinttype   = {arXiv},
   journaltitle = {Quarterly Journal of the Royal Meteorological Society},
   title        = {Scale-selective dissipation in energy-conserving finite element schemes for two-dimensional turbulence},
+  url          = {http://arxiv.org/abs/1611.02623}
 }
 
 @article{Natale2017,
@@ -784,17 +793,17 @@
   doi          = {10.1093/imanum/drx033},
   journaltitle = {IMA Journal of Numerical Analysis},
   pages        = {drx033},
-  title        = {{A variational $H(\mathrm{div})$ finite-element discretization approach for perfect incompressible fluids}},
+  title        = {{A variational $H(\mathrm{div})$ finite-element discretization approach for perfect incompressible fluids}}
 }
 
 @misc{Natale2020,
-  author      = {Natale, Andrea and Todeschi, Gabriele},
-  url         = {https://arxiv.org/abs/2003.04558},
-  date        = {2020},
-  eprint      = {2003.04558},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {A mixed finite element discretization of dynamical optimal transport},
+  author       = {Natale, Andrea and Todeschi, Gabriele},
+  date         = {2020},
+  eprint       = {2003.04558},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {A mixed finite element discretization of dynamical optimal transport},
+  url          = {https://arxiv.org/abs/2003.04558}
 }
 
 @article{Ovchinnikov2019,
@@ -807,7 +816,7 @@
   issue        = {1},
   journaltitle = {Russian Journal of Numerical Analysis and Mathematical Modelling},
   title        = {Robust regularization of topology optimization problems with a posteriori error estimators},
-  volume       = {34},
+  volume       = {34}
 }
 
 @article{Paganini2018,
@@ -820,7 +829,7 @@
   journaltitle = {SIAM Journal on Scientific Computing},
   number       = {4},
   title        = {{Higher-order moving mesh methods for PDE-constrained shape optimization}},
-  volume       = {40},
+  volume       = {40}
 }
 
 @article{Pan2019,
@@ -831,29 +840,29 @@
   journaltitle = {Ocean Modelling},
   pages        = {68--83},
   title        = {{Multi-layer non-hydrostatic free surface modelling using the discontinuous Galerkin method}},
-  volume       = {134},
+  volume       = {134}
 }
 
 @inproceedings{Park2019,
-  author    = {Park, Michael A and Balan, Aravind and Anderson, William K and Galbraith, Marshall C and Caplan, Philip and Carson, Hugh A and Michal, Todd R and Krakos, Joshua A and Kamenetskiy, Dmitry S and Loseille, Adrien and others},
-  booktitle = {AIAA Scitech 2019 Forum},
-  date      = {2019},
-  pages     = {1723},
-  title     = {Verification of unstructured grid adaptation components},
+  author       = {Park, Michael A and Balan, Aravind and Anderson, William K and Galbraith, Marshall C and Caplan, Philip and Carson, Hugh A and Michal, Todd R and Krakos, Joshua A and Kamenetskiy, Dmitry S and Loseille, Adrien and others},
+  booktitle    = {AIAA Scitech 2019 Forum},
+  date         = {2019},
+  doi          = {10.2514/6.2019-1723},
+  pages        = {1723},
+  title        = {Verification of unstructured grid adaptation components}
 }
 
 @thesis{Pembery2019,
-  author      = {Pembery, Owen Rhys},
-  institution = {University of Bath},
-  url         = {http://www.bath.ac.uk/~masigg/theses/Pembery_thesis.pdf},
-  date        = {2019},
-  title       = {{The Helmholtz Equation in Heterogeneous and Random Media: Analysis and Numerics}},
-  type        = {phdthesis},
+  author       = {Pembery, Owen Rhys},
+  date         = {2019},
+  institution  = {University of Bath},
+  title        = {{The Helmholtz Equation in Heterogeneous and Random Media: Analysis and Numerics}},
+  type         = {phdthesis},
+  url          = {http://www.bath.ac.uk/~masigg/theses/Pembery_thesis.pdf}
 }
 
 @article{Pimanov2018,
   author       = {Pimanov, V. and Oseledets, I.},
-  url          = {https://arxiv.org/abs/1712.03017},
   date         = {2018},
   doi          = {10.1007/s00158-018-1985-4},
   eprint       = {1712.03017},
@@ -862,7 +871,8 @@
   issue        = {4},
   journaltitle = {Structural and Multidisciplinary Optimization},
   title        = {{Robust topology optimization using a posteriori error estimator for the finite element method}},
-  volume       = {58},
+  url          = {https://arxiv.org/abs/1712.03017},
+  volume       = {58}
 }
 
 @article{Roy2019,
@@ -876,49 +886,49 @@
   journaltitle = {Journal of Computational Physics},
   pages        = {636--652},
   title        = {A block preconditioner for non-isothermal flow in porous media},
-  volume       = {395},
+  volume       = {395}
 }
 
 @misc{Roy2019a,
-  author      = {Roy, Thomas and Jönsthövel, Tom B and Lemon, Christopher and Wathen, Andrew J},
-  url         = {https://arxiv.org/abs/1907.04229},
-  date        = {2019},
-  eprint      = {1907.04229},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{A constrained pressure-temperature residual (CPTR) method for non-isothermal multiphase flow in porous media}},
+  author       = {Roy, Thomas and Jönsthövel, Tom B and Lemon, Christopher and Wathen, Andrew J},
+  date         = {2019},
+  eprint       = {1907.04229},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{A constrained pressure-temperature residual (CPTR) method for non-isothermal multiphase flow in porous media}},
+  url          = {https://arxiv.org/abs/1907.04229}
 }
 
 @thesis{Roy2019b,
-  author      = {Roy, Thomas},
-  institution = {University of Oxford},
-  url         = {https://ora.ox.ac.uk/objects/uuid:478d84ed-fd67-4fd5-ba69-b7c962792c67},
-  date        = {2019},
-  title       = {Preconditioning for thermal reservoir simulation},
-  type        = {phdthesis},
+  author       = {Roy, Thomas},
+  date         = {2019},
+  institution  = {University of Oxford},
+  title        = {Preconditioning for thermal reservoir simulation},
+  type         = {phdthesis},
+  url          = {https://ora.ox.ac.uk/objects/uuid:478d84ed-fd67-4fd5-ba69-b7c962792c67}
 }
 
 @article{Saak2019,
   author       = {Saak, Jens and Siebelts, Dirk and Werner, Steffen W. R.},
-  location     = {Berlin, Boston},
-  publisher    = {De Gruyter},
-  url          = {https://doi.org/10.1515/auto-2019-0027},
   date         = {2019},
   doi          = {10.1515/auto-2019-0027},
   journaltitle = {at - Automatisierungstechnik},
+  location     = {Berlin, Boston},
   number       = {8},
   pages        = {648--667},
+  publisher    = {De Gruyter},
   title        = {A comparison of second-order model order reduction methods for an artificial fishtail},
-  volume       = {67},
+  url          = {https://doi.org/10.1515/auto-2019-0027},
+  volume       = {67}
 }
 
 @inproceedings{Salwa2016,
-  author    = {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark A.},
-  booktitle = {Proceedings of the 35th International Conference on Offshore Mechanics and Arctic Engineering},
-  date      = {2016-06},
-  doi       = {10.1115/OMAE2016-54897},
-  title     = {{Variational modelling of wave-structure interactions for offshore wind turbines}},
-  volume    = {Volume 6: Ocean Space Utilization; Ocean Renewable Energy},
+  author       = {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark A.},
+  booktitle    = {Proceedings of the 35th International Conference on Offshore Mechanics and Arctic Engineering},
+  date         = {2016-06},
+  doi          = {10.1115/OMAE2016-54897},
+  title        = {{Variational modelling of wave-structure interactions for offshore wind turbines}},
+  volume       = {Volume 6: Ocean Space Utilization; Ocean Renewable Energy}
 }
 
 @article{Salwa2017,
@@ -927,26 +937,26 @@
   doi          = {10.1007/s10665-017-9936-4},
   issn         = {1573-2703},
   journaltitle = {Journal of Engineering Mathematics},
-  title        = {{Variational modelling of wave--structure interactions with an offshore wind-turbine mast}},
+  title        = {{Variational modelling of wave--structure interactions with an offshore wind-turbine mast}}
 }
 
 @book{Schwedes2017,
-  author    = {Schwedes, Tobias and Ham, David A. and Funke, Simon W. and Piggott, Matthew D.},
-  publisher = {Springer International Publishing},
-  url       = {https://doi.org/10.1007/978-3-319-59483-5},
-  date      = {2017},
-  doi       = {10.1007/978-3-319-59483-5},
-  title     = {Mesh Dependence in {PDE}-Constrained Optimisation},
+  author       = {Schwedes, Tobias and Ham, David A. and Funke, Simon W. and Piggott, Matthew D.},
+  date         = {2017},
+  doi          = {10.1007/978-3-319-59483-5},
+  publisher    = {Springer International Publishing},
+  title        = {Mesh Dependence in {PDE}-Constrained Optimisation},
+  url          = {https://doi.org/10.1007/978-3-319-59483-5}
 }
 
 @misc{Shipton2017,
-  author      = {Shipton, J. and Cotter, C. J.},
-  url         = {https://arxiv.org/abs/1707.00855},
-  date        = {2017},
-  eprint      = {1707.00855},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {{Higher-order compatible finite element schemes for the nonlinear rotating shallow water equations on the sphere}},
+  author       = {Shipton, J. and Cotter, C. J.},
+  date         = {2017},
+  eprint       = {1707.00855},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {{Higher-order compatible finite element schemes for the nonlinear rotating shallow water equations on the sphere}},
+  url          = {https://arxiv.org/abs/1707.00855}
 }
 
 @article{Siebelts2018,
@@ -959,83 +969,83 @@
   number       = {2},
   pages        = {319--324},
   title        = {{Modeling and Motion Planning for an Artificial Fishtail}},
-  volume       = {51},
+  volume       = {51}
 }
 
 @misc{Valseth2020,
-  author      = {Valseth, Eirik and Romkes, Albert},
-  url         = {https://arxiv.org/abs/2003.10904},
-  date        = {2020},
-  eprint      = {2003.10904},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {Goal-Oriented Error Estimation for the Automatic Variationally Stable FE Method for Convection-Dominated Diffusion Problems},
+  author       = {Valseth, Eirik and Romkes, Albert},
+  date         = {2020},
+  eprint       = {2003.10904},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {Goal-Oriented Error Estimation for the Automatic Variationally Stable FE Method for Convection-Dominated Diffusion Problems},
+  url          = {https://arxiv.org/abs/2003.10904}
 }
 
 @article{Vouriot2019,
   author       = {Vouriot, Carolanne VM and Angeloudis, Athanasios and Kramer, Stephan C and Piggott, Matthew D},
-  publisher    = {Springer},
   date         = {2019},
+  doi          = {10.1007/s10652-018-9626-4},
   journaltitle = {Environmental Fluid Mechanics},
   number       = {2},
   pages        = {329--348},
+  publisher    = {Springer},
   title        = {Fate of large-scale vortices in idealized tidal lagoons},
-  volume       = {19},
+  volume       = {19}
 }
 
 @article{Wallwork2019,
-  author    = {Wallwork, Joseph and Barral, Nicolas and Kramer, Stephan and Ham, David and Piggott, Matthew},
-  publisher = {EarthArXiv},
-  date      = {2019},
-  doi       = {10.31223/osf.io/cs4we},
-  title     = {Goal-oriented Error Estimation and Mesh Adaptation for Shallow Water Modelling},
+  author       = {Wallwork, Joseph and Barral, Nicolas and Kramer, Stephan and Ham, David and Piggott, Matthew},
+  date         = {2019},
+  doi          = {10.31223/osf.io/cs4we},
+  publisher    = {EarthArXiv},
+  title        = {Goal-oriented Error Estimation and Mesh Adaptation for Shallow Water Modelling}
 }
 
 @inproceedings{Wallwork2020,
-  author    = {Wallwork, Joseph G and Barral, Nicolas and Ham, David A and Piggott, Matthew D},
-  publisher = {Zenodo},
-  url       = {https://doi.org/10.5281/zenodo.3653373},
-  booktitle = {Proceedings of the 28th International Meshing Roundtable},
-  date      = {2020-02},
-  doi       = {10.5281/zenodo.3653373},
-  pages     = {83--100},
-  title     = {Anisotropic Goal-Oriented Mesh Adaptation in Firedrake},
+  author       = {Wallwork, Joseph G and Barral, Nicolas and Ham, David A and Piggott, Matthew D},
+  booktitle    = {Proceedings of the 28th International Meshing Roundtable},
+  date         = {2020-02},
+  doi          = {10.5281/zenodo.3653373},
+  pages        = {83--100},
+  publisher    = {Zenodo},
+  title        = {Anisotropic Goal-Oriented Mesh Adaptation in Firedrake},
+  url          = {https://doi.org/10.5281/zenodo.3653373}
 }
 
 @misc{Wimmer2019,
-  author      = {Wimmer, Golo and Cotter, Colin and Bauer, Werner},
-  url         = {https://arxiv.org/abs/1901.06349},
-  date        = {2019},
-  eprint      = {1901.06349},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {Energy conserving upwinded compatible finite element schemes for the rotating shallow water equations},
+  author       = {Wimmer, Golo and Cotter, Colin and Bauer, Werner},
+  date         = {2019},
+  eprint       = {1901.06349},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {Energy conserving upwinded compatible finite element schemes for the rotating shallow water equations},
+  url          = {https://arxiv.org/abs/1901.06349}
 }
 
 @misc{Wimmer2020,
-  author      = {Wimmer, Golo A. and Cotter, Colin J. and Bauer, Werner},
-  url         = {https://arxiv.org/abs/2001.09590},
-  date        = {2020},
-  eprint      = {2001.09590},
-  eprintclass = {math.NA},
-  eprinttype  = {arXiv},
-  title       = {Energy conserving SUPG methods for compatible finite element schemes in numerical weather prediction},
+  author       = {Wimmer, Golo A. and Cotter, Colin J. and Bauer, Werner},
+  date         = {2020},
+  eprint       = {2001.09590},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  title        = {Energy conserving SUPG methods for compatible finite element schemes in numerical weather prediction},
+  url          = {https://arxiv.org/abs/2001.09590}
 }
 
 @article{Xia2020,
   author       = {Xia, Jingmin and Farrell, Patrick E and Castro, Saullo GP},
-  publisher    = {Elsevier},
   date         = {2020},
   doi          = {10.1016/j.tws.2020.106662},
   journaltitle = {Thin-Walled Structures},
   pages        = {106662},
+  publisher    = {Elsevier},
   title        = {Nonlinear bifurcation analysis of stiffener profiles via deflation techniques},
-  volume       = {149},
+  volume       = {149}
 }
 
 @article{Yamazaki2017,
   author       = {Yamazaki, Hiroe and Shipton, Jemma and Cullen, Michael J. P. and Mitchell, Lawrence and Cotter, Colin J.},
-  url          = {http://arxiv.org/abs/1611.04929},
   date         = {2017},
   doi          = {10.1016/j.jcp.2017.04.006},
   eprint       = {1611.04929},
@@ -1044,26 +1054,27 @@
   journaltitle = {Journal of Computational Physics},
   pages        = {130--149},
   title        = {{Vertical slice modelling of nonlinear Eady waves using a compatible finite element method}},
-  volume       = {343},
+  url          = {http://arxiv.org/abs/1611.04929},
+  volume       = {343}
 }
 
 @misc{Zhang2019,
-  author      = {Zhang, Hong and Constantinescu, Emil M. and Smith, Barry F.},
-  url         = {https://arxiv.org/abs/1912.07696},
-  date        = {2019},
-  eprint      = {1912.07696},
-  eprintclass = {cs.MS},
-  eprinttype  = {arXiv},
-  title       = {PETSc TSAdjoint: a discrete adjoint ODE solver for first-order and second-order sensitivity analysis},
+  author       = {Zhang, Hong and Constantinescu, Emil M. and Smith, Barry F.},
+  date         = {2019},
+  eprint       = {1912.07696},
+  eprintclass  = {cs.MS},
+  eprinttype   = {arXiv},
+  title        = {PETSc TSAdjoint: a discrete adjoint ODE solver for first-order and second-order sensitivity analysis},
+  url          = {https://arxiv.org/abs/1912.07696}
 }
 
 @misc{Zimmerman2019,
-  author      = {Zimmerman, Alexander Gary and Kowalski, Julia},
-  url         = {https://arxiv.org/abs/1907.04414},
-  date        = {2019},
-  eprint      = {1907.04414},
-  eprintclass = {physics.comp-ph},
-  eprinttype  = {arXiv},
-  title       = {Simulating convection-coupled phase-change in enthalpy form with mixed finite elements},
+  author       = {Zimmerman, Alexander Gary and Kowalski, Julia},
+  date         = {2019},
+  eprint       = {1907.04414},
+  eprintclass  = {physics.comp-ph},
+  eprinttype   = {arXiv},
+  title        = {Simulating convection-coupled phase-change in enthalpy form with mixed finite elements},
+  url          = {https://arxiv.org/abs/1907.04414}
 }
 

--- a/docs/source/_static/firedrake-apps.bib
+++ b/docs/source/_static/firedrake-apps.bib
@@ -1,1239 +1,1069 @@
-@InProceedings{Andrej2018,
-  author =       {J. {Andrej} and T. {Meurer}},
-  title =        {Flatness-based constrained optimal control of
-                  reaction-diffusion systems},
-  booktitle =    {2018 Annual American Control Conference (ACC)},
-  year =         2018,
-  pages =        {2539-2544},
-  month =        {June},
-  doi =          {10.23919/ACC.2018.8431201},
-  issn =         {2378-5861},
+@inproceedings{Andrej2018,
+  author    = {{Andrej}, J. and {Meurer}, T.},
+  booktitle = {2018 Annual American Control Conference (ACC)},
+  date      = {2018-06},
+  doi       = {10.23919/ACC.2018.8431201},
+  issn      = {2378-5861},
+  pages     = {2539--2544},
+  title     = {Flatness-based constrained optimal control of reaction-diffusion systems},
 }
 
-@PhdThesis{Andrej2019,
-  author =    {Andrej, Julian},
-  title =     {Modeling and optimal control of multiphysics 
-              problems using the finite element method},
-  year =      {2019},
-  keywords =  {finite element method; FEM; flatness-based control; 
-              optimal control; multiphysics; control theory},
-  url =       {https://macau.uni-kiel.de/receive/diss_mods_00025104}
+@thesis{Andrej2019,
+  author   = {Andrej, Julian},
+  url      = {https://macau.uni-kiel.de/receive/diss_mods_00025104},
+  date     = {2019},
+  keywords = {finite element method; FEM; flatness-based control; optimal control; multiphysics; control theory},
+  title    = {Modeling and optimal control of multiphysics problems using the finite element method},
+  type     = {phdthesis},
 }
 
-@Misc{Angeloudis2017,
-  author =       {Athanasios Angeloudis and Matthew D. Piggott and
-                  Stephan C. Kramer and Alexandros Avdis and Daniel
-                  Coles and Marios Christou},
-  title =        {{Comparison of 0-D, 1-D and 2-D model capabilities
-                  for tidal range energy resource assessments}},
-  year =         2017,
-  eprint =       {sjxf4},
-  archiveprefix ={EarthArXiv},
-  doi =          {10.17605/osf.io/sjxf4}
+@misc{Angeloudis2017,
+  author     = {Angeloudis, Athanasios and Piggott, Matthew D. and Kramer, Stephan C. and Avdis, Alexandros and Coles, Daniel and Christou, Marios},
+  date       = {2017},
+  doi        = {10.17605/osf.io/sjxf4},
+  eprint     = {sjxf4},
+  eprinttype = {EarthArXiv},
+  title      = {{Comparison of 0-D, 1-D and 2-D model capabilities for tidal range energy resource assessments}},
 }
 
-@Article{Angeloudis2018,
-  author =       {Athanasios Angeloudis and Stephan C. Kramer and
-                  Alexandros Avdis and Matthew D. Piggott},
-  title =        {Optimising tidal range power plant operation},
-  journal =      {Applied Energy},
-  year =         2018,
-  volume =       212,
-  pages =        {680 - 690},
-  issn =         {0306-2619},
-  doi =          {10.1016/j.apenergy.2017.12.052},
+@article{Angeloudis2018,
+  author       = {Angeloudis, Athanasios and Kramer, Stephan C. and Avdis, Alexandros and Piggott, Matthew D.},
+  date         = {2018},
+  doi          = {10.1016/j.apenergy.2017.12.052},
+  issn         = {0306-2619},
+  journaltitle = {Applied Energy},
+  pages        = {680--690},
+  title        = {Optimising tidal range power plant operation},
+  volume       = {212},
 }
 
-@InProceedings{Angeloudis2018a,
-  author =       {Angeloudis, A and Hawkins, N and Kramer, SC and
-                  Piggott, MD},
-  title =        {Comparison of twin-basin lagoon systems against
-                  conventional tidal power plant designs},
-  booktitle =    {Advances in Renewable Energies Offshore: Proceedings
-                  of the 3rd International Conference on Renewable
-                  Energies Offshore (RENEW 2018), October 8-10, 2018,
-                  Lisbon, Portugal},
-  year =         2018,
-  pages =        159,
-  organization = {CRC Press}
+@inproceedings{Angeloudis2018a,
+  author       = {Angeloudis, A and Hawkins, N and Kramer, SC and Piggott, MD},
+  organization = {CRC Press},
+  booktitle    = {Advances in Renewable Energies Offshore: Proceedings of the 3rd International Conference on Renewable Energies Offshore (RENEW 2018), October 8-10, 2018, Lisbon, Portugal},
+  date         = {2018},
+  pages        = {159},
+  title        = {Comparison of twin-basin lagoon systems against conventional tidal power plant designs},
 }
 
-@Article{Angeloudis2019,
-  author =       {Angeloudis, Athanasios},
-  title =        {Tidal range structure operation assessment and
-                  optimisation},
-  journal =      {Dams and Reservoirs},
-  year =         2019,
-  volume =       29,
-  number =       2,
-  pages =        {45-54},
-  doi =          {10.1680/jdare.18.00042},
+@article{Angeloudis2019,
+  author       = {Angeloudis, Athanasios},
+  date         = {2019},
+  doi          = {10.1680/jdare.18.00042},
+  journaltitle = {Dams and Reservoirs},
+  number       = {2},
+  pages        = {45--54},
+  title        = {Tidal range structure operation assessment and optimisation},
+  volume       = {29},
 }
 
-@Article{Angeloudis2020,
-  title =     {On the potential of linked-basin tidal power plants:
-              an operational and coastal modelling assessment},
-  author =    {Angeloudis, Athanasios and Kramer, Stephan C 
-              and Hawkins, Noah and Piggott, Matthew},
-  year =      {2020},
+@article{Angeloudis2020,
+  author    = {Angeloudis, Athanasios and Kramer, Stephan C and Hawkins, Noah and Piggott, Matthew},
   publisher = {EarthArXiv},
-  doi =       {10.31223/osf.io/ancu8}
+  date      = {2020},
+  doi       = {10.31223/osf.io/ancu8},
+  title     = {On the potential of linked-basin tidal power plants: an operational and coastal modelling assessment},
 }
 
-@Article{Baker2020,
-  title =     {Modelling the ecological impacts of tidal energy barrages},
-  author =    {Baker, Amy L and Craighead, Robert M and Jarvis, Emma J and
-              Stenton, Harriett C and Angeloudis, Athanasios and Mackie, Lucas
-              and Avdis, Alexandros and Piggott, Matthew and Hill, Jon},
-  year =      {2020},
+@article{Baker2020,
+  author    = {Baker, Amy L and Craighead, Robert M and Jarvis, Emma J and Stenton, Harriett C and Angeloudis, Athanasios and Mackie, Lucas and Avdis, Alexandros and Piggott, Matthew and Hill, Jon},
   publisher = {EarthArXiv},
-  doi =       {10.31223/osf.io/vapmu},
-  url =       {https://doi.org/10.31223/osf.io/vapmu}
-}
-
-@Misc{Barral2016,
-  author =       {Barral, Nicolas and Knepley, Matthew G and Lange,
-                  Michael and Piggott, Matthew D and Gorman, Gerard J},
-  title =        {{Anisotropic mesh adaptation in Firedrake with PETSc
-                  DMPlex}},
-  year =         2016,
-  primaryclass = {math.NA},
-  eprint =       {1610.09874},
-  archiveprefix ={arXiv},
-  url =          {http://arxiv.org/abs/1610.09874},
-}
-
-@Misc{Bauer2018,
-  author =       {Werner Bauer and Colin J. Cotter},
-  title =        {{Energy-enstrophy conserving compatible finite
-                  element schemes for the shallow water equations on
-                  rotating domains with boundaries}},
-  year =         2018,
-  archiveprefix ={arXiv},
-  eprint =       {1801.00691},
-  primaryclass = {math.NA},
-  url =          {https://arxiv.org/abs/1801.00691}
-}
-
-@Misc{Bendall2017,
-  author =       {Bendall, Thomas M and Cotter, Colin J},
-  title =        {{Statistical properties of an enstrophy conserving
-                  discretisation for the stochastic quasi-geostrophic
-                  equation}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1710.04845},
-  primaryclass = {math.NA}
-}
-
-@Article{Bendall2019,
-  title =     {The `recovered space' advection scheme for
-              lowest-order compatible finite element methods},
-  author =    {Bendall, Thomas M and Cotter, Colin J and Shipton, Jemma},
-  journal =   {Journal of Computational Physics},
-  volume =    {390},
-  pages =     {342--358},
-  year =      {2019},
-  publisher = {Elsevier},
-  doi = {10.1016/j.jcp.2019.04.013}
-}
-
-@Misc{Bendall2019b,
-    title =         {{A Compatible Finite Element Discretisation
-                     for the Moist Compressible Euler Equations}},
-    author =        {Thomas M. Bendall and Thomas H. Gibson and
-                     Jemma Shipton and Colin J. Cotter and Ben Shipway},
-    year =          {2019},
-    eprint =        {1910.01857},
-    archivePrefix = {arXiv},
-    primaryClass =  {math.NA}
-}
-
-@PhdThesis{Betteridge2019,
-  title =   {{Efficient elliptic solvers for higher order DG discretisations 
-          on modern architectures and applications in atmospheric modelling}},
-  author =  {Betteridge, Jack},
-  year =    {2019},
-  file =    {https://people.bath.ac.uk/masigg/theses/Betteridge_thesis.pdf}
-}
-
-@Misc{Bihlo2019,
-  author =       {Alex Bihlo and James Jackaman and Francis
-                  Valiquette},
-  title =        {On the development of symmetry-preserving finite
-                  element schemes for ordinary differential equations},
-  year =         2019,
-  eprint =       {1907.00961},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-}
-
-@InProceedings{Bokhove2016,
-  author =       {Onno Bokhove and Anna Kalogirou},
-  title =        {Variational water wave modelling: from continuum to
-                  experiment},
-  booktitle =    {Lectures on the theory of water waves},
-  year =         2016,
-  editor =       {Thomas J. Bridges and Mark D. Groves and David P.
-                  Nicholls},
-  volume =       426,
-  series =       {LMS Lecture Note Series},
-  pages =        {226--260},
-  publisher =    {Cambridge University Press},
-  url =
-                  {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf}
-}
-
-@Article{Braun2017,
-  author =       {Moritz Braun and Kingsley O. Obodo},
-  title =        {Multi-domain muffin tin finite element density
-                  functional calculations for small molecules},
-  journal =      {Computers & Mathematics with Applications},
-  year =         2017,
-  issn =         {0898-1221},
-  doi =          {10.1016/j.camwa.2016.12.003},
-  url =
-                  {http://www.sciencedirect.com/science/article/pii/S0898122116306745},
-}
-
-@Misc{Brugnoli2020,
-  title =         {{Port-Hamiltonian flexible multibody dynamics}},
-  author =        {Andrea Brugnoli and Daniel Alazar and 
-                  Valérie Pommier-Budinger and Denis Matignon},
-  year =          {2020},
-  eprint =        {2002.12816},
-  archivePrefix = {arXiv},
-  primaryClass =  {physics.class-ph}
-}
-
-@Article{Budd2018,
-  author =       {Budd, Chris J. and McRae, Andrew T.T. and Cotter,
-                  Colin J.},
-  title =        {{The scaling and skewness of optimally transported
-                  meshes on the sphere}},
-  journal =      {Journal of Computational Physics},
-  year =         2018,
-  volume =       375,
-  pages =        {540--564},
-  doi =          {10.1016/j.jcp.2018.08.028},
-  eprint =       {1711.00260},
-  archiveprefix ={arXiv}
-}
-
-@Article{Chang2017,
-  author =       {Chang, J. and Nakshatrala, K.B. and Knepley, M.G.
-                  and Johnsson, L.},
-  title =        {A performance spectrum for parallel computational
-                  frameworks that solve PDEs},
-  journal =      {Concurrency and Computation: Practice and
-                  Experience},
-  year =         2017,
-  volume =       30,
-  number =       11,
-  pages =        {e4401},
-  keywords =     {finite element methods, hardware architecture, high
-                  performance computing, parallel computing,
-                  scientific software, solvers and preconditioners},
-  doi =          {10.1002/cpe.4401},
-  url =
-                  {https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.4401},
-  eprint =       {1705.03625},
-  archiveprefix ={arXiv},
-}
-
-@Article{Chang2017a,
-  author =       {J. Chang and K.B. Nakshatrala},
-  title =        {Variational inequality approach to enforcing the
-                  non-negative constraint for advection–diffusion
-                  equations},
-  journal =      {Computer Methods in Applied Mechanics and
-                  Engineering},
-  year =         2017,
-  volume =       320,
-  pages =        {287-334},
-  issn =         {0045-7825},
-  eprint =       {1611.08758},
-  archiveprefix ={arXiv},
-  primaryclass = {cs.CE},
-  doi =          {10.1016/j.cma.2017.03.022},
-}
-
-@PhdThesis{Chang2017b,
-  author =       {Justin Chang},
-  title =        {Structure-preserving high performance computational
-                  methods for transport in porous media},
-  school =       {University of Houston},
-  year =         2017
-}
-
-@Misc{Chang2018,
-  author =       {J. Chang and M. S. Fabian and M. G. Knepley and R.
-                  T. Mills},
-  title =        {{Comparative study of finite element methods using
-                  the Time-Accuracy-Size (TAS) spectrum analysis}},
-  year =         2018,
-  archiveprefix ={arXiv},
-  primaryclass = {cs.MS},
-  eprint =       {1802.07832},
-  url =          {https://arxiv.org/abs/1802.07832}
-}
-
-@Misc{Chaudhry2020,
-  title =         {{A Least-Squares Finite Element Reduced Basis Method}},
-  author =        {Jehanzeb Hameed Chaudhry and Luke N. Olson and Peter Sentz},
-  year =          {2020},
-  eprint =        {2003.04555},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
-}
-
-@Misc{Chiw2017,
-  author =       {Charisee Chiw and Gordon Kindlmann and John Reppy},
-  title =        {{An exploiration to visualize finite element data
-                  with a DSL}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1706.05718},
-  primaryclass = {cs.HC}
-}
-
-@Misc{Collin2019,
-  title =         {{An Adaptive Savitsky-Golay Filter for Smoothing
-                   Finite Element Computation}},
-  author =        {Teodoro Collin and Gordon Kindlmann and
-                   L. Ridgway Scott},
-  year =          {2019},
-  eprint =        {1911.00790},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
-}
-
-@InProceedings{Collin2019,
-  title =         {Point Movement in a DSL for Higher-Order FEM
-                   Visualization},
-  author =        {Collin, Teodoro and Chiw, Charisee and
-                   Scott, L Ridgway and Reppy, John and Kindlmann, Gordon},
-  booktitle =     {2019 IEEE Visualization Conference (VIS)},
-  pages =         {281--285},
-  year =          {2019},
-  organization =  {IEEE},
-  doi = {10.1109/VISUAL.2019.8933623}
-} 
-
-@Article{Cotter2014,
-  author =       {Colin J. Cotter and Robert C. Kirby},
-  title =        {Mixed finite elements for global tide models},
-  journal =      {Numerische Mathematik},
-  year =         2015,
-  pages =        {1--23},
-  doi =          {10.1007/s00211-015-0748-z},
-  url =          {http://arxiv.org/abs/1410.0045}
-}
-
-@Misc{Cotter2015,
-  author =       {Colin J. Cotter and David A. Ham and Andrew T. T.
-                  McRae and Lawrence Mitchell and Andrea Natale},
-  title =        {On the shallow atmosphere approximation in finite
-                  element dynamical cores},
-  year =         2015,
-  url =          {http://arxiv.org/abs/1410.3069},
-  archiveprefix ={arXiv},
-  eprint =       {1410.3069}
-}
-
-@Article{Cotter2016,
-  author =       {Colin J. Cotter and Dmitri Kuzmin},
-  title =        {Embedded discontinuous {Galerkin} transport schemes
-                  with localised limiters},
-  journal =      {Journal of Computational Physics},
-  year =         2016,
-  volume =       311,
-  pages =        {363--373},
-  archiveprefix ={arXiv},
-  eprint =       {1509.04431},
-  primaryclass = {math.NA},
-  doi =          {10.1016/j.jcp.2016.02.021},
-  url =          {http://arxiv.org/abs/1509.04431},
-}
-
-@Article{Cotter2018,
-  author =       {Colin J. Cotter and P. Jameson Graber and Robert C.
-                  Kirby},
-  title =        {{Mixed finite elements for global tide models with
-                  nonlinear damping}},
-  journal =      {Numerische Mathematik},
-  year =         2018,
-  volume =       140,
-  issue =        4,
-  doi =          {10.1007/s00211-018-0980-4},
-  archiveprefix ={arXiv},
-  eprint =       {1706.01352},
-  primaryclass = {math.NA}
-}
-
-@Article{Cotter2019,
-  author =       {Cotter, Colin and Crisan, Dan and Holm, Darryl D and
-                  Pan, Wei and Shevchenko, Igor},
-  title =        {{Numerically Modeling Stochastic Lie Transport in
-                  Fluid Dynamics}},
-  journal =      {Multiscale Modeling \& Simulation},
-  year =         2019,
-  volume =       17,
-  number =       1,
-  pages =        {192--232},
-  publisher =    {SIAM},
-  doi =          {10.1137/18M1167929},
-  archiveprefix ={arXiv},
-  primaryclass = {physics.flu-dyn},
-  eprint =       {1801.09729},
-}
-
-@Misc{Dokken2020,
-  title =         {{Automatic shape derivatives for transient 
-                  PDEs in FEniCS and Firedrake}},
-  author =        {Jørgen S. Dokken and Sebastian K. Mitusch
-                   and Simon W. Funke},
-  year =          {2020},
-  eprint =        {2001.10058},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.OC}
-}
-
-@Article{Eldred2019,
-  author =       {Eldred, Christopher and Dubos, Thomas and Kritsikis,
-                  Evaggelos},
-  title =        {{A quasi-Hamiltonian discretization of the thermal
-                  shallow water equations}},
-  journal =      {Journal of Computational Physics},
-  year =         2019,
-  volume =       379,
-  pages =        {1--31},
-  publisher =    {Elsevier},
-  archiveprefix ={HAL},
-  doi =          {10.1016/j.jcp.2018.10.038},
-  eprint =       {hal-01847698},
-}
-
-@Article{Farrell2019,
-  author =       {Patrick E. Farrell and Lawrence Mitchell and Florian
-                  Wechsung},
-  title =        {{An augmented Lagrangian preconditioner for the 3D
-                  stationary incompressible Navier–-Stokes equations
-                  at high Reynolds number}},
-  journal =      {SIAM Journal on Scientific Computing},
-  volume =       41,
-  pages =        {A3073-A3096},
-  issue =        5,
-  year =         2019,
-  archiveprefix ={arXiv},
-  eprint =       {1810.03315},
-  primaryclass = {math.NA}
-}
-
-@Misc{Farrell2019a,
-  author =       {Patrick E. Farrell and Pablo Alexei Gazca-Orozco and
-                  Endre S\"uli},
-  title =        {{Numerical Analysis of Unsteady Implicitly
-                  Constituted Incompressible Fluids: Three-Field
-                  Formulation}},
-  year =         2019,
-  eprint =       {1904.09136},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA}
-}
-
-@Misc{Farrell2019b,
-  author =       {Patrick E. Farrell and Yunhui He and Scott P.
-                  MacLachlan},
-  title =        {{A local Fourier analysis of additive Vanka
-                  relaxation for the Stokes equations}},
-  year =         2019,
-  eprint =       {1908.09949},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA}
-}
-
-@Article{Farrell2019c,
-  author =       {Patrick E. Farrell and Matteo Croci and Thomas M.
-                  Surowiec},
-  title =        {Deflation for semismooth equations},
-  journal =      {Optimization Methods and Software},
-  year =         2019,
-  volume =       0,
-  number =       0,
-  pages =        {1-24},
-  publisher =    {Taylor & Francis},
-  doi =          {10.1080/10556788.2019.1613655},
-  archiveprefix ={arXiv},
-  eprint =       {1904.13299},
-  primaryclass = {math.OC}
-}
-
-@Misc{Farrell2019d,
-  title =         {{PCPATCH: software for the topological construction 
-                   of multigrid relaxation methods}},
-  author =        {Patrick E. Farrell and Matthew G. Knepley
-                   and Lawrence Mitchell and Florian Wechsung},
-  year =          {2019},
-  eprint =        {1912.08516},
-  archivePrefix = {arXiv},
-  primaryClass =  {cs.MS}
-}
-
-@Article{Farrell2020a,
-  title =     {{Numerical Analysis of Unsteady Implicitly Constituted 
-               Incompressible Fluids: 3-Field Formulation}},
-  author =    {Farrell, PE and Gazca-Orozco, PA and Süli, E},
-  journal =   {SIAM Journal on Numerical Analysis},
-  volume =    {58},
-  number =    {1},
-  pages =     {757--787},
-  year =      {2020},
-  publisher = {SIAM},
-  doi = {10.1137/19M125738X}
-}
-
-@Misc{Farrell2020b,
-  title =         {Robust multigrid methods for nearly incompressible elasticity using macro elements},
-  author =        {Patrick E. Farrell and Lawrence Mitchell and L. Ridgway Scott and Florian Wechsung},
-  year =          {2020},
-  eprint =        {2002.02051},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
-}
-
-@Book{Gibson2019,
-  author =       {Thomas H. Gibson and Andrew T.T. McRae and Colin J.
-                  Cotter and Lawrence Mitchell and David A. Ham},
-  title =        {{Compatible Finite Element Methods for Geophysical
-                  Flows: automation and implementation using Firedrake}},
-  publisher =    {Springer International Publishing},
-  year =         2019,
-  doi =          {10.1007/978-3-030-23957-2},
-  url =          {https://doi.org/10.1007/978-3-030-23957-2}
-}
-
-
-@Article{Gidel2017,
-  author =       {Gidel, F. and Bokhove, O. and Kalogirou, A.},
-  title =        {Variational modelling of extreme waves through
-                  oblique interaction of solitary waves: application
-                  to {Mach} reflection},
-  journal =      {Nonlinear Processes in Geophysics},
-  year =         2017,
-  volume =       24,
-  pages =        {43--60},
-  doi =          {10.5194/npg-24-43-2017}
-}
-
-@InProceedings{Gidel2017a,
-  author =       {Floriane Gidel and Onno Bokhove and Mark Kelmanson},
-  title =        {Driven nonlinear potential flow with wave breaking
-                  at shallow-water beaches},
-  booktitle =    {Proceedings of the ASME 2017 36th International
-                  Conference on Ocean, Offshore and Arctic
-                  Engineering},
-  year =         2017,
-  pages =        {V001T01A053},
-  doi =          {10.1115/omae2017-61974}
-}
-
-@Misc{Gjerde2018,
-  author =       {Ingeborg G. Gjerde and Kundan Kumar and Jan M.
-                  Nordbotten and Barbara Wohlmuth},
-  title =        {Splitting method for elliptic equations with line
-                  sources},
-  year =         2018,
-  archiveprefix ={arXiv},
-  eprint =       {1810.12979},
-  primaryclass = {math.NA}
-}
-
-@Article{Harcourt2019,
-  author =       {Freddie Harcourt and Athanasios Angeloudis and
-                  Matthew D. Piggott},
-  title =        {Utilising the flexible generation potential of tidal
-                  range power plants to optimise economic value},
-  journal =      {Applied Energy},
-  year =         2019,
-  volume =       237,
-  pages =        {873 - 884},
-  issn =         {0306-2619},
-  doi =          {10.1016/j.apenergy.2018.12.091},
-  eprint =       {j2u9k},
-  archiveprefix ={EarthArXiv},
-}
-
-
-@Article{He2020,
-  author =    {He, Yunhui and MacLachlan, Scott},
-  title =     {{Two-level Fourier analysis of multigrid for higher-order
-               finite-element discretizations of the Laplacian}},
-  journal =   {Numerical Linear Algebra with Applications},
-  pages =     {e2285},
-  keywords =  {finite-element method, higher-order elements,
-               Jacobi iteration, local Fourier analysis, multigrid},
-  doi =       {10.1002/nla.2285},
-  url =       {https://onlinelibrary.wiley.com/doi/abs/10.1002/nla.2285},
-}
-
-@Article{Huber2020,
-   title =      {{Polymer-bonded anisotropic SrFe12O19 filaments
-                 for fused filament fabrication}},
-   volume =     {127},
-   ISSN =       {1089-7550},
-   url =        {http://dx.doi.org/10.1063/1.5139493},
-   doi =        {10.1063/1.5139493},
-   number =     {6},
-   journal =    {Journal of Applied Physics},
-   publisher =  {AIP Publishing},
-   author =     {Huber, Christian and Cano, Santiago and
-                 Teliban, Iulian and Schuschnigg, Stephan
-                 and Groenefeld, Martin and Suess, Dieter},
-   year =       {2020},
-   month =      {Feb},
-   pages =      {063904}
-}
-
-@Misc{Iglesias2017,
-  author =       {Jos\'e A. Iglesias and Kevin Sturm and Florian
-                  Wechsung},
-  title =        {Shape optimisation with nearly conformal
-                  transformations},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1710.06496},
-  primaryclass = {math.OC}
-}
-
-@Article{Iglesias2018,
-  author =       {Iglesias, J. and Sturm, K. and Wechsung, F.},
-  title =        {{Two-Dimensional Shape Optimization with Nearly
-                  Conformal Transformations}},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2018,
-  volume =       40,
-  number =       6,
-  pages =        {A3807-A3830},
-  doi =          {10.1137/17M1152711},
-  eprint =       {1710.06496},
-  archiveprefix ={arXiv},
-  primaryclass = {math.OC},
-}
-
-@Misc{Jackaman2017,
-  author =       {James Jackaman and Georgios Papamikos and Tristan
-                  Pryor},
-  title =        {{The design of conservative finite element
-                  discretisations for the vectorial modified KdV
-                  equation}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1710.03527},
-  primaryclass = {math.NA}
-}
-
-@Misc{Jackaman2018,
-  author =       {James Jackaman and Tristan Pryor},
-  title =        {{Conservative Galerkin methods for dispersive
-                  Hamiltonian problems}},
-  year =         2018,
-  eprint =       {1811.09999},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-}
-
-@Article{Jacobs2015,
-  author =       {Christian T. Jacobs and Matthew D. Piggott},
-  title =        {{Firedrake-Fluids} v0.1: numerical modelling of
-                  shallow water flows using an automated solution
-                  framework},
-  journal =      {Geoscientific Model Development},
-  year =         2015,
-  volume =       8,
-  number =       3,
-  pages =        {533--547},
-  url =          {http://www.geosci-model-dev.net/8/533/2015/},
-  doi =          {10.5194/gmd-8-533-2015}
-}
-
-@Misc{Joshaghani2018,
-  author =       {M. S. Joshaghani and S. H. S. Joodat and K. B.
-                  Nakshatrala},
-  title =        {A stabilized mixed discontinuous Galerkin
-                  formulation for double porosity/permeability model},
-  year =         2018,
-  archiveprefix ={arXiv},
-  eprint =       {1805.01389},
-  primaryclass = {cs.CE}
-}
-
-@Article{Joshaghani2019,
-  author =       {Joshaghani, MS and Chang, J and Nakshatrala, KB and
-                  Knepley, Matthew G},
-  title =        {Composable block solvers for the four-field double
-                  porosity/permeability model},
-  journal =      {Journal of Computational Physics},
-  year =         2019,
-  volume =       386,
-  pages =        {428--466},
-  publisher =    {Elsevier},
-  doi =          {10.1016/j.jcp.2019.02.020},
-  archiveprefix ={arXiv},
-  eprint =       {1808.08328},
-  primaryclass = {cs.CE},
-}
-
-@Article{Kalogirou2016,
-  author =       {Anna Kalogirou and Erietta E. Moulopoulou and Onno
-                  Bokhove},
-  title =        {{Variational finite element methods for waves in a
-                  Hele–Shaw tank}},
-  journal =      {Applied Mathematical Modelling},
-  year =         2016,
-  pages =        {7493--7503},
-  issn =         {0307-904X},
-  doi =          {10.1016/j.apm.2016.02.036},
-  url =
-                  {http://www.sciencedirect.com/science/article/pii/S0307904X1630110X},
-}
-
-@InProceedings{Kalogirou2016a,
-  author =       {Anna Kalogirou and Onno Bokhove},
-  title =        {Mathematical and numerical modelling of wave impact
-                  on wave-energy buoys},
-  booktitle =    {Proceedings of the ASME 2016 35th International
-                  Conference on Ocean, Offshore and Arctic
-                  Engineering},
-  year =         2016,
-  pages =        {V007T06A067},
-  doi =          {10.1115/OMAE2016-54937}
-}
-
-@InProceedings{Kalogirou2017,
-  author =       {Anna Kalogirou and Onno Bokhove and David Ham},
-  title =        {Modelling of Nonlinear Wave-Buoy Dynamics Using
-                  Constrained Variational Methods},
-  booktitle =    {Proceedings of the ASME 2017 36th International
-                  Conference on Ocean, Offshore and Arctic
-                  Engineering},
-  year =         2017,
-  pages =        {V07AT06A060},
-  doi =          {10.1115/omae2017-61966}
-}
-
-@Article{Karna2018,
-  author =       {K\"arn\"a, T. and Kramer, S. C. and Mitchell, L. and
-                  Ham, D. A. and Piggott, M. D. and Baptista, A. M.},
-  title =        {Thetis coastal ocean model: discontinuous Galerkin
-                  discretization for the three-dimensional hydrostatic
-                  equations},
-  journal =      {Geoscientific Model Development},
-  year =         2018,
-  volume =       11,
-  number =       11,
-  pages =        {4359--4382},
-  url =          {https://www.geosci-model-dev.net/11/4359/2018/},
-  doi =          {10.5194/gmd-11-4359-2018}
-}
-
-@PhdThesis{Kater2019
-  title =   {Mathematical Modeling, Motion Planning and Control
-             of Elastic Structures with Piezoelectric Elements},
-  author =  {Kater, Andreas},
-  year =    {2019},
-  school =  {Christian-Albrechts Universit{\"a}t Kiel},
-  file =    {https://macau.uni-kiel.de/servlets/MCRFileNodeServlet/dissertation_derivate_00008486/kater_thesis.pdf?AC=Y}
-}
-
-@Misc{Kawecki2017,
-  author =       {Ellya L. Kawecki},
-  title =        {{A DGFEM for Uniformly Elliptic Two Dimensional
-                  Oblique Boundary Value Problems}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  eprint =       {1711.01836}
-}
-
-@Article{Kawecki2019,
-  author =       {Kawecki, Ellya L.},
-  title =        {{A DGFEM for nondivergence form elliptic equations
-                  with Cordes coefficients on curved domains}},
-  journal =      {Numerical Methods for Partial Differential
-                  Equations},
-  year =         2019,
-  volume =       35,
-  number =       5,
-  pages =        {1717-1744},
-  doi =          {10.1002/num.22372},
-  archiveprefix ={arXiv},
-  eprint =       {1708.05028},
-  primaryclass = {math.NA},
-}
-
-@Misc{Kawecki2019a,
-  author =       {Ellya L. Kawecki},
-  title =        {{Finite element theory on curved domains with
-                  applications to DGFEMs}},
-  year =         2019,
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  eprint =       {1903.08735}
-}
-
-@Article{Kirby2020,
-  title =     {{Optimal-order preconditioners for the Morse--Ingard equations}},
-  author =    {Kirby, Robert C and Coogan, Peter},
-  journal =   {Computers \& Mathematics with Applications},
-  volume =    {79},
-  number =    {8},
-  pages =     {2458--2471},
-  year =      {2020},
-  publisher = {Elsevier},
-  doi = {10.1016/j.camwa.2019.11.011}
-}
-
-@InProceedings{Lange2015,
-  author =       {Lange, Michael and Knepley, Matthew G. and Gorman,
-                  Gerard J.},
-  title =        {{Flexible, Scalable Mesh and Data Management Using
-                  PETSc DMPlex}},
-  booktitle =    {Proceedings of the 3rd International Conference on
-                  Exascale Applications and Software},
-  year =         2015,
-  series =       {EASC '15},
-  pages =        {71--76},
-  address =      {Edinburgh, Scotland, UK},
-  publisher =    {University of Edinburgh},
-  isbn =         {978-0-9926615-1-9},
-  location =     {Edinburgh, UK},
-  numpages =     6,
-  url =          {http://dl.acm.org/citation.cfm?id=2820083.2820097},
-  archiveprefix ={arXiv},
-  primaryclass = {cs.MS},
-  eprint =       {1505.04633}
-}
-
-@Misc{Loe2019,
-  title =         {{Polynomial Preconditioned GMRES to Reduce Communication in Parallel Computing}},
-  author =        {Jennifer A. Loe and Heidi K. Thornquist and Erik G. Boman},
-  year =          {2019},
-  eprint =        {1907.00072},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
-}
-
-@Article{Maddison2019,
-  title =     {{Automated Calculation of Higher Order Partial
-               Differential Equation Constrained Derivative Information}},
-  author =    {Maddison, James R and Goldberg, Daniel N
-               and Goddard, Benjamin D},
-  journal =   {SIAM Journal on Scientific Computing},
-  volume =    {41},
-  number =    {5},
-  pages =     {C417--C445},
-  year =      {2019},
-  publisher = {SIAM},
-  doi = {10.1137/18M1209465}
-}
-
-@Misc{Mapakshi2017,
-  author =       {N. K. Mapakshi and J. Chang and K. B. Nakshatrala},
-  title =        {A scalable variational inequality approach for flow
-                  through porous media models with pressure-dependent
-                  viscosity},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1710.02620},
-  primaryclass = {cs.ME}
-}
-
-@Article{McCormack2018,
-  author =       {Kimberley A. McCormack and Marc A. Hesse},
-  title =        {{Modeling the poroelastic response to megathrust
-                  earthquakes: A look at the 2012 Mw 7.6 Costa Rican
-                  event}},
-  journal =      {Advances in Water Resources},
-  year =         2018,
-  volume =       114,
-  pages =        {236-248},
-  doi =          {10.1016/j.advwatres.2018.02.014}
-}
-
-@Article{McRae2018,
-  author =       {Andrew T. T. McRae and Colin J. Cotter and Chris J.
-                  Budd},
-  title =        {{Optimal-Transport-Based Mesh Adaptivity on the
-                  Plane and Sphere Using Finite Elements}},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2018,
-  volume =       40,
-  number =       2,
-  pages =        {A1121-A1148},
-  doi =          {10.1137/16M1109515},
-  eprint =       {1612.08077},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  url =          {http://arxiv.org/abs/1612.08077}
-}
-
-@Article{Natale2016,
-  author =       {Andrea Natale and Jemma Shipton and Colin J. Cotter},
-  title =        {Compatible finite element spaces for geophysical
-                  fluid dynamics},
-  journal =      {Dynamics and Statistics of the Climate System},
-  year =         2016,
-  volume =       1,
-  issue =        1,
-  doi =          {10.1093/climsys/dzw005},
-  eprint =       {1605.00551},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  url =          {http://arxiv.org/abs/1605.00551}
-}
-
-@Article{Natale2016a,
-  author =       {Andrea Natale and Colin J. Cotter},
-  title =        {Scale-selective dissipation in energy-conserving
-                  finite element schemes for two-dimensional
-                  turbulence},
-  journal =      {Quarterly Journal of the Royal Meteorological
-                  Society},
-  year =         2017,
-  eprint =       {1611.02623},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  url =          {http://arxiv.org/abs/1611.02623},
-  doi =          {10.1002/qj.3063},
-}
-
-@Article{Natale2017,
-  author =       {Andrea Natale and Colin J. Cotter},
-  title =        {{A variational $H(\mathrm{div})$ finite-element
-                  discretization approach for perfect incompressible
-                  fluids}},
-  journal =      {IMA Journal of Numerical Analysis},
-  year =         2017,
-  pages =        {drx033},
-  doi =          {10.1093/imanum/drx033}
-}
-
-@Misc{Natale2020,
-  title =         {A mixed finite element discretization of dynamical
-                   optimal transport},
-  author =        {Andrea Natale and Gabriele Todeschi},
-  year =          {2020},
-  eprint =        {2003.04558},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
-}
-
-@Article{Ovchinnikov2019,
-  author =       {G. V. Ovchinnikov and D. Zorin and I. V. Oseledets},
-  title =        {Robust regularization of topology optimization
-                  problems with a posteriori error estimators},
-  journal =      {Russian Journal of Numerical Analysis and
-                  Mathematical Modelling},
-  year =         2019,
-  volume =       34,
-  issue =        1,
-  doi =          {10.1515/rnam-2019-0005},
-  archiveprefix ={arXiv},
-  eprint =       {1705.07316},
-  primaryclass = {math.NA}
-}
-
-@Article{Paganini2018,
-  author =       {Alberto Paganini and Florian Wechsung and Patrick E.
-                  Farrell},
-  title =        {{Higher-order moving mesh methods for
-                  PDE-constrained shape optimization}},
-  journal =      {SIAM Journal on Scientific Computing},
-  year =         2018,
-  volume =       40,
-  number =       4,
-  doi =          {10.1137/17M1133956},
-  archiveprefix ={arXiv},
-  eprint =       {1706.03117},
-  primaryclass = {math.NA}
-}
-
-@Article{Pan2019,
-  author =       {Wei Pan and Stephan C. Kramer and Matthew D.
-                  Piggott},
-  title =        {{Multi-layer non-hydrostatic free surface modelling
-                  using the discontinuous Galerkin method}},
-  journal =      {Ocean Modelling},
-  year =         2019,
-  volume =       134,
-  pages =        {68-83},
-  issn =         {1463-5003},
-  doi =          {10.1016/j.ocemod.2019.01.003},
-}
-
-@InProceedings{Park2019,
-  title =     {Verification of unstructured grid adaptation components},
-  author =    {Park, Michael A and Balan, Aravind and Anderson, William K and
-               Galbraith, Marshall C and Caplan, Philip and Carson, Hugh A and
-               Michal, Todd R and Krakos, Joshua A and Kamenetskiy, Dmitry S and
-               Loseille, Adrien and others},
+  url       = {https://doi.org/10.31223/osf.io/vapmu},
+  date      = {2020},
+  doi       = {10.31223/osf.io/vapmu},
+  title     = {Modelling the ecological impacts of tidal energy barrages},
+}
+
+@misc{Barral2016,
+  author      = {Barral, Nicolas and Knepley, Matthew G and Lange, Michael and Piggott, Matthew D and Gorman, Gerard J},
+  url         = {http://arxiv.org/abs/1610.09874},
+  date        = {2016},
+  eprint      = {1610.09874},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Anisotropic mesh adaptation in Firedrake with PETSc DMPlex}},
+}
+
+@misc{Bauer2018,
+  author      = {Bauer, Werner and Cotter, Colin J.},
+  url         = {https://arxiv.org/abs/1801.00691},
+  date        = {2018},
+  eprint      = {1801.00691},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Energy-enstrophy conserving compatible finite element schemes for the shallow water equations on rotating domains with boundaries}},
+}
+
+@misc{Bendall2017,
+  author      = {Bendall, Thomas M and Cotter, Colin J},
+  url         = {https://arxiv.org/abs/1710.04845},
+  date        = {2017},
+  eprint      = {1710.04845},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Statistical properties of an enstrophy conserving discretisation for the stochastic quasi-geostrophic equation}},
+}
+
+@article{Bendall2019,
+  author       = {Bendall, Thomas M and Cotter, Colin J and Shipton, Jemma},
+  publisher    = {Elsevier},
+  date         = {2019},
+  doi          = {10.1016/j.jcp.2019.04.013},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {342--358},
+  title        = {The `recovered space' advection scheme for lowest-order compatible finite element methods},
+  volume       = {390},
+}
+
+@misc{Bendall2019b,
+  author      = {Bendall, Thomas M. and Gibson, Thomas H. and Shipton, Jemma and Cotter, Colin J. and Shipway, Ben},
+  url         = {https://arxiv.org/abs/1910.01857},
+  date        = {2019},
+  eprint      = {1910.01857},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{A Compatible Finite Element Discretisation for the Moist Compressible Euler Equations}},
+}
+
+@thesis{Betteridge2019,
+  author = {Betteridge, Jack},
+  date   = {2019},
+  file   = {https://people.bath.ac.uk/masigg/theses/Betteridge_thesis.pdf},
+  title  = {{Efficient elliptic solvers for higher order DG discretisations on modern architectures and applications in atmospheric modelling}},
+  type   = {phdthesis},
+}
+
+@misc{Bihlo2019,
+  author      = {Bihlo, Alex and Jackaman, James and Valiquette, Francis},
+  url         = {https://arxiv.org/abs/1907.00961},
+  date        = {2019},
+  eprint      = {1907.00961},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {On the development of symmetry-preserving finite element schemes for ordinary differential equations},
+}
+
+@inproceedings{Bokhove2016,
+  author    = {Bokhove, Onno and Kalogirou, Anna},
+  editor    = {Bridges, Thomas J. and Groves, Mark D. and Nicholls, David P.},
+  publisher = {Cambridge University Press},
+  url       = {http://www1.maths.leeds.ac.uk/~matak/documents/lms-cup2015.pdf},
+  booktitle = {Lectures on the theory of water waves},
+  date      = {2016},
+  pages     = {226--260},
+  series    = {LMS Lecture Note Series},
+  title     = {Variational water wave modelling: from continuum to experiment},
+  volume    = {426},
+}
+
+@article{Braun2017,
+  author       = {Braun, Moritz and Obodo, Kingsley O.},
+  url          = {http://www.sciencedirect.com/science/article/pii/S0898122116306745},
+  date         = {2017},
+  doi          = {10.1016/j.camwa.2016.12.003},
+  issn         = {0898-1221},
+  journaltitle = {Computers & Mathematics with Applications},
+  title        = {Multi-domain muffin tin finite element density functional calculations for small molecules},
+}
+
+@misc{Brugnoli2020,
+  author      = {Brugnoli, Andrea and Alazar, Daniel and Pommier-Budinger, Valérie and Matignon, Denis},
+  url         = {https://arxiv.org/abs/2002.12816},
+  date        = {2020},
+  eprint      = {2002.12816},
+  eprintclass = {physics.class-ph},
+  eprinttype  = {arXiv},
+  title       = {{Port-Hamiltonian flexible multibody dynamics}},
+}
+
+@article{Budd2018,
+  author       = {Budd, Chris J. and McRae, Andrew T.T. and Cotter, Colin J.},
+  date         = {2018},
+  doi          = {10.1016/j.jcp.2018.08.028},
+  eprint       = {1711.00260},
+  eprinttype   = {arXiv},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {540--564},
+  title        = {{The scaling and skewness of optimally transported meshes on the sphere}},
+  volume       = {375},
+}
+
+@article{Chang2017,
+  author       = {Chang, J. and Nakshatrala, K.B. and Knepley, M.G. and Johnsson, L.},
+  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/cpe.4401},
+  date         = {2017},
+  doi          = {10.1002/cpe.4401},
+  eprint       = {1705.03625},
+  eprinttype   = {arXiv},
+  journaltitle = {Concurrency and Computation: Practice and Experience},
+  keywords     = {finite element methods,hardware architecture,high performance computing,parallel computing,scientific software,solvers and preconditioners},
+  number       = {11},
+  pages        = {e4401},
+  title        = {A performance spectrum for parallel computational frameworks that solve PDEs},
+  volume       = {30},
+}
+
+@article{Chang2017a,
+  author       = {Chang, J. and Nakshatrala, K.B.},
+  date         = {2017},
+  doi          = {10.1016/j.cma.2017.03.022},
+  eprint       = {1611.08758},
+  eprintclass  = {cs.CE},
+  eprinttype   = {arXiv},
+  issn         = {0045-7825},
+  journaltitle = {Computer Methods in Applied Mechanics and Engineering},
+  pages        = {287--334},
+  title        = {Variational inequality approach to enforcing the non-negative constraint for advection–diffusion equations},
+  volume       = {320},
+}
+
+@thesis{Chang2017b,
+  author      = {Chang, Justin},
+  institution = {University of Houston},
+  date        = {2017},
+  title       = {Structure-preserving high performance computational methods for transport in porous media},
+  type        = {phdthesis},
+}
+
+@misc{Chang2018,
+  author      = {Chang, J. and Fabian, M. S. and Knepley, M. G. and Mills, R. T.},
+  url         = {https://arxiv.org/abs/1802.07832},
+  date        = {2018},
+  eprint      = {1802.07832},
+  eprintclass = {cs.MS},
+  eprinttype  = {arXiv},
+  title       = {{Comparative study of finite element methods using the Time-Accuracy-Size (TAS) spectrum analysis}},
+}
+
+@misc{Chaudhry2020,
+  author      = {Chaudhry, Jehanzeb Hameed and Olson, Luke N. and Sentz, Peter},
+  url         = {https://arxiv.org/abs/2003.04555},
+  date        = {2020},
+  eprint      = {2003.04555},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{A Least-Squares Finite Element Reduced Basis Method}},
+}
+
+@misc{Chiw2017,
+  author      = {Chiw, Charisee and Kindlmann, Gordon and Reppy, John},
+  url         = {https://arxiv.org/abs/1706.05718},
+  date        = {2017},
+  eprint      = {1706.05718},
+  eprintclass = {cs.HC},
+  eprinttype  = {arXiv},
+  title       = {{An exploiration to visualize finite element data with a DSL}},
+}
+
+@misc{Collin2019,
+  author      = {Collin, Teodoro and Kindlmann, Gordon and Scott, L. Ridgway},
+  url         = {https://arxiv.org/abs/1911.00790},
+  date        = {2019},
+  eprint      = {1911.00790},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{An Adaptive Savitsky-Golay Filter for Smoothing Finite Element Computation}},
+}
+
+@article{Cotter2014,
+  author       = {Cotter, Colin J. and Kirby, Robert C.},
+  url          = {http://arxiv.org/abs/1410.0045},
+  date         = {2015},
+  doi          = {10.1007/s00211-015-0748-z},
+  journaltitle = {Numerische Mathematik},
+  pages        = {1--23},
+  title        = {Mixed finite elements for global tide models},
+}
+
+@misc{Cotter2015,
+  author     = {Cotter, Colin J. and Ham, David A. and McRae, Andrew T. T. and Mitchell, Lawrence and Natale, Andrea},
+  url        = {http://arxiv.org/abs/1410.3069},
+  date       = {2015},
+  eprint     = {1410.3069},
+  eprinttype = {arXiv},
+  title      = {On the shallow atmosphere approximation in finite element dynamical cores},
+}
+
+@article{Cotter2016,
+  author       = {Cotter, Colin J. and Kuzmin, Dmitri},
+  url          = {http://arxiv.org/abs/1509.04431},
+  date         = {2016},
+  doi          = {10.1016/j.jcp.2016.02.021},
+  eprint       = {1509.04431},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {363--373},
+  title        = {Embedded discontinuous {Galerkin} transport schemes with localised limiters},
+  volume       = {311},
+}
+
+@article{Cotter2018,
+  author       = {Cotter, Colin J. and Graber, P. Jameson and Kirby, Robert C.},
+  date         = {2018},
+  doi          = {10.1007/s00211-018-0980-4},
+  eprint       = {1706.01352},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issue        = {4},
+  journaltitle = {Numerische Mathematik},
+  title        = {{Mixed finite elements for global tide models with nonlinear damping}},
+  volume       = {140},
+}
+
+@article{Cotter2019,
+  author       = {Cotter, Colin and Crisan, Dan and Holm, Darryl D and Pan, Wei and Shevchenko, Igor},
+  publisher    = {SIAM},
+  date         = {2019},
+  doi          = {10.1137/18M1167929},
+  eprint       = {1801.09729},
+  eprintclass  = {physics.flu-dyn},
+  eprinttype   = {arXiv},
+  journaltitle = {Multiscale Modeling \& Simulation},
+  number       = {1},
+  pages        = {192--232},
+  title        = {{Numerically Modeling Stochastic Lie Transport in Fluid Dynamics}},
+  volume       = {17},
+}
+
+@misc{Dokken2020,
+  author      = {Dokken, Jørgen S. and Mitusch, Sebastian K. and Funke, Simon W.},
+  url         = {https://arxiv.org/abs/2001.10058},
+  date        = {2020},
+  eprint      = {2001.10058},
+  eprintclass = {math.OC},
+  eprinttype  = {arXiv},
+  title       = {{Automatic shape derivatives for transient PDEs in FEniCS and Firedrake}},
+}
+
+@article{Eldred2019,
+  author       = {Eldred, Christopher and Dubos, Thomas and Kritsikis, Evaggelos},
+  publisher    = {Elsevier},
+  date         = {2019},
+  doi          = {10.1016/j.jcp.2018.10.038},
+  eprint       = {hal-01847698},
+  eprinttype   = {HAL},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {1--31},
+  title        = {{A quasi-Hamiltonian discretization of the thermal shallow water equations}},
+  volume       = {379},
+}
+
+@article{Farrell2019,
+  author       = {Farrell, Patrick E. and Mitchell, Lawrence and Wechsung, Florian},
+  url          = {https://arxiv.org/abs/1810.03315},
+  date         = {2019},
+  eprint       = {1810.03315},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issue        = {5},
+  journaltitle = {SIAM Journal on Scientific Computing},
+  pages        = {A3073--A3096},
+  title        = {{An augmented Lagrangian preconditioner for the 3D stationary incompressible Navier–-Stokes equations at high Reynolds number}},
+  volume       = {41},
+}
+
+@misc{Farrell2019a,
+  author      = {Farrell, Patrick E. and Gazca-Orozco, Pablo Alexei and Süli, Endre},
+  url         = {https://arxiv.org/abs/1904.09136},
+  date        = {2019},
+  eprint      = {1904.09136},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Numerical Analysis of Unsteady Implicitly Constituted Incompressible Fluids: Three-Field Formulation}},
+}
+
+@misc{Farrell2019b,
+  author      = {Farrell, Patrick E. and He, Yunhui and MacLachlan, Scott P.},
+  url         = {https://arxiv.org/abs/1908.09949},
+  date        = {2019},
+  eprint      = {1908.09949},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{A local Fourier analysis of additive Vanka relaxation for the Stokes equations}},
+}
+
+@article{Farrell2019c,
+  author       = {Farrell, Patrick E. and Croci, Matteo and Surowiec, Thomas M.},
+  publisher    = {Taylor & Francis},
+  date         = {2019},
+  doi          = {10.1080/10556788.2019.1613655},
+  eprint       = {1904.13299},
+  eprintclass  = {math.OC},
+  eprinttype   = {arXiv},
+  journaltitle = {Optimization Methods and Software},
+  pages        = {1--24},
+  title        = {Deflation for semismooth equations},
+}
+
+@misc{Farrell2019d,
+  author      = {Farrell, Patrick E. and Knepley, Matthew G. and Mitchell, Lawrence and Wechsung, Florian},
+  url         = {https://arxiv.org/abs/1912.08516},
+  date        = {2019},
+  eprint      = {1912.08516},
+  eprintclass = {cs.MS},
+  eprinttype  = {arXiv},
+  title       = {{PCPATCH: software for the topological construction of multigrid relaxation methods}},
+}
+
+@article{Farrell2020a,
+  author       = {Farrell, PE and Gazca-Orozco, PA and Süli, E},
+  publisher    = {SIAM},
+  date         = {2020},
+  doi          = {10.1137/19M125738X},
+  journaltitle = {SIAM Journal on Numerical Analysis},
+  number       = {1},
+  pages        = {757--787},
+  title        = {{Numerical Analysis of Unsteady Implicitly Constituted Incompressible Fluids: 3-Field Formulation}},
+  volume       = {58},
+}
+
+@misc{Farrell2020b,
+  author      = {Farrell, Patrick E. and Mitchell, Lawrence and Scott, L. Ridgway and Wechsung, Florian},
+  url         = {https://arxiv.org/abs/2002.02051},
+  date        = {2020},
+  eprint      = {2002.02051},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {Robust multigrid methods for nearly incompressible elasticity using macro elements},
+}
+
+@book{Gibson2019,
+  author    = {Gibson, Thomas H. and McRae, Andrew T.T. and Cotter, Colin J. and Mitchell, Lawrence and Ham, David A.},
+  publisher = {Springer International Publishing},
+  url       = {https://doi.org/10.1007/978-3-030-23957-2},
+  date      = {2019},
+  doi       = {10.1007/978-3-030-23957-2},
+  title     = {{Compatible Finite Element Methods for Geophysical Flows: automation and implementation using Firedrake}},
+}
+
+@article{Gidel2017,
+  author       = {Gidel, F. and Bokhove, O. and Kalogirou, A.},
+  date         = {2017},
+  doi          = {10.5194/npg-24-43-2017},
+  journaltitle = {Nonlinear Processes in Geophysics},
+  pages        = {43--60},
+  title        = {Variational modelling of extreme waves through oblique interaction of solitary waves: application to {Mach} reflection},
+  volume       = {24},
+}
+
+@inproceedings{Gidel2017a,
+  author    = {Gidel, Floriane and Bokhove, Onno and Kelmanson, Mark},
+  booktitle = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
+  date      = {2017},
+  doi       = {10.1115/omae2017-61974},
+  pages     = {V001T01A053},
+  title     = {Driven nonlinear potential flow with wave breaking at shallow-water beaches},
+}
+
+@misc{Gjerde2018,
+  author      = {Gjerde, Ingeborg G. and Kumar, Kundan and Nordbotten, Jan M. and Wohlmuth, Barbara},
+  url         = {https://arxiv.org/abs/1810.12979},
+  date        = {2018},
+  eprint      = {1810.12979},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {Splitting method for elliptic equations with line sources},
+}
+
+@article{Harcourt2019,
+  author       = {Harcourt, Freddie and Angeloudis, Athanasios and Piggott, Matthew D.},
+  date         = {2019},
+  doi          = {10.1016/j.apenergy.2018.12.091},
+  eprint       = {j2u9k},
+  eprinttype   = {EarthArXiv},
+  issn         = {0306-2619},
+  journaltitle = {Applied Energy},
+  pages        = {873--884},
+  title        = {Utilising the flexible generation potential of tidal range power plants to optimise economic value},
+  volume       = {237},
+}
+
+@article{He2020,
+  author       = {He, Yunhui and MacLachlan, Scott},
+  url          = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nla.2285},
+  doi          = {10.1002/nla.2285},
+  journaltitle = {Numerical Linear Algebra with Applications},
+  keywords     = {finite-element method,higher-order elements,Jacobi iteration,local Fourier analysis,multigrid},
+  pages        = {e2285},
+  title        = {{Two-level Fourier analysis of multigrid for higher-order finite-element discretizations of the Laplacian}},
+}
+
+@article{Huber2020,
+  author       = {Huber, Christian and Cano, Santiago and Teliban, Iulian and Schuschnigg, Stephan and Groenefeld, Martin and Suess, Dieter},
+  publisher    = {AIP Publishing},
+  url          = {http://dx.doi.org/10.1063/1.5139493},
+  date         = {2020-02},
+  doi          = {10.1063/1.5139493},
+  issn         = {1089-7550},
+  journaltitle = {Journal of Applied Physics},
+  number       = {6},
+  pages        = {063904},
+  title        = {{Polymer-bonded anisotropic SrFe12O19 filaments for fused filament fabrication}},
+  volume       = {127},
+}
+
+@misc{Iglesias2017,
+  author      = {Iglesias, José A. and Sturm, Kevin and Wechsung, Florian},
+  url         = {https://arxiv.org/abs/1710.06496},
+  date        = {2017},
+  eprint      = {1710.06496},
+  eprintclass = {math.OC},
+  eprinttype  = {arXiv},
+  title       = {Shape optimisation with nearly conformal transformations},
+}
+
+@article{Iglesias2018,
+  author       = {Iglesias, J. and Sturm, K. and Wechsung, F.},
+  date         = {2018},
+  doi          = {10.1137/17M1152711},
+  eprint       = {1710.06496},
+  eprintclass  = {math.OC},
+  eprinttype   = {arXiv},
+  journaltitle = {SIAM Journal on Scientific Computing},
+  number       = {6},
+  pages        = {A3807--A3830},
+  title        = {{Two-Dimensional Shape Optimization with Nearly Conformal Transformations}},
+  volume       = {40},
+}
+
+@misc{Jackaman2017,
+  author      = {Jackaman, James and Papamikos, Georgios and Pryor, Tristan},
+  url         = {https://arxiv.org/abs/1710.03527},
+  date        = {2017},
+  eprint      = {1710.03527},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{The design of conservative finite element discretisations for the vectorial modified KdV equation}},
+}
+
+@misc{Jackaman2018,
+  author      = {Jackaman, James and Pryor, Tristan},
+  url         = {https://arxiv.org/abs/1811.09999},
+  date        = {2018},
+  eprint      = {1811.09999},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Conservative Galerkin methods for dispersive Hamiltonian problems}},
+}
+
+@article{Jacobs2015,
+  author       = {Jacobs, Christian T. and Piggott, Matthew D.},
+  url          = {http://www.geosci-model-dev.net/8/533/2015/},
+  date         = {2015},
+  doi          = {10.5194/gmd-8-533-2015},
+  journaltitle = {Geoscientific Model Development},
+  number       = {3},
+  pages        = {533--547},
+  title        = {{Firedrake-Fluids} v0.1: numerical modelling of shallow water flows using an automated solution framework},
+  volume       = {8},
+}
+
+@misc{Joshaghani2018,
+  author      = {Joshaghani, M. S. and Joodat, S. H. S. and Nakshatrala, K. B.},
+  url         = {https://arxiv.org/abs/1805.01389},
+  date        = {2018},
+  eprint      = {1805.01389},
+  eprintclass = {cs.CE},
+  eprinttype  = {arXiv},
+  title       = {A stabilized mixed discontinuous Galerkin formulation for double porosity/permeability model},
+}
+
+@article{Joshaghani2019,
+  author       = {Joshaghani, MS and Chang, J and Nakshatrala, KB and Knepley, Matthew G},
+  publisher    = {Elsevier},
+  date         = {2019},
+  doi          = {10.1016/j.jcp.2019.02.020},
+  eprint       = {1808.08328},
+  eprintclass  = {cs.CE},
+  eprinttype   = {arXiv},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {428--466},
+  title        = {Composable block solvers for the four-field double porosity/permeability model},
+  volume       = {386},
+}
+
+@article{Kalogirou2016,
+  author       = {Kalogirou, Anna and Moulopoulou, Erietta E. and Bokhove, Onno},
+  url          = {http://www.sciencedirect.com/science/article/pii/S0307904X1630110X},
+  date         = {2016},
+  doi          = {10.1016/j.apm.2016.02.036},
+  issn         = {0307-904X},
+  journaltitle = {Applied Mathematical Modelling},
+  pages        = {7493--7503},
+  title        = {{Variational finite element methods for waves in a Hele–Shaw tank}},
+}
+
+@inproceedings{Kalogirou2016a,
+  author    = {Kalogirou, Anna and Bokhove, Onno},
+  booktitle = {Proceedings of the ASME 2016 35th International Conference on Ocean, Offshore and Arctic Engineering},
+  date      = {2016},
+  doi       = {10.1115/OMAE2016-54937},
+  pages     = {V007T06A067},
+  title     = {Mathematical and numerical modelling of wave impact on wave-energy buoys},
+}
+
+@inproceedings{Kalogirou2017,
+  author    = {Kalogirou, Anna and Bokhove, Onno and Ham, David},
+  booktitle = {Proceedings of the ASME 2017 36th International Conference on Ocean, Offshore and Arctic Engineering},
+  date      = {2017},
+  doi       = {10.1115/omae2017-61966},
+  pages     = {V07AT06A060},
+  title     = {Modelling of Nonlinear Wave-Buoy Dynamics Using Constrained Variational Methods},
+}
+
+@article{Karna2018,
+  author       = {Kärnä, T. and Kramer, S. C. and Mitchell, L. and Ham, D. A. and Piggott, M. D. and Baptista, A. M.},
+  url          = {https://www.geosci-model-dev.net/11/4359/2018/},
+  date         = {2018},
+  doi          = {10.5194/gmd-11-4359-2018},
+  journaltitle = {Geoscientific Model Development},
+  number       = {11},
+  pages        = {4359--4382},
+  title        = {Thetis coastal ocean model: discontinuous Galerkin discretization for the three-dimensional hydrostatic equations},
+  volume       = {11},
+}
+
+@thesis{Kater2019,
+  author      = {Kater, Andreas},
+  institution = {Christian-Albrechts Universität Kiel},
+  url         = {https://macau.uni-kiel.de/servlets/MCRFileNodeServlet/dissertation_derivate_00008486/kater_thesis.pdf},
+  date        = {2019},
+  title       = {Mathematical Modeling, Motion Planning and Control of Elastic Structures with Piezoelectric Elements},
+  type        = {phdthesis},
+}
+
+@misc{Kawecki2017,
+  author      = {Kawecki, Ellya L.},
+  url         = {https://arxiv.org/abs/1711.01836},
+  date        = {2017},
+  eprint      = {1711.01836},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{A DGFEM for Uniformly Elliptic Two Dimensional Oblique Boundary Value Problems}},
+}
+
+@article{Kawecki2019,
+  author       = {Kawecki, Ellya L.},
+  date         = {2019},
+  doi          = {10.1002/num.22372},
+  eprint       = {1708.05028},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {Numerical Methods for Partial Differential Equations},
+  number       = {5},
+  pages        = {1717--1744},
+  title        = {{A DGFEM for nondivergence form elliptic equations with Cordes coefficients on curved domains}},
+  volume       = {35},
+}
+
+@misc{Kawecki2019a,
+  author      = {Kawecki, Ellya L.},
+  url         = {https://arxiv.org/abs/1903.08735},
+  date        = {2019},
+  eprint      = {1903.08735},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Finite element theory on curved domains with applications to DGFEMs}},
+}
+
+@article{Kirby2020,
+  author       = {Kirby, Robert C and Coogan, Peter},
+  publisher    = {Elsevier},
+  date         = {2020},
+  doi          = {10.1016/j.camwa.2019.11.011},
+  journaltitle = {Computers \& Mathematics with Applications},
+  number       = {8},
+  pages        = {2458--2471},
+  title        = {{Optimal-order preconditioners for the Morse--Ingard equations}},
+  volume       = {79},
+}
+
+@inproceedings{Lange2015,
+  author      = {Lange, Michael and Knepley, Matthew G. and Gorman, Gerard J.},
+  location    = {Edinburgh, UK},
+  publisher   = {University of Edinburgh},
+  url         = {http://dl.acm.org/citation.cfm?id=2820083.2820097},
+  booktitle   = {Proceedings of the 3rd International Conference on Exascale Applications and Software},
+  date        = {2015},
+  eprint      = {1505.04633},
+  eprintclass = {cs.MS},
+  eprinttype  = {arXiv},
+  isbn        = {978-0-9926615-1-9},
+  pages       = {71--76},
+  series      = {EASC '15},
+  title       = {{Flexible, Scalable Mesh and Data Management Using PETSc DMPlex}},
+}
+
+@misc{Loe2019,
+  author      = {Loe, Jennifer A. and Thornquist, Heidi K. and Boman, Erik G.},
+  url         = {https://arxiv.org/abs/1907.00072},
+  date        = {2019},
+  eprint      = {1907.00072},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Polynomial Preconditioned GMRES to Reduce Communication in Parallel Computing}},
+}
+
+@article{Maddison2019,
+  author       = {Maddison, James R and Goldberg, Daniel N and Goddard, Benjamin D},
+  publisher    = {SIAM},
+  date         = {2019},
+  doi          = {10.1137/18M1209465},
+  journaltitle = {SIAM Journal on Scientific Computing},
+  number       = {5},
+  pages        = {C417--C445},
+  title        = {{Automated Calculation of Higher Order Partial Differential Equation Constrained Derivative Information}},
+  volume       = {41},
+}
+
+@misc{Mapakshi2017,
+  author      = {Mapakshi, N. K. and Chang, J. and Nakshatrala, K. B.},
+  url         = {https://arxiv.org/abs/1710.02620},
+  date        = {2017},
+  eprint      = {1710.02620},
+  eprintclass = {cs.ME},
+  eprinttype  = {arXiv},
+  title       = {A scalable variational inequality approach for flow through porous media models with pressure-dependent viscosity},
+}
+
+@article{McCormack2018,
+  author       = {McCormack, Kimberley A. and Hesse, Marc A.},
+  date         = {2018},
+  doi          = {10.1016/j.advwatres.2018.02.014},
+  journaltitle = {Advances in Water Resources},
+  pages        = {236--248},
+  title        = {{Modeling the poroelastic response to megathrust earthquakes: A look at the 2012 Mw 7.6 Costa Rican event}},
+  volume       = {114},
+}
+
+@article{McRae2018,
+  author       = {McRae, Andrew T. T. and Cotter, Colin J. and Budd, Chris J.},
+  url          = {http://arxiv.org/abs/1612.08077},
+  date         = {2018},
+  doi          = {10.1137/16M1109515},
+  eprint       = {1612.08077},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {SIAM Journal on Scientific Computing},
+  number       = {2},
+  pages        = {A1121--A1148},
+  title        = {{Optimal-Transport-Based Mesh Adaptivity on the Plane and Sphere Using Finite Elements}},
+  volume       = {40},
+}
+
+@article{Natale2016,
+  author       = {Natale, Andrea and Shipton, Jemma and Cotter, Colin J.},
+  url          = {http://arxiv.org/abs/1605.00551},
+  date         = {2016},
+  doi          = {10.1093/climsys/dzw005},
+  eprint       = {1605.00551},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issue        = {1},
+  journaltitle = {Dynamics and Statistics of the Climate System},
+  title        = {Compatible finite element spaces for geophysical fluid dynamics},
+  volume       = {1},
+}
+
+@article{Natale2016a,
+  author       = {Natale, Andrea and Cotter, Colin J.},
+  url          = {http://arxiv.org/abs/1611.02623},
+  date         = {2017},
+  doi          = {10.1002/qj.3063},
+  eprint       = {1611.02623},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {Quarterly Journal of the Royal Meteorological Society},
+  title        = {Scale-selective dissipation in energy-conserving finite element schemes for two-dimensional turbulence},
+}
+
+@article{Natale2017,
+  author       = {Natale, Andrea and Cotter, Colin J.},
+  date         = {2017},
+  doi          = {10.1093/imanum/drx033},
+  journaltitle = {IMA Journal of Numerical Analysis},
+  pages        = {drx033},
+  title        = {{A variational $H(\mathrm{div})$ finite-element discretization approach for perfect incompressible fluids}},
+}
+
+@misc{Natale2020,
+  author      = {Natale, Andrea and Todeschi, Gabriele},
+  url         = {https://arxiv.org/abs/2003.04558},
+  date        = {2020},
+  eprint      = {2003.04558},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {A mixed finite element discretization of dynamical optimal transport},
+}
+
+@article{Ovchinnikov2019,
+  author       = {Ovchinnikov, G. V. and Zorin, D. and Oseledets, I. V.},
+  date         = {2019},
+  doi          = {10.1515/rnam-2019-0005},
+  eprint       = {1705.07316},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issue        = {1},
+  journaltitle = {Russian Journal of Numerical Analysis and Mathematical Modelling},
+  title        = {Robust regularization of topology optimization problems with a posteriori error estimators},
+  volume       = {34},
+}
+
+@article{Paganini2018,
+  author       = {Paganini, Alberto and Wechsung, Florian and Farrell, Patrick E.},
+  date         = {2018},
+  doi          = {10.1137/17M1133956},
+  eprint       = {1706.03117},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {SIAM Journal on Scientific Computing},
+  number       = {4},
+  title        = {{Higher-order moving mesh methods for PDE-constrained shape optimization}},
+  volume       = {40},
+}
+
+@article{Pan2019,
+  author       = {Pan, Wei and Kramer, Stephan C. and Piggott, Matthew D.},
+  date         = {2019},
+  doi          = {10.1016/j.ocemod.2019.01.003},
+  issn         = {1463-5003},
+  journaltitle = {Ocean Modelling},
+  pages        = {68--83},
+  title        = {{Multi-layer non-hydrostatic free surface modelling using the discontinuous Galerkin method}},
+  volume       = {134},
+}
+
+@inproceedings{Park2019,
+  author    = {Park, Michael A and Balan, Aravind and Anderson, William K and Galbraith, Marshall C and Caplan, Philip and Carson, Hugh A and Michal, Todd R and Krakos, Joshua A and Kamenetskiy, Dmitry S and Loseille, Adrien and others},
   booktitle = {AIAA Scitech 2019 Forum},
-  pages =     {1723},
-  year =      {2019}
-} 
-
-@PhdThesis{Pembery2019,
-  title =   {{The Helmholtz Equation in Heterogeneous and Random Media:
-             Analysis and Numerics}},
-  author =  {Pembery, Owen Rhys},
-  year =    {2019},
-  school =  {University of Bath},
-  url =     {http://www.bath.ac.uk/~masigg/theses/Pembery_thesis.pdf}
+  date      = {2019},
+  pages     = {1723},
+  title     = {Verification of unstructured grid adaptation components},
 }
 
-@Article{Pimanov2018,
-  author =       {V. Pimanov and I. Oseledets},
-  title =        {{Robust topology optimization using a posteriori
-                  error estimator for the finite element method}},
-  journal =      {Structural and Multidisciplinary Optimization},
-  year =         2018,
-  volume =       58,
-  issue =        4,
-  doi =          {10.1007/s00158-018-1985-4},
-  archiveprefix ={arXiv},
-  eprint =       {1712.03017},
-  primaryclass = {math.NA},
-  url =          {https://arxiv.org/abs/1712.03017}
+@thesis{Pembery2019,
+  author      = {Pembery, Owen Rhys},
+  institution = {University of Bath},
+  url         = {http://www.bath.ac.uk/~masigg/theses/Pembery_thesis.pdf},
+  date        = {2019},
+  title       = {{The Helmholtz Equation in Heterogeneous and Random Media: Analysis and Numerics}},
+  type        = {phdthesis},
 }
 
-@Article{Roy2019,
-  author =       {Thomas Roy and Tom B. Jönsthövel and Christopher
-                  Lemon and Andrew J. Wathen},
-  title =        {A block preconditioner for non-isothermal flow in
-                  porous media},
-  journal =      {Journal of Computational Physics},
-  year =         2019,
-  volume =       395,
-  pages =        {636-652},
-  issn =         {0021-9991},
-  doi =          {10.1016/j.jcp.2019.06.038},
-  eprint =       {1902.00095},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
+@article{Pimanov2018,
+  author       = {Pimanov, V. and Oseledets, I.},
+  url          = {https://arxiv.org/abs/1712.03017},
+  date         = {2018},
+  doi          = {10.1007/s00158-018-1985-4},
+  eprint       = {1712.03017},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issue        = {4},
+  journaltitle = {Structural and Multidisciplinary Optimization},
+  title        = {{Robust topology optimization using a posteriori error estimator for the finite element method}},
+  volume       = {58},
 }
 
-@Misc{Roy2019a,
-  author =       {Thomas Roy and Tom B Jönsthövel and Christopher
-                  Lemon and Andrew J Wathen},
-  title =        {{A constrained pressure-temperature residual (CPTR)
-                  method for non-isothermal multiphase flow in porous
-                  media}},
-  year =         2019,
-  eprint =       {1907.04229},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
+@article{Roy2019,
+  author       = {Roy, Thomas and Jönsthövel, Tom B. and Lemon, Christopher and Wathen, Andrew J.},
+  date         = {2019},
+  doi          = {10.1016/j.jcp.2019.06.038},
+  eprint       = {1902.00095},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  issn         = {0021-9991},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {636--652},
+  title        = {A block preconditioner for non-isothermal flow in porous media},
+  volume       = {395},
 }
 
-@PhdThesis{Roy2019b,
-  title =   {Preconditioning for thermal reservoir simulation},
-  author =  {Roy, Thomas},
-  year =    {2019},
-  school =  {University of Oxford},
-  url =     {https://ora.ox.ac.uk/objects/uuid:478d84ed-fd67-4fd5-ba69-b7c962792c67}
+@misc{Roy2019a,
+  author      = {Roy, Thomas and Jönsthövel, Tom B and Lemon, Christopher and Wathen, Andrew J},
+  url         = {https://arxiv.org/abs/1907.04229},
+  date        = {2019},
+  eprint      = {1907.04229},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{A constrained pressure-temperature residual (CPTR) method for non-isothermal multiphase flow in porous media}},
 }
 
-@Article{Saak2019,
-  author =       {Jens Saak and Dirk Siebelts and Steffen W. R. Werner},
-  title =        {A comparison of second-order model order reduction methods for an artificial fishtail},
-  journal =      {at - Automatisierungstechnik},
-  year =         2019,
-  publisher =    {De Gruyter},
-  address =      {Berlin, Boston},
-  volume =       67,
-  number =       8,
-  pages =        {648--667},
-  doi =          {10.1515/auto-2019-0027}
-  url =          {https://doi.org/10.1515/auto-2019-0027}
+@thesis{Roy2019b,
+  author      = {Roy, Thomas},
+  institution = {University of Oxford},
+  url         = {https://ora.ox.ac.uk/objects/uuid:478d84ed-fd67-4fd5-ba69-b7c962792c67},
+  date        = {2019},
+  title       = {Preconditioning for thermal reservoir simulation},
+  type        = {phdthesis},
 }
 
-@InProceedings{Salwa2016,
-  author =       {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark
-                  A.},
-  title =        {{Variational modelling of wave-structure
-                  interactions for offshore wind turbines}},
-  booktitle =    {Proceedings of the 35th International Conference on
-                  Offshore Mechanics and Arctic Engineering},
-  year =         2016,
-  volume =       {Volume 6: Ocean Space Utilization; Ocean Renewable
-                  Energy},
-  month =        {June},
-  doi =          {10.1115/OMAE2016-54897}
+@article{Saak2019,
+  author       = {Saak, Jens and Siebelts, Dirk and Werner, Steffen W. R.},
+  location     = {Berlin, Boston},
+  publisher    = {De Gruyter},
+  url          = {https://doi.org/10.1515/auto-2019-0027},
+  date         = {2019},
+  doi          = {10.1515/auto-2019-0027},
+  journaltitle = {at - Automatisierungstechnik},
+  number       = {8},
+  pages        = {648--667},
+  title        = {A comparison of second-order model order reduction methods for an artificial fishtail},
+  volume       = {67},
 }
 
-@Article{Salwa2017,
-  author =       {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark
-                  A.},
-  title =        {{Variational modelling of wave--structure
-                  interactions with an offshore wind-turbine mast}},
-  journal =      {Journal of Engineering Mathematics},
-  year =         2017,
-  month =        {Sep},
-  day =          15,
-  issn =         {1573-2703},
-  doi =          {10.1007/s10665-017-9936-4}
+@inproceedings{Salwa2016,
+  author    = {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark A.},
+  booktitle = {Proceedings of the 35th International Conference on Offshore Mechanics and Arctic Engineering},
+  date      = {2016-06},
+  doi       = {10.1115/OMAE2016-54897},
+  title     = {{Variational modelling of wave-structure interactions for offshore wind turbines}},
+  volume    = {Volume 6: Ocean Space Utilization; Ocean Renewable Energy},
 }
 
-@Book{Schwedes2017,
-  author =       {Tobias Schwedes and David A. Ham and Simon W. Funke
-                  and Matthew D. Piggott},
-  title =        {Mesh Dependence in {PDE}-Constrained Optimisation},
-  publisher =    {Springer International Publishing},
-  year =         2017,
-  doi =          {10.1007/978-3-319-59483-5},
-  url =          {https://doi.org/10.1007/978-3-319-59483-5}
+@article{Salwa2017,
+  author       = {Salwa, Tomasz and Bokhove, Onno and Kelmanson, Mark A.},
+  date         = {2017-09-15},
+  doi          = {10.1007/s10665-017-9936-4},
+  issn         = {1573-2703},
+  journaltitle = {Journal of Engineering Mathematics},
+  title        = {{Variational modelling of wave--structure interactions with an offshore wind-turbine mast}},
 }
 
-@Misc{Shipton2017,
-  author =       {Shipton, J. and Cotter, C. J.},
-  title =        {{Higher-order compatible finite element schemes for
-                  the nonlinear rotating shallow water equations on
-                  the sphere}},
-  year =         2017,
-  archiveprefix ={arXiv},
-  eprint =       {1707.00855},
-  primaryclass = {math.NA},
+@book{Schwedes2017,
+  author    = {Schwedes, Tobias and Ham, David A. and Funke, Simon W. and Piggott, Matthew D.},
+  publisher = {Springer International Publishing},
+  url       = {https://doi.org/10.1007/978-3-319-59483-5},
+  date      = {2017},
+  doi       = {10.1007/978-3-319-59483-5},
+  title     = {Mesh Dependence in {PDE}-Constrained Optimisation},
 }
 
-@Article{Siebelts2018,
-  author =       {Dirk Siebelts and Andreas Kater and Thomas Meurer},
-  title =        {{Modeling and Motion Planning for an Artificial
-                  Fishtail}},
-  journal =      {IFAC-PapersOnLine},
-  year =         2018,
-  volume =       51,
-  number =       2,
-  pages =        {319--324},
-  note =         {9th Vienna International Conference on Mathematical
-                  Modelling},
-  issn =         {2405-8963},
-  doi =          {10.1016/j.ifacol.2018.03.055},
+@misc{Shipton2017,
+  author      = {Shipton, J. and Cotter, C. J.},
+  url         = {https://arxiv.org/abs/1707.00855},
+  date        = {2017},
+  eprint      = {1707.00855},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {{Higher-order compatible finite element schemes for the nonlinear rotating shallow water equations on the sphere}},
 }
 
-@Misc{Valseth2020,
-  title =         {Goal-Oriented Error Estimation for the Automatic 
-                   Variationally Stable FE Method for Convection-Dominated
-                   Diffusion Problems},
-  author =        {Eirik Valseth and Albert Romkes},
-  year =          {2020},
-  eprint =        {2003.10904},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
+@article{Siebelts2018,
+  author       = {Siebelts, Dirk and Kater, Andreas and Meurer, Thomas},
+  date         = {2018},
+  doi          = {10.1016/j.ifacol.2018.03.055},
+  issn         = {2405-8963},
+  journaltitle = {IFAC-PapersOnLine},
+  note         = {9th Vienna International Conference on Mathematical Modelling},
+  number       = {2},
+  pages        = {319--324},
+  title        = {{Modeling and Motion Planning for an Artificial Fishtail}},
+  volume       = {51},
 }
 
-@Article{Vouriot2019,
-  author =       {Vouriot, Carolanne VM and Angeloudis, Athanasios and
-                  Kramer, Stephan C and Piggott, Matthew D},
-  title =        {Fate of large-scale vortices in idealized tidal
-                  lagoons},
-  journal =      {Environmental Fluid Mechanics},
-  year =         2019,
-  volume =       19,
-  number =       2,
-  pages =        {329--348},
-  publisher =    {Springer}
+@misc{Valseth2020,
+  author      = {Valseth, Eirik and Romkes, Albert},
+  url         = {https://arxiv.org/abs/2003.10904},
+  date        = {2020},
+  eprint      = {2003.10904},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {Goal-Oriented Error Estimation for the Automatic Variationally Stable FE Method for Convection-Dominated Diffusion Problems},
 }
 
-@Article{Wallwork2019,
-  title =     {Goal-oriented Error Estimation and Mesh Adaptation
-               for Shallow Water Modelling},
-  author =    {Wallwork, Joseph and Barral, Nicolas and Kramer, Stephan
-               and Ham, David and Piggott, Matthew},
-  year =      {2019},
+@article{Vouriot2019,
+  author       = {Vouriot, Carolanne VM and Angeloudis, Athanasios and Kramer, Stephan C and Piggott, Matthew D},
+  publisher    = {Springer},
+  date         = {2019},
+  journaltitle = {Environmental Fluid Mechanics},
+  number       = {2},
+  pages        = {329--348},
+  title        = {Fate of large-scale vortices in idealized tidal lagoons},
+  volume       = {19},
+}
+
+@article{Wallwork2019,
+  author    = {Wallwork, Joseph and Barral, Nicolas and Kramer, Stephan and Ham, David and Piggott, Matthew},
   publisher = {EarthArXiv},
-  doi = {10.31223/osf.io/cs4we}
-}
- 
-@InProceedings{Wallwork2020,
-  author =       {Joseph G Wallwork and Nicolas Barral and
-                  David A Ham and Matthew D Piggott},
-  title =        {Anisotropic Goal-Oriented Mesh Adaptation in
-                   Firedrake},
-  booktitle =    {Proceedings of the 28th International
-                  Meshing Roundtable},
-  year =         2020,
-  pages =        {83--100},
-  publisher =    {Zenodo},
-  month =        feb,
-  doi =          {10.5281/zenodo.3653373},
-  url =          {https://doi.org/10.5281/zenodo.3653373}
+  date      = {2019},
+  doi       = {10.31223/osf.io/cs4we},
+  title     = {Goal-oriented Error Estimation and Mesh Adaptation for Shallow Water Modelling},
 }
 
-@Misc{Wimmer2019,
-  author =       {Golo Wimmer and Colin Cotter and Werner Bauer},
-  title =        {Energy conserving upwinded compatible finite element
-                  schemes for the rotating shallow water equations},
-  year =         2019,
-  archiveprefix ={arXiv},
-  eprint =       {1901.06349},
-  primaryclass = {math.NA},
+@inproceedings{Wallwork2020,
+  author    = {Wallwork, Joseph G and Barral, Nicolas and Ham, David A and Piggott, Matthew D},
+  publisher = {Zenodo},
+  url       = {https://doi.org/10.5281/zenodo.3653373},
+  booktitle = {Proceedings of the 28th International Meshing Roundtable},
+  date      = {2020-02},
+  doi       = {10.5281/zenodo.3653373},
+  pages     = {83--100},
+  title     = {Anisotropic Goal-Oriented Mesh Adaptation in Firedrake},
 }
 
-@Misc{Wimmer2020,
-  title =         {Energy conserving SUPG methods for compatible finite
-                   element schemes in numerical weather prediction},
-  author =        {Golo A. Wimmer and Colin J. Cotter and Werner Bauer},
-  year =          {2020},
-  eprint =        {2001.09590},
-  archivePrefix = {arXiv},
-  primaryClass =  {math.NA}
+@misc{Wimmer2019,
+  author      = {Wimmer, Golo and Cotter, Colin and Bauer, Werner},
+  url         = {https://arxiv.org/abs/1901.06349},
+  date        = {2019},
+  eprint      = {1901.06349},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {Energy conserving upwinded compatible finite element schemes for the rotating shallow water equations},
 }
 
-@Article{Xia2020,
-  title =     {Nonlinear bifurcation analysis of stiffener profiles
-               via deflation techniques},
-  author =    {Xia, Jingmin and Farrell, Patrick E and Castro, Saullo GP},
-  journal =   {Thin-Walled Structures},
-  volume =    {149},
-  pages =     {106662},
-  year =      {2020},
-  publisher = {Elsevier},
-  doi = {10.1016/j.tws.2020.106662}
+@misc{Wimmer2020,
+  author      = {Wimmer, Golo A. and Cotter, Colin J. and Bauer, Werner},
+  url         = {https://arxiv.org/abs/2001.09590},
+  date        = {2020},
+  eprint      = {2001.09590},
+  eprintclass = {math.NA},
+  eprinttype  = {arXiv},
+  title       = {Energy conserving SUPG methods for compatible finite element schemes in numerical weather prediction},
 }
 
-@Article{Yamazaki2017,
-  author =       {Yamazaki, Hiroe and Shipton, Jemma and Cullen,
-                  Michael J. P. and Mitchell, Lawrence and Cotter,
-                  Colin J.},
-  title =        {{Vertical slice modelling of nonlinear Eady waves
-                  using a compatible finite element method}},
-  journal =      {Journal of Computational Physics},
-  year =         2017,
-  volume =       343,
-  pages =        {130--149},
-  doi =          {10.1016/j.jcp.2017.04.006},
-  eprint =       {1611.04929},
-  archiveprefix ={arXiv},
-  primaryclass = {math.NA},
-  url =          {http://arxiv.org/abs/1611.04929}
+@article{Xia2020,
+  author       = {Xia, Jingmin and Farrell, Patrick E and Castro, Saullo GP},
+  publisher    = {Elsevier},
+  date         = {2020},
+  doi          = {10.1016/j.tws.2020.106662},
+  journaltitle = {Thin-Walled Structures},
+  pages        = {106662},
+  title        = {Nonlinear bifurcation analysis of stiffener profiles via deflation techniques},
+  volume       = {149},
 }
 
-@Misc{Zhang2019,
-    title =         {PETSc TSAdjoint: a discrete adjoint ODE solver for
-                     first-order and second-order sensitivity analysis},
-    author =        {Hong Zhang and Emil M. Constantinescu and Barry F. Smith},
-    year =          {2019},
-    eprint =        {1912.07696},
-    archivePrefix = {arXiv},
-    primaryClass =  {cs.MS}
+@article{Yamazaki2017,
+  author       = {Yamazaki, Hiroe and Shipton, Jemma and Cullen, Michael J. P. and Mitchell, Lawrence and Cotter, Colin J.},
+  url          = {http://arxiv.org/abs/1611.04929},
+  date         = {2017},
+  doi          = {10.1016/j.jcp.2017.04.006},
+  eprint       = {1611.04929},
+  eprintclass  = {math.NA},
+  eprinttype   = {arXiv},
+  journaltitle = {Journal of Computational Physics},
+  pages        = {130--149},
+  title        = {{Vertical slice modelling of nonlinear Eady waves using a compatible finite element method}},
+  volume       = {343},
 }
 
-@Misc{Zimmerman2019,
-    title =         {Simulating convection-coupled phase-change in
-                     enthalpy form with mixed finite elements},
-    author =        {Alexander Gary Zimmerman and Julia Kowalski},
-    year =          {2019},
-    eprint =        {1907.04414},
-    archivePrefix = {arXiv},
-    primaryClass =  {physics.comp-ph}
+@misc{Zhang2019,
+  author      = {Zhang, Hong and Constantinescu, Emil M. and Smith, Barry F.},
+  url         = {https://arxiv.org/abs/1912.07696},
+  date        = {2019},
+  eprint      = {1912.07696},
+  eprintclass = {cs.MS},
+  eprinttype  = {arXiv},
+  title       = {PETSc TSAdjoint: a discrete adjoint ODE solver for first-order and second-order sensitivity analysis},
 }
+
+@misc{Zimmerman2019,
+  author      = {Zimmerman, Alexander Gary and Kowalski, Julia},
+  url         = {https://arxiv.org/abs/1907.04414},
+  date        = {2019},
+  eprint      = {1907.04414},
+  eprintclass = {physics.comp-ph},
+  eprinttype  = {arXiv},
+  title       = {Simulating convection-coupled phase-change in enthalpy form with mixed finite elements},
+}
+

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1031,6 +1031,7 @@ def install_documentation_dependencies():
     log.info("Installing documentation dependencies")
     run_pip_install(["sphinx"])
     run_pip_install(["sphinxcontrib-bibtex"])
+    run_pip_install(["bibtexparser"])
     run_pip_install(["git+https://github.com/sphinx-contrib/youtube.git"])
 
 

--- a/scripts/firedrake-preprocess-bibtex
+++ b/scripts/firedrake-preprocess-bibtex
@@ -16,7 +16,6 @@ parser.add_argument("bibtex-file", help="The BibTeX file to process")
 parser.add_argument("--validate", action='store_true',
                     help="Instead of rewriting the bibtex file, raise an exception if anything would have changed.")
 
-
 args = parser.parse_args()
 
 filename = sys.argv[1]
@@ -25,17 +24,17 @@ parser = bibtexparser.bparser.BibTexParser()
 parser.common_strings = True
 parser.ignore_nonstandard_types = False
 
-with open(filename) as bibtex_file: 
+with open(filename) as bibtex_file:
     bib_database = parser.parse_file(bibtex_file)
 
 for entry in bib_database.entries:
-    if not "url" in entry and \
-       not "doi" in entry:
+    if "url" not in entry and \
+       "doi" not in entry:
         if entry.get("archiveprefix", None) == "arXiv":
             entry["url"] = "https://arxiv.org/abs/" + entry["eprint"]
         else:
             raise ValueError("%s in bibliograpy %s\n has no url and no DOI.\n" % (entry["ID"], filename))
-    
+
 writer = BibTexWriter()
 writer.indent = '  '     # indent entries with 2 spaces instead of one
 writer.align_values = True
@@ -48,8 +47,7 @@ if args.validate:
             inbuffer = bibtex_file.read()
         if processed != inbuffer:
             raise ValueError("%s would be changed by firedrake-preprocess-bibtex. Please preprocess it and commit the result" % filename)
-        
+
 else:
     with open(filename, 'w') as bibfile:
         bibfile.write(writer.write(bib_database))
-

--- a/scripts/firedrake-preprocess-bibtex
+++ b/scripts/firedrake-preprocess-bibtex
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import sys
+import io
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+try:
+    from bibtexparser.bwriter import BibTexWriter
+    import bibtexparser
+except ImportError:
+    raise ImportError("Failed to import bibtexparser. Run:\n firedrake-update --documentation-dependencies")
+
+
+parser = ArgumentParser(description="""Ensure BibTeX entries for inclusion in the Firedrake website have a
+URL or DOI, and impose clean formatting.""",
+                        formatter_class=RawDescriptionHelpFormatter)
+parser.add_argument("bibtex-file", help="The BibTeX file to process")
+parser.add_argument("--validate", action='store_true',
+                    help="Instead of rewriting the bibtex file, raise an exception if anything would have changed.")
+
+
+args = parser.parse_args()
+
+filename = sys.argv[1]
+
+parser = bibtexparser.bparser.BibTexParser()
+parser.common_strings = True
+parser.ignore_nonstandard_types = False
+
+with open(filename) as bibtex_file: 
+    bib_database = parser.parse_file(bibtex_file)
+
+for entry in bib_database.entries:
+    if not "url" in entry and \
+       not "doi" in entry:
+        if entry.get("archiveprefix", None) == "arXiv":
+            entry["url"] = "https://arxiv.org/abs/" + entry["eprint"]
+        else:
+            raise ValueError("%s in bibliograpy %s\n has no url and no DOI.\n" % (entry["ID"], filename))
+    
+writer = BibTexWriter()
+writer.indent = '  '     # indent entries with 2 spaces instead of one
+writer.align_values = True
+
+if args.validate:
+    with io.StringIO() as outbuffer:
+        outbuffer.write(writer.write(bib_database))
+        processed = outbuffer.getvalue()
+        with open(filename) as bibtex_file:
+            inbuffer = bibtex_file.read()
+        if processed != inbuffer:
+            raise ValueError("%s would be changed by firedrake-preprocess-bibtex. Please preprocess it and commit the result" % filename)
+        
+else:
+    with open(filename, 'w') as bibfile:
+        bibfile.write(writer.write(bib_database))
+

--- a/scripts/firedrake-preprocess-bibtex
+++ b/scripts/firedrake-preprocess-bibtex
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import sys
 import io
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 try:
@@ -12,13 +11,13 @@ except ImportError:
 parser = ArgumentParser(description="""Ensure BibTeX entries for inclusion in the Firedrake website have a
 URL or DOI, and impose clean formatting.""",
                         formatter_class=RawDescriptionHelpFormatter)
-parser.add_argument("bibtex-file", help="The BibTeX file to process")
+parser.add_argument("bibtex_file", help="The BibTeX file to process")
 parser.add_argument("--validate", action='store_true',
                     help="Instead of rewriting the bibtex file, raise an exception if anything would have changed.")
 
 args = parser.parse_args()
 
-filename = sys.argv[1]
+filename = args.bibtex_file
 
 parser = bibtexparser.bparser.BibTexParser()
 parser.common_strings = True


### PR DESCRIPTION
This change introduces a mechanism for ensuring that all of the publications on the publications page of the website have a URL or DOI associated with them. The mechanism is a new script `firedrake-preprocess-bibtex`. This adds urls to the bibtex file for arxiv papers, and throws an error for any other bibtex entry which has neither a URL or a DOI. The script also has a verification mode which is used to ensure a test fail if a bibtex entry without a URL or DOI is inserted. As a side effect, because the bibtex files are parsed and rewritten, we get some uniformity of formatting among entries.