### PR TITLE
Adding nemesis as mpich device

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   environment {
     FIREDRAKE_CI_TESTS = "1"
     DOCKER_CREDENTIALS = credentials('f52ccab9-5250-4b17-9fb6-c3f1ebdcc986')
-    PETSC_CONFIGURE_OPTIONS = "--with-make-np=12"
+    PETSC_CONFIGURE_OPTIONS = "--with-make-np=12 --download-mpich-device=ch3:sock"
   }
   stages {
     stage('BuildAndTest') {

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -33,6 +33,17 @@ use Firedrake::
 
      source firedrake/bin/activate.csh
 
+
+Installation and MPI
+--------------------
+
+By default, ``firedrake-install`` will prompt the PETSc installer to
+download and install its own MPICH library and executables in the
+virtual environment.  This has implications for the performance of the
+resulting library when run in parallel.  Instructions on how best to
+configure MPI for the installation process are `found here
+<https://www.firedrakeproject.org/parallelism.html>`_.
+
 Testing the installation
 ------------------------
 

--- a/docs/source/parallelism.rst
+++ b/docs/source/parallelism.rst
@@ -17,6 +17,40 @@ called ``mpiexec``.  For example, to run a simulation in a file named
 
    mpiexec -n 16 python simulation.py
 
+
+Installing for parallel use
+===========================
+
+By default, Firedrake makes use of an MPICH library that is
+downloaded, configured, and installed in the virtual environment as
+part of the PETSc installation procedure.  If you do not intend to use
+parallelism, or only use it in a limited way, this will be sufficient
+for your needs.  The default MPICH installation uses ``nemesis`` as the
+MPI channel, which is reasonably fast, but imposes a hard limit on the
+maximum number of concurrent MPI threads equal to the number of cores
+on your machine.  If you would like to be able to *oversubscribe* your
+machine, and run more threads than cores, you need to change the MPICH
+device at install time to ``sock``, by setting an environment variable
+before you run ``firedrake-install``:
+
+.. code-block:: shell
+
+   export PETSC_CONFIGURE_OPTIONS="--download-mpich-device=ch3:sock"
+
+If parallel performance is important to you (e.g., for generating
+reliable timings or using a supercomputer), then you should probably
+be using an MPICH library tuned for your system.  If you have a
+system-wide install already available, then you can simply tell the
+firedrake installer to use it, by running:
+
+.. code-block:: shell
+
+   python3 firedrake-install --mpiexec=mpiexec --mpicc=mpicc --mpicxx=mpicxx --mpif90=mpif90
+
+where ``mpiexec``, ``mpicc``, ``mpicxx``, and ``mpif90`` are the
+commands to run an MPI job and to compile C, C++, and Fortran 90 code,
+respectively.
+
 Printing in parallel
 ====================
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -551,7 +551,6 @@ if options.get("mpiexec") is not None:
 else:
     # Download mpich if the user does not tell us about an MPI.
     petsc_options.add("--download-mpich")
-    petsc_options.add("--download-mpich-device=ch3:nemesis")
 
 petsc_options = list(petsc_options) + shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", ""))
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -551,6 +551,7 @@ if options.get("mpiexec") is not None:
 else:
     # Download mpich if the user does not tell us about an MPI.
     petsc_options.add("--download-mpich")
+    petsc_options.add("--download-mpich-device=ch3:nemesis")
 
 petsc_options = list(petsc_options) + shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", ""))
 


### PR DESCRIPTION
The default MPICH installed by PETSc gives poor parallel scaling in some instances.  This updates that default to the "nemesis" device that appears to give better performance.