### PR TITLE
Fix annotation of uninitialised self-dependent project

### DIFF
--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -29,16 +29,17 @@ class FunctionMixin(FloatingType):
 
             annotate = annotate_tape(kwargs)
 
-            with stop_annotating():
-                output = project(self, b, *args, **kwargs)
-
             if annotate:
-                bcs = kwargs.pop("bcs", [])
-                block = ProjectBlock(b, self.function_space(), output, bcs)
+                bcs = kwargs.get("bcs", [])
+                block = ProjectBlock(b, self.function_space(), self, bcs)
 
                 tape = get_working_tape()
                 tape.add_block(block)
 
+            with stop_annotating():
+                output = project(self, b, *args, **kwargs)
+
+            if annotate:
                 block.add_output(output.create_block_variable())
 
             return output

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
-from pyadjoint.overloaded_type import create_overloaded_object
 from firedrake.adjoint.blocks import ProjectBlock
+from firedrake import function
 
 
 def annotate_project(project):
@@ -16,19 +16,24 @@ def annotate_project(project):
         visualisation)."""
 
         annotate = annotate_tape(kwargs)
+        if annotate:
+            bcs = kwargs.get("bcs", [])
+            sb_kwargs = ProjectBlock.pop_kwargs(kwargs)
+            if isinstance(args[1], function.Function):
+                # block should be created before project because output might also be an input that needs checkpointing
+                output = args[1]
+                V = output.function_space()
+                block = ProjectBlock(args[0], V, output, bcs, **sb_kwargs)
+
         with stop_annotating():
             output = project(*args, **kwargs)
-        output = create_overloaded_object(output)
 
         if annotate:
-            bcs = kwargs.pop("bcs", [])
-            sb_kwargs = ProjectBlock.pop_kwargs(kwargs)
-            block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
-
             tape = get_working_tape()
+            if not isinstance(args[1], function.Function):
+                block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
             tape.add_block(block)
-
-            block.add_output(output.block_variable)
+            block.add_output(output.create_block_variable())
 
         return output
 


### PR DESCRIPTION
Fix for #1758. Also fixes the annotation of the `project` _function_ (which was more generally broken). Tests in https://github.com/dolfin-adjoint/pyadjoint/tree/test-firedrake-project