### PR TITLE
Fix quick testing instructions

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -41,7 +41,7 @@ that Firedrake is fully functional. Activate the venv_ as above and
 then run::
 
   cd $VIRTUAL_ENV/src/firedrake
-  python3 -m pytest tests/regression/ -k "poisson_strong | stokes_mini | dg_advection"
+  pytest tests/regression/ -k "poisson_strong or stokes_mini or dg_advection"
 
 This command will run a few of the unit tests, which exercise a good
 chunk of the functionality of the library. These tests should take a


### PR DESCRIPTION
The previous instructions caused a `ERROR: Wrong expression passed to '-k': poisson_strong | stokes_mini | dg_advection: at column 16: unexpected character "|"` error for me. @danshapero has confirmed this new wording works