### PR TITLE
Fix python3.8 issues during install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -835,7 +835,7 @@ def build_and_install_petsc():
     with directory("petsc"):
         petsc_dir, petsc_arch = get_petsc_dir()
         check_call(["rm", "-rf", os.path.join(petsc_dir, petsc_arch)])
-        check_call(["./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + list(petsc_options))
+        check_call(["python3", "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + list(petsc_options))
         check_call(["make", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch), "all"])
 
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1289,9 +1289,9 @@ if mode == "install":
     if sys.version_info >= (3, 8):
         log.info("Pip installing VTK for Python3.8")
         if osname == "Darwin":
-            run_pip_install("https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-macosx_10_14_x86_64.whl")
+            run_pip_install(["https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-macosx_10_14_x86_64.whl"])
         elif osname == "Linux":
-            run_pip_install("https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-linux_x86_64.whl")
+            run_pip_install(["https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20200224/vtk-8.1.2-cp38-cp38-linux_x86_64.whl"])
 
 
 petsc_dir, petsc_arch = get_petsc_dir()


### PR DESCRIPTION
Hi all, this small PR fixes #1679.

First issue is that arguments for `run_pip_install` needed to be in a list.
Second issue is PETSc defaults to running configure with python. Since `firedrake-install` is called with python3, PETSc configure should also be called with python3. In case python is not present on the system, install will error out.

Jenkins should be ignored for these, they slipped under the radar because Jenkins doesn't build firedrake with python3.8.

Tested in ubuntu 20.04 docker image.

Kind regards,
Darko