### PR TITLE
Hooking up KMV elements

### DIFF
--- a/demos/demo_references.bib
+++ b/demos/demo_references.bib
@@ -249,3 +249,26 @@
   url = "http://proceedings.asmedigitalcollection.asme.org/proceeding.aspx?articleID=2570974"
 }
 
+@Article{Chin:1999,
+ author={Chin-Joe-Kong, MJS and Mulder, Wim A and Van Veldhuizen, M},
+ title={Higher-order triangular and tetrahedral finite elements with mass lumping for solving the wave equation},
+ journal={Journal of Engineering Mathematics},
+ volume={35},
+ number={4},
+ pages={405--426},
+ year={1999},
+ publisher={Springer},
+ doi={https://doi.org/10.1023/A:1004420829610},
+}
+
+@article{Geevers:2018,
+ author={Geevers, Sjoerd and Mulder, Wim A and van der Vegt, Jaap JW},
+ title={New higher-order mass-lumped tetrahedral elements for wave propagation modelling},
+ journal={SIAM journal on scientific computing},
+ volume={40},
+ number={5},
+ pages={A2830--A2857},
+ year={2018},
+ publisher={SIAM},
+ doi={https://doi.org/10.1137/18M1175549},
+}

--- a/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
+++ b/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
@@ -1,0 +1,178 @@
+
+Scalar wave equation with higher-order mass lumping
+===================================================
+
+
+    **Here we focus on solving the scalar wave equation with a
+    fully-explicit, higher-order (e.g., :math:`p < 5`) mass
+    lumping technique. This scalar wave equation is widely used
+    in seismology to model seismic waves and is especially popular
+    in algorithms for geophysical exploration such as Full Waveform
+    Inversion and Reverse Time Migration. This tutorial demonstrates how to
+    use the mass-lumped triangular elements originally discovered in
+    :cite:`Kong:1999` and later improved in :cite:`Geevers` into the
+    Firedrake environment.**
+
+    **The tutorial was prepared by `Keith J. Roberts
+    <mailto:krober@usp.br>`__**
+
+
+The scalar wave equation solved here is:
+
+.. math::
+
+    \rho \partial_{t}^2 u = \nabla \cdot c \nabla u + f
+
+    u = 0
+
+    u \vert_{t=0} = u_0
+
+    \partial_{t} u \vert_{t=0} = v_0
+
+The weak formulation is finding :math:`u \in V` such that:
+
+.. math::
+
+    <\partial_t(\rho \partial_t u), v> + a(u,v) = (f,w)
+
+Here :math:`<\cdot, \cdot>` denotes the pairing between :math:`H^{-1}(\Omega)` and :math:`H^{1}_{0}(\Omega)`, :math:`(\cdot, \cdot)` denotes the :math:`L^{2}(\Omega)` inner product, and :math:`a(\cdot, \cdot) : H^{1}_{0}(\Omega) \times H^{1}_{0}(\Omega)\rightarrow ℝ` is the elliptical operator given by:
+
+.. math::
+
+    a(u, v) := \int_{\Omega} c \nabla u \cdot \nabla v  \mathrm d x
+
+We solve the above weak formulation using the finite element method.
+
+In time, we use simple central scheme that is formally 2nd order accurate.
+
+.. note::
+    Mass lumping is a common technique in finite elements to produce a diagonal mass matrix that can be trivially inverted and thus result in very efficient explicit time integration scheme. It's usually done with nodal basis functions and an inexact quadrature rule for the mass matrix. A diagonal matrix is obtained when the integration points coincide with the nodes of the basis function. However, when using elements of :math:`p \ge 2`, this technique does not result in a stable and accurate finite element scheme.
+
+In the work of :cite:`Kong:1999` and later :cite:`Geevers:2018`, several triangular and tetrahedral elements were discovered that could produce convergent and stable mass lumping for :math:`p \ge 2`. Here we implemented eight of them for use within the Firedrake computing environment (e.g., five triangular elements :math:`p \le 5` and three tetrahdrals up to :math:`p \le 3`). We honorifically refer to the elements as `KMV` elements (i.e., Kong-Mulder-Veldhuizen).
+
+We can then start our Python script loading Firedrake *and* fiat/finat, which is used to build the special quadrature rules::
+
+    from firedrake import *
+    import FIAT
+    import finat
+    import math
+
+A simple triangular mesh is created::
+
+    mesh = UnitSquareMesh(50, 50)
+
+We choose a degree 2 `KMV` continuous function space, and set up the
+function space, the function to hold the seismic velocity, and some functions used in timestepping::
+
+    V = FunctionSpace(mesh, "KMV", 2)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    c = Function(V) # Acoustic wave velocity
+
+    u_np1 = Function(V)  # timestep n+1
+    u_n = Function(V)    # timestep n
+    u_nm1 = Function(V)  # timestep n-1
+
+.. note::
+    The user can select orders up to P=5 for triangles and up to P=3 for tetrahedral.
+
+Output file to hold the simulation results::
+
+    outfile = File("out.pvd")
+
+Now we set the time-stepping variables::
+
+    T = 1.0
+    dt = 0.001
+    t = 0
+    step = 0
+
+In seismology, often [Ricker wavelets](https://wiki.seg.org/wiki/Dictionary:Ricker_wavelet) are used to force the domain, which have only one parameter: a peak frequency :math:`freq`. Here we inject a Ricker forcing function into the domain. We also specify the seismic velocity in the domain :math:`c` to be a constant however this is arbitrary::
+
+    freq = 6
+    c = Function(V).assign(1.5)
+
+The following two functions are used to inject the Ricker wavelet source into the domain::
+
+    # Source function
+    def RickerWavelet(t, freq, amp=1.0):
+        # shift so the entire waveform is injected
+        t = t - (math.sqrt(6.0) / (math.pi * freq))
+        return amp * (
+            1.0 - (1.0 / 2.0) * (2.0 * math.pi * freq) * (2.0 * math.pi * freq) * t * t
+        )
+
+
+    # Kernel function to apply the source function
+    def delta_expr(x0, x, y, sigma_x=2000.0):
+        sigma_x = Constant(sigma_x)
+        return exp(-sigma_x * ((x - x0[0]) ** 2 + (y - x0[1]) ** 2))
+
+In order to achieve a diagonal mass matrix, a custom quadrature rule must be used (note we specify the degree here too)::
+
+    Tria = FIAT.reference_element.UFCTriangle()
+    qr_rule = finat.quadrature.make_quadrature(Tria, 2, "KMV")
+
+Here we set up the mass matrix and specify the special quadrature rule to render the matrix diagonal::
+
+    m = (1.0 / (c * c)) * (u - 2.0 * u_n + u_nm1) / Constant(dt * dt) * v * dx(rule=qr_rule)
+
+The stiffness matrix is treated explictly::
+
+    a = dot(grad(u_n), grad(v)) * dx
+
+The source term is injected into the central of the unit square::
+
+    x, y = SpatialCoordinate(mesh)
+    source = Constant([0.5, 0.5])
+    delta = Interpolator(delta_expr(source, x, y), V)
+    ricker = Constant(0.0)
+    expr = Function(delta.interpolate()) * ricker
+    ricker.assign(RickerWavelet(t, freq))
+    f = Function(V).assign(expr)
+
+Finally, we define our variational form :math:`F`, assemble it, and then create a cached PETSc solver object to efficiently timestep with::
+
+    F = m + a - f * v * dx
+    a, r = lhs(F), rhs(F)
+    A = assemble(a)
+    solver = LinearSolver(A, P=None, solver_parameters={"ksp_type": "preonly", "pc_type": "jacobi"})
+
+.. note::
+    We inform PETSc to not solve anything by passing an dictionary of options! These options tell PETSc to only do a simple Jacobi pre-conditioning step, which for our case solves our diagonal system exactly.
+
+Now we are ready to start the time-stepping loop::
+
+    step = 0
+    while t < T:
+        step += 1
+
+        # Update the RHS vector accordingly
+
+        ricker.assign(RickerWavelet(t, freq))
+        f.assign(expr)
+
+        R = assemble(r)
+
+        # Call the solver object to do pointwise division and solve the system.
+
+        solver.solve(u_np1, R)
+
+        # Exchange the solution at the timestepping levels.
+
+        u_nm1.assign(u_n)
+        u_n.assign(u_np1)
+
+        # Write the solution to the file for visualization in ParaView.
+
+        t += dt
+        if step % 10 == 0:
+            print("Elapsed time is: "+str(t))
+            outfile.write(u_n, time=t)
+
+.. rubric:: References
+
+.. bibliography:: demo_references.bib
+   :filter: docname in docnames

--- a/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
+++ b/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
@@ -21,7 +21,7 @@ The scalar wave equation is:
 
 .. math::
 
-    \frac{1}{c^2} \partial_{t}^2 u = \nabla \cdot c \nabla u + f
+    \rho \partial_{t}^2 u = \nabla \cdot c^2 \nabla u + f
 
     u = 0
 
@@ -35,7 +35,7 @@ The weak formulation is finding :math:`u \in V` such that:
 
 .. math::
 
-    <\partial_t(\frac{1}{c^2} \partial_t u), v> + a(u,v) = (f,w)
+    <\partial_t(\rho \partial_t u), v> + a(u,v) = (f,w)
 
 where :math:`<\cdot, \cdot>` denotes the pairing between :math:`H^{-1}(\Omega)` and :math:`H^{1}_{0}(\Omega)`, :math:`(\cdot, \cdot)` denotes the :math:`L^{2}(\Omega)` inner product, and :math:`a(\cdot, \cdot) : H^{1}_{0}(\Omega) \times H^{1}_{0}(\Omega)\rightarrow ℝ` is the elliptic operator given by:
 
@@ -125,7 +125,7 @@ To discretize :math:`\partial_{t}^2 u` we use a central scheme which is formally
 
     \partial_{t}^2 u = \frac{u^{n+1} - 2*u^{n} + u^{n-1}}{\Delta t^2}
 
-Substituting the above into the time derivative term in the variational form leads to
+Substituting the above into the time derivative term (and dividing by :math:`c^2`)in the variational form leads to
 
 .. math::
 

--- a/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
+++ b/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
@@ -43,25 +43,26 @@ Here :math:`<\cdot, \cdot>` denotes the pairing between :math:`H^{-1}(\Omega)` a
 
 We solve the above weak formulation using the finite element method.
 
-In time, we use simple central scheme that is formally 2nd order accurate.
+In time, we use a central scheme that is formally 2nd order accurate.
 
 .. note::
     Mass lumping is a common technique in finite elements to produce a diagonal mass matrix that can be trivially inverted and thus result in very efficient explicit time integration scheme. It's usually done with nodal basis functions and an inexact quadrature rule for the mass matrix. A diagonal matrix is obtained when the integration points coincide with the nodes of the basis function. However, when using elements of :math:`p \ge 2`, this technique does not result in a stable and accurate finite element scheme.
 
 In the work of :cite:`Kong:1999` and later :cite:`Geevers:2018`, several triangular and tetrahedral elements were discovered that could produce convergent and stable mass lumping for :math:`p \ge 2`. Here we implemented eight of them for use within the Firedrake computing environment (e.g., five triangular elements :math:`p \le 5` and three tetrahdrals up to :math:`p \le 3`). We honorifically refer to the elements as `KMV` elements (i.e., Kong-Mulder-Veldhuizen).
 
-We can then start our Python script loading Firedrake *and* fiat/finat, which is used to build the special quadrature rules::
+We can then start our Python script loading Firedrake *and* fiat/finat, which the latter is used to build the special quadrature rules to produce the diagonal mass matrix::
 
     from firedrake import *
     import FIAT
     import finat
+
     import math
 
 A simple triangular mesh is created::
 
     mesh = UnitSquareMesh(50, 50)
 
-We choose a degree 2 `KMV` continuous function space, and set up the
+We choose a degree 2 `KMV` continuous function space, set up the
 function space, the function to hold the seismic velocity, and some functions used in timestepping::
 
     V = FunctionSpace(mesh, "KMV", 2)
@@ -69,7 +70,7 @@ function space, the function to hold the seismic velocity, and some functions us
     u = TrialFunction(V)
     v = TestFunction(V)
 
-    c = Function(V) # Acoustic wave velocity
+    c = Function(V) # Scalar wave velocity
 
     u_np1 = Function(V)  # timestep n+1
     u_n = Function(V)    # timestep n
@@ -78,18 +79,18 @@ function space, the function to hold the seismic velocity, and some functions us
 .. note::
     The user can select orders up to P=5 for triangles and up to P=3 for tetrahedral.
 
-Output file to hold the simulation results::
+We create an output file to hold the simulation results::
 
     outfile = File("out.pvd")
 
-Now we set the time-stepping variables::
+Now we set the time-stepping variables performing a simulation for 1 second::
 
     T = 1.0
     dt = 0.001
     t = 0
     step = 0
 
-In seismology, often [Ricker wavelets](https://wiki.seg.org/wiki/Dictionary:Ricker_wavelet) are used to force the domain, which have only one parameter: a peak frequency :math:`freq`. Here we inject a Ricker forcing function into the domain. We also specify the seismic velocity in the domain :math:`c` to be a constant however this is arbitrary::
+In seismology, often [Ricker wavelets](https://wiki.seg.org/wiki/Dictionary:Ricker_wavelet) are used to excite the domain, which have only one free parameter: a peak frequency :math:`freq`. Here we inject a Ricker forcing function into the domain with a frequncy of 6 Hz. We also specify the seismic velocity in the domain :math:`c` to be a constant for simplicity::
 
     freq = 6
     c = Function(V).assign(1.5)
@@ -98,7 +99,7 @@ The following two functions are used to inject the Ricker wavelet source into th
 
     # Source function
     def RickerWavelet(t, freq, amp=1.0):
-        # shift so the entire waveform is injected
+        # Shift in time so the entire wavelet is injected
         t = t - (math.sqrt(6.0) / (math.pi * freq))
         return amp * (
             1.0 - (1.0 / 2.0) * (2.0 * math.pi * freq) * (2.0 * math.pi * freq) * t * t
@@ -115,15 +116,16 @@ In order to achieve a diagonal mass matrix, a custom quadrature rule must be use
     Tria = FIAT.reference_element.UFCTriangle()
     qr_rule = finat.quadrature.make_quadrature(Tria, 2, "KMV")
 
-Here we set up the mass matrix and specify the special quadrature rule to render the matrix diagonal::
+Now we specify the variational form. First, we set up the mass matrix and specify the special quadrature rule to render the matrix diagonal
+by passing a kwarg `rule` to the `dx` object::
 
     m = (1.0 / (c * c)) * (u - 2.0 * u_n + u_nm1) / Constant(dt * dt) * v * dx(rule=qr_rule)
 
-The stiffness matrix is treated explictly::
+The stiffness matrix using a standard quadrature rule and is treated explictly::
 
     a = dot(grad(u_n), grad(v)) * dx
 
-The source term is injected into the central of the unit square::
+The source term is injected into the central of the unit square. We use an `Interpolator` object, which could be used to efficiently force different source locations::
 
     x, y = SpatialCoordinate(mesh)
     source = Constant([0.5, 0.5])
@@ -131,9 +133,12 @@ The source term is injected into the central of the unit square::
     ricker = Constant(0.0)
     expr = Function(delta.interpolate()) * ricker
     ricker.assign(RickerWavelet(t, freq))
+
+The time varying function is assigned to `f`, which will be updated in the timestepping loop::
+
     f = Function(V).assign(expr)
 
-Finally, we define our variational form :math:`F`, assemble it, and then create a cached PETSc solver object to efficiently timestep with::
+Finally, we define the whole variational form :math:`F`, assemble it, and then create a cached PETSc `LinearSolver` object to efficiently timestep with::
 
     F = m + a - f * v * dx
     a, r = lhs(F), rhs(F)
@@ -141,7 +146,7 @@ Finally, we define our variational form :math:`F`, assemble it, and then create 
     solver = LinearSolver(A, P=None, solver_parameters={"ksp_type": "preonly", "pc_type": "jacobi"})
 
 .. note::
-    We inform PETSc to not solve anything by passing an dictionary of options! These options tell PETSc to only do a simple Jacobi pre-conditioning step, which for our case solves our diagonal system exactly.
+    We inform PETSc to not solve anything by passing an dictionary of options. These options tell PETSc to only do a simple Jacobi pre-conditioning step, which for our case solves our diagonal system exactly.
 
 Now we are ready to start the time-stepping loop::
 
@@ -149,18 +154,18 @@ Now we are ready to start the time-stepping loop::
     while t < T:
         step += 1
 
-        # Update the RHS vector accordingly
+        # Update the RHS vector according to the current simulation time `t`
 
         ricker.assign(RickerWavelet(t, freq))
         f.assign(expr)
 
         R = assemble(r)
 
-        # Call the solver object to do pointwise division and solve the system.
+        # Call the solver object to do pointwise division to solve the system.
 
         solver.solve(u_np1, R)
 
-        # Exchange the solution at the timestepping levels.
+        # Exchange the solution at the two timestepping levels.
 
         u_nm1.assign(u_n)
         u_n.assign(u_np1)

--- a/tests/regression/test_project_interp_KMV.py
+++ b/tests/regression/test_project_interp_KMV.py
@@ -1,0 +1,67 @@
+import pytest
+import numpy as np
+from firedrake import *
+import FIAT
+import finat
+
+
+def run_interpolation_KMV(MeshClass, r, d):
+    if MeshClass.__name__ == "UnitSquareMesh":
+        mesh = MeshClass(2 ** r, 2 ** r)
+        x, y = SpatialCoordinate(mesh)
+        f = (1 + 8 * pi * pi) * cos(x * pi * 2) * cos(y * pi * 2)
+    elif MeshClass.__name__ == "UnitCubeMesh":
+        mesh = MeshClass(2 ** r, 2 ** r, 2 ** r)
+        x, y, z = SpatialCoordinate(mesh)
+        f = (1 + 8 * pi * pi) * cos(x * pi * 2) * cos(y * pi * 2) * cos(z * pi * 2)
+    V = FunctionSpace(mesh, "KMV", d)
+    v1 = interpolate(f, V)
+    return errornorm(f, v1)
+
+
+@pytest.mark.parametrize("MeshClass_max_deg", [(UnitSquareMesh, 6), (UnitCubeMesh, 4)])
+def test_interpolation_KMV(MeshClass_max_deg):
+    MeshClass, max_deg = MeshClass_max_deg
+    for deg in range(1, max_deg):
+        errors = [run_interpolation_KMV(MeshClass, r, deg) for r in range(3, 6)]
+        errors = np.asarray(errors)
+        l2conv = np.log2(errors[:-1] / errors[1:])
+        assert (l2conv > deg + 0.7).all()
+
+
+def run_projection_KMV(MeshClass, r, d):
+    if MeshClass.__name__ == "UnitSquareMesh":
+        mesh = MeshClass(2 ** r, 2 ** r)
+        x, y = SpatialCoordinate(mesh)
+        f = sin(x * pi) * sin(2 * pi * y)
+        T = FIAT.reference_element.UFCTriangle()
+    elif MeshClass.__name__ == "UnitCubeMesh":
+        mesh = MeshClass(2 ** r, 2 ** r, 2 ** r)
+        x, y, z = SpatialCoordinate(mesh)
+        f = sin(x * pi) * sin(2 * pi * y) * sin(2 * pi * z)
+        T = FIAT.reference_element.UFCTetrahedron()
+
+    # Define variational problem
+    V = FunctionSpace(mesh, "KMV", d)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    qr = finat.quadrature.make_quadrature(T, d, "KMV")
+    # Compute solution using lumping
+    p = Function(V)
+    solve(
+        inner(u, v) * dx(rule=qr) == inner(f, v) * dx(rule=qr),
+        p,
+        solver_parameters={
+            "ksp_type": "preonly",
+            "pc_type": "jacobi",
+        },
+    )
+    return norm(p - interpolate(f, V))
+
+
+@pytest.mark.parametrize("MeshClass_max_deg", [(UnitSquareMesh, 6), (UnitCubeMesh, 4)])
+def test_projection_KMV(MeshClass_max_deg):
+    MeshClass, max_deg = MeshClass_max_deg
+    for deg in range(1, max_deg):
+        error = run_projection_KMV(MeshClass, 3, deg)
+        assert np.abs(error) < 1e-15

--- a/tests/regression/test_project_interp_KMV.py
+++ b/tests/regression/test_project_interp_KMV.py
@@ -1,67 +1,73 @@
 import pytest
 import numpy as np
 from firedrake import *
-import FIAT
 import finat
 
 
-def run_interpolation_KMV(MeshClass, r, d):
-    if MeshClass.__name__ == "UnitSquareMesh":
-        mesh = MeshClass(2 ** r, 2 ** r)
-        x, y = SpatialCoordinate(mesh)
-        f = (1 + 8 * pi * pi) * cos(x * pi * 2) * cos(y * pi * 2)
-    elif MeshClass.__name__ == "UnitCubeMesh":
-        mesh = MeshClass(2 ** r, 2 ** r, 2 ** r)
-        x, y, z = SpatialCoordinate(mesh)
-        f = (1 + 8 * pi * pi) * cos(x * pi * 2) * cos(y * pi * 2) * cos(z * pi * 2)
-    V = FunctionSpace(mesh, "KMV", d)
-    v1 = interpolate(f, V)
-    return errornorm(f, v1)
+@pytest.fixture(params=["square", "cube"])
+def mesh_type(request):
+    return request.param
 
 
-@pytest.mark.parametrize("MeshClass_max_deg", [(UnitSquareMesh, 6), (UnitCubeMesh, 4)])
-def test_interpolation_KMV(MeshClass_max_deg):
-    MeshClass, max_deg = MeshClass_max_deg
-    for deg in range(1, max_deg):
-        errors = [run_interpolation_KMV(MeshClass, r, deg) for r in range(3, 6)]
+@pytest.fixture
+def mesh(mesh_type):
+    return {
+        "square": lambda n: UnitSquareMesh(2 ** n, 2 ** n),
+        "cube": lambda n: UnitCubeMesh(2 ** n, 2 ** n, 2 ** n),
+    }[mesh_type]
+
+
+@pytest.fixture
+def max_degree(mesh_type):
+    return {"square": 6, "cube": 4}[mesh_type]
+
+
+@pytest.fixture
+def interpolation_expr(mesh_type):
+    return {
+        "square": lambda x, y: (1 + 8 * pi * pi) * cos(x * pi * 2) * cos(y * pi * 2),
+        "cube": lambda x, y, z: (1 + 8 * pi * pi)
+        * cos(x * pi * 2)
+        * cos(y * pi * 2)
+        * cos(z * pi * 2),
+    }[mesh_type]
+
+
+def run_interpolation(mesh, expr, p):
+    expr = expr(*SpatialCoordinate(mesh))
+    V = FunctionSpace(mesh, "KMV", p)
+    return errornorm(expr, interpolate(expr, V))
+
+
+def test_interpolation_KMV(mesh, max_degree, interpolation_expr):
+    for p in range(1, max_degree):
+        errors = [
+            run_interpolation(mesh(r), interpolation_expr, p) for r in range(3, 6)
+        ]
         errors = np.asarray(errors)
         l2conv = np.log2(errors[:-1] / errors[1:])
-        assert (l2conv > deg + 0.7).all()
+        assert (l2conv > p + 0.7).all()
 
 
-def run_projection_KMV(MeshClass, r, d):
-    if MeshClass.__name__ == "UnitSquareMesh":
-        mesh = MeshClass(2 ** r, 2 ** r)
-        x, y = SpatialCoordinate(mesh)
-        f = sin(x * pi) * sin(2 * pi * y)
-        T = FIAT.reference_element.UFCTriangle()
-    elif MeshClass.__name__ == "UnitCubeMesh":
-        mesh = MeshClass(2 ** r, 2 ** r, 2 ** r)
-        x, y, z = SpatialCoordinate(mesh)
-        f = sin(x * pi) * sin(2 * pi * y) * sin(2 * pi * z)
-        T = FIAT.reference_element.UFCTetrahedron()
-
-    # Define variational problem
-    V = FunctionSpace(mesh, "KMV", d)
-    u = TrialFunction(V)
-    v = TestFunction(V)
-    qr = finat.quadrature.make_quadrature(T, d, "KMV")
-    # Compute solution using lumping
-    p = Function(V)
+def run_projection(mesh, expr, p):
+    V = FunctionSpace(mesh, "KMV", p)
+    T = V.finat_element.cell
+    u, v = TrialFunction(V), TestFunction(V)
+    qr = finat.quadrature.make_quadrature(T, p, "KMV")
+    r = Function(V)
+    f = interpolate(expr(*SpatialCoordinate(mesh)), V)
     solve(
         inner(u, v) * dx(rule=qr) == inner(f, v) * dx(rule=qr),
-        p,
+        r,
         solver_parameters={
             "ksp_type": "preonly",
             "pc_type": "jacobi",
         },
     )
-    return norm(p - interpolate(f, V))
+    return norm(r - f)
 
 
-@pytest.mark.parametrize("MeshClass_max_deg", [(UnitSquareMesh, 6), (UnitCubeMesh, 4)])
-def test_projection_KMV(MeshClass_max_deg):
-    MeshClass, max_deg = MeshClass_max_deg
-    for deg in range(1, max_deg):
-        error = run_projection_KMV(MeshClass, 3, deg)
-        assert np.abs(error) < 1e-15
+def test_projection_KMV(mesh, max_degree, interpolation_expr):
+    for p in range(1, max_degree):
+        error = run_projection(mesh(1), interpolation_expr, p)
+        assert np.abs(error) < 1e-14


### PR DESCRIPTION
This follows the work done in fiat to implement the higher-order mass lumped KMV elements to land these elements in Firedrake with tests and a demo.

I've created a test to test `interpolation`, which checks the convergent rates *without* the special quadrature rules to verify that it is a valid element. 

And then I test `projection` ...which projects a solution onto the element *with* the special quadrature rules and differences the analytical solution against the projected solution. 

I also created a demo in the spirit of the other mass-lumping example on the website. This demo highlights how to use the elements, form the special quadrature rules, and lump the mass matrix. 

~~I'm aware Firedrake master is broken at the moment but the tests I've added for these elements pass locally on the latest master of everything.~~

