### PR TITLE
Don't install exodus by default

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -488,7 +488,6 @@ if not options["minimal_petsc"]:
     # File formats
     petsc_options.add("--download-netcdf")
     petsc_options.add("--download-pnetcdf")
-    petsc_options.add("--download-exodusii")
     # Sparse direct solvers
     petsc_options.add("--download-suitesparse")
     petsc_options.add("--download-pastix")


### PR DESCRIPTION
ExodusII is used by very few users (none?) and sometimes causes installation issues. This PR just removes it from the set of things we install by default.