### PR TITLE
flowchart for debugging install problems

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,8 +24,10 @@
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.mathjax', 'sphinx.ext.intersphinx',
+              'sphinx.ext.mathjax',
+              'sphinx.ext.intersphinx',
               'sphinx.ext.viewcode',
+              'sphinx.ext.graphviz',
               'sphinxcontrib.youtube',
               'sphinxcontrib.bibtex']
 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -57,6 +57,26 @@ venv_ as above and then run::
   where ``LOCALHOSTNAME`` is the name returned by running the `hostname`
   command. Should the local host name change, this may require updating.
 
+Upgrade
+-------
+
+The install script will install an upgrade script in
+`firedrake/bin/firedrake-update`. Running this script will update
+Firedrake and all its dependencies.
+
+.. note::
+
+   You should activate the venv_ before running
+   `firedrake-update`.
+
+Just like the ``firedrake-install`` script, running::
+
+    firedrake-update --help
+
+gives a full list of update options. For instance additional Firedrake
+packages can be installed into an existing Firedrake installation using
+``firedrake-update``.
+
 Debugging install problems
 --------------------------
 
@@ -82,6 +102,23 @@ diagnose what's going wrong, **please include the following log files**:
 Likewise, if it's ``firedrake-update`` that fails, please include the
 file ``firedrake-update.log``. You can find this in the Firedrake
 virtual environment.
+
+Recovering from a broken installation script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you find yourself in the unfortunate position that
+``firedrake-update`` won't run because of a bug, and the bug has been
+fixed in Firedrake master, then the following procedure will rebuild
+``firedrake-update`` using the latest version.
+
+From the top directory of your Firedrake install,
+type::
+
+  cd src/firedrake
+  git pull
+  ./scripts/firedrake-install --rebuild-script
+
+You should now be able to run ``firedrake-update``.
 
 System requirements
 -------------------
@@ -164,44 +201,6 @@ MacPorts installed, you should ensure that ``/opt/local/bin`` and
 ``/opt/local/sbin`` are removed from your ``PATH`` when installing or
 using Firedrake. This should ensure that no MacPorts installed tools
 are found.
-
-Upgrade
--------
-
-The install script will install an upgrade script in
-`firedrake/bin/firedrake-update`. Running this script will update
-Firedrake and all its dependencies.
-
-.. note::
-
-   You should activate the venv_ before running
-   `firedrake-update`.
-
-Just like the ``firedrake-install`` script, running::
-
-    firedrake-update --help
-
-gives a full list of update options. For instance additional Firedrake
-packages can be installed into an existing Firedrake installation using
-``firedrake-update``.
-
-
-Recovering from a broken installation script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you find yourself in the unfortunate position that
-``firedrake-update`` won't run because of a bug, and the bug has been
-fixed in Firedrake master, then the following procedure will rebuild
-``firedrake-update`` using the latest version.
-
-From the top directory of your Firedrake install,
-type::
-
-  cd src/firedrake
-  git pull
-  ./scripts/firedrake-install --rebuild-script
-
-You should now be able to run ``firedrake-update``.
 
 
 Visualisation software

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -33,16 +33,6 @@ use Firedrake::
 
      source firedrake/bin/activate.csh
 
-Reporting installation bugs
----------------------------
-
-If ``firedrake-install`` fails to work, please report a bug so that we
-can fix it for you by creating a new `github issue
-<https://github.com/firedrakeproject/firedrake/issues>`__.  Please
-include the log file ``firedrake-install.log`` in your bug report.
-Similarly if ``firedrake-update`` fails, it produces a
-``firedrake-update.log`` file which will help us to debug the problem.
-
 Testing the installation
 ------------------------
 
@@ -67,6 +57,29 @@ venv_ as above and then run::
   where ``LOCALHOSTNAME`` is the name returned by running the `hostname`
   command. Should the local host name change, this may require updating.
 
+Debugging install problems
+--------------------------
+
+If ``firedrake-install`` fails, the following flowchart describes some
+common build problems and how to solve them. If you understand the
+prognosis and feel comfortable making these fixes yourself then great!
+If not, feel free to ask for more help in our
+:doc:`Slack channel </contact>`.
+
+.. graphviz:: install-debug.dot
+
+If you don't see the issue you're experiencing in this chart, please
+report a bug by creating a new `github issue
+<https://github.com/firedrakeproject/firedrake/issues>`__. To help us
+diagnose what's going wrong, please include the log file
+``firedrake-install.log`` in your bug report. Likewise, if it's
+``firedrake-update`` that fails, please include the file
+``firedrake-update.log``. If the installation is failing at building
+PETSc, find the ``src/petsc/`` directory inside the directory where the
+Firedrake virtual environment was created. The PETSc directory should
+contain a file ``configure.log`` and possibly also ``make.log`` if it
+got that far. Please send these along too as they contain valuable
+information about what went wrong with PETSc.
 
 System requirements
 -------------------

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -86,11 +86,17 @@ virtual environment.
 System requirements
 -------------------
 
-The installation script is tested on Ubuntu and MacOS X. Installation
-is likely to work well on other Linux platforms, although the script
-may stop to ask you to install some dependency packages. Installation
-on other Unix platforms may work but is untested. On Linux systems
-that do not use the Debian package management system, it will be
+Firedrake requires Python 3.6 or later. The installation script is
+tested on Ubuntu and MacOS X. On Ubuntu 18.04 or later, the system
+installed Python 3 is supported and tested. On MacOS, the homebrew_
+installed Python 3 is supported and tested::
+
+  brew install python3
+
+Installation is likely to work well on other Linux platforms, although
+the script may stop to ask you to install some dependency packages.
+Installation on other Unix platforms may work but is untested. On Linux
+systems that do not use the Debian package management system, it will be
 necessary to pass the `--no-package-manager` option to the install
 script. In this case, it is the user's responsibilty to ensure that
 they have the system dependencies:
@@ -112,26 +118,43 @@ Windows Subsystem for Linux. There are more detailed
 Installation on previous versions of Windows is unlikely to work.
 
 
-Supported Python distributions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+System anti-requirements
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Firedrake requires Python 3.6 or later.
+We strive to make Firedrake work on as many platforms as we can. Some
+tools, however, make this challenging or impossible for end users.
 
-On Ubuntu (18.04 or later), the system installed Python 3 is supported and tested.
+**Anaconda.** The Anaconda Python distribution and package manager are
+often recommended in introductory data science courses because it does
+effectively handle many aggravating problems of dependency management.
+Unfortunately, Anaconda does a poor job of isolating itself from the
+rest of your system and assumes that it will be both the only Python
+installation and the only supplier of any dependent packages. Anaconda
+will install compilers and MPI compiler wrappers and put its compilers
+right at the top of your ``PATH``. This is a problem because Firedrake
+needs to build and use its own MPI. (We keep our MPI isolated from the
+rest of your system through virtual environments.) When installed on a
+platform with Anaconda, Firedrake can accidentally try to link to the
+incompatible Anaconda installation of MPI.
 
-On Mac OS, the homebrew_ installed Python 3 is supported and tested::
+There are three ways to work around this problem.
 
-  brew install python3
+1. Remove Anaconda entirely.
+2. Modify your ``PATH`` environment variable to remove any traces of
+   Anaconda, then install Firedrake. If you need Anaconda later, you
+   can re-enable it with a shell script that will add those directories
+   back onto your path.
+3. Use a tool like pyenv_, which makes it possible to switch between
+   different versions of Python on a per-terminal session or per-
+   directory basis.
 
-If instead you choose to install Python 3 using the official Mac OS
-installer on the Python website, you need to be aware that that
-installation will not have a working SSL by default. You need to
-follow the SSL certificate instructions given in the installation process (or in
-``/Applications/Python X.X/ReadMe.rtf`` after installation).
+**MacOS system Python.** The official MacOS installer on the Python
+website does not have a working SSL by default. A working SSL is
+necessary to securely fetch dependent packages from the internet. You
+can enable SSL with the system Python, but we strongly recommend using
+a Python version installed via Homebrew instead.
 
-Additional considerations for MacPorts users
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+**MacPorts.**
 Mac OS has multiple competing package managers which sometimes cause
 issues for users attempting to install Firedrake. In particular, the
 assembler provided by MacPorts is incompatible with the Mac system
@@ -222,3 +245,4 @@ packages for which these are also dependencies.
 .. _venv: https://docs.python.org/3/tutorial/venv.html
 .. _homebrew: https://brew.sh/
 .. _PETSc: https://www.mcs.anl.gov/petsc/
+.. _pyenv: https://github.com/pyenv/pyenv

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -84,49 +84,6 @@ gives a full list of update options. For instance additional Firedrake
 packages can be installed into an existing Firedrake installation using
 ``firedrake-update``.
 
-Debugging install problems
---------------------------
-
-If ``firedrake-install`` fails, the following flowchart describes some
-common build problems and how to solve them. If you understand the
-prognosis and feel comfortable making these fixes yourself then great!
-If not, feel free to ask for more help in our
-:doc:`Slack channel </contact>`.
-
-.. graphviz:: install-debug.dot
-
-If you don't see the issue you're experiencing in this chart, please
-ask us on Slack or report a bug by creating a new `github issue
-<https://github.com/firedrakeproject/firedrake/issues>`__. To help us
-diagnose what's going wrong, **please include the following log files**:
-
-* ``firedrake-install.log`` from Firedrake, which you can find in the
-  directory where you invoked ``firedrake-install`` from
-* ``configure.log`` and ``make.log`` from PETSc, which you can find in
-  ``src/petsc/`` inside the directory where Firedrake virtual
-  environment was created
-
-Likewise, if it's ``firedrake-update`` that fails, please include the
-file ``firedrake-update.log``. You can find this in the Firedrake
-virtual environment.
-
-Recovering from a broken installation script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you find yourself in the unfortunate position that
-``firedrake-update`` won't run because of a bug, and the bug has been
-fixed in Firedrake master, then the following procedure will rebuild
-``firedrake-update`` using the latest version.
-
-From the top directory of your Firedrake install,
-type::
-
-  cd src/firedrake
-  git pull
-  ./scripts/firedrake-install --rebuild-script
-
-You should now be able to run ``firedrake-update``.
-
 System requirements
 -------------------
 
@@ -160,7 +117,6 @@ Firedrake has been successfully installed on Windows 10 using the
 Windows Subsystem for Linux. There are more detailed
 `instructions here <https://github.com/firedrakeproject/firedrake/wiki/Installing-on-Windows-Subsystem-for-Linux>`_.
 Installation on previous versions of Windows is unlikely to work.
-
 
 System anti-requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -208,6 +164,48 @@ MacPorts installed, you should ensure that ``/opt/local/bin`` and
 using Firedrake. This should ensure that no MacPorts installed tools
 are found.
 
+Debugging install problems
+--------------------------
+
+If ``firedrake-install`` fails, the following flowchart describes some
+common build problems and how to solve them. If you understand the
+prognosis and feel comfortable making these fixes yourself then great!
+If not, feel free to ask for more help in our
+:doc:`Slack channel </contact>`.
+
+.. graphviz:: install-debug.dot
+
+If you don't see the issue you're experiencing in this chart, please
+ask us on Slack or report a bug by creating a new `github issue
+<https://github.com/firedrakeproject/firedrake/issues>`__. To help us
+diagnose what's going wrong, **please include the following log files**:
+
+* ``firedrake-install.log`` from Firedrake, which you can find in the
+  directory where you invoked ``firedrake-install`` from
+* ``configure.log`` and ``make.log`` from PETSc, which you can find in
+  ``src/petsc/`` inside the directory where Firedrake virtual
+  environment was created
+
+Likewise, if it's ``firedrake-update`` that fails, please include the
+file ``firedrake-update.log``. You can find this in the Firedrake
+virtual environment.
+
+Recovering from a broken installation script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you find yourself in the unfortunate position that
+``firedrake-update`` won't run because of a bug, and the bug has been
+fixed in Firedrake master, then the following procedure will rebuild
+``firedrake-update`` using the latest version.
+
+From the top directory of your Firedrake install,
+type::
+
+  cd src/firedrake
+  git pull
+  ./scripts/firedrake-install --rebuild-script
+
+You should now be able to run ``firedrake-update``.
 
 Visualisation software
 ----------------------

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -36,12 +36,19 @@ use Firedrake::
 Testing the installation
 ------------------------
 
-It is recommended to run the test suite after installation to check
-that the Firedrake installation is fully functional.  Activate the
-venv_ as above and then run::
+We recommend that you run the test suite after installation to check
+that Firedrake is fully functional. Activate the venv_ as above and
+then run::
 
-  cd firedrake/src/firedrake
-  make alltest
+  cd $VIRTUAL_ENV/src/firedrake
+  python3 -m pytest tests/regression/ -k "poisson_strong | stokes_mini | dg_advection"
+
+This command will run a few of the unit tests, which exercise a good
+chunk of the functionality of the library. These tests should take a
+minute or less. If they fail to run for any reason, please see the
+section below on how to diagnose and debug a failed installation. If
+you want to run the entire test suite you can to ``make alltest``
+instead, but this takes several hours.
 
 .. note::
 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -47,7 +47,7 @@ This command will run a few of the unit tests, which exercise a good
 chunk of the functionality of the library. These tests should take a
 minute or less. If they fail to run for any reason, please see the
 section below on how to diagnose and debug a failed installation. If
-you want to run the entire test suite you can to ``make alltest``
+you want to run the entire test suite you can do ``make alltest``
 instead, but this takes several hours.
 
 .. note::
@@ -188,9 +188,8 @@ There are three ways to work around this problem.
    Anaconda, then install Firedrake. If you need Anaconda later, you
    can re-enable it with a shell script that will add those directories
    back onto your path.
-3. Use a tool like pyenv_, which makes it possible to switch between
-   different versions of Python on a per-terminal session or per-
-   directory basis.
+3. Use a `Docker image <https://hub.docker.com/r/firedrakeproject/firedrake>`_
+   that we've built with Firedrake and its dependencies already installed.
 
 **MacOS system Python.** The official MacOS installer on the Python
 website does not have a working SSL by default. A working SSL is
@@ -251,4 +250,3 @@ packages for which these are also dependencies.
 .. _venv: https://docs.python.org/3/tutorial/venv.html
 .. _homebrew: https://brew.sh/
 .. _PETSc: https://www.mcs.anl.gov/petsc/
-.. _pyenv: https://github.com/pyenv/pyenv

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -69,17 +69,19 @@ If not, feel free to ask for more help in our
 .. graphviz:: install-debug.dot
 
 If you don't see the issue you're experiencing in this chart, please
-report a bug by creating a new `github issue
+ask us on Slack or report a bug by creating a new `github issue
 <https://github.com/firedrakeproject/firedrake/issues>`__. To help us
-diagnose what's going wrong, please include the log file
-``firedrake-install.log`` in your bug report. Likewise, if it's
-``firedrake-update`` that fails, please include the file
-``firedrake-update.log``. If the installation is failing at building
-PETSc, find the ``src/petsc/`` directory inside the directory where the
-Firedrake virtual environment was created. The PETSc directory should
-contain a file ``configure.log`` and possibly also ``make.log`` if it
-got that far. Please send these along too as they contain valuable
-information about what went wrong with PETSc.
+diagnose what's going wrong, **please include the following log files**:
+
+* ``firedrake-install.log`` from Firedrake, which you can find in the
+  directory where you invoked ``firedrake-install`` from
+* ``configure.log`` and ``make.log`` from PETSc, which you can find in
+  ``src/petsc/`` inside the directory where Firedrake virtual
+  environment was created
+
+Likewise, if it's ``firedrake-update`` that fails, please include the
+file ``firedrake-update.log``. You can find this in the Firedrake
+virtual environment.
 
 System requirements
 -------------------

--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -1,0 +1,35 @@
+digraph triage {
+    node [shape=rect];
+
+    can_install [label="Install succeeded?"];
+    install_succeeded [label="yes"];
+    install_failed [label="no"];
+    can_import [label="Can you import\nfiredrake in Python?"];
+    venv_activated [label="venv activated?"];
+    install_script_up_to_date [label="Install script\nup to date?"];
+    using_anaconda [label="Using\nAnaconda?"];
+    python_version [label="Python 3.5?"];
+    using_macos [label="Using\nMacOS?"];
+    using_homebrew [label="Using\nHomebrew?"];
+
+    activate_venv [label="Activate the\nvenv first."];
+    uninstall_anaconda [label="Get rid\nof Anaconda."];
+    update_python [label="Get Python 3.6+"];
+    update_install_script [label="Fetch new\ninstall script"];
+    get_homebrew [label="Use Homebrew."];
+    brew_doctor [label="brew doctor"];
+
+    can_install -> install_succeeded;
+    install_succeeded -> can_import;
+    can_import -> venv_activated [label="no"];
+    venv_activated -> activate_venv [label="no"];
+
+    can_install -> install_failed;
+    install_failed -> {install_script_up_to_date, using_anaconda, python_version, using_macos};
+    install_script_up_to_date -> update_install_script [label="no"];
+    python_version -> update_python [label="yes"];
+    using_anaconda -> uninstall_anaconda [label="yes"];
+    using_macos -> using_homebrew [label="yes"];
+    using_homebrew -> get_homebrew [label="no"];
+    using_homebrew -> brew_doctor [label="yes"];
+}

--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -13,7 +13,7 @@ digraph triage {
     using_homebrew [label="Using\nHomebrew?"];
 
     activate_venv [label="Activate the\nvenv first."];
-    uninstall_anaconda [label="Get rid\nof Anaconda."];
+    uninstall_anaconda [label="Deactivate\nAnaconda."];
     update_python [label="Get Python 3.6+"];
     update_install_script [label="Fetch new\ninstall script"];
     get_homebrew [label="Use Homebrew."];

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1195,6 +1195,8 @@ if mode == "install" or not args.update_script:
         if args.opencascade:
             required_packages.append("liboce-ocaf-dev")
             required_packages.append("swig")
+        if args.documentation_dependencies:
+            required_packages.append("graphviz")
     else:
         log.warning("You do not appear to be running Linux or MacOS. Please do not be surprised if this install fails.")
 


### PR DESCRIPTION
This adds the Sphinx graphviz extension and a .dot file containing the flowchart of how to debug broken installs. I put a few things on the graph to start but obviously there are a lot more, which I can add based on previous issues.

You can bikeshed a lot on the formatting of the rendered graph. I think the important things are to match the font face and size of the rest of the webpage and that it doesn't get super wide.