### PR TITLE
Fix mesh labels for refining meshes

### DIFF
--- a/firedrake/cython/mgimpl.pyx
+++ b/firedrake/cython/mgimpl.pyx
@@ -294,44 +294,31 @@ def coarse_to_fine_cells(mc, mf, clgmaps, flgmaps):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def filter_exterior_facet_labels(PETSc.DM plex):
-    """Remove exterior facet labels from things that aren't facets.
-
+def filter_labels(PETSc.DM dm, keep, *label_names):
+    """Remove labels from points that are not in keep.
+    :arg dm: DM object with labels.
+    :arg keep: subsection of the DMs chart on which to retain label values.
+    :arg label_names: names of labels (strings) to clear.
     When refining, every point "underneath" the refined entity
-    receives its label.  But we want the facet label to really only
-    apply to facets, so clear the labels from everything else."""
+    receives its label. But we typically have labels applied only to
+    entities of a given stratum height (and rely on that elsewhere),
+    so clear the labels from everything else.
+    """
     cdef:
-        PetscInt pStart, pEnd, fStart, fEnd, p, value
-        PetscBool has_bdy_ids, has_bdy_faces
-        DMLabel exterior_facets = NULL
-        DMLabel boundary_ids = NULL
-        DMLabel boundary_faces = NULL
+        PetscInt pStart, pEnd, kStart, kEnd, p, value
+        DMLabel dmlabel = NULL
 
-    pStart, pEnd = plex.getChart()
-    fStart, fEnd = plex.getHeightStratum(1)
+    pStart, pEnd = dm.getChart()
+    kStart, kEnd = keep
 
-    # Plex will always have an exterior_facets label (maybe
-    # zero-sized), but may not always have boundary_ids or
-    # boundary_faces.
-    has_bdy_ids = plex.hasLabel(dmcommon.FACE_SETS_LABEL)
-    has_bdy_faces = plex.hasLabel("boundary_faces")
-
-    CHKERR(DMGetLabel(plex.dm, <const char*>b"exterior_facets", &exterior_facets))
-    if has_bdy_ids:
-        label = dmcommon.FACE_SETS_LABEL.encode()
-        CHKERR(DMGetLabel(plex.dm, <const char*>label, &boundary_ids))
-    if has_bdy_faces:
-        CHKERR(DMGetLabel(plex.dm, <const char*>b"boundary_faces", &boundary_faces))
-    for p in range(pStart, pEnd):
-        if p < fStart or p >= fEnd:
-            CHKERR(DMLabelGetValue(exterior_facets, p, &value))
-            if value >= 0:
-                CHKERR(DMLabelClearValue(exterior_facets, p, value))
-            if has_bdy_ids:
-                CHKERR(DMLabelGetValue(boundary_ids, p, &value))
+    for label in label_names:
+        if not dm.hasLabel(label):
+            # Nothing to clear here.
+            continue
+        label = label.encode()
+        CHKERR(DMGetLabel(dm.dm, <const char*>label, &dmlabel))
+        for p in range(pStart, pEnd):
+            if p < kStart or p >= kEnd:
+                CHKERR(DMLabelGetValue(dmlabel, p, &value))
                 if value >= 0:
-                    CHKERR(DMLabelClearValue(boundary_ids, p, value))
-            if has_bdy_faces:
-                CHKERR(DMLabelGetValue(boundary_faces, p, &value))
-                if value >= 0:
-                    CHKERR(DMLabelClearValue(boundary_faces, p, value))
+                    CHKERR(DMLabelClearValue(dmlabel, p, value))

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import firedrake
 from firedrake.utils import cached_property
 from firedrake.cython import mgimpl as impl
-from firedrake.cython.dmplex import CELL_SETS_LABEL, FACE_SETS_LABEL
+from firedrake.cython.dmcommon import CELL_SETS_LABEL, FACE_SETS_LABEL
 from .utils import set_level
 
 

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import firedrake
 from firedrake.utils import cached_property
 from firedrake.cython import mgimpl as impl
+from firedrake.cython.dmplex import CELL_SETS_LABEL, FACE_SETS_LABEL
 from .utils import set_level
 
 
@@ -127,7 +128,11 @@ def MeshHierarchy(mesh, refinement_levels,
         # Remove vertex (and edge) points from labels on exterior
         # facets.  Interior facets will be relabeled in Mesh
         # construction below.
-        impl.filter_exterior_facet_labels(rdm)
+        impl.filter_labels(rdm, rdm.getHeightStratum(1),
+                           "exterior_facets", "boundary_faces",
+                           FACE_SETS_LABEL)
+        impl.filter_labels(rdm, rdm.getHeightStratum(0),
+                           CELL_SETS_LABEL)
         rdm.removeLabel("pyop2_core")
         rdm.removeLabel("pyop2_owned")
         rdm.removeLabel("pyop2_ghost")


### PR DESCRIPTION
When creating a mesh hierarchy, we need to properly filter mesh labels that are attached to the mesh (e.g., by gmsh).  This generalizes what was in place to do this.  (This is all @wence- 's code, but I'd like to see it merged to support some work on nasty domains...)