### PR TITLE
Python 3.8 fixes (and Isambard)

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -8,3 +8,4 @@ pylint
 randomgen==1.16.4
 vtk
 pkgconfig
+cached_property

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -87,7 +87,11 @@ else:
 
 # Set up logging
 # Log to file at DEBUG level
-logfile = os.path.join(logfile_directory, 'firedrake-%s.log' % mode)
+if ("-h" in sys.argv) or ("--help" in sys.argv):
+    # Don't log if help displayed to avoid overwriting an existing log
+    logfile = os.devnull
+else:
+    logfile = os.path.join(logfile_directory, 'firedrake-%s.log' % mode)
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(levelname)-6s %(message)s',
                     filename=logfile,

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -253,6 +253,8 @@ honoured.""",
                         help="Name of the venv to create (default is 'firedrake')")
     parser.add_argument("--install", action="append", dest="packages",
                         help="Additional packages to be installed. The address should be in format vcs+protocol://repo_url/#egg=pkg&subdirectory=pkg_dir . Some additional packages have shortcut install options for more information see --install-help.")
+    parser.add_argument("--pip-install", action="append", dest="pip_packages",
+                        help="Pip install additional packages into the venv")
     parser.add_argument("--install-help", action="store_true",
                         help="Provide information on packages which can be installed using shortcut names.")
     parser.add_argument("--cache-dir", type=str,
@@ -1271,6 +1273,13 @@ if mode == "install":
 
     # We haven't activated the venv so we need to manually set the environment.
     os.environ["VIRTUAL_ENV"] = firedrake_env
+
+    # Pre-install requested packages
+    if args.pip_packages is not None:
+        for package in args.pip_packages:
+            command = pipinstall + package.split()
+            run_pip(command)
+
 
 petsc_dir, petsc_arch = get_petsc_dir()
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1287,8 +1287,9 @@ if mode == "install":
 
     # If Python 3.8 or later install VTK from custom wheel
     if sys.version_info >= (3, 8):
+        log.info("Pip installing VTK for Python3.8")
         if osname == "Darwin":
-            print("Wheel is pending for Mac")
+            run_pip_install("https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-macosx_10_14_x86_64.whl")
         elif osname == "Linux":
             run_pip_install("https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-linux_x86_64.whl")
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1278,7 +1278,7 @@ if mode == "install":
     if args.pip_packages is not None:
         for package in args.pip_packages:
             log.info("Pip installing %s to venv" % package)
-            run_pip(package.split())
+            run_pip_install(package.split())
 
 
 petsc_dir, petsc_arch = get_petsc_dir()

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1285,6 +1285,13 @@ if mode == "install":
             log.info("Pip installing %s to venv" % package)
             run_pip_install(package.split())
 
+    # If Python 3.8 or later install VTK from custom wheel
+    if sys.version_info >= (3, 8):
+        if osname == "Darwin":
+            print("Wheel is pending for Mac")
+        elif osname == "Linux":
+            run_pip_install("https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-linux_x86_64.whl")
+
 
 petsc_dir, petsc_arch = get_petsc_dir()
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1277,8 +1277,8 @@ if mode == "install":
     # Pre-install requested packages
     if args.pip_packages is not None:
         for package in args.pip_packages:
-            command = pipinstall + package.split()
-            run_pip(command)
+            log.info("Pip installing %s to venv" % package)
+            run_pip(package.split())
 
 
 petsc_dir, petsc_arch = get_petsc_dir()


### PR DESCRIPTION
This PR adds functionality for adding Python packages to the venv before any other packages are installed. This has the following consequences:
- Support for Python 3.8 by providing a wheel.
    - This is done automagically by sniffing the Python version at install time (no user intervention required).
- Better support for building on HPC/unusual architectures. Packages that can't be found or inexplicably fail can be installed from custom locations/wheels or just before other packages.
    - Specifically, there is better support for building on Isambard, the UK tier 2 ARM HPC facility.
    - This can now be done using Firedrake master (once merged) rather than custom install script, this should make [PR 1550](https://github.com/firedrakeproject/firedrake/pull/1550) obsolete.
    - Build instructions for Isambard have been updated and available [here](https://github.com/firedrakeproject/isambard/tree/alternative_install).
- This PR also fixes [issue 1502](https://github.com/firedrakeproject/firedrake/issues/1502), since I kept doing this :roll_eyes:.