### PR TITLE
Make Gouraud shading default for tripcolor unless DG0

### DIFF
--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -178,8 +178,7 @@ def _plot_2d_field(method_name, function, *args, complex_component="real", **kwa
         function = interpolate(sqrt(inner(function, function)), Q)
 
     num_sample_points = kwargs.pop("num_sample_points", 10)
-    coords, vals, triangles = _two_dimension_triangle_func_val(function,
-                                                               num_sample_points)
+    coords, vals, triangles = _two_dimension_triangle_func_val(function, num_sample_points)
 
     coords = toreal(coords, "real")
     x, y = coords[:, 0], coords[:, 1]
@@ -231,13 +230,15 @@ def tripcolor(function, *args, complex_component="real", **kwargs):
     :arg kwargs: same as for matplotlib
     :return: matplotlib :class:`PolyCollection <matplotlib.collections.PolyCollection>` object
     """
+    element = function.ufl_element()
+    dg0 = (element.family() == "Discontinuous Lagrange") and (element.degree() == 0)
+    kwargs["shading"] = kwargs.get("shading", "flat" if dg0 else "gouraud")
     return _plot_2d_field("tripcolor", function, *args, complex_component=complex_component, **kwargs)
 
 
 def _trisurf_3d(axes, function, *args, complex_component="real", vmin=None, vmax=None, norm=None, **kwargs):
     num_sample_points = kwargs.pop("num_sample_points", 10)
-    coords, vals, triangles = _two_dimension_triangle_func_val(function,
-                                                               num_sample_points)
+    coords, vals, triangles = _two_dimension_triangle_func_val(function, num_sample_points)
     coords = toreal(coords, "real")
     vals = toreal(vals, complex_component)
     vertices = coords[triangles]

--- a/tests/output/test_plotting.py
+++ b/tests/output/test_plotting.py
@@ -73,9 +73,30 @@ def test_plotting_scalar_field():
     assert filled_contours.filled
     fig.colorbar(filled_contours, ax=axes[1])
 
-    collection = tripcolor(f, axes=axes[2])
-    assert collection is not None
-    fig.colorbar(collection, ax=axes[2])
+
+def test_tripcolor_shading():
+    mesh = UnitSquareMesh(10, 10)
+    x = SpatialCoordinate(mesh)
+
+    V0 = FunctionSpace(mesh, "DG", 0)
+    f0 = Function(V0)
+
+    V1 = FunctionSpace(mesh, "DG", 1)
+    f1 = Function(V1)
+
+    f0.project(x[0] + x[1])
+    f1.project(x[0] + x[1])
+
+    fig, axes = plt.subplots(ncols=3, sharex=True, sharey=True)
+
+    collection = tripcolor(f0, num_sample_points=1, axes=axes[0])
+    assert collection.get_array().shape == f0.dat.data_ro[:].shape
+
+    collection = tripcolor(f1, num_sample_points=1, axes=axes[1])
+    assert collection.get_array().shape == f1.dat.data_ro[:].shape
+
+    collection = tripcolor(f1, num_sample_points=1, shading="flat", axes=axes[2])
+    assert collection.get_array().shape == f0.dat.data_ro[:].shape
 
 
 def test_plotting_quadratic():


### PR DESCRIPTION
The tripcolor function currently defaults to flat shading, which uses a single color for each triangle. This patch makes tripcolor use flat shading only for DG(0) spaces. For everything else, tripcolor will default to Gouraud shading, which uses a linear color gradient in each cell. This gives much better plots for DG(1) or CG(1) or higher functions.