### PR TITLE
Various fixes in FunctionMergeBlock

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -254,8 +254,8 @@ class FunctionMergeBlock(Block, Backend):
         sub_func = deps[0].checkpoint
         parent_in = deps[1].checkpoint
         parent_out = self.get_outputs()[0].checkpoint
-        self.backend.Function.assign(parent_out, parent_in)
-        self.backend.Function.assign(self.backend.Function.sub(parent_out, self.idx), sub_func)
+        parent_out.assign(parent_in)
+        parent_out.sub(self.idx).assign(sub_func)
 
 
 class MeshOutputBlock(Block):


### PR DESCRIPTION
1. Merge block does not register the parent mixed function that it merges into, as a dependency, but it does change the state of that mixed function thus creating a new blockvariable on the output. This means pyadjoint looses track of the dependency of that output state on the control
2. the adjoint is incorrect: the adjoint solution of the output of merge-block should be restricted to serve as the adjoint solution associated with the input sub-function
3. the forward replay is also incorrect: when merging into a mixed function it shouldn't just replay the merge into the output checkpoint, the output checkpoint as it won't be initialised - it should first receive a copy of the checkpointed full mixed function before the merge

Partial fix for #1843