### PR TITLE
Enable slate tensors with variable-layers extruded mesh

### DIFF
--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -94,9 +94,6 @@ class LocalKernelBuilder(object):
         """
         assert isinstance(expression, slate.TensorBase)
 
-        if expression.ufl_domain().variable_layers:
-            raise NotImplementedError("Variable layers not yet handled in Slate.")
-
         # Collect terminals, expressions, and reference counts
         temps = OrderedDict()
         coeff_vecs = OrderedDict()
@@ -428,9 +425,6 @@ class LocalLoopyKernelBuilder(object):
         """
 
         assert isinstance(expression, slate.TensorBase)
-
-        if expression.ufl_domain().variable_layers:
-            raise NotImplementedError("Variable layers not yet handled in Slate.")
 
         self.expression = expression
         self.tsfc_parameters = tsfc_parameters


### PR DESCRIPTION
This just removes two asserts that claim slate does not work with
variable layers - but this has presumably been fixed in #1715
Adds test for assembly of mass and inverse mass matrix on such mesh.