### PR TITLE
Fix memory leak in bc.apply + cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,14 @@
 *.pvtu
 *.so
 *.vtu
+.DS_Store
 __pycache__/
 /demos/**/*.py
 /demos/immersed_fem/immersed_domain.msh
 /docs/build/
 /docs/notebooks/.ipynb_checkpoints/
 /docs/source/firedrake.rst
+/docs/source/firedrake.adjoint.rst
 /docs/source/firedrake.cython.rst
 /docs/source/firedrake.matrix_free.rst
 /docs/source/firedrake.mg.rst

--- a/firedrake/adjoint/dirichletbc.py
+++ b/firedrake/adjoint/dirichletbc.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from pyadjoint.overloaded_type import FloatingType
 from .blocks import DirichletBCBlock
-from pyadjoint.tape import no_annotations
+from pyadjoint.tape import stop_annotating, annotate_tape
 
 
 class DirichletBCMixin(FloatingType):
@@ -20,14 +20,17 @@ class DirichletBCMixin(FloatingType):
 
     @staticmethod
     def _ad_annotate_apply(apply):
-        @no_annotations
         @wraps(apply)
         def wrapper(self, *args, **kwargs):
-            for arg in args:
-                if not hasattr(arg, "bcs"):
-                    arg.bcs = []
-            arg.bcs.append(self)
-            return apply(self, *args, **kwargs)
+            annotate = annotate_tape(kwargs)
+            if annotate:
+                for arg in args:
+                    if not hasattr(arg, "bcs"):
+                        arg.bcs = []
+                arg.bcs.append(self)
+            with stop_annotating():
+                ret = apply(self, *args, **kwargs)
+            return ret
         return wrapper
 
     def _ad_create_checkpoint(self):

--- a/tests/regression/test_adjoint_bc.py
+++ b/tests/regression/test_adjoint_bc.py
@@ -1,0 +1,31 @@
+import gc
+from firedrake import *
+
+
+def howmany(cls):
+    n = 0
+    for x in gc.get_objects():
+        try:
+            if isinstance(x, cls):
+                n += 1
+        except (ReferenceError, AttributeError):
+            pass
+    return n
+
+
+def test_bcs_collected_when_not_annotating():
+    mesh = UnitTriangleMesh()
+
+    V = FunctionSpace(mesh, "DG", 0)
+
+    u = Function(V)
+
+    def run(u, n):
+        for _ in range(n):
+            bc = DirichletBC(u.function_space(), 0, "on_boundary")
+            bc.apply(u)
+
+    before = howmany(DirichletBC)
+    run(u, 100)
+    after = howmany(DirichletBC)
+    assert before == after

--- a/tests/regression/test_adjoint_bc.py
+++ b/tests/regression/test_adjoint_bc.py
@@ -13,7 +13,7 @@ def howmany(cls):
     return n
 
 
-def test_bcs_collected_when_not_annotating():
+def test_bcs_garbage_collected_when_not_annotating():
     mesh = UnitTriangleMesh()
 
     V = FunctionSpace(mesh, "DG", 0)
@@ -27,5 +27,9 @@ def test_bcs_collected_when_not_annotating():
 
     before = howmany(DirichletBC)
     run(u, 100)
+    gc.collect()
     after = howmany(DirichletBC)
-    assert before == after
+    # BC objects hold refcycles in the adjoint mixin, hence we're just
+    # going to check that we didn't leak any new ones after the
+    # collection sweep.
+    assert before >= after


### PR DESCRIPTION
The `bc.apply` annotation unconditionally saved the bc on the function it was applied to. Causing a memory leak. This was noticed in defcon where new bc objects are made as part of the continuation/deflation process, but applied to the same state vector.

This is clearly a memory leak full stop, but I don't have any pyadjoint-fu, so I'm not going to try and fix it there. At the very least, this patch removes the behaviour that in annotations off mode, something still happens.

In addition, a bunch of cleanups such that if we're not in adjoint mode, the wrappers/decorators really are no-ops.

Please audit carefully.