### PR TITLE
Fix test_aw convergence error

### DIFF
--- a/tests/regression/test_aw.py
+++ b/tests/regression/test_aw.py
@@ -90,7 +90,7 @@ def test_aw(stress_element):
                   "snes_linesearch_type": "basic",
                   "snes_monitor": None,
                   "mat_type": "aij",
-                  "snes_max_it": 10,
+                  "snes_max_it": 15,
                   "snes_lag_jacobian": -2,
                   "snes_lag_preconditioner": -2,
                   "ksp_type": "preonly",


### PR DESCRIPTION
The `test_aw[conforming]` test has been exhibiting some odd behaviour. On Jenkins it would occasionally fail on the complex branch (#1867) and on my machine (Ubuntu 18.04) it failed on both real and complex unless the `PYOP2_DEBUG=1` flag was added. The failure was a convergence error with convergence taking a few more iterations than the maximum limit.

The current theory is that the vector registers in Intel chips have a lower precision than the scalar ones leading to different convergence behaviour when optimisation is turned on.

Comments welcome. Are you all happy with this solution?