### PR TITLE
Update how PlaneSmoother computes its coordinates

### DIFF
--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -13,6 +13,7 @@ from functools import partial
 import numpy
 from ufl import VectorElement, MixedElement
 from tsfc.kernel_interface.firedrake_loopy import make_builder
+import weakref
 
 import ctypes
 from pyop2 import op2
@@ -568,11 +569,21 @@ def select_entity(p, dm=None, exclude=None):
 class PlaneSmoother(object):
     @staticmethod
     def coords(dm, p):
-        coordsSection = dm.getCoordinateSection()
-        coordsDM = dm.getCoordinateDM()
-        dim = coordsDM.getDimension()
-        coordsVec = dm.getCoordinatesLocal()
-        return dm.getVecClosure(coordsSection, coordsVec, p).reshape(-1, dim).mean(axis=0)
+        mesh = dm.getAttr("__firedrake_mesh__")
+
+        data = mesh.coordinates.dat.data_ro
+        coordsDM = mesh.coordinates.function_space().dm
+        coordsSection = coordsDM.getDefaultSection()
+
+        closure_of_p = [x for x in dm.getTransitiveClosure(p, useCone=True)[0] if coordsSection.getDof(x) > 0]
+
+        gdim = data.shape[1]
+        bary = numpy.zeros(gdim)
+        for p_ in closure_of_p:
+            (dof, offset) = (coordsSection.getDof(p_), coordsSection.getOffset(p_))
+            bary += data[offset:offset+dof].reshape(gdim)
+        bary /= len(closure_of_p)
+        return bary
 
     def sort_entities(self, dm, axis, dir, ndiv):
         # compute
@@ -658,6 +669,7 @@ class PatchBase(PCSNESBase):
 
         mesh = J.ufl_domain()
         self.plex = mesh._plex
+        self.plex.setAttr("__firedrake_mesh__", weakref.proxy(mesh))
         self.ctx = ctx
 
         if mesh.cell_set._extruded:

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -592,8 +592,10 @@ class PlaneSmoother(object):
 
         mesh = dm.getAttr("__firedrake_mesh__")
         ele = mesh.coordinates.function_space().ufl_element()
-        if ele.family() in ["Discontinuous Lagrange", "DQ"]:
-            # Ah, we got a periodic mesh. We need to interpolate to CGk
+        V = mesh.coordinates.function_space()
+        if V.finat_element.entity_dofs() == V.finat_element.entity_closure_dofs():
+            # We're using DG or DQ for our coordinates, so we got
+            # a periodic mesh. We need to interpolate to CGk
             # with access descriptor MAX to define a consistent opinion
             # about where the vertices are.
             CGkele = ele.reconstruct(family="Lagrange")

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -821,7 +821,10 @@ class PatchBase(PCSNESBase):
     def destroy(self, obj):
         # In this destructor we clean up the __firedrake_mesh__ we set on the plex.
         d = self.plex.getDict()
-        del d["__firedrake_mesh__"]
+        try:
+            del d["__firedrake_mesh__"]
+        except KeyError:
+            pass
 
     def user_construction_op(self, obj, *args, **kwargs):
         prefix = obj.getOptionsPrefix()

--- a/tests/regression/test_line_smoother_periodic.py
+++ b/tests/regression/test_line_smoother_periodic.py
@@ -1,0 +1,98 @@
+from firedrake import *
+
+
+# Useful for making a periodic hierarchy
+def periodise(m):
+    coord_fs = VectorFunctionSpace(m, "DG", 1, dim=2)
+    old_coordinates = m.coordinates
+    new_coordinates = Function(coord_fs)
+    domain = "{[i, j]: 0 <= i < old_coords.dofs and 0 <= j < new_coords.dofs}"
+    instructions = """
+    <float64> Y = 0
+    <float64> pi = 3.141592653589793
+    for i
+        Y = Y + old_coords[i, 1]
+    end
+    for j
+        new_coords[j, 0] = atan2(old_coords[j, 1], old_coords[j, 0]) / (pi* 2)
+        new_coords[j, 0] = if(new_coords[j, 0] < 0, new_coords[j, 0] + 1, new_coords[j, 0])
+        new_coords[j, 0] = if(new_coords[j, 0] == 0 and Y < 0, 1, new_coords[j, 0])
+        new_coords[j, 0] = new_coords[j, 0] * Lx[0]
+        new_coords[j, 1] = old_coords[j, 2] * Ly[0]
+    end
+    """
+    cLx = Constant(1)
+    cLy = Constant(1)
+    par_loop((domain, instructions), dx,
+             {"new_coords": (new_coordinates, WRITE),
+              "old_coords": (old_coordinates, READ),
+              "Lx": (cLx, READ),
+              "Ly": (cLy, READ)},
+             is_loopy_kernel=True)
+    return Mesh(new_coordinates)
+
+
+def test_line_smoother_periodic():
+    N = 10
+    H = 0.1
+    nsmooth = 3
+    nref = 1
+
+    # Making a periodic hierarchy:
+    # first make a hierarchy of the cylinder meshes,
+    # then periodise each one
+    baseMesh = CylinderMesh(N, N, 1.0, H)
+
+    mh = MeshHierarchy(baseMesh, nref)
+    meshes = tuple(periodise(m) for m in mh)
+    mh = HierarchyBase(meshes, mh.coarse_to_fine_cells, mh.fine_to_coarse_cells)
+    mesh = mh[-1]
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u = Function(V)
+    v = TestFunction(V)
+    bc = DirichletBC(V, Constant(0), [1, 2])
+
+    F = dot(grad(u), grad(v))*dx - inner(Constant(1), v)*dx
+
+    base = {"snes_type": "ksponly",
+            "ksp_type": "fgmres",
+            "ksp_monitor": None,
+            "ksp_max_it": 100,
+            "ksp_rtol": 1.0e-5}
+
+    mg_levels = {"ksp_max_it": nsmooth,
+                 "ksp_monitor": None,
+                 "ksp_norm_type": "unpreconditioned",
+                 "pc_type": "python",
+                 "pc_python_type": "firedrake.PatchPC",
+                 "patch_pc_patch_save_operators": True,
+                 "patch_pc_patch_local_type": "additive",
+                 "patch_pc_patch_construct_type": "python",
+                 "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
+                 "patch_pc_patch_construct_ps_sweeps": "0-%d" % (N+1),
+                 "patch_sub_ksp_type": "preonly",
+                 "patch_sub_pc_type": "lu"}
+
+    params = {"ksp_type": "richardson",
+              "ksp_richardson_self_scale": False,
+              "ksp_norm_type": "unpreconditioned",
+              "pc_type": "mg",
+              "pc_mg_type": "full",
+              "pc_mg_log": None,
+              "mg_levels": mg_levels,
+              "mg_coarse_pc_type": "python",
+              "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+              "mg_coarse_assembled": {"mat_type": "aij",
+                                      "pc_type": "telescope",
+                                      "pc_telescope_subcomm_type": "contiguous",
+                                      "telescope_pc_type": "lu",
+                                      "telescope_pc_factor_mat_solver_type": "superlu_dist"}}
+
+    params = {**base, **params}
+
+    problem = NonlinearVariationalProblem(F, u, bcs=bc)
+    solver = NonlinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+
+    assert solver.snes.ksp.its <= 4

--- a/tests/regression/test_line_smoother_periodic.py
+++ b/tests/regression/test_line_smoother_periodic.py
@@ -33,7 +33,7 @@ def periodise(m):
 
 
 def test_line_smoother_periodic():
-    N = 10
+    N = 3
     H = 0.1
     nsmooth = 3
     nref = 1
@@ -95,4 +95,4 @@ def test_line_smoother_periodic():
     solver = NonlinearVariationalSolver(problem, solver_parameters=params)
     solver.solve()
 
-    assert solver.snes.ksp.its <= 4
+    assert solver.snes.ksp.its <= 5


### PR DESCRIPTION
At the moment `PlaneSmoother` just gets the coordinates of a point from the Plex. This has the downside that it does the wrong thing when the PETSc's opinion of the coordinates and Firedrake's diverge, as when applied to a periodic problem.

This PR fixes this by always using Firedrake's opinion of the coordinates. It also adds a test to show how to make a periodic mesh hierarchy for solving periodic problems with GMG and how to use `PlaneSmoother` to do line relaxation on a problem with a large aspect ratio.