### PR TITLE
Fix CoordinatelessFunction UFL Function Space

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -59,7 +59,7 @@ class CoordinatelessFunction(ufl.Coefficient):
                                            functionspaceimpl.MixedFunctionSpace)), \
             "Can't make a CoordinatelessFunction defined on a " + str(type(function_space))
 
-        ufl.Coefficient.__init__(self, function_space.ufl_element())
+        ufl.Coefficient.__init__(self, function_space.ufl_function_space())
 
         self.comm = function_space.comm
         self._function_space = function_space

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -38,11 +38,11 @@ def make_scalar_element(mesh, family, degree, vfamily, vdegree):
        :meth:`.MeshGeometry.init`) as appropriate.
     """
     mesh.init()
-    if isinstance(family, ufl.FiniteElementBase):
-        return family
-
     topology = mesh.topology
     cell = topology.ufl_cell()
+    if isinstance(family, ufl.FiniteElementBase):
+        return family.reconstruct(cell=cell)
+
 
     if isinstance(cell, ufl.TensorProductCell) \
        and vfamily is not None and vdegree is not None:

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -43,7 +43,6 @@ def make_scalar_element(mesh, family, degree, vfamily, vdegree):
     if isinstance(family, ufl.FiniteElementBase):
         return family.reconstruct(cell=cell)
 
-
     if isinstance(cell, ufl.TensorProductCell) \
        and vfamily is not None and vdegree is not None:
         la = ufl.FiniteElement(family,

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -828,7 +828,7 @@ class RealFunctionSpace(FunctionSpace):
     value_size = 1
 
     def __init__(self, mesh, element, name):
-        self._ufl_element = element
+        self._ufl_function_space = ufl.FunctionSpace(mesh.ufl_mesh(), element)
         self.name = name
         self.comm = mesh.comm
         self._mesh = mesh

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -831,7 +831,8 @@ class ExtrudedMeshTopology(MeshTopology):
         self._cell_numbering = mesh._cell_numbering
         self._entity_classes = mesh._entity_classes
         self._subsets = {}
-        self._ufl_cell = ufl.TensorProductCell(mesh.ufl_cell(), ufl.interval)
+        cell = ufl.TensorProductCell(mesh.ufl_cell(), ufl.interval)
+        self._ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1, dim=cell.topological_dimension()))
         if layers.shape:
             self.variable_layers = True
             extents = extnum.layer_extents(self._plex,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -437,8 +437,8 @@ class MeshTopology(object):
         nfacets = self.comm.allreduce(nfacets, op=MPI.MAX)
 
         self._grown_halos = False
-        self._ufl_cell = ufl.Cell(_cells[dim][nfacets])
-
+        cell = ufl.Cell(_cells[dim][nfacets])
+        self._ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1, dim=dim))
         # A set of weakrefs to meshes that are explicitly labelled as being
         # parallel-compatible for interpolation/projection/supermeshing
         # To set, do e.g.
@@ -514,7 +514,11 @@ class MeshTopology(object):
 
     def ufl_cell(self):
         """The UFL :class:`~ufl.classes.Cell` associated with the mesh."""
-        return self._ufl_cell
+        return self._ufl_mesh.ufl_cell()
+
+    def ufl_mesh(self):
+        """The UFL :class:`~ufl.classes.Mesh` associated with the mesh."""
+        return self._ufl_mesh
 
     @utils.cached_property
     def cell_closure(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -437,6 +437,13 @@ class MeshTopology(object):
         nfacets = self.comm.allreduce(nfacets, op=MPI.MAX)
 
         self._grown_halos = False
+        # Note that the geometric dimension of the cell is not set here
+        # despite it being a property of a UFL cell. It will default to
+        # equal the topological dimension.
+        # Firedrake mesh topologies, by convention, which specifically
+        # represent a mesh topology (as here) have geometric dimension
+        # equal their topological dimension. This is reflected in the
+        # corresponding UFL mesh.
         cell = ufl.Cell(_cells[tdim][nfacets])
         self._ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1, dim=cell.topological_dimension()))
         # A set of weakrefs to meshes that are explicitly labelled as being
@@ -513,11 +520,29 @@ class MeshTopology(object):
         return self
 
     def ufl_cell(self):
-        """The UFL :class:`~ufl.classes.Cell` associated with the mesh."""
+        """The UFL :class:`~ufl.classes.Cell` associated with the mesh.
+
+        .. note::
+
+            By convention, the UFL cells which specifically
+            represent a mesh topology have geometric dimension equal their
+            topological dimension. This is true even for immersed manifold
+            meshes.
+
+        """
         return self._ufl_mesh.ufl_cell()
 
     def ufl_mesh(self):
-        """The UFL :class:`~ufl.classes.Mesh` associated with the mesh."""
+        """The UFL :class:`~ufl.classes.Mesh` associated with the mesh.
+
+        .. note::
+
+            By convention, the UFL cells which specifically
+            represent a mesh topology have geometric dimension equal their
+            topological dimension. This convention will be reflected in this
+            UFL mesh and is true even for immersed manifold meshes.
+
+        """
         return self._ufl_mesh
 
     @utils.cached_property


### PR DESCRIPTION
**EDIT: Up to date description**

Following #1652 , this ensures that the correct UFL mesh and UFL function space are made when making a `CoordinatelessFunction`. To do this
  1. A `ufl.classes.Mesh` representing the mesh topology is created is created when creating a `MeshTopology`.
     - Note that, by convention, the the UFL cells which correspond to a particular `MeshTopology` (accessed via the `.topological` property of a firedrake mesh) have geometric dimension equal to their topological dimension. This remains true should a mesh be a manifold immersed in a higher dimensional space.
  2. A `ufl.classes.FunctionSpace` representing a function space on a mesh topology is created when creating a `FunctionSpace`.
  3. The `ufl.classes.FunctionSpace` created for each `FunctionSpace` is then used _explicitly_ when calling `ufl.Coefficient.__init__` in `CoordinatelessFunction`.

Prior to this PR in `CoordinatelessFunction`, the line `ufl.Coefficient.__init__(self, function_space.ufl_element())` would create a UFL mesh _implicitly_ using the `function_space.ufl_element()` which, as stated above, has topological dimension equal to the geometric dimension by convention even for immersed manifold meshes. This led to confusion that is now avoided by explicitly creating a `ufl.classes.Mesh` when creating a  `MeshTopology` and correcponding `ufl.classes.FunctionSpace` when creating a `FunctionSpace`.

Todo:
 - [x] Note in a comment the convention for gdim == tdim in `MeshTopology`

**EDIT: Out of date original description (from which the below discussion flowed):**

Following #1652 , this ensures that the correct UFL mesh and UFL function space are made when making a `CoordinatelessFunction`. This is of particular importance during mesh generation. 

See for example  lines `1369` to `1383` in `firedrake/mesh.py`:

```python
    def callback(self):
        """Finish initialisation."""
        del self._callback
        # Finish the initialisation of mesh topology
        self.topology.init()

        coordinates_fs = functionspace.VectorFunctionSpace(self.topology, "Lagrange", 1,
                                                           dim=geometric_dim)

        coordinates_data = dmplex.reordered_coords(plex, coordinates_fs.dm.getDefaultSection(),
                                                   (self.num_vertices(), geometric_dim))

        coordinates = function.CoordinatelessFunction(coordinates_fs,
                                                      val=coordinates_data,
                                                      name="Coordinates")
```
When creating the `function_space` geometric dimension information is given (`dim=geometric_dim`). Now when the `CoordinatelessFunction` is created, the internal UFL mesh and UFL function space have the correct geometric dimension.

Prior to this in `CoordinatelessFunction`, the line `ufl.Coefficient.__init__(self, function_space.ufl_element())` would create a UFL mesh with geometric dimension equal to the firedrake mesh's topological dimension which was incorrect for immersed manifold meshes. For more, see the discussion in #1652 .