### PR TITLE
Rename MeshTopology _plex property _topology_dm

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -132,7 +132,7 @@ class BCBase(object):
         # convert: (i, j, (k, l)) -> ((i, ), (j, ), (k, l))
         sub_d = [as_tuple(i) for i in sub_d]
 
-        ndim = self.function_space().mesh()._plex.getDimension()
+        ndim = self.function_space().mesh()._topology_dm.getDimension()
         sd = [[] for _ in range(ndim)]
         for i in sub_d:
             sd[ndim - len(i)].append(i)

--- a/firedrake/cython/dmplex.pyx
+++ b/firedrake/cython/dmplex.pyx
@@ -453,7 +453,7 @@ def create_section(mesh, nodes_per_entity, on_base=False):
         else:
             nodes_per_entity = sum(nodes_per_entity[:, i]*(mesh.layers - i) for i in range(2))
 
-    dm = mesh._plex
+    dm = mesh._topology_dm
     renumbering = mesh._plex_renumbering
     section = PETSc.Section().create(comm=mesh.comm)
     pStart, pEnd = dm.getChart()
@@ -544,7 +544,7 @@ def get_cell_nodes(mesh,
         flat_index[i] = flat_index_list[i]
 
     # Fill cell nodes
-    cStart, cEnd = mesh._plex.getHeightStratum(0)
+    cStart, cEnd = mesh._topology_dm.getHeightStratum(0)
     cell_nodes = np.empty((cEnd - cStart, dofs_per_cell), dtype=IntType)
     cell_numbering = mesh._cell_numbering
     for c in range(cStart, cEnd):
@@ -598,7 +598,7 @@ def get_facet_nodes(mesh, np.ndarray[PetscInt, ndim=2, mode="c"] cell_nodes, lab
     if label not in {"interior_facets", "exterior_facets"}:
         raise ValueError("Unsupported facet label '%s'", label)
 
-    dm = mesh._plex
+    dm = mesh._topology_dm
     variable = mesh.variable_layers
 
     if variable and offset is None:

--- a/firedrake/cython/extrusion_numbering.pyx
+++ b/firedrake/cython/extrusion_numbering.pyx
@@ -341,7 +341,7 @@ def node_classes(mesh, nodes_per_entity):
 
     node_classes = numpy.zeros(3, dtype=IntType)
 
-    dm = mesh._plex
+    dm = mesh._topology_dm
     dimension = dm.getDimension()
     stratum_bounds = numpy.zeros((dimension + 1, 2), dtype=IntType)
     for i in range(dimension + 1):
@@ -385,7 +385,7 @@ def entity_layers(mesh, height, label=None):
         const PetscInt *renumbering
         PetscBool flg
 
-    dm = mesh._plex
+    dm = mesh._topology_dm
 
     hStart, hEnd = dm.getHeightStratum(height)
     if label is None:
@@ -472,7 +472,7 @@ def top_bottom_boundary_nodes(mesh,
         if section.getDof(facet_points[i]) != section.getDof(facet_points[0]):
             raise ValueError("All vertical facets should mask same number of dofs")
 
-    dm = mesh._plex
+    dm = mesh._topology_dm
     fStart, fEnd = dm.getHeightStratum(1)
     if top:
         num_indices = (section.getDof(top_facet) * ncell

--- a/firedrake/cython/mgimpl.pyx
+++ b/firedrake/cython/mgimpl.pyx
@@ -241,8 +241,8 @@ def coarse_to_fine_cells(mc, mf, clgmaps, flgmaps):
         np.ndarray[PetscInt, ndim=2, mode="c"] fine_to_coarse
         np.ndarray[PetscInt, ndim=1, mode="c"] co2n, fn2o, idx
 
-    cdm = mc._plex
-    fdm = mf._plex
+    cdm = mc._topology_dm
+    fdm = mf._topology_dm
     dim = cdm.getDimension()
     nref = 2 ** dim
     ncoarse = mc.cell_set.size

--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -87,7 +87,7 @@ def get_node_set(mesh, key):
     nodes_per_entity, real_tensorproduct = key
     global_numbering = get_global_numbering(mesh, (nodes_per_entity, real_tensorproduct))
     node_classes = mesh.node_classes(nodes_per_entity, real_tensorproduct=real_tensorproduct)
-    halo = halo_mod.Halo(mesh._plex, global_numbering)
+    halo = halo_mod.Halo(mesh._topology_dm, global_numbering)
     node_set = op2.Set(node_classes, halo=halo, comm=mesh.comm)
     extruded = mesh.cell_set._extruded
 
@@ -124,7 +124,7 @@ def get_facet_node_list(mesh, kind, cell_node_list, offsets):
         nodes.
     """
     assert kind in ["interior_facets", "exterior_facets"]
-    if mesh._plex.getStratumSize(kind, 1) > 0:
+    if mesh._topology_dm.getStratumSize(kind, 1) > 0:
         return dmplex.get_facet_nodes(mesh, cell_node_list, kind, offsets)
     else:
         return numpy.array([], dtype=IntType)

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -369,7 +369,7 @@ class FunctionSpace(object):
         dm = self.dof_dset.dm
         _, level = get_level(self.mesh())
         dmhooks.attach_hooks(dm, level=level,
-                             sf=self.mesh()._plex.getPointSF(),
+                             sf=self.mesh()._topology_dm.getPointSF(),
                              section=self._shared_data.global_numbering)
         # Remember the function space so we can get from DM back to FunctionSpace.
         dmhooks.set_function_space(dm, self)
@@ -859,7 +859,7 @@ class RealFunctionSpace(FunctionSpace):
         dm = self.dof_dset.dm
         _, level = get_level(self.mesh())
         dmhooks.attach_hooks(dm, level=level,
-                             sf=self.mesh()._plex.getPointSF(),
+                             sf=self.mesh()._topology_dm.getPointSF(),
                              section=None)
         # Remember the function space so we can get from DM back to FunctionSpace.
         dmhooks.set_function_space(dm, self)

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -92,7 +92,7 @@ def MeshHierarchy(mesh, refinement_levels,
         callback receives the refined DM (and the current level).
     :arg mesh_builder: Function to turn a DM into a :class:`~.Mesh`. Used by pyadjoint.
     """
-    cdm = mesh._plex
+    cdm = mesh._topology_dm
     cdm.setRefinementUniform(True)
     dms = []
     if mesh.comm.size > 1 and mesh._grown_halos:
@@ -151,10 +151,10 @@ def MeshHierarchy(mesh, refinement_levels,
 
     lgmaps = []
     for i, m in enumerate(meshes):
-        no = impl.create_lgmap(m._plex)
+        no = impl.create_lgmap(m._topology_dm)
         m.init()
-        o = impl.create_lgmap(m._plex)
-        m._plex.setRefineLevel(i)
+        o = impl.create_lgmap(m._topology_dm)
+        m._topology_dm.setRefineLevel(i)
         lgmaps.append((no, o))
 
     coarse_to_fine_cells = []

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -90,7 +90,7 @@ class ASMLinesmoothPC(ASMPatchPC):
     def get_patches(self, V):
         mesh = V._mesh
         assert mesh.cell_set._extruded
-        dm = mesh._plex
+        dm = mesh._topology_dm
         section = V.dm.getDefaultSection()
         lgmap = V.dof_dset.lgmap
 

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -687,7 +687,7 @@ class PatchBase(PCSNESBase):
             bcs = ctx._problem.bcs
 
         mesh = J.ufl_domain()
-        self.plex = mesh._plex
+        self.plex = mesh._topology_dm
         # We need to attach the mesh to the plex, so that
         # PlaneSmoothers (and any other user-customised patch
         # constructors) can use firedrake's opinion of what


### PR DESCRIPTION
This generalisation will allow meshes made with other DMs. Note this is an API change (though not officially public facing).