### PR TITLE
Interpolation onto a Vertex Only Mesh (old)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
               sh 'mkdir tmp'
               dir('tmp') {
                 timestamps {
-                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager --package-branch tsfc dual_base_fiat --package-branch FInAT dual_base_fiat || (cat firedrake-install.log && /bin/false)'
+                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager --package-branch tsfc 0d-mesh-interpolation --package-branch FInAT 0d-mesh-interpolation || (cat firedrake-install.log && /bin/false)'
                 }
               }
             }

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2595,33 +2595,39 @@ def remove_ghosts_pic(PETSc.DM swarm, PETSc.DM plex):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def label_pic_parent_cell_nums(PETSc.DM swarm, parentmesh):
+def label_pic_parent_cell_info(PETSc.DM swarm, parentmesh):
     """
     For each PIC in the input swarm, label its `parentcellnum` field with
-    the relevant cell number from the `parentmesh` in which is it emersed.
-    The cell numbering is that given by the `parentmesh.locate_cell`
-    method.
+    the relevant cell number from the `parentmesh` in which is it emersed
+    and the `refcoord` field with the relevant cell reference coordinate.
+    This information is given by the
+    `parentmesh.locate_cell_and_reference_coordinate` method.
+
+    For a swarm with N PICs emersed in `parentmesh`
+    the `parentcellnum` field is N long and
+    the `refcoord` field is N*parentmesh.topological_dimension() long.
 
     :arg swarm: The DMSWARM which contains the PICs immersed in
         `parentmesh`
     :arg parentmesh: The mesh within with the `swarm` PICs are immersed.
 
     ..note:: All PICs must be within the parentmesh or this will try to
-             assign `None` (returned by `parentmesh.locate_cell`) to a
-             `PetscReal`.
+             assign `None` (returned by
+             `parentmesh.locate_cell_and_reference_coordinate`) to the
+             `parentcellnum` or `refcoord` fields.
+
+
     """
     cdef:
-        PetscInt num_vertices, i, dim, parent_cell_num
+        PetscInt num_vertices, i, gdim, tdim
+        PetscInt parent_cell_num
         np.ndarray[PetscReal, ndim=2, mode="c"] swarm_coords
         np.ndarray[PetscInt, ndim=1, mode="c"] parent_cell_nums
+        np.ndarray[PetscReal, ndim=2, mode="c"] reference_coords
+        np.ndarray[PetscReal, ndim=1, mode="c"] reference_coord
 
-    if type(swarm) is not PETSc.DMSwarm:
-        raise ValueError("swarm must be a DMSwarm")
-
-    if parentmesh.topology_dm.handle != swarm.getCellDM().handle:
-        raise ValueError("parentmesh.topology_dm is not the swarm's CellDM")
-
-    dim = parentmesh.geometric_dimension()
+    gdim = parentmesh.geometric_dimension()
+    tdim = parentmesh.topological_dimension()
 
     num_vertices = swarm.getLocalSize()
 
@@ -2631,21 +2637,24 @@ def label_pic_parent_cell_nums(PETSc.DM swarm, parentmesh):
     max_num_vertices = comm.allreduce(num_vertices, op=MPI.MAX)
 
     # Create an out of mesh point to use in locate_cell when needed
-    out_of_mesh_point = np.full((1, dim), np.inf)
+    out_of_mesh_point = np.full((1, gdim), np.inf)
 
     # get fields - NOTE this isn't copied so make sure
     # swarm.restoreField is called for each field too!
-    swarm_coords = swarm.getField("DMSwarmPIC_coor").reshape((num_vertices, dim))
+    swarm_coords = swarm.getField("DMSwarmPIC_coor").reshape((num_vertices, gdim))
     parent_cell_nums = swarm.getField("parentcellnum")
+    reference_coords = swarm.getField("refcoord").reshape((num_vertices, tdim))
 
     # find parent cell numbers
     for i in range(max_num_vertices):
         if i < num_vertices:
-            parent_cell_num = parentmesh.locate_cell(swarm_coords[i])
+            parent_cell_num, reference_coord = parentmesh.locate_cell_and_reference_coordinate(swarm_coords[i])
             parent_cell_nums[i] = parent_cell_num
+            reference_coords[i] = reference_coord
         else:
             parentmesh.locate_cell(out_of_mesh_point)  # should return None
 
     # have to restore fields once accessed to allow access again
+    swarm.restoreField("refcoord")
     swarm.restoreField("parentcellnum")
     swarm.restoreField("DMSwarmPIC_coor")

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2694,9 +2694,8 @@ def fill_reference_coordinates_function(reference_coordinates_f):
     # get reference coord field - NOTE isn't copied so could have GC issues!
     reference_coords = swarm.getField("refcoord").reshape((num_vertices, parent_tdim))
 
-    # find parent cell numbers
-    for i in range(num_vertices):
-        reference_coordinates_f.dat.data[i] = reference_coords[i]
+    # store reference coord field in Function Dat.
+    reference_coordinates_f.dat.data[:] = reference_coords[:]
 
     # have to restore fields once accessed to allow access again
     swarm.restoreField("refcoord")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1997,6 +1997,10 @@ def VertexOnlyMesh(mesh, vertexcoords):
 
     vmesh.__init__(coordinates)
 
+    # Save vertex reference coordinate (within reference cell) in function
+    reference_coordinates_fs = functionspace.VectorFunctionSpace(vmesh, "DG", 0, dim=tdim)
+    vmesh.reference_coordinates = dmcommon.fill_reference_coordinates_function(function.Function(reference_coordinates_fs))
+
     return vmesh
 
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1298,6 +1298,23 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         size = list(self._entity_classes[self.cell_dimension(), :])
         return op2.Set(size, "Cells", comm=self.comm)
 
+    @property
+    def cell_parent_cell_list(self):
+        """Return a list of parent mesh cells numbers in vertex only
+        mesh cell order.
+        """
+        cell_parent_cell_list = np.copy(self.topology_dm.getField("parentcellnum"))
+        self.topology_dm.restoreField("parentcellnum")
+        return cell_parent_cell_list
+
+    @property
+    def cell_parent_cell_map(self):
+        """Return the :class:`pyop2.Map` from vertex only mesh cells to
+        parent mesh cells.
+        """
+        return op2.Map(self.cell_set, self._parent_mesh.cell_set, 1,
+                       self.cell_parent_cell_list, "cell_parent_cell")
+
 
 class MeshGeometry(ufl.Mesh, MeshGeometryMixin):
     """A representation of mesh topology and geometry."""

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1965,9 +1965,9 @@ def VertexOnlyMesh(mesh, vertexcoords):
     if pdim != gdim:
         raise ValueError(f"Mesh geometric dimension {gdim} must match point list dimension {pdim}")
 
-    swarm = _pic_swarm_in_plex(mesh.topology.topology_dm, vertexcoords, fields=[("parentcellnum", 1, IntType)])
+    swarm = _pic_swarm_in_plex(mesh.topology.topology_dm, vertexcoords, fields=[("parentcellnum", 1, IntType), ("refcoord", tdim, RealType)])
 
-    dmcommon.label_pic_parent_cell_nums(swarm, mesh)
+    dmcommon.label_pic_parent_cell_info(swarm, mesh)
 
     # Topology
     topology = VertexOnlyMeshTopology(swarm, mesh.topology, name="swarmmesh", reorder=False)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1473,11 +1473,13 @@ values from f.)"""
         return spatialindex.from_regions(coords_min, coords_max)
 
     def locate_cell(self, x, tolerance=None):
-        """Locate cell containg given point.
+        """Locate cell containing a given point.
 
         :arg x: point coordinates
-        :kwarg tolerance: for checking if a point is in a cell.
-        :returns: cell number (int), or None (if the point is not in the domain)
+        :kwarg tolerance: for checking if a point is in a cell. Default
+            is None.
+        :returns: cell number (int), or None (if the point is not 
+            in the domain)
         """
 
         if self.variable_layers:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1487,6 +1487,8 @@ values from f.)"""
         if not np.allclose(x.imag, 0):
             raise ValueError("Point coordinates must have zero imaginary part")
         x = x.real.copy()
+        if x.size != self.geometric_dimension():
+            raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
         X = np.empty_like(x)
         cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
                                                     x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1498,6 +1498,30 @@ values from f.)"""
         else:
             return cell
 
+    def locate_reference_coordinate(self, x, tolerance=None):
+        """Get reference coordinates of a given point in its cell. Which
+        cell the point is in can be queried with the locate_cell method.
+
+        :arg x: point coordinates
+        :kwarg tolerance: for checking if a point is in a cell. Default
+            is None.
+        :returns: reference coordinates within cell (numpy array) or
+            None (if the point is not in the domain)
+        """
+        if self.variable_layers:
+            raise NotImplementedError("Cell reference coordinates not implemented for variable layers")
+        x = np.asarray(x, dtype=utils.ScalarType)
+        if x.size != self.geometric_dimension():
+            raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
+        X = np.empty_like(x)
+        cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
+                                                    x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
+        if cell == -1:
+            return None
+        else:
+            return X
+
     def _c_locator(self, tolerance=None):
         from pyop2 import compilation
         from pyop2.utils import get_petsc_dir

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -109,7 +109,7 @@ def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
     assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
 
 
-@pytest.mark.xfail(reason="Sparsity creation issue")
+# TODO: Add vector and tensor tests
 def test_scalar_function_interpolator(parentmesh, vertexcoords, fs):
     # try and make reusable Interpolator from V to W
     vm = VertexOnlyMesh(parentmesh, vertexcoords)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -84,7 +84,6 @@ def pseudo_random_coords(size):
 
 # NOTE: these _spatialcoordinate tests should be equivalent to some kind of
 # interpolation from a CG1 VectorFunctionSpace (I think)
-@pytest.mark.xfail
 def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro
@@ -96,7 +95,6 @@ def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     assert np.allclose(w_expr.dat.data_ro, np.sum(vertexcoords, axis=1))
 
 
-@pytest.mark.xfail
 def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro
@@ -111,7 +109,7 @@ def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
     assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="can't interpolate onto vector function spaces yet")
 def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro
@@ -121,7 +119,7 @@ def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     assert np.allclose(w_expr.dat.data_ro, 2*np.asarray(vertexcoords))
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="can't interpolate onto vector function spaces yet")
 def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vfs_fam, vfs_deg, vfs_typ = vfs
@@ -133,7 +131,7 @@ def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
     assert np.allclose(w_v.dat.data_ro, 2*np.asarray(vertexcoords))
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="can't interpolate onto tensor function spaces yet")
 def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro
@@ -145,7 +143,7 @@ def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
     assert np.allclose(w_expr.dat.data_ro, result)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="can't interpolate onto tensor function spaces yet")
 def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -1,0 +1,165 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+
+# Utility Functions and Fixtures
+
+# NOTE we don't include interval mesh since many of the function spaces
+# here are not defined on it.
+@pytest.fixture(params=[pytest.param("interval", marks=pytest.mark.xfail(reason="swarm not implemented in 1d")),
+                        "square",
+                        "squarequads",
+                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "cube",
+                        "tetrahedron",
+                        pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
+                        pytest.param("periodicrectangle", marks=pytest.mark.xfail(reason="meshes made from coordinate fields are not supported"))],
+                ids=lambda x: f"{x}-mesh")
+def parentmesh(request):
+    if request.param == "interval":
+        return UnitIntervalMesh(1)
+    elif request.param == "square":
+        return UnitSquareMesh(1, 1)
+    elif request.param == "squarequads":
+        return UnitSquareMesh(2, 2, quadrilateral=True)
+    elif request.param == "extruded":
+        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+    elif request.param == "cube":
+        return UnitCubeMesh(1, 1, 1)
+    elif request.param == "tetrahedron":
+        return UnitTetrahedronMesh()
+    elif request.param == "immersedsphere":
+        return UnitIcosahedralSphereMesh()
+    elif request.param == "periodicrectangle":
+        return PeriodicRectangleMesh(3, 3, 1, 1)
+
+
+@pytest.fixture(params=[0, 1, 100], ids=lambda x: f"{x}-coords")
+def vertexcoords(request, parentmesh):
+    size = (request.param, parentmesh.geometric_dimension())
+    return pseudo_random_coords(size)
+
+
+@pytest.fixture(params=[("CG", 2, FunctionSpace),
+                        ("DG", 2, FunctionSpace)],
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def fs(request):
+    return request.param
+
+
+@pytest.fixture(params=[("CG", 2, VectorFunctionSpace),
+                        ("N1curl", 2, FunctionSpace),
+                        ("N2curl", 2, FunctionSpace),
+                        ("N1div", 2, FunctionSpace),
+                        ("N2div", 2, FunctionSpace),
+                        ("N1curl", 2, VectorFunctionSpace),
+                        ("N1div", 2, VectorFunctionSpace)],
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def vfs(request):
+    return request.param
+
+
+@pytest.fixture(params=[("CG", 2, TensorFunctionSpace),
+                        ("BDM", 2, VectorFunctionSpace),
+                        ("Regge", 1, FunctionSpace)],
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def tfs(request):
+    return request.param
+
+
+def pseudo_random_coords(size):
+    """
+    Get an array of pseudo random coordinates with coordinate elements
+    between -0.5 and 1.5. The random numbers are consistent for any
+    given `size` since `numpy.random.seed(0)` is called each time this
+    is used.
+    """
+    np.random.seed(0)
+    a, b = -0.5, 1.5
+    return (b - a) * np.random.random_sample(size=size) + a
+
+
+# Tests
+
+# NOTE: these _spatialcoordinate tests should be equivalent to some kind of
+# interpolation from a CG1 VectorFunctionSpace (I think)
+@pytest.mark.xfail
+def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = FunctionSpace(vm, "DG", 0)
+    from functools import reduce
+    from operator import add
+    expr = reduce(add, SpatialCoordinate(parentmesh))
+    w_expr = interpolate(expr, W)
+    assert np.allclose(w_expr.dat.data_ro, np.sum(vertexcoords, axis=1))
+
+
+@pytest.mark.xfail
+def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    fs_fam, fs_deg, fs_typ = fs
+    V = fs_typ(parentmesh, fs_fam, fs_deg)
+    W = FunctionSpace(vm, "DG", 0)
+    from functools import reduce
+    from operator import add
+    expr = reduce(add, SpatialCoordinate(parentmesh))
+    v = Function(V).interpolate(expr)
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
+
+
+@pytest.mark.xfail
+def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = VectorFunctionSpace(vm, "DG", 0)
+    expr = 2 * SpatialCoordinate(parentmesh)
+    w_expr = interpolate(expr, W)
+    assert np.allclose(w_expr.dat.data_ro, 2*np.asarray(vertexcoords))
+
+
+@pytest.mark.xfail
+def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vfs_fam, vfs_deg, vfs_typ = vfs
+    V = vfs_typ(parentmesh, vfs_fam, vfs_deg)
+    W = VectorFunctionSpace(vm, "DG", 0)
+    expr = 2 * SpatialCoordinate(parentmesh)
+    v = Function(V).interpolate(expr)
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, 2*np.asarray(vertexcoords))
+
+
+@pytest.mark.xfail
+def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = TensorFunctionSpace(vm, "DG", 0)
+    x = SpatialCoordinate(parentmesh)
+    expr = 2 * as_tensor([x, x])
+    w_expr = interpolate(expr, W)
+    result = 2 * np.asarray([[vertexcoords[i], vertexcoords[i]] for i in range(len(vertexcoords))])
+    assert np.allclose(w_expr.dat.data_ro, result)
+
+
+@pytest.mark.xfail
+def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    tfs_fam, tfs_deg, tfs_typ = tfs
+    V = tfs_typ(parentmesh, tfs_fam, tfs_deg)
+    W = TensorFunctionSpace(vm, "DG", 0)
+    x = SpatialCoordinate(parentmesh)
+    expr = 2 * as_tensor([x, x])
+    v = Function(V).interpolate(expr)
+    result = 2 * np.asarray([[vertexcoords[i], vertexcoords[i]] for i in range(len(vertexcoords))])
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, result)
+
+# TODO: Add parallel tests
+# @pytest.mark.parallel
+# def test_scalar_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+#     test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -125,9 +125,6 @@ def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
         if parentmesh.ufl_cell().cellname() == "quadrilateral":
             if not (vfs_fam == "RTCE" or vfs_fam == "RTCF"):
                 pytest.skip(f"{vfs_fam} does not support {parentmesh.ufl_cell()} cells")
-            # TODO: Remove this else when fixed
-            else:
-                pytest.skip(f"Some complex merge related problem for {vfs_fam}, get this from loopy: TypeError: unsupported type for persistent hash keying: <class 'complex'>")
         elif parentmesh.ufl_cell().cellname() == "triangle" or parentmesh.ufl_cell().cellname() == "tetrahedron":
             if (not (vfs_fam == "N1curl" or vfs_fam == "N2curl"
                      or vfs_fam == "N1div" or vfs_fam == "N2div")):

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -203,7 +203,39 @@ def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
     w_v = interpolate(v, W)
     assert np.allclose(w_v.dat.data_ro, result)
 
-# TODO: Add parallel tests
-# @pytest.mark.parallel
-# def test_scalar_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
-#     test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+@pytest.mark.parallel
+def test_scalar_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.parallel
+def test_scalar_function_interpolation_parallel(parentmesh, vertexcoords, fs):
+    test_scalar_function_interpolation(parentmesh, vertexcoords, fs)
+
+
+@pytest.mark.parallel
+def test_scalar_function_interpolator_parallel(parentmesh, vertexcoords, fs):
+    test_scalar_function_interpolator(parentmesh, vertexcoords, fs)
+
+
+@pytest.mark.parallel
+def test_vector_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.skip(reason="Skipping parallel tests using in-test logic is buggy")
+@pytest.mark.parallel
+def test_vector_function_interpolation_parallel(parentmesh, vertexcoords, vfs):
+    test_vector_function_interpolation(parentmesh, vertexcoords, vfs)
+
+
+@pytest.mark.parallel
+def test_tensor_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.skip(reason="Skipping parallel tests using in-test logic is buggy")
+@pytest.mark.parallel
+def test_tensor_function_interpolation_parallel(parentmesh, vertexcoords, tfs):
+    test_tensor_function_interpolation(parentmesh, vertexcoords, tfs)


### PR DESCRIPTION
Draft for changes needed to interpolate onto a Vertex Only Mesh from a suitable parent mesh (to resolve #1795).

Based on top of branch `dual_base_fiat` - see draft PR #1743. Base should change to master when that PR is complete (or if this diverges and stops being dependent on #1743).

Linked PRs: https://github.com/firedrakeproject/tsfc/pull/226 & https://github.com/FInAT/FInAT/pull/66

To-do:

- [ ] Merge PRs this sits on top of (FInAT dual evalutation)
- [ ] Test parallel
- [ ] Test mixed spaces
- [ ] Fix assembly across different meshes for this case (for `E` on a `VertexOnlyMesh` and `R` on its parent mesh, `J = firedrake.assemble(E + R)` does not work but `J = firedrake.assemble(E) + firedrake.assemble(R)` does)
- [ ] Fix `firedrake_adjoint.minimize` here for Newton-CG (need hessian for Interpolation matrix I think) - see #1942