### PR TITLE
Show durations of slowest tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ python -m pip list
                 sh '''
 . ./firedrake/bin/activate
 cd firedrake/src/firedrake
-python -m pytest -n 11 --cov firedrake -v tests
+python -m pytest --durations=200 -n 11 --cov firedrake -v tests
 '''
               }
             }


### PR DESCRIPTION
Add the timings of the slowest 200 tests to the test output so as to guide the culling of tests.