### PR TITLE
Tweaks to zenodo documentation

### DIFF
--- a/docs/source/zenodo.rst
+++ b/docs/source/zenodo.rst
@@ -52,7 +52,9 @@ scripts in your path.
 
    This file could, for example, contain DOIs of any archived
    simulation code that you used over and above the core Firedrake
-   components.
+   components.  It can also be a single python script or a tarball (or
+   other archive) of your code and any data required to reproduce your
+   results.
 
    This will create a file ``firedrake.json`` containing the required
    information.
@@ -111,16 +113,21 @@ of Firedrake components you used. This covers your bases as far as
 concerns Firedrake, but doesn't cover your code which uses
 Firedrake. Best practice in computational science also demands that
 you provide the code which you used to conduct your experiments. You
-could attach a tarball as a supplement to your paper, or you could
-also use Zenodo. Using Zenodo in combination with GitHub for this
-purpose is documented `by github here
+could attach a tarball as a supplement to your paper, embed a tarball
+(or single script) in the Zenodo release generated to record your
+Firedrake components, or you could also use Zenodo to generate a DOI
+directly from your GitHub source repository. Using Zenodo in
+combination with GitHub for this purpose is documented `by github here
 <https://guides.github.com/activities/citable-code/>`_.
 
 .. note::
 
    If you archive your code before running ``firedrake-zenodo``, you
    can ensure that the eventual release also references these DOIs by
-   providing them as part of the ``--info-file`` argument.
+   providing them in a text file via the ``--info-file`` argument.
+   You can also directly attach your code (either a single script or a
+   single archive containing it) to the Firedrake Zenodo release using
+   the same argument.
 
 Cite your sources
 ~~~~~~~~~~~~~~~~~

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -9,3 +9,4 @@ randomgen==1.16.4
 vtk==8.1.2
 pkgconfig
 cached_property
+requests

--- a/scripts/firedrake-zenodo
+++ b/scripts/firedrake-zenodo
@@ -105,7 +105,7 @@ parser.add_argument("--bibtex-file", action="store", nargs=1, default=["firedrak
 parser.add_argument("--title", "-t", action="store", nargs=1,
                     help="""Short description of the reason for this release.  Will be formatted as 'Software used in "TITLE"'""")
 parser.add_argument("--info-file", action="store", nargs=1,
-                    help="""File containing additional information to be added to the Zenodo meta-record (e.g. dois linking to your simulation code).  Will be uploaded to Zenodo using the provided name.""")
+                    help="""File containing additional information to be added to the Zenodo meta-record (e.g. dois linking to your simulation code, or an archive of your simulation code and any necessary data).  Will be uploaded to Zenodo using the provided name.""")
 parser.add_argument("--new-version-of", action="store", nargs=1,
                     help="Is this release a new version of a previous release (e.g. round two of a paper). If so, provide the DOI of the meta-release this is a new version of.")
 parser.add_argument("--honour-petsc-dir", action="store_true",


### PR DESCRIPTION
I was slightly confused by the documentation on how to use Zenodo, which didn't seem to cover the common use-case of passing a tarball to the `--info-file` option of the script.  This changes the documentation (for both the webpage and the `--help` option) to (hopefully) be more clear.

I also discovered an untracked dependency for `firedrake-zenodo` of the `requests` module, and added that to `requirements-ext.txt`