### PR TITLE
Add a "crossed" cutting of hexadra in BoxMesh

### DIFF
--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -421,3 +421,11 @@ def test_changing_default_reorder_works(reorder):
         assert m._did_reordering == reorder
     finally:
         parameters["reorder_meshes"] = old_reorder
+
+
+@pytest.mark.parametrize("kind, num_cells",
+                         [("default", 6), ("crossed", 5)])
+def test_boxmesh_kind(kind, num_cells):
+    m = BoxMesh(1, 1, 1, 1, 1, 1, diagonal=kind)
+    m.init()
+    assert m.num_cells() == num_cells


### PR DESCRIPTION
Here is to cut a hexadra into 5 tetrahedra in a "crossed" way.

The default cutting of a BoxMesh in Firedrake is (6 tetrahedra)

![default](https://user-images.githubusercontent.com/48932582/87134553-bbcbdb80-c290-11ea-9ba1-9a41a285e6f2.png)

and now we can cut into 5 tetrahedra (less biased) as shows in the following

![crossed](https://user-images.githubusercontent.com/48932582/87135762-6395d900-c292-11ea-99e2-188ca656dc73.png)

Both pictures are taken from [https://www.ics.uci.edu/~eppstein/projects/tetra/](url).