### PR TITLE
Cache aux coordinate functions in mesh

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1042,8 +1042,9 @@ class MeshGeometry(ufl.Mesh, MeshGeometryMixin):
         self._coordinates = coordinates
 
         # Cached coordinate functions in different function spaces
-        # dict: FunctionSpace -> (coordinate Function, interpolator)
-        self.aux_coordinate_functions = {}
+        # In practice we store the interpolator object which contains the func
+        # dict: UFL element -> coordinate interpolator
+        self.aux_coord_interpolators = weakref.WeakValueDictionary()
 
     def init(self):
         """Finish the initialisation of the mesh.  Most of the time
@@ -1100,7 +1101,7 @@ values from f.)"""
 
         Mesh coordinates are re-interpolated on aux functions.
         """
-        for _, interpolator in self.aux_coordinate_functions.values():
+        for interpolator in self.aux_coord_interpolators.values():
             interpolator.interpolate()
 
     @utils.cached_property

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1041,6 +1041,10 @@ class MeshGeometry(ufl.Mesh, MeshGeometryMixin):
 
         self._coordinates = coordinates
 
+        # Cached coordinate functions in different function spaces
+        # dict: FunctionSpace -> (coordinate Function, interpolator)
+        self.aux_coordinate_functions = {}
+
     def init(self):
         """Finish the initialisation of the mesh.  Most of the time
         this is carried out automatically, however, in some cases (for
@@ -1089,6 +1093,15 @@ object whose coordinates are f's values.  (This will not copy the
 values from f.)"""
 
         raise AttributeError(message)
+
+    def update_aux_coordinates(self):
+        """
+        Updates all cached aux-coordinate functions.
+
+        Mesh coordinates are re-interpolated on aux functions.
+        """
+        for _, interpolator in self.aux_coordinate_functions.values():
+            interpolator.interpolate()
 
     @utils.cached_property
     def cell_sizes(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -446,7 +446,9 @@ class MeshTopology(object):
         # equal their topological dimension. This is reflected in the
         # corresponding UFL mesh.
         cell = ufl.Cell(_cells[tdim][nfacets])
-        self._ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1, dim=cell.topological_dimension()))
+        element = ufl.FiniteElement("Lagrange", cell, 1, variant="equispaced")
+        vector_element = ufl.VectorElement(element, dim=cell.topological_dimension())
+        self._ufl_mesh = ufl.Mesh(vector_element)
         # A set of weakrefs to meshes that are explicitly labelled as being
         # parallel-compatible for interpolation/projection/supermeshing
         # To set, do e.g.
@@ -858,7 +860,9 @@ class ExtrudedMeshTopology(MeshTopology):
         self._entity_classes = mesh._entity_classes
         self._subsets = {}
         cell = ufl.TensorProductCell(mesh.ufl_cell(), ufl.interval)
-        self._ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1, dim=cell.topological_dimension()))
+        element = ufl.FiniteElement("Lagrange", cell, 1, variant="equispaced")
+        vector_element = ufl.VectorElement(element, dim=cell.topological_dimension())
+        self._ufl_mesh = ufl.Mesh(vector_element)
         if layers.shape:
             self.variable_layers = True
             extents = extnum.layer_extents(self._topology_dm,

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -420,11 +420,13 @@ class File(object):
     def _prepare_output(self, function, max_elem):
         from firedrake import FunctionSpace, VectorFunctionSpace, \
             TensorFunctionSpace, Function, Projector, Interpolator
+        from tsfc.finatinterface import create_element as create_finat_element
 
         name = function.name()
         # Need to project/interpolate?
-        # If space is not the max element, we can do so.
-        if function.ufl_element == max_elem:
+        # If space is not the max element, we must do so.
+        finat_elem = function.function_space().finat_element
+        if finat_elem == create_finat_element(max_elem):
             return OFunction(array=get_array(function),
                              name=name, function=function)
         #  OK, let's go and do it.

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -909,7 +909,9 @@ def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
     coords *= scale
     m = mesh.Mesh(plex, dim=3, reorder=reorder, distribution_parameters=distribution_parameters)
     if degree > 1:
-        new_coords = function.Function(functionspace.VectorFunctionSpace(m, "CG", degree))
+        element = ufl.FiniteElement("Lagrange", m.ufl_cell(), degree, variant="equispaced")
+        vector_element = ufl.VectorElement(element)
+        new_coords = function.Function(functionspace.FunctionSpace(m, vector_element))
         new_coords.interpolate(ufl.SpatialCoordinate(m))
         # "push out" to sphere
         new_coords.dat.data[:] *= (radius / np.linalg.norm(new_coords.dat.data, axis=1)).reshape(-1, 1)
@@ -998,7 +1000,10 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     m = mesh.Mesh(plex, dim=3, reorder=reorder, distribution_parameters=distribution_parameters)
     if degree > 1:
         # use it to build a higher-order mesh
-        m = mesh.Mesh(interpolate(ufl.SpatialCoordinate(m), VectorFunctionSpace(m, "CG", degree)))
+        element = ufl.FiniteElement("Lagrange", m.ufl_cell(), degree, variant="equispaced")
+        vector_element = ufl.VectorElement(element)
+        fs_coords = functionspace.FunctionSpace(m, vector_element)
+        m = mesh.Mesh(interpolate(ufl.SpatialCoordinate(m), fs_coords))
 
     # remap to a cone
     x, y, z = ufl.SpatialCoordinate(m)
@@ -1030,7 +1035,9 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
                                                                y*scale,
                                                                znew]),
                                Vc)
-    Vlow = VectorFunctionSpace(m, "CG", 1)
+    element = ufl.FiniteElement("Lagrange", m.ufl_cell(), 1, variant="equispaced")
+    vector_element = ufl.VectorElement(element)
+    Vlow = functionspace.FunctionSpace(m, vector_element)
     Xlow = interpolate(Xlatitudinal, Vlow)
     r = ufl.sqrt(Xlow[0]**2 + Xlow[1]**2 + Xlow[2]**2)
     Xradial = Constant(radius)*Xlow/r
@@ -1224,7 +1231,9 @@ def CubedSphereMesh(radius, refinement_level=0, degree=1,
     m = mesh.Mesh(plex, dim=3, reorder=reorder, distribution_parameters=distribution_parameters)
 
     if degree > 1:
-        new_coords = function.Function(functionspace.VectorFunctionSpace(m, "Q", degree))
+        element = ufl.FiniteElement("Lagrange", m.ufl_cell(), degree, variant="equispaced")
+        vector_element = ufl.VectorElement(element)
+        new_coords = function.Function(functionspace.FunctionSpace(m, vector_element))
         new_coords.interpolate(ufl.SpatialCoordinate(m))
         # "push out" to sphere
         new_coords.dat.data[:] *= (radius / np.linalg.norm(new_coords.dat.data, axis=1)).reshape(-1, 1)


### PR DESCRIPTION
Currently each `File` object stores its own coordinate function in case the output function space differs from the `mesh.coordinates` function space. This is inefficient if user creates multiple `File` objects that have the same output function space.

In this PR the aux coordinate functions are stored in `MeshGeometry` instead.

Addresses #1763. Sits on top of #1732.