### PR TITLE
Dual Evaluation with FInAT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
               sh 'mkdir tmp'
               dir('tmp') {
                 timestamps {
-                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager || (cat firedrake-install.log && /bin/false)'
+                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager --package-branch tsfc dual_base_fiat --package-branch FInAT dual_base_fiat || (cat firedrake-install.log && /bin/false)'
                 }
               }
             }

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -243,7 +243,7 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
         kernel = op2.Kernel(ast, ast.name, requires_zeroed_output_arguments=True)
     elif hasattr(expr, "eval"):
         to_pts = []
-        for dual in to_element.fiat_equivalent.dual_basis():
+        for dual in to_element.dual_basis():
             if not isinstance(dual, FIAT.functional.PointEvaluation):
                 raise NotImplementedError("Can only interpolate Python kernels with Lagrange elements")
             pts, = dual.pt_dict.keys()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -7,7 +7,7 @@ from ufl.algorithms import extract_arguments
 
 from pyop2 import op2
 
-from tsfc.finatinterface import create_base_element
+from tsfc.finatinterface import create_element
 from tsfc import compile_expression_dual_evaluation
 
 import firedrake
@@ -211,7 +211,7 @@ def make_interpolator(expr, V, subset, access):
 @utils.known_pyop2_safe
 def _interpolator(V, tensor, expr, subset, arguments, access):
     try:
-        to_element = create_base_element(V.ufl_element())
+        to_element = create_element(V.ufl_element())
     except KeyError:
         # FInAT only elements
         raise NotImplementedError("Don't know how to create FIAT element for %s" % V.ufl_element())
@@ -317,7 +317,7 @@ def compile_python_kernel(expression, to_pts, to_element, fs, coords):
     function provided."""
 
     coords_space = coords.function_space()
-    coords_element = create_base_element(coords_space.ufl_element()).fiat_equivalent
+    coords_element = create_element(coords_space.ufl_element()).fiat_equivalent
 
     X_remap = list(coords_element.tabulate(0, to_pts).values())[0]
 

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -162,44 +162,6 @@ def test_hcurl_2d():
     assert np.allclose(g.dat.data, h.dat.data)
 
 
-def test_hdiv_2d():
-    mesh = UnitCubedSphereMesh(2)
-    x = SpatialCoordinate(mesh)
-    mesh.init_cell_orientations(x)
-    x = mesh.coordinates
-
-    U = FunctionSpace(mesh, 'RTCF', 1)
-    V = FunctionSpace(mesh, 'RTCF', 2)
-    c = as_vector([x[1], -x[0], 0.0])
-
-    f = interpolate(c, U)
-    g = interpolate(f, V)
-
-    # g shall be equivalent to:
-    h = interpolate(f, V)
-
-    assert np.allclose(g.dat.data, h.dat.data)
-
-
-def test_hcurl_2d():
-    mesh = UnitCubedSphereMesh(2)
-    x = SpatialCoordinate(mesh)
-    mesh.init_cell_orientations(x)
-    x = mesh.coordinates
-
-    U = FunctionSpace(mesh, 'RTCE', 1)
-    V = FunctionSpace(mesh, 'RTCE', 2)
-    c = as_vector([-x[1], x[0], 0.0])
-
-    f = interpolate(c, U)
-    g = interpolate(f, V)
-
-    # g shall be equivalent to:
-    h = interpolate(f, V)
-
-    assert np.allclose(g.dat.data, h.dat.data)
-
-
 def test_cell_orientation():
     m = UnitCubedSphereMesh(2)
     x = SpatialCoordinate(m)

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -80,6 +80,23 @@ def test_vector():
     assert np.allclose(g.dat.data, h.dat.data)
 
 
+def test_tensor():
+    mesh = UnitSquareMesh(2, 2)
+    x = SpatialCoordinate(mesh)
+    U = TensorFunctionSpace(mesh, 'P', 1)
+    V = TensorFunctionSpace(mesh, 'CG', 2)
+
+    c = as_tensor(((Constant(2.0), x[1]), (x[0], x[0] * x[1])))
+
+    f = project(c, U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = project(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
 def test_constant_expression():
     m = UnitTriangleMesh()
     x = SpatialCoordinate(m)
@@ -103,6 +120,82 @@ def test_compound_expression():
 
     # g shall be equivalent to:
     h = interpolate(3.0 + sin(pi * x[0]), V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_hdiv_2d():
+    mesh = UnitCubedSphereMesh(2)
+    x = SpatialCoordinate(mesh)
+    mesh.init_cell_orientations(x)
+    x = mesh.coordinates
+
+    U = FunctionSpace(mesh, 'RTCF', 1)
+    V = FunctionSpace(mesh, 'RTCF', 2)
+    c = as_vector([x[1], -x[0], 0.0])
+
+    f = project(c, U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = project(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_hcurl_2d():
+    mesh = UnitCubedSphereMesh(2)
+    x = SpatialCoordinate(mesh)
+    mesh.init_cell_orientations(x)
+    x = mesh.coordinates
+
+    U = FunctionSpace(mesh, 'RTCE', 1)
+    V = FunctionSpace(mesh, 'RTCE', 2)
+    c = as_vector([-x[1], x[0], 0.0])
+
+    f = project(c, U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = project(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_hdiv_2d():
+    mesh = UnitCubedSphereMesh(2)
+    x = SpatialCoordinate(mesh)
+    mesh.init_cell_orientations(x)
+    x = mesh.coordinates
+
+    U = FunctionSpace(mesh, 'RTCF', 1)
+    V = FunctionSpace(mesh, 'RTCF', 2)
+    c = as_vector([x[1], -x[0], 0.0])
+
+    f = interpolate(c, U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = interpolate(f, V)
+
+    assert np.allclose(g.dat.data, h.dat.data)
+
+
+def test_hcurl_2d():
+    mesh = UnitCubedSphereMesh(2)
+    x = SpatialCoordinate(mesh)
+    mesh.init_cell_orientations(x)
+    x = mesh.coordinates
+
+    U = FunctionSpace(mesh, 'RTCE', 1)
+    V = FunctionSpace(mesh, 'RTCE', 2)
+    c = as_vector([-x[1], x[0], 0.0])
+
+    f = interpolate(c, U)
+    g = interpolate(f, V)
+
+    # g shall be equivalent to:
+    h = interpolate(f, V)
 
     assert np.allclose(g.dat.data, h.dat.data)
 


### PR DESCRIPTION
Performing dual evaluation in FInAT has been a long awaited feature in firedrake. This allows interaction with dual_evaluation methods in FInAT. To be used with corresponding branches in [FInAT #57](https://github.com/FInAT/FInAT/pull/57) and [TSFC #218](https://github.com/firedrakeproject/tsfc/pull/218).