### PR TITLE
install: Install all MPI wrappers as shell scripts

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1321,32 +1321,23 @@ petsc_dir, petsc_arch = get_petsc_dir()
 should_link = not args.honour_petsc_dir or options.get("mpicc") is not None
 
 # Set up the MPI wrappers
-for opt in ["mpicc", "mpicxx", "mpif90"]:
+for opt in ["mpicc", "mpicxx", "mpif90", "mpiexec"]:
     if options.get(opt):
         name = options[opt]
         src = shutil.which(name)
     else:
         src = os.path.join(petsc_dir, petsc_arch, "bin", opt)
     dest = os.path.join(firedrake_env, "bin", opt)
+    # Remove old symlinks
     if os.path.lexists(dest):
         os.remove(dest)
+    elif os.path.exists(dest):
+        os.remove(dest)
     if should_link:
-        log.debug("Creating a symlink from %s to %s" % (src, dest))
-        os.symlink(src, dest)
-
-if options.get("mpiexec"):
-    mpiexec_loc = shutil.which(options.get("mpiexec"))
-else:
-    mpiexec_loc = os.path.join(petsc_dir, petsc_arch, "bin", "mpiexec")
-mpiexecf = os.path.join(firedrake_env, "bin", "mpiexec")
-if os.path.exists(mpiexecf):
-    os.remove(mpiexecf)
-if should_link:
-    log.debug("Creating an mpiexec wrapper for %s" % mpiexec_loc)
-    with open(mpiexecf, "w") as mpiexec:
-        contents = '#!/bin/bash' + os.linesep + mpiexec_loc + ' "$@"'
-        mpiexec.write(contents)
-    os.chmod(mpiexecf, os.stat(mpiexecf).st_mode | stat.S_IEXEC)
+        log.debug("Creating a wrapper for %s from %s to %s" % (opt, src, dest))
+        with open(dest, "w") as f:
+            f.write('#!/bin/bash' + os.linesep + src + ' "$@"')
+        os.chmod(dest, os.stat(dest).st_mode | stat.S_IEXEC)
 
 cc = options["mpicc"]
 cxx = options["mpicxx"]


### PR DESCRIPTION
Fixes #1809 where the wrapper expects to be executed from its install
directory.