### PR TITLE
Fix transfer manager logic for non-tensor-product elements on tensor product cells

### DIFF
--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -68,7 +68,7 @@ class TransferManager(object):
     def is_native(self, element):
         if element in self.native_transfers.keys():
             return True
-        if isinstance(element.cell(), ufl.TensorProductCell):
+        if isinstance(element.cell(), ufl.TensorProductCell) and len(element.sub_elements()) > 0:
             return reduce(and_, map(self.is_native, element.sub_elements()))
         return element.family() in native
 

--- a/tests/regression/test_prolong_ncf_cube.py
+++ b/tests/regression/test_prolong_ncf_cube.py
@@ -1,0 +1,21 @@
+from firedrake import *
+
+
+def test_prolong_ncf_cube():
+    base = UnitSquareMesh(1, 1, quadrilateral=True)
+    basemh = MeshHierarchy(base, 1)
+    mh = ExtrudedMeshHierarchy(basemh, 1, base_layer=1)
+    meshc, meshf = mh
+
+    k = 2
+    Vc = FunctionSpace(meshc, "NCF", k)
+    Qc = FunctionSpace(meshc, "DQ", k-1)
+    Zc = MixedFunctionSpace([Vc, Qc])
+    Vf = FunctionSpace(meshf, "NCF", k)
+    Qf = FunctionSpace(meshf, "DQ", k-1)
+    Zf = MixedFunctionSpace([Vf, Qf])
+
+    zc = Function(Zc)
+    zf = Function(Zf)
+    tm = TransferManager()
+    tm.prolong(zc, zf)


### PR DESCRIPTION
Without this, the test yields


```
/home/pefarrell/git/firedrake/tests/regression/test_prolong_ncf_cube.py:21: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
firedrake/mg/embedded.py:265: in prolong
    self.op(uc, uf, transfer_op=Op.PROLONG)
firedrake/mg/embedded.py:224: in op
    if self.is_native(source_element) and self.is_native(target_element):
firedrake/mg/embedded.py:72: in is_native
    return reduce(and_, map(self.is_native, element.sub_elements()))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <firedrake.mg.embedded.TransferManager object at 0x145a68ca2e10>
element = EnrichedElement(HDivElement(TensorProductElement(FiniteElement('RTCF', quadrilateral, 2), FiniteElement('Discontinuous...ent('DQ', quadrilateral, 1), FiniteElement('Lagrange', interval, 2), cell=TensorProductCell(quadrilateral, interval))))

    def is_native(self, element):
        if element in self.native_transfers.keys():
            return True
        if isinstance(element.cell(), ufl.TensorProductCell):
>           return reduce(and_, map(self.is_native, element.sub_elements()))
E           TypeError: reduce() of empty sequence with no initial value

```