### PR TITLE
Changed int type. Fix for PETSc with int64 indices

### DIFF
--- a/firedrake/cython/dmplex.pyx
+++ b/firedrake/cython/dmplex.pyx
@@ -692,7 +692,7 @@ def boundary_nodes(V, sub_domain, method):
 
     local_nodes = np.empty((len(boundary_dofs),
                             len(boundary_dofs[0])),
-                           dtype=IntType)
+                           dtype=np.int32)
     for k, v in boundary_dofs.items():
         local_nodes[k, :] = v
 


### PR DESCRIPTION
This fixes a bug when using PETSc with int64 indices.