### PR TITLE
Make p-multigrid transfer operators matrix-free

### DIFF
--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -311,6 +311,8 @@ void restriction(double *restrict Rc, const double *Rf)
                      self.uc.dat(op2.WRITE, self.Vc.cell_node_map()),
                      self.uf.dat(op2.READ, self.Vf.cell_node_map()))
 
+        [bc.zero(self.uc) for bc in self.Vc_bcs]
+
         with self.uc.dat.vec_ro as xc:
             xc.copy(resc)
 
@@ -321,6 +323,8 @@ void restriction(double *restrict Rc, const double *Rf)
 
         with self.uc.dat.vec_wo as xc_:
             xc.copy(xc_)
+
+        [bc.zero(self.uc) for bc in self.Vc_bcs]
 
         op2.par_loop(self.prolong_kernel, self.mesh.cell_set,
                      self.uf.dat(op2.WRITE, self.Vf.cell_node_map()),

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -301,8 +301,7 @@ void restriction(double *restrict Rc, const double *restrict Rf, const double *r
         """
         self.weight = firedrake.Function(Vf)
         firedrake.par_loop((domain, instructions), firedrake.dx, {"w": (self.weight, op2.INC)},
-                 is_loopy_kernel=True)
-
+                           is_loopy_kernel=True)
 
     @staticmethod
     def prolongation_transfer_kernel_action(Vf, uc):
@@ -328,6 +327,8 @@ void restriction(double *restrict Rc, const double *restrict Rf, const double *r
         with self.uc.dat.vec_wo as xc:
             xc.set(0)
 
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
+
         op2.par_loop(self.restrict_kernel, self.mesh.cell_set,
                      self.uc.dat(op2.INC, self.uc.cell_node_map()),
                      self.uf.dat(op2.READ, self.uf.cell_node_map()),
@@ -351,6 +352,8 @@ void restriction(double *restrict Rc, const double *restrict Rf, const double *r
         op2.par_loop(self.prolong_kernel, self.mesh.cell_set,
                      self.uf.dat(op2.WRITE, self.Vf.cell_node_map()),
                      self.uc.dat(op2.READ, self.Vc.cell_node_map()))
+
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
 
         with self.uf.dat.vec_ro as xf_:
             if inc:
@@ -395,6 +398,8 @@ class MixedInterpolationMatrix(object):
         with self.uc.dat.vec_wo as xc:
             xc.set(0)
 
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
+
         for (i, standalone) in enumerate(self.standalones):
             op2.par_loop(standalone.restrict_kernel, standalone.mesh.cell_set,
                          self.uc.split()[i].dat(op2.INC, standalone.Vc.cell_node_map()),
@@ -417,6 +422,8 @@ class MixedInterpolationMatrix(object):
             op2.par_loop(standalone.prolong_kernel, standalone.mesh.cell_set,
                          self.uf.split()[i].dat(op2.WRITE, standalone.Vf.cell_node_map()),
                          self.uc.split()[i].dat(op2.READ, standalone.Vc.cell_node_map()))
+
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
 
         with self.uf.dat.vec_ro as xf_:
             if inc:

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1,5 +1,4 @@
 from functools import partial
-from itertools import chain
 import numpy as np
 
 from ufl import MixedElement, VectorElement, TensorElement, replace
@@ -237,23 +236,6 @@ class PMGPC(PCBase):
         self.ppc.view(viewer)
 
 
-def prolongation_transfer_kernel_full(Pk, P1):
-    # Works for Pk, Pm; I just retain the notation
-    # P1 to remind you that P1 is of lower degree
-    # than Pk
-    from tsfc import compile_expression_dual_evaluation
-    from tsfc.fiatinterface import create_element
-    from firedrake import TestFunction
-
-    expr = TestFunction(P1)
-    coords = Pk.ufl_domain().coordinates
-    to_element = create_element(Pk.ufl_element(), vector_is_mixed=False)
-
-    ast, oriented, needs_cell_sizes, coefficients, _ = compile_expression_dual_evaluation(expr, to_element, coords, coffee=False)
-    kernel = op2.Kernel(ast, ast.name)
-    return kernel
-
-
 class StandaloneInterpolationMatrix(object):
     """
     Interpolation matrix for a single standalone space.
@@ -439,46 +421,7 @@ class MixedInterpolationMatrix(object):
             w.axpy(1.0, y)
 
 
-def prolongation_matrix_full(Pk, P1, Pk_bcs, P1_bcs):
-    sp = op2.Sparsity((Pk.dof_dset,
-                       P1.dof_dset),
-                      (Pk.cell_node_map(),
-                       P1.cell_node_map()))
-    mat = op2.Mat(sp, PETSc.ScalarType)
-    mesh = Pk.ufl_domain()
-
-    fele = Pk.ufl_element()
-    if isinstance(fele, MixedElement) and not isinstance(fele, (VectorElement, TensorElement)):
-        for i in range(fele.num_sub_elements()):
-            Pk_bcs_i = [bc for bc in Pk_bcs if bc.function_space().index == i]
-            P1_bcs_i = [bc for bc in P1_bcs if bc.function_space().index == i]
-
-            rlgmap, clgmap = mat[i, i].local_to_global_maps
-            rlgmap = Pk.sub(i).local_to_global_map(Pk_bcs_i, lgmap=rlgmap)
-            clgmap = P1.sub(i).local_to_global_map(P1_bcs_i, lgmap=clgmap)
-            unroll = any(bc.function_space().component is not None
-                         for bc in chain(Pk_bcs_i, P1_bcs_i) if bc is not None)
-            matarg = mat[i, i](op2.WRITE, (Pk.sub(i).cell_node_map(), P1.sub(i).cell_node_map()),
-                               lgmaps=(rlgmap, clgmap), unroll_map=unroll)
-            op2.par_loop(prolongation_transfer_kernel_full(Pk.sub(i), P1.sub(i)), mesh.cell_set,
-                         matarg)
-
-    else:
-        rlgmap, clgmap = mat.local_to_global_maps
-        rlgmap = Pk.local_to_global_map(Pk_bcs, lgmap=rlgmap)
-        clgmap = P1.local_to_global_map(P1_bcs, lgmap=clgmap)
-        unroll = any(bc.function_space().component is not None
-                     for bc in chain(Pk_bcs, P1_bcs) if bc is not None)
-        matarg = mat(op2.WRITE, (Pk.cell_node_map(), P1.cell_node_map()),
-                     lgmaps=(rlgmap, clgmap), unroll_map=unroll)
-        op2.par_loop(prolongation_transfer_kernel_full(Pk, P1), mesh.cell_set,
-                     matarg)
-
-    mat.assemble()
-    return mat.handle
-
-
-def prolongation_matrix_matfree(Vf, Vc, Vf_bcs, Vc_bcs):
+def prolongation_matrix(Vf, Vc, Vf_bcs, Vc_bcs):
     fele = Vf.ufl_element()
     if isinstance(fele, MixedElement) and not isinstance(fele, (VectorElement, TensorElement)):
         ctx = MixedInterpolationMatrix(Vf, Vc, Vf_bcs, Vc_bcs)
@@ -490,6 +433,3 @@ def prolongation_matrix_matfree(Vf, Vc, Vf_bcs, Vc_bcs):
     M_shll.setUp()
 
     return M_shll
-
-
-prolongation_matrix = prolongation_matrix_matfree

--- a/tests/multigrid/test_p_multigrid.py
+++ b/tests/multigrid/test_p_multigrid.py
@@ -15,7 +15,12 @@ def mesh(request):
     return mesh
 
 
-def test_p_multigrid_scalar(mesh):
+@pytest.fixture(params=["matfree", "aij"], scope="module")
+def mat_type(request):
+    return request.param
+
+
+def test_p_multigrid_scalar(mesh, mat_type):
     V = FunctionSpace(mesh, "CG", 4)
 
     u = Function(V)
@@ -39,6 +44,7 @@ def test_p_multigrid_scalar(mesh):
           "pc_python_type": "firedrake.PMGPC",
           "pmg_pc_mg_type": "multiplicative",
           "pmg_mg_levels": relax,
+          "pmg_mg_levels_transfer_mat_type": mat_type,
           "pmg_mg_coarse_ksp_type": "richardson",
           "pmg_mg_coarse_ksp_max_it": 1,
           "pmg_mg_coarse_ksp_norm_type": "unpreconditioned",


### PR DESCRIPTION
The current implementation of transfer operators assembles the prolongation matrix. For high polynomial degree this is quite dense, and assembling it is a bad idea. This pull request instead implements matrix-free transfer operators. This is much more efficient in memory and allows us to solve problems we couldn't before.

The p-multigrid tests pass, with the same iteration counts and minor differences in residuals due to roundoff.