### PR TITLE
TinyASM backend for ASMPatchPC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         sh 'mkdir tmp'
         dir('tmp') {
           timestamps {
-            sh '../scripts/firedrake-install --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager || (cat firedrake-install.log && /bin/false)'
+            sh '../scripts/firedrake-install --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager || (cat firedrake-install.log && /bin/false)'
           }
         }
       }

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -9,4 +9,4 @@ USER firedrake
 WORKDIR /home/firedrake
 
 # Now install extra Firedrake components.
-RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --slepc --install thetis --install gusto --install icepack"
+RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --tinyasm --slepc --install thetis --install gusto --install icepack"

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -6,6 +6,13 @@ from firedrake.petsc import PETSc
 from firedrake.dmhooks import get_function_space
 import numpy
 
+try:
+    from tinyasm import _tinyasm as tinyasm
+    have_tinyasm = True
+except ImportError:
+    have_tinyasm = False
+
+
 __all__ = ("ASMPatchPC", "ASMStarPC", "ASMVankaPC", "ASMLinesmoothPC")
 
 

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -26,7 +26,7 @@ class ASMPatchPC(PCBase):
     @property
     @abc.abstractmethod
     def _prefix(self):
-        "Options prefix for the solver"
+        "Options prefix for the solver (should end in an underscore)"
 
     def initialize(self, pc):
         # Get context from pc

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -171,7 +171,6 @@ class ASMVankaPC(ASMPatchPC):
     def get_patches(self, V):
         mesh = V._mesh
         mesh_dm = mesh._topology_dm
-        lgmap = V.dof_dset.lgmap
 
         # Obtain the topological entities to use to construct the stars
         depth = PETSc.Options().getInt(self.prefix + "construct_dim", default=-1)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -59,7 +59,7 @@ class FiredrakeConfiguration(dict):
                            "minimal_petsc", "mpicc", "mpicxx", "mpif90", "mpiexec", "disable_ssh",
                            "honour_petsc_dir", "with_parmetis",
                            "slepc", "packages", "honour_pythonpath",
-                           "opencascade",
+                           "opencascade", "tinyasm",
                            "petsc_int_type", "cache_dir", "remove_build_files"]
 
 
@@ -212,6 +212,8 @@ honoured.""",
                         help="Install SLEPc along with PETSc.")
     parser.add_argument("--opencascade", action="store_true",
                         help="Install OpenCASCADE for CAD integration.")
+    parser.add_argument("--tinyasm", action="store_true",
+                        help="Install TinyASM as backend for ASMPatchPC.")
     parser.add_argument("--disable-ssh", action="store_true",
                         help="Do not attempt to use ssh to clone git repositories: fall immediately back to https.")
     parser.add_argument("--no-package-manager", action='store_false', dest="package_manager",
@@ -336,6 +338,8 @@ else:
                         help="Install SLEPc along with PETSc")
     parser.add_argument("--opencascade", action="store_true", dest="opencascade", default=config["options"].get("opencascade", False),
                         help="Install OpenCASCADE for CAD integration.")
+    parser.add_argument("--tinyasm", action="store_true", dest="tinyasm", default=config["options"].get("tinyasm", False),
+                        help="Install TinyASM as backend for ASMPatchPC.")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--honour-petsc-dir", action="store_true",
                        default=config["options"].get("honour_petsc_dir", False),
@@ -934,6 +938,32 @@ def build_and_install_libsupermesh():
                 check_call(["make", "install"])
     else:
         log.info("No need to rebuild libsupermesh")
+
+
+def build_and_install_tinyasm():
+    log.info("Installing TinyASM")
+    if os.path.exists("TinyASM"):
+        log.info("Updating the git repository for TinyASM")
+        with directory("TinyASM"):
+            check_call(["git", "fetch"])
+            git_sha = check_output(["git", "rev-parse", "HEAD"])
+            git_sha_new = check_output(["git", "rev-parse", "@{u}"])
+            tinyasm_changed = git_sha != git_sha_new
+            if tinyasm_changed:
+                check_call(["git", "reset", "--hard"])
+                check_call(["git", "pull"])
+    else:
+        git_clone("git+https://github.com/florianwechsung/TinyASM.git")
+        tinyasm_changed = True
+
+    if tinyasm_changed:
+        with directory("TinyASM"):
+            # Clean source directory
+            check_call(["git", "reset", "--hard"])
+            check_call(["git", "clean", "-f", "-x", "-d"])
+            run_pip_install(["-e", "."])
+    else:
+        log.info("No need to rebuild TinyASM")
 
 
 def build_and_install_pythonocc():
@@ -1541,6 +1571,9 @@ with environment(**compiler_env):
 
         if options["opencascade"]:
             build_and_install_pythonocc()
+
+        if options["tinyasm"]:
+            build_and_install_tinyasm()
 
     if args.documentation_dependencies:
         install_documentation_dependencies()

--- a/tests/regression/test_linesmoother.py
+++ b/tests/regression/test_linesmoother.py
@@ -1,5 +1,10 @@
 import pytest
 from firedrake import *
+try:
+    import tinyasm  # noqa: F401
+    marks = ()
+except ImportError:
+    marks = pytest.mark.skip(reason="No tinyasm")
 
 
 @pytest.fixture(params=["Interval", "Triangle", "Quad"])
@@ -38,8 +43,12 @@ def expected(mesh_type):
         return [9, 20]
 
 
-def test_linesmoother(mesh, S1family, expected):
+@pytest.fixture(params=["petscasm", pytest.param("tinyasm", marks=marks)])
+def backend(request):
+    return request.param
 
+
+def test_linesmoother(mesh, S1family, expected, backend):
     nits = []
     for degree in range(2):
         S1 = FiniteElement(S1family, mesh._base_mesh.ufl_cell(), degree+1)
@@ -91,6 +100,7 @@ def test_linesmoother(mesh, S1family, expected):
               'sub_0': {'sub_pc_type': 'jacobi'},
               'sub_1': {'pc_type': 'python',
                         'pc_python_type': 'firedrake.ASMLinesmoothPC',
+                        'pc_linesmooth_backend': backend,
                         'pc_linesmooth_codims': '0'}}
 
         wave_parameters['hybridization'].update(ls)


### PR DESCRIPTION
This adds a simple alternative backend to PETSc PCASM for the ASMPatchPC. It builds on #1773 

While PCASM is great for domain decomposition problems where you may want to use other sophisticated solvers on each domain, we are often interested in the limit of many, small patches. In that case, the fastest thing to do is often to just compute the explicit inverse and then apply it each iteration. (Instead of for example computing the LU factorisation and then doing two triangular solves each time). In addition, this avoids the overhead of having KSP and PC objects for every single patch.

For the tests in `test_star_pc.py` this results in a speedup between 2x and 4x.
```
diff --git a/tests/regression/test_star_pc.py b/tests/regression/test_star_pc.py
index ae6f0377..1c4f54dc 100644
--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -158,13 +158,18 @@ def test_star_equivalence(problem_type):

     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=star_params, nullspace=nsp)
+    import time
+    t0 = time.time()
     star_solver.solve()
+    t1 = time.time()
+    print('Time using petsc', t1-t0)
     star_its = star_solver.snes.getLinearSolveIterations()

     try:
         from tinyasm import _tinyasm as tasm  # noqa
         have_tinyasm = True
     except ImportError:
+        print('does not have tinyasm')
         have_tinyasm = False

     if have_tinyasm:
@@ -172,7 +177,10 @@ def test_star_equivalence(problem_type):
         u.assign(0)
         nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
         tinyasm_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=star_params, nullspace=nsp)
+        t0 = time.time()
         tinyasm_solver.solve()
+        t1 = time.time()
+        print('Time using TinyASM', t1-t0)
         tinyasm_its = tinyasm_solver.snes.getLinearSolveIterations()
     else:
         tinyasm_its = star_its
```
```
Time using petsc 0.6164448261260986
Time using TinyASM 0.13721990585327148
Time using petsc 2.2604024410247803
Time using TinyASM 0.9665257930755615
Time using petsc 0.5605008602142334
Time using TinyASM 0.13840794563293457
```

The TinyASM code currently lives in https://github.com/florianwechsung/tinyasm, but I'd be happy to move it over to the firedrake organisation. I added an option `--tinyasm` to the install script as well.