### PR TITLE
Adding ASMStarPC

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -156,7 +156,7 @@ class ASMVankaPC(ASMPatchPC):
         depth = PETSc.Options().getInt(self.prefix + "construct_dim", default=-1)
         height = PETSc.Options().getInt(self.prefix + "construct_codim", default=-1)
         if (depth == -1 and height == -1) or (depth != -1 and height != -1):
-            raise ValueError(f"Must set exactly one of {self.prefix + 'construct_dim'} or {self.prefix + 'construct_codim'}!")
+            raise ValueError(f"Must set exactly one of {self.prefix}construct_dim or {self.prefix}construct_codim")
 
         # Accessing .indices causes the allocation of a global array,
         # so we need to cache these for efficiency

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -49,11 +49,6 @@ class ASMPatchPC(PCBase):
         if "sub_pc_factor_shift_type" not in opts:
             opts["sub_pc_factor_shift_type"] = "NONE"
 
-        # Try to do this programatically
-        # ksp = asmpc.getASMSubKSP()
-        # ksp.pc.setType(PETSc.PC.Type.LU)
-        # ksp.pc.setFactorShift(shift_type=PETSc.Mat.FactorShiftType.NONZERO)
-
         asmpc.setFromOptions()
         self.asmpc = asmpc
 

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -36,10 +36,24 @@ class ASMPatchPC(PCBase):
         # Create new PC object as ASM type and set index sets for patches
         asmpc = PETSc.PC().create(comm=pc.comm)
         asmpc.incrementTabLevel(1, parent=pc)
-        asmpc.setOptionsPrefix(self.prefix + "_sub")
+        asmpc.setOptionsPrefix(self.prefix + "sub_")
         asmpc.setOperators(*pc.getOperators())
         asmpc.setType(asmpc.Type.ASM)
         asmpc.setASMLocalSubdomains(len(ises), ises)
+
+        # Set default solver parameters
+        asmpc.setASMType(PETSc.PC.ASMType.BASIC)
+        opts = PETSc.Options(asmpc.getOptionsPrefix())
+        if "sub_pc_type" not in opts:
+            opts["sub_pc_type"] = "lu"
+        if "sub_pc_factor_shift_type" not in opts:
+            opts["sub_pc_factor_shift_type"] = "NONE"
+
+        # Try to do this programatically
+        # ksp = asmpc.getASMSubKSP()
+        # ksp.pc.setType(PETSc.PC.Type.LU)
+        # ksp.pc.setFactorShift(shift_type=PETSc.Mat.FactorShiftType.NONZERO)
+
         asmpc.setFromOptions()
         self.asmpc = asmpc
 

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -53,8 +53,8 @@ class ASMPatchPC(PCBase):
         '''
         pass
 
-    def view(self, pc):
-        self.ampc.view()
+    def view(self, pc, viewer=None):
+        self.asmpc.view(viewer=viewer)
 
     def update(self, pc):
         self.asmpc.setUp()

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -1,0 +1,294 @@
+import pytest
+from firedrake import *
+
+
+@pytest.fixture(params=["scalar", "vector", "mixed"])
+def problem_type(request):
+    return request.param
+
+
+def test_star_equivalence(problem_type):
+    distribution_parameters = {"partition": True,
+                               "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+
+    if problem_type == "scalar":
+        base = UnitSquareMesh(10, 10, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 2, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = FunctionSpace(mesh, "CG", 1)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        a = inner(grad(u), grad(v))*dx - inner(Constant(1), v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        star_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 0.5,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.ASMStarPC",
+                       "mg_levels_pc_star_construct_dim": 0}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 0.5,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "jacobi"}
+
+    elif problem_type == "vector":
+        base = UnitCubeMesh(2, 2, 2, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 2, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = FunctionSpace(mesh, "RT", 2)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        (x, y, z) = SpatialCoordinate(mesh)
+        f = as_vector([x*(1-x), y*(1-y), z*(1-z)])
+        a = inner(div(u), div(v))*dx + inner(u, v)*dx - inner(f, v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        star_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "cg",
+                       "pc_type": "mg",
+                       "pc_mg_type": "full",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 1/4,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.ASMStarPC",
+                       "mg_levels_pc_star_construct_dim": 1,
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "cg",
+                       "pc_type": "mg",
+                       "pc_mg_type": "full",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 1/4,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.PatchPC",
+                       "mg_levels_patch_pc_patch_save_operators": True,
+                       "mg_levels_patch_pc_patch_construct_type": "star",
+                       "mg_levels_patch_pc_patch_construct_dim": 1,
+                       "mg_levels_patch_pc_patch_sub_mat_type": "seqdense",
+                       "mg_levels_patch_sub_ksp_type": "preonly",
+                       "mg_levels_patch_sub_pc_type": "lu",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    elif problem_type == "mixed":
+        base = UnitSquareMesh(5, 5, distribution_parameters=distribution_parameters, quadrilateral=True)
+        mh = MeshHierarchy(base, 1, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V1 = VectorFunctionSpace(mesh, "CG", 2)
+        V2 = FunctionSpace(mesh, "CG", 1)
+        V = MixedFunctionSpace([V1, V2])
+
+        u = Function(V)
+        (z, p) = split(u)
+        (v, q) = split(TestFunction(V))
+
+        a = inner(grad(z), grad(v))*dx - inner(p, div(v))*dx - inner(q, div(z))*dx
+
+        bcs = DirichletBC(V.sub(0), Constant((1., 0.)), "on_boundary")
+        nsp = MixedVectorSpaceBasis(V, [V.sub(0), VectorSpaceBasis(constant=True)])
+
+        star_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "chebyshev",
+                       "mg_levels_ksp_max_it": 2,
+                       "mg_levels_ksp_convergence_test": "skip",
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.ASMStarPC",
+                       "mg_levels_pc_star_construct_dim": 0,
+                       "mg_levels_pc_star_sub_sub_pc_factor_shift_type": "nonzero",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "chebyshev",
+                       "mg_levels_ksp_max_it": 2,
+                       "mg_levels_ksp_convergence_test": "skip",
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.PatchPC",
+                       "mg_levels_patch_pc_patch_save_operators": True,
+                       "mg_levels_patch_pc_patch_construct_type": "star",
+                       "mg_levels_patch_pc_patch_construct_dim": 0,
+                       "mg_levels_patch_pc_patch_sub_mat_type": "seqdense",
+                       "mg_levels_patch_sub_ksp_type": "preonly",
+                       "mg_levels_patch_sub_pc_type": "lu",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
+    star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=star_params, nullspace=nsp)
+    star_solver.solve()
+    star_its = star_solver.snes.getLinearSolveIterations()
+
+    u.assign(0)
+    comp_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=comp_params, nullspace=nsp)
+    comp_solver.solve()
+    comp_its = comp_solver.snes.getLinearSolveIterations()
+
+    assert star_its == comp_its
+
+
+def test_vanka_equivalence(problem_type):
+    distribution_parameters = {"partition": True,
+                               "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+
+    if problem_type == "scalar":
+        base = UnitSquareMesh(10, 10, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 2, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = FunctionSpace(mesh, "CG", 1)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        a = inner(grad(u), grad(v))*dx - inner(Constant(1), v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        vanka_params = {"mat_type": "aij",
+                        "snes_type": "ksponly",
+                        "ksp_type": "richardson",
+                        "pc_type": "mg",
+                        "pc_mg_type": "multiplicative",
+                        "pc_mg_cycles": "v",
+                        "mg_levels_ksp_type": "richardson",
+                        "mg_levels_ksp_richardson_scale": 1/10,
+                        "mg_levels_ksp_max_it": 1,
+                        "mg_levels_pc_type": "python",
+                        "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
+                        "mg_levels_pc_vanka_construct_codim": 0,
+                        "mg_coarse_pc_type": "python",
+                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 1/10,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.PatchPC",
+                       "mg_levels_patch_pc_patch_save_operators": True,
+                       "mg_levels_patch_pc_patch_construct_type": "vanka",
+                       "mg_levels_patch_pc_patch_construct_codim": 0,
+                       "mg_levels_patch_pc_patch_sub_mat_type": "seqdense",
+                       "mg_levels_patch_sub_ksp_type": "preonly",
+                       "mg_levels_patch_sub_pc_type": "lu",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    elif problem_type == "vector":
+        base = UnitSquareMesh(2, 2, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 1, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = FunctionSpace(mesh, "RT", 1)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        (x, y) = SpatialCoordinate(mesh)
+        f = as_vector([x*(1-x), y*(1-y)])
+        a = inner(div(u), div(v))*dx + inner(u, v)*dx - inner(f, v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        vanka_params = {"mat_type": "aij",
+                        "snes_type": "ksponly",
+                        "ksp_type": "cg",
+                        "pc_type": "mg",
+                        "pc_mg_type": "full",
+                        "mg_levels_ksp_type": "richardson",
+                        "mg_levels_ksp_richardson_scale": 3/10,
+                        "mg_levels_ksp_max_it": 1,
+                        "mg_levels_pc_type": "python",
+                        "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
+                        "mg_levels_pc_vanka_construct_codim": 0,
+                        "mg_coarse_pc_type": "python",
+                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "cg",
+                       "pc_type": "mg",
+                       "pc_mg_type": "full",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 3/10,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.PatchPC",
+                       "mg_levels_patch_pc_patch_save_operators": True,
+                       "mg_levels_patch_pc_patch_construct_type": "vanka",
+                       "mg_levels_patch_pc_patch_construct_codim": 0,
+                       "mg_levels_patch_pc_patch_sub_mat_type": "seqdense",
+                       "mg_levels_patch_sub_ksp_type": "preonly",
+                       "mg_levels_patch_sub_pc_type": "lu",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    elif problem_type == "mixed":
+        return
+
+    nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
+    star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=vanka_params, nullspace=nsp)
+    star_solver.solve()
+    star_its = star_solver.snes.getLinearSolveIterations()
+
+    u.assign(0)
+    comp_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=comp_params, nullspace=nsp)
+    comp_solver.solve()
+    comp_its = comp_solver.snes.getLinearSolveIterations()
+
+    assert star_its == comp_its


### PR DESCRIPTION
This subclasses `ASMPatchPC` to implement a patch-based additive Schwarz PC using the topological star of a given mesh entity.  This is primarily intended for use as a relaxation scheme within multigrid, so tests are provided to make sure that it does so correctly, comparing against `jacobi` in the case where the star is just a single DoF, and against `PatchPC` for more complicated examples.

This also includes a couple of fixes to aspects of `ASMPatchPC` that didn't work for me: changing the options prefix to append an underscore instead of prepend one, and to make the `view` method work.