### PR TITLE
Implement efficient adjoint solve

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -100,14 +100,12 @@ class SolveVarFormBlock(GenericSolveBlock):
 
 class NonlinearVariationalSolveBlock(GenericSolveBlock):
     def __init__(self, equation, func, bcs, problem_J, solver_params, solver_kwargs, **kwargs):
-        lhs = equation.lhs
-        rhs = equation.rhs
-
+        self.equation = equation
         self.problem_J = problem_J
         self.solver_params = solver_params.copy()
         self.solver_kwargs = solver_kwargs
 
-        super().__init__(lhs, rhs, func, bcs, **{**solver_kwargs, **kwargs})
+        super().__init__(self.equation.lhs, self.equation.rhs, func, bcs, **{**solver_kwargs, **kwargs})
 
         if self.problem_J is not None:
             for coeff in self.problem_J.coefficients():
@@ -124,8 +122,9 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         return self._ad_nlvs._problem.u
 
     def _ad_assign_map(self, form):
+        count_map = self._ad_nlvs._problem._ad_count_map
         assign_map = {}
-        form_ad_count_map = dict((coeff._ad_count, coeff) for coeff in form.coefficients())
+        form_ad_count_map = dict((count_map[coeff], coeff) for coeff in form.coefficients())
         for block_variable in self.get_dependencies():
             coeff = block_variable.output
             if isinstance(coeff, (self.backend.Coefficient, self.backend.Constant)):

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -123,11 +123,13 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
 
     def _ad_assign_map(self, form):
         assign_map = {}
-        form_ad_id_map = dict((coeff._ad_id, coeff) for coeff in form.coefficients())
+        form_ad_count_map = dict((coeff._ad_count, coeff) for coeff in form.coefficients())
         for block_variable in self.get_dependencies():
-            coeff_id = id(block_variable.output)
-            if coeff_id in form_ad_id_map:
-                assign_map[form_ad_id_map[coeff_id]] = block_variable.saved_output
+            coeff = block_variable.output
+            if isinstance(coeff, (self.backend.Coefficient, self.backend.Constant)):
+                coeff_count = coeff.count()
+                if coeff_count in form_ad_count_map:
+                    assign_map[form_ad_count_map[coeff_count]] = block_variable.saved_output
         return assign_map
 
     def _ad_assign_coefficients(self, form, func=None):

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -117,10 +117,14 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         J = self.problem_J
         if J is not None:
             J = self._replace_form(J, func)
+            J._cache = self.problem_J._cache
+        lhs._cache = self.equation.lhs._cache
+
         solver = self._ad_nlvs
         solver.replace_forms(lhs, func, bcs, J)
         solver.parameters.update(self.solver_params)
         solver.solve()
+        func.assign(solver._problem.u)
         return func
 
 

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -100,12 +100,14 @@ class SolveVarFormBlock(GenericSolveBlock):
 
 class NonlinearVariationalSolveBlock(GenericSolveBlock):
     def __init__(self, equation, func, bcs, problem_J, solver_params, solver_kwargs, **kwargs):
-        self.equation = equation
+        lhs = equation.lhs
+        rhs = equation.rhs
+
         self.problem_J = problem_J
         self.solver_params = solver_params.copy()
         self.solver_kwargs = solver_kwargs
 
-        super().__init__(self.equation.lhs, self.equation.rhs, func, bcs, **{**solver_kwargs, **kwargs})
+        super().__init__(lhs, rhs, func, bcs, **{**solver_kwargs, **kwargs})
 
         if self.problem_J is not None:
             for coeff in self.problem_J.coefficients():

--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -21,6 +21,7 @@ class NonlinearVariationalProblemMixin:
             self._ad_count_map = {}
         return wrapper
 
+
 class NonlinearVariationalSolverMixin:
     @staticmethod
     def _ad_annotate_init(init):
@@ -112,8 +113,8 @@ class NonlinearVariationalSolverMixin:
                 _ad_count_map[J_replace_map[coeff]] = coeff.count()
 
         nlvp = NonlinearVariationalProblem(replace(problem.F, F_replace_map),
-                                          F_replace_map[problem.u],
-                                          bcs=problem.bcs,
-                                          J=replace(problem.J, J_replace_map))
+                                           F_replace_map[problem.u],
+                                           bcs=problem.bcs,
+                                           J=replace(problem.J, J_replace_map))
         nlvp._ad_count_map = _ad_count_map
         return nlvp

--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -21,6 +21,9 @@ class NonlinearVariationalProblemMixin:
             self._ad_count_map = {}
         return wrapper
 
+    def _ad_count_map_update(self, updated_ad_count_map):
+        self._ad_count_map = updated_ad_count_map
+
 
 class NonlinearVariationalSolverMixin:
     @staticmethod
@@ -116,5 +119,5 @@ class NonlinearVariationalSolverMixin:
                                            F_replace_map[problem.u],
                                            bcs=problem.bcs,
                                            J=replace(problem.J, J_replace_map))
-        nlvp._ad_count_map = _ad_count_map
+        nlvp._ad_count_map_update(_ad_count_map)
         return nlvp

--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -5,6 +5,7 @@ from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_
 from firedrake.adjoint.blocks import NonlinearVariationalSolveBlock
 from ufl import replace
 
+
 class NonlinearVariationalProblemMixin:
     @staticmethod
     def _ad_annotate_init(init):

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 
 __all__ = ("PETSc", "OptionsManager")
 
+PETSc.Sys.popErrorHandler()
 
 def flatten_parameters(parameters, sep="_"):
     """Flatten a nested parameters dict, joining keys with sep.

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager
 
 __all__ = ("PETSc", "OptionsManager")
 
-PETSc.Sys.popErrorHandler()
 
 def flatten_parameters(parameters, sep="_"):
     """Flatten a nested parameters dict, joining keys with sep.

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -39,7 +39,7 @@ def is_form_consistent(is_linear, bcs):
         raise TypeError("Form style mismatch: some forms are given in 'F == 0' style, but others are given in 'A == b' style.")
 
 
-class NonlinearVariationalProblem(object):
+class NonlinearVariationalProblem(NonlinearVariationalProblemMixin):
     r"""Nonlinear variational problem F(u; v) = 0."""
 
     @NonlinearVariationalProblemMixin._ad_annotate_init

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -10,7 +10,6 @@ from firedrake import utils
 from firedrake.petsc import PETSc, OptionsManager
 from firedrake.bcs import DirichletBC
 from firedrake.adjoint import NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin
-from ufl.algorithms.analysis import extract_coefficients
 
 __all__ = ["LinearVariationalProblem",
            "LinearVariationalSolver",
@@ -242,24 +241,6 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         :raises ValueError: if called after the transfer manager is setup.
         """
         self._ctx.transfer_manager = manager
-
-    def replace_forms(self, F, u, bcs, J):
-        self.assign_coefficients(self._problem.F, F)
-        self.assign_coefficients(self._ctx.F, F)
-
-        self.assign_coefficients(self._problem.J, J)
-        self.assign_coefficients(self._ctx.J, J)
-
-        Jp_eq_J = self._problem.Jp is None and all(bc.Jp_eq_J for bc in bcs)
-        if (self._ctx.mat_type != self._ctx.pmat_type or not Jp_eq_J) and self._problem.Jp is None:
-            self.assign_coefficients(self._ctx.Jp, self._ctx.J)
-
-        self.assign_coefficients(self._problem.u, u)
-        self.assign_coefficients(self._ctx._x, u)
-
-    def assign_coefficients(self, expr1, expr2):
-        for cof1, cof2 in zip(extract_coefficients(expr1), extract_coefficients(expr2)):
-            cof1.assign(cof2)
 
     @NonlinearVariationalSolverMixin._ad_annotate_solve
     def solve(self, bounds=None):

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -242,6 +242,20 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         """
         self._ctx.transfer_manager = manager
 
+    def replace_forms(self, F, u, bcs, J):
+        self._problem.J = J
+        self._ctx.J = J
+
+        self._problem.u = u
+        self._ctx._x = u
+
+        self._problem.F = F
+        self._ctx.F = F
+
+        Jp_eq_J = self._problem.Jp is None and all(bc.Jp_eq_J for bc in bcs)
+        if (self._ctx.mat_type != self._ctx.pmat_type or not Jp_eq_J) and self._problem.Jp is None:
+            self._ctx.Jp = self._ctx.J
+
     @NonlinearVariationalSolverMixin._ad_annotate_solve
     def solve(self, bounds=None):
         r"""Solve the variational problem.

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -10,6 +10,7 @@ from firedrake import utils
 from firedrake.petsc import PETSc, OptionsManager
 from firedrake.bcs import DirichletBC
 from firedrake.adjoint import NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin
+from ufl.algorithms.analysis import extract_coefficients
 
 __all__ = ["LinearVariationalProblem",
            "LinearVariationalSolver",
@@ -243,18 +244,22 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         self._ctx.transfer_manager = manager
 
     def replace_forms(self, F, u, bcs, J):
-        self._problem.J = J
-        self._ctx.J = J
+        self.assign_coefficients(self._problem.F, F)
+        self.assign_coefficients(self._ctx.F, F)
 
-        self._problem.u = u
-        self._ctx._x = u
-
-        self._problem.F = F
-        self._ctx.F = F
+        self.assign_coefficients(self._problem.J, J)
+        self.assign_coefficients(self._ctx.J, J)
 
         Jp_eq_J = self._problem.Jp is None and all(bc.Jp_eq_J for bc in bcs)
         if (self._ctx.mat_type != self._ctx.pmat_type or not Jp_eq_J) and self._problem.Jp is None:
-            self._ctx.Jp = self._ctx.J
+            self.assign_coefficients(self._ctx.Jp, self._ctx.J)
+
+        self.assign_coefficients(self._problem.u, u)
+        self.assign_coefficients(self._ctx._x, u)
+
+    def assign_coefficients(self, expr1, expr2):
+        for cof1, cof2 in zip(extract_coefficients(expr1), extract_coefficients(expr2)):
+            cof1.assign(cof2)
 
     @NonlinearVariationalSolverMixin._ad_annotate_solve
     def solve(self, bounds=None):


### PR DESCRIPTION
Currently for the replay functionality of the `NonlinearVariationalSolveBlock`, we construct a new `NonlinearVariationalProblem` and a `NonlinearVariationalSolver` every time ` _forward_solve` is called. This change implements a more efficient approach that creates a clone of each NonlinearVariationSolver instance instead and continuously modifies it to replay the forward problem, reducing the overhead cost of the re-computation. To demonstrate improvements in the run time, we take the burgers equation (code: https://github.com/dolfin-adjoint/pyadjoint/blob/master/tests/firedrake_adjoint/test_burgers_newton.py) with a 10000 unit interval mesh and measure the average time it takes to solve the equation over 10 runs:
```
Annotation off: 7.73(s)
Annotation on: 11.64(s)
```
Then computing the average time it takes to replay the equation over the course of 10 runs, we get the following results:
```
Existing implementation: 62.76(s)
New implementation: 19.65(s)
```
