### PR TITLE
Add firedrake youtube channel to documentation

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -59,6 +59,10 @@ notebooks <https://jupyter.org/>`__ that are a more interactive way of
 getting to know Firedrake.  They are described in more detail :doc:`on
 their own page <notebooks>`.
 
+Youtube Channel
+---------------
+Firedrake has a `youtube channel <https://www.youtube.com/channel/UCwwT3kL0HHCv_O3VaeX3GUg>`__ where recorded tutorials are occasionally uploaded.
+
 .. only:: html
 
   API documentation


### PR DESCRIPTION
This follows a suggestion to include a link in the Firedrake slack channel.

~(NB: not yet built docs locally - will do once firedrake update has completed)~ built locally.