### PR TITLE
Pinned VTK to 8.1.2 to prevent import error

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -6,6 +6,6 @@ ipython
 matplotlib
 pylint
 randomgen==1.16.4
-vtk
+vtk==8.1.2
 pkgconfig
 cached_property


### PR DESCRIPTION
Small fix to prevent VTK 9.0 being installed