### PR TITLE
blas kernels for p-MG grid transfer

### DIFF
--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -598,6 +598,8 @@ class MixedInterpolationMatrix(object):
         with self.uc.dat.vec_wo as xc:
             xc.set(0)
 
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
+
         for (i, standalone) in enumerate(self.standalones):
             op2.par_loop(standalone.restrict_kernel, standalone.mesh.cell_set,
                          self.uc.split()[i].dat(op2.INC, standalone.Vc.cell_node_map()),
@@ -620,6 +622,8 @@ class MixedInterpolationMatrix(object):
             op2.par_loop(standalone.prolong_kernel, standalone.mesh.cell_set,
                          self.uf.split()[i].dat(op2.WRITE, standalone.Vf.cell_node_map()),
                          self.uc.split()[i].dat(op2.READ, standalone.Vc.cell_node_map()))
+        
+        [bc.zero(self.uf) for bc in self.Vf_bcs]
 
         with self.uf.dat.vec_ro as xf_:
             if inc:

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -509,10 +509,8 @@ class StandaloneInterpolationMatrix(object):
             return;
         }}
         """
-
-        op2.configuration["ldflags"] = "-lblas"
-        self.prolong_kernel = op2.Kernel(prolong_code, "prolongation")
-        self.restrict_kernel = op2.Kernel(restrict_code, "restriction")
+        self.prolong_kernel = op2.Kernel(prolong_code, "prolongation", ldargs=["-lblas"])
+        self.restrict_kernel = op2.Kernel(restrict_code, "restriction", ldargs=["-lblas"])
 
     @staticmethod
     def get_nodes_1d(V):

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -372,6 +372,23 @@ class StandaloneInterpolationMatrix(object):
             double *A1, double *A2, double *A3,
             double *x , double *y){
 
+        /* Kronecker matrix-vector product
+
+        y = op(A) * x,  A = kron(A3, kron(A2, A1))
+
+        where:
+        op(A) = transpose(A) if tflag>0 else A
+        op(A1) is mx-by-nx,
+        op(A2) is my-by-ny,
+        op(A3) is mz-by-nz,
+        x is (nx*ny*nz)-by-nel,
+        y is (mx*my*mz)-by-nel.
+
+        Important notes:
+        The input data in x is destroyed in the process.
+        Need to allocate nel*max(mx, nx)*max(my, ny)*max(mz, nz) memory for both x and y.
+         */
+
         int m,n,k,s,p,lda;
         char TA1, TA2, TA3;
         char tran='T', notr='N';

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -467,6 +467,9 @@ class StandaloneInterpolationMatrix(object):
         # We transpose before and after the multiplcation times J to have each component
         # stored contiguously as a scalar field, thus reducing the number of dgemm calls.
 
+        # We could benefit from loop tiling for the transpose, but that makes the code
+        # more complicated.
+
         prolong_code = f"""
         {kronmxv_code}
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -294,7 +294,7 @@ def tensor_product_space_query(V):
     if isinstance(ele, firedrake.TensorProductElement):
         family = set(e.family() for e in ele.sub_elements())
         try:
-            variant, = set(e.variant() for e in ele.sub_elements())
+            variant, = set(e.variant() or "spectral" for e in ele.sub_elements())
         except ValueError:
             # Mixed variants
             variant = "mixed"

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -305,7 +305,7 @@ def tensor_product_space_query(V):
 
     isCG = family <= {"Q", "Lagrange"}
     isDG = family <= {"DQ", "Discontinuous Lagrange"}
-    use_tensorproduct = use_tensorproduct and iscube and (isCG or isDG)
+    use_tensorproduct = use_tensorproduct and iscube and (isCG or isDG) and variant == "spectral"
     return use_tensorproduct, N, family, variant
 
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -269,7 +269,7 @@ def tensor_product_space_query(V):
     V must be either CG(N) or DG(N) on quads or hexes (same N along every direction).
 
     :arg V: FunctionSpace
-    :returns: 3-tuple of (use_tensorproduct, degree, family)
+    :returns: 4-tuple of (use_tensorproduct, degree, family, variant)
     """
     from FIAT import reference_element
     ndim = V.ufl_domain().topological_dimension()

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -272,7 +272,7 @@ def tensor_product_space_query(V):
     :returns: 3-tuple of (use_tensorproduct, degree, family)
     """
     from FIAT import reference_element
-    iscube = reference_element.is_hypercube(V.finat_element.cell)
+    iscube = V.finat_element.cell.get_dimension() > 1 and reference_element.is_hypercube(V.finat_element.cell)
 
     ele = V.ufl_element()
     if isinstance(ele, (firedrake.VectorElement, firedrake.TensorElement)):


### PR DESCRIPTION
Implement custom blas kernels when StandaloneInterpolationMatrix is instantiated between two CG/DG spaces with tensor product cells. This is meant to be temporary until we get structure-preserving symbolic dual evaluation.

As a result, we obtain optimal complexity for the p-MG grid transfer operators.
For this example we have setup a mesh with 64 hexes and CG(N). 

Before the custom kernel we were getting a segfault for N=31, and notice the different complexities.
![noblas_4x4x4](https://user-images.githubusercontent.com/6486130/84685741-ab933b80-af32-11ea-9692-f9acad46766a.png)

After custom kernel:
![blas_4x4x4](https://user-images.githubusercontent.com/6486130/84685775-b8b02a80-af32-11ea-9d76-c19a647273fb.png)
