### PR TITLE
Add SLEPc to full-featured Docker image

### DIFF
--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -9,4 +9,4 @@ USER firedrake
 WORKDIR /home/firedrake
 
 # Now install extra Firedrake components.
-RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --install thetis --install gusto --install icepack"
+RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --slepc --install thetis --install gusto --install icepack"


### PR DESCRIPTION
This should make it easier to give demos of how to use Firedrake for eigenvalue problems.