### PR TITLE
Add functools.wraps for adjoint wrappers

### DIFF
--- a/firedrake/adjoint/assembly.py
+++ b/firedrake/adjoint/assembly.py
@@ -1,9 +1,11 @@
+from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from pyadjoint.overloaded_type import create_overloaded_object
 from firedrake.adjoint.blocks import AssembleBlock
 
 
 def annotate_assemble(assemble):
+    @wraps(assemble)
     def wrapper(*args, **kwargs):
         """When a form is assembled, the information about its nonlinear dependencies is lost,
         and it is no longer easy to manipulate. Therefore, we decorate :func:`.assemble`

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from pyadjoint.tape import get_working_tape, annotate_tape
 from pyadjoint.overloaded_type import OverloadedType, create_overloaded_object
 from pyadjoint.reduced_functional_numpy import gather
@@ -13,6 +14,7 @@ class ConstantMixin(OverloadedType):
 
     @staticmethod
     def _ad_annotate_init(init):
+        @wraps(init)
         def wrapper(self, *args, **kwargs):
             OverloadedType.__init__(self, *args,
                                     block_class=kwargs.pop("block_class", None),
@@ -27,6 +29,7 @@ class ConstantMixin(OverloadedType):
 
     @staticmethod
     def _ad_annotate_assign(assign):
+        @wraps(assign)
         def wrapper(self, *args, **kwargs):
             annotate = annotate_tape(kwargs)
             if annotate:

--- a/firedrake/adjoint/dirichletbc.py
+++ b/firedrake/adjoint/dirichletbc.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from pyadjoint.overloaded_type import FloatingType
 from .blocks import DirichletBCBlock
 from pyadjoint.tape import no_annotations
@@ -6,6 +7,7 @@ from pyadjoint.tape import no_annotations
 class DirichletBCMixin(FloatingType):
     @staticmethod
     def _ad_annotate_init(init):
+        @wraps(init)
         def wrapper(self, *args, **kwargs):
             FloatingType.__init__(self,
                                   *args,
@@ -19,6 +21,7 @@ class DirichletBCMixin(FloatingType):
     @staticmethod
     def _ad_annotate_apply(apply):
         @no_annotations
+        @wraps(apply)
         def wrapper(self, *args, **kwargs):
             for arg in args:
                 if not hasattr(arg, "bcs"):

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import ufl
 from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape, no_annotations
@@ -9,6 +10,7 @@ class FunctionMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_init(init):
+        @wraps(init)
         def wrapper(self, *args, **kwargs):
             FloatingType.__init__(self, *args,
                                   block_class=kwargs.pop("block_class", None),
@@ -22,7 +24,7 @@ class FunctionMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_project(project):
-
+        @wraps(project)
         def wrapper(self, b, *args, **kwargs):
 
             annotate = annotate_tape(kwargs)
@@ -44,7 +46,7 @@ class FunctionMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_split(split):
-
+        @wraps(split)
         def wrapper(self, *args, **kwargs):
             annotate = annotate_tape(kwargs)
             with stop_annotating():
@@ -65,7 +67,7 @@ class FunctionMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_copy(copy):
-
+        @wraps(copy)
         def wrapper(self, *args, **kwargs):
             annotate = annotate_tape(kwargs)
             func = copy(self, *args, **kwargs)
@@ -86,7 +88,7 @@ class FunctionMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_assign(assign):
-
+        @wraps(assign)
         def wrapper(self, other, *args, **kwargs):
             """To disable the annotation, just pass :py:data:`annotate=False` to this routine, and it acts exactly like the
             Firedrake assign call."""

--- a/firedrake/adjoint/mesh.py
+++ b/firedrake/adjoint/mesh.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from pyadjoint.overloaded_type import OverloadedType
 from pyadjoint.tape import no_annotations
 
@@ -5,6 +6,7 @@ from pyadjoint.tape import no_annotations
 class MeshGeometryMixin(OverloadedType):
     @staticmethod
     def _ad_annotate_init(init):
+        @wraps(init)
         def wrapper(self, *args, **kwargs):
             OverloadedType.__init__(self, *args, **kwargs)
             init(self, *args, **kwargs)
@@ -22,12 +24,8 @@ class MeshGeometryMixin(OverloadedType):
 
     @staticmethod
     def _ad_annotate_coordinates_function(coordinates_function):
-        # Name hacking to not end up when caching the coordinates_function with the name 'wrapper',
-        # which causes the cached result to not be used anymore. Put simply, every time the coordinates_function will be
-        # called it will create a new coordinates Function with the same value, causing error since coordinates_function
-        # will be a new object (i.e. with a different `count`).
-        # TODO: there might be a way of keeping the name wrapper by using functools.wraps
-        def _coordinates_function(self, *args, **kwargs):
+        @wraps(coordinates_function)
+        def wrapper(self, *args, **kwargs):
             from .blocks import MeshInputBlock, MeshOutputBlock
             f = coordinates_function(self)
             f.block_class = MeshInputBlock
@@ -38,7 +36,7 @@ class MeshGeometryMixin(OverloadedType):
             f.output_block_class = MeshOutputBlock
             f._ad_outputs = [self]
             return f
-        return _coordinates_function
+        return wrapper
 
     def _ad_function_space(self):
         if self._ad_coordinate_space is None:

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -1,10 +1,11 @@
+from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from pyadjoint.overloaded_type import create_overloaded_object
 from firedrake.adjoint.blocks import ProjectBlock
 
 
 def annotate_project(project):
-
+    @wraps(project)
     def wrapper(*args, **kwargs):
         """The project call performs an equation solve, and so it too must be annotated so that the
         adjoint and tangent linear models may be constructed automatically by pyadjoint.

--- a/firedrake/adjoint/solving.py
+++ b/firedrake/adjoint/solving.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape
 
 from firedrake.adjoint.blocks import SolveVarFormBlock, SolveLinearSystemBlock
@@ -29,6 +30,7 @@ def annotate_solve(solve):
 
     """
 
+    @wraps(solve)
     def wrapper(*args, **kwargs):
 
         annotate = annotate_tape(kwargs)

--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
 from firedrake.adjoint.blocks import NonlinearVariationalSolveBlock
 
@@ -6,6 +7,7 @@ class NonlinearVariationalProblemMixin:
     @staticmethod
     def _ad_annotate_init(init):
         @no_annotations
+        @wraps(init)
         def wrapper(self, *args, **kwargs):
             init(self, *args, **kwargs)
             self._ad_F = self.F
@@ -20,6 +22,7 @@ class NonlinearVariationalSolverMixin:
     @staticmethod
     def _ad_annotate_init(init):
         @no_annotations
+        @wraps(init)
         def wrapper(self, problem, *args, **kwargs):
             init(self, problem, *args, **kwargs)
             self._ad_problem = problem
@@ -30,6 +33,7 @@ class NonlinearVariationalSolverMixin:
 
     @staticmethod
     def _ad_annotate_solve(solve):
+        @wraps(solve)
         def wrapper(self, **kwargs):
             """To disable the annotation, just pass :py:data:`annotate=False` to this routine, and it acts exactly like the
             Firedrake solve call. This is useful in cases where the solve is known to be irrelevant or diagnostic


### PR DESCRIPTION
Current adjoint annotation wrappers override the docstring and the name of the underlying method, leading to inadequate docstrings and to some caching name issue for `MeshGeometry._coordinates_function`. 

This PR is related to the following issue #1680 