### PR TITLE
Fix issue #1841

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -121,7 +121,8 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         self._ad_nlvs_replace_forms()
         self._ad_nlvs.parameters.update(self.solver_params)
         self._ad_nlvs.solve()
-        return self._ad_nlvs._problem.u
+        func.assign(self._ad_nlvs._problem.u)
+        return func
 
     def _ad_assign_map(self, form):
         count_map = self._ad_nlvs._problem._ad_count_map
@@ -135,19 +136,14 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
                     assign_map[form_ad_count_map[coeff_count]] = block_variable.saved_output
         return assign_map
 
-    def _ad_assign_coefficients(self, form, func=None):
+    def _ad_assign_coefficients(self, form):
         assign_map = self._ad_assign_map(form)
-        if func is not None and self._ad_nlvs._problem.u in assign_map:
-            self.backend.Function.assign(func, assign_map[self._ad_nlvs._problem.u])
-            assign_map[self._ad_nlvs._problem.u] = func
-
         for coeff, value in assign_map.items():
             coeff.assign(value)
 
     def _ad_nlvs_replace_forms(self):
         problem = self._ad_nlvs._problem
-        func = self.backend.Function(problem.u.function_space())
-        self._ad_assign_coefficients(problem.F, func)
+        self._ad_assign_coefficients(problem.F)
         self._ad_assign_coefficients(problem.J)
 
 


### PR DESCRIPTION
The function returned by _forward_solve() containing the solution on
replay is used by pyadjoint as the new checkpoint, so we can't just
return the same problem.u every time. Instead copy the solution in
the provided func which is created new by pyadjoint at each solve to
store the solution.

Also, for the initial guess just let the value of problem.u be
overwritten by the checkpoint - this happens automatically as it is also
registered as a dependency - rather than trying to keep the problem.u
value of the previous replay solve. In the typical case where the
initial guess just comes from the previous solve in the forward model,
this should do the same in a full replay. However if, for some reason
the initial guess is set differently in the forward model, the replay
should do the same. This is also more correct in the case of partial
replays (from checkpointing).