### PR TITLE
Fix _ad_assign_numpy and _ad_to_list methods of Constant

### DIFF
--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -85,7 +85,7 @@ class ConstantMixin(OverloadedType):
     @staticmethod
     def _ad_assign_numpy(dst, src, offset):
         l = dst.ufl_element().value_size()
-        dst.assign(numpy.reshape(src[offset:offset + l], dst.ufl_shape))
+        dst.assign(numpy.reshape(src[offset:offset + l], dst.ufl_shape), annotate=False)
         offset += l
         return dst, offset
 

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -5,7 +5,6 @@ from pyadjoint.reduced_functional_numpy import gather
 
 from firedrake.functionspace import FunctionSpace
 from firedrake.adjoint.blocks import ConstantAssignBlock
-from firedrake import Constant
 
 import numpy
 
@@ -85,16 +84,14 @@ class ConstantMixin(OverloadedType):
 
     @staticmethod
     def _ad_assign_numpy(dst, src, offset):
-        dst.assign(Constant(numpy.reshape(src[offset:offset + dst.value_size()], dst.ufl_shape)))
-        offset += dst.value_size()
+        l = dst.ufl_element().value_size()
+        dst.assign(numpy.reshape(src[offset:offset + l], dst.ufl_shape))
+        offset += l
         return dst, offset
 
     @staticmethod
     def _ad_to_list(m):
-        a = numpy.zeros(m.value_size())
-        p = numpy.zeros(m.value_size())
-        m.eval(a, p)
-        return a.tolist()
+        return m.values().tolist()
 
     def _ad_copy(self):
         return self._constant_from_values()


### PR DESCRIPTION
These are called when using one of scipy's optimisation routines with Constants
as control, to pack adjoint values into numpy arrays. Their current version seem to be copied from fenics_adjoint and do not work.