### PR TITLE
Some improvements in slate compilation time

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -103,8 +103,10 @@ def compile_expression(slate_expr, tsfc_parameters=None, coffee=False):
     # If the expression has already been symbolically compiled, then
     # simply reuse the produced kernel.
     cache = slate_expr._metakernel_cache
-    if tsfc_parameters is None:
-        tsfc_parameters = parameters["form_compiler"]
+    params = parameters["form_compiler"].copy()
+    if tsfc_parameters is not None:
+        params.update(tsfc_parameters)
+    tsfc_parameters = params
     key = str(sorted(tsfc_parameters.items()))
     try:
         return cache[key]

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -145,11 +145,14 @@ def generate_loopy_kernel(slate_expr, tsfc_parameters=None):
     # Create a loopy builder for the Slate expression,
     # e.g. contains the loopy kernels coming from TSFC
     gem_expr, var2terminal = slate_to_gem(slate_expr)
-    slate_loopy = gem_to_loopy(gem_expr)
+
+    scalar_type = tsfc_parameters["scalar_type"]
+    slate_loopy, output_arg = gem_to_loopy(gem_expr, var2terminal, scalar_type)
+
     builder = LocalLoopyKernelBuilder(expression=slate_expr,
                                       tsfc_parameters=tsfc_parameters)
-    loopy_merged = merge_loopy(slate_loopy, builder, var2terminal)
 
+    loopy_merged = merge_loopy(slate_loopy, output_arg, builder, var2terminal)
     loopy_merged = loopy.register_function_id_to_in_knl_callable_mapper(loopy_merged, inv_fn_lookup)
     loopy_merged = loopy.register_function_id_to_in_knl_callable_mapper(loopy_merged, solve_fn_lookup)
 
@@ -604,16 +607,19 @@ def parenthesize(arg, prec=None, parent=None):
     return "(%s)" % arg
 
 
-def gem_to_loopy(gem_expr):
+def gem_to_loopy(gem_expr, var2terminal, scalar_type):
     """ Method encapsulating stage 2.
     Converts the gem expression dag into imperoc first, and then further into loopy.
-    :return slate_loopy: loopy kernel for slate operations.
+    :return slate_loopy: 2-tuple of loopy kernel for slate operations
+        and loopy GlobalArg for the output variable.
     """
     # Creation of return variables for outer loopy
     shape = gem_expr.shape if len(gem_expr.shape) != 0 else (1,)
     idx = make_indices(len(shape))
     indexed_gem_expr = gem.Indexed(gem_expr, idx)
-    arg = [loopy.GlobalArg("output", shape=shape)]
+    args = ([loopy.GlobalArg("output", shape=shape, dtype=scalar_type)]
+            + [loopy.GlobalArg(var.name, shape=var.shape, dtype=scalar_type)
+               for var in var2terminal.keys()])
     ret_vars = [gem.Indexed(gem.Variable("output", shape), idx)]
 
     preprocessed_gem_expr = impero_utils.preprocess_gem([indexed_gem_expr])
@@ -625,7 +631,7 @@ def gem_to_loopy(gem_expr):
     impero_c = impero_utils.compile_gem(assignments, (), remove_zeros=False)
 
     # Part B: impero_c to loopy
-    return generate_loopy(impero_c, arg, parameters["form_compiler"]["scalar_type"], "slate_loopy", [])
+    return generate_loopy(impero_c, args, scalar_type, "slate_loopy", []), args[0].copy()
 
 
 def slate_to_cpp(expr, temps, prec=None):

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -19,7 +19,7 @@ import firedrake.slate.slate as slate
 from firedrake.slate.slac.tsfc_driver import compile_terminal_form
 
 from firedrake.parameters import parameters
-from tsfc.loopy import create_domains
+from tsfc.loopy import create_domains, assign_dtypes
 
 from pytools import UniqueNameGenerator
 
@@ -607,7 +607,9 @@ class LocalLoopyKernelBuilder(object):
         tensor2temp = OrderedDict()
         inits = []
         for gem_tensor, slate_tensor in var2terminal.items():
+            (_, dtype), = assign_dtypes([gem_tensor], self.tsfc_parameters["scalar_type"])
             loopy_tensor = loopy.TemporaryVariable(gem_tensor.name,
+                                                   dtype=dtype,
                                                    shape=gem_tensor.shape,
                                                    address_space=loopy.AddressSpace.LOCAL)
             tensor2temp[slate_tensor] = loopy_tensor

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -1,4 +1,5 @@
 import numpy as np
+from itertools import count
 from coffee import base as ast
 
 from collections import OrderedDict, Counter, namedtuple
@@ -437,13 +438,14 @@ class LocalLoopyKernelBuilder(object):
         self.expression = expression
         self.tsfc_parameters = tsfc_parameters
         self.bag = None
+        self.kernel_counter = count()
 
     def tsfc_cxt_kernels(self, terminal):
         r"""Gathers all :class:`~.ContextKernel`\s containing all TSFC kernels,
         and integral type information.
         """
 
-        return compile_terminal_form(terminal, prefix="subkernel%s_" % terminal._output_string,
+        return compile_terminal_form(terminal, prefix=f"subkernel{next(self.kernel_counter)}_",
                                      tsfc_parameters=self.tsfc_parameters, coffee=False)
 
     def shape(self, tensor):

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -4,7 +4,7 @@ from coffee import base as ast
 
 from collections import OrderedDict, Counter, namedtuple
 
-from firedrake.slate.slac.utils import traverse_dags, eigen_tensor, Transformer
+from firedrake.slate.slac.utils import traverse_dags, Transformer
 from firedrake.utils import cached_property
 
 from tsfc.finatinterface import create_element
@@ -262,7 +262,6 @@ class LocalKernelBuilder(object):
                 coords = coordinates
 
             for split_kernel in cxt_kernel.tsfc_kernels:
-                indices = split_kernel.indices
                 kinfo = split_kernel.kinfo
                 kint_type = kinfo.integral_type
                 needs_cell_sizes = needs_cell_sizes or kinfo.needs_cell_sizes
@@ -283,9 +282,8 @@ class LocalKernelBuilder(object):
                     args.append(self.cell_size_sym)
 
                 # Assembly calls within the macro kernel
-                tensor = eigen_tensor(exp, self.temps[exp], indices)
                 call = ast.FunCall(kinfo.kernel.name,
-                                   tensor,
+                                   self.temps[exp],
                                    self.coord_sym,
                                    *args)
 

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -18,7 +18,6 @@ from functools import singledispatch
 import firedrake.slate.slate as slate
 from firedrake.slate.slac.tsfc_driver import compile_terminal_form
 
-from firedrake.parameters import parameters
 from tsfc.loopy import create_domains, assign_dtypes
 
 from pytools import UniqueNameGenerator
@@ -653,7 +652,7 @@ class LocalLoopyKernelBuilder(object):
     def generate_wrapper_kernel_args(self, tensor2temp, templated_subkernels):
         coords_extent = self.extent(self.expression.ufl_domain().coordinates)
         args = [loopy.GlobalArg(self.coordinates_arg, shape=coords_extent,
-                                dtype=parameters["form_compiler"]["scalar_type"])]
+                                dtype=self.tsfc_parameters["scalar_type"])]
 
         for loopy_inner in templated_subkernels:
             for arg in loopy_inner.args[1:]:
@@ -666,12 +665,12 @@ class LocalLoopyKernelBuilder(object):
             if isinstance(coeff, OrderedDict):
                 for (name, extent) in coeff.values():
                     arg = loopy.GlobalArg(name, shape=extent,
-                                          dtype=parameters["form_compiler"]["scalar_type"])
+                                          dtype=self.tsfc_parameters["scalar_type"])
                     args.append(arg)
             else:
                 (name, extent) = coeff
                 arg = loopy.GlobalArg(name, shape=extent,
-                                      dtype=parameters["form_compiler"]["scalar_type"])
+                                      dtype=self.tsfc_parameters["scalar_type"])
                 args.append(arg)
 
         if self.bag.needs_cell_facets:

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -29,7 +29,7 @@ particular integral type.
                      provided by TSFC."""
 
 
-def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None, coffee=True):
+def compile_terminal_form(tensor, prefix, *, tsfc_parameters=None, coffee=True):
     """Compiles the TSFC form associated with a Slate :class:`Tensor`
     object. This function will return a :class:`ContextKernel`
     which stores information about the original tensor, integral types
@@ -48,16 +48,13 @@ def compile_terminal_form(tensor, prefix=None, tsfc_parameters=None, coffee=True
         "Only terminal tensors have forms associated with them!"
     )
     # Sets a default name for the subkernel prefix.
-    # NOTE: the builder will choose a prefix independent of
-    # the tensor name for code idempotency reasons, but is not
-    # strictly required.
-    prefix = prefix or "subkernel%s_" % tensor.__str__()
     mapper = RemoveRestrictions()
     integrals = map(partial(map_integrand_dags, mapper),
                     tensor.form.integrals())
 
     transformed_integrals = transform_integrals(integrals)
     cxt_kernels = []
+    assert prefix is not None
     for orig_it_type, integrals in transformed_integrals.items():
         subkernel_prefix = prefix + "%s_to_" % orig_it_type
         form = Form(integrals)

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -243,42 +243,6 @@ def slate2gem(expression):
     return mapper(expression), mapper.var2terminal
 
 
-def eigen_tensor(expr, temporary, index):
-    """Returns an appropriate assignment statement for populating a particular
-    `Eigen::MatrixBase` tensor. If the tensor is mixed, then access to the
-    :meth:`block` of the eigen tensor is provided. Otherwise, no block
-    information is needed and the tensor is returned as is.
-
-    :arg expr: a `slate.Tensor` node.
-    :arg temporary: the associated temporary of the expr argument.
-    :arg index: a tuple of integers used to determine row and column
-                information. This is provided by the SplitKernel
-                associated with the expr.
-    """
-    if expr.is_mixed:
-        try:
-            row, col = index
-        except ValueError:
-            row = index[0]
-            col = 0
-        rshape = expr.shapes[0][row]
-        rstart = sum(expr.shapes[0][:row])
-        try:
-            cshape = expr.shapes[1][col]
-            cstart = sum(expr.shapes[1][:col])
-        except KeyError:
-            cshape = 1
-            cstart = 0
-
-        tensor = ast.FlatBlock("%s.block<%d, %d>(%d, %d)" % (temporary,
-                                                             rshape, cshape,
-                                                             rstart, cstart))
-    else:
-        tensor = temporary
-
-    return tensor
-
-
 def depth_first_search(graph, node, visited, schedule):
     """A recursive depth-first search (DFS) algorithm for
     traversing a DAG consisting of Slate expressions.

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -15,7 +15,7 @@ from functools import singledispatch
 import firedrake.slate.slate as sl
 import loopy as lp
 from loopy.program import make_program
-from loopy.transform.callable import inline_callable_kernel, register_callable_kernel
+from loopy.transform.callable import register_callable_kernel
 import itertools
 
 
@@ -346,12 +346,9 @@ def merge_loopy(slate_loopy, output_arg, builder, var2terminal):
     slate_wrapper = lp.make_function(domains, insns, args, name="slate_wrapper",
                                      seq_dependencies=True, target=lp.CTarget())
 
-    # Generate program from kernel, so that one can register and inline kernels
+    # Generate program from kernel, so that one can register kernels
     prg = make_program(slate_wrapper)
     for tsfc_loopy in tsfc_kernels:
         prg = register_callable_kernel(prg, tsfc_loopy)
-        prg = inline_callable_kernel(prg, tsfc_loopy.name)
     prg = register_callable_kernel(prg, slate_loopy)
-    prg = inline_callable_kernel(prg, slate_loopy.name)
-
     return prg

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -318,7 +318,7 @@ def topological_sort(exprs):
     return schedule
 
 
-def merge_loopy(slate_loopy, builder, var2terminal):
+def merge_loopy(slate_loopy, output_arg, builder, var2terminal):
     """ Merges tsfc loopy kernels and slate loopy kernel into a wrapper kernel."""
     from firedrake.slate.slac.kernel_builder import SlateWrapperBag
     coeffs = builder.collect_coefficients()
@@ -333,12 +333,11 @@ def merge_loopy(slate_loopy, builder, var2terminal):
                                     for terminal in terminal_tensors)))
 
     # Construct args
-    args = slate_loopy.args.copy() + builder.generate_wrapper_kernel_args(tensor2temp, tsfc_kernels)
-
+    args = [output_arg] + builder.generate_wrapper_kernel_args(tensor2temp, tsfc_kernels)
     # Munge instructions
     insns = inits
     insns.extend(tsfc_calls)
-    insns += builder.slate_call(slate_loopy)
+    insns.append(builder.slate_call(slate_loopy, tensor2temp.values()))
 
     # Inames come from initialisations + loopyfying kernel args and lhs
     domains = builder.bag.index_creator.domains

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -167,7 +167,7 @@ class TensorBase(object, metaclass=ABCMeta):
         """
         shapes = OrderedDict()
         for i, fs in enumerate(self.arg_function_spaces):
-            shapes[i] = tuple(V.finat_element.space_dimension() * V.value_size
+            shapes[i] = tuple(int(V.finat_element.space_dimension() * V.value_size)
                               for V in fs)
         return shapes
 


### PR DESCRIPTION
With the slate->loopy pipeline, codegen for slate expressions has gone up quite a lot. For example here: https://jenkins.ese.ic.ac.uk/blue/organizations/jenkins/firedrake/detail/master/277/pipeline/67

The top test length culprits are now all slate tests with the longest taking over half an our. All of this time is spent in codegen, with a warm cache it takes about 3 seconds.

These changes remove the need to inline the slate and tsfc kernels into the slate wrapper. While this may not be the preferred option long term, it approximately halves the time loopy spends in codegen. I would therefore advocate that we do something like this until loopy codegen is blazing fast.

As a consequence, I tidy up the loopy merging a little bit such that the `slate_loopy` call doesn't rely on inlining to resolve a bunch of the variables it references.