### PR TITLE
ASM: Set the LGMap for tinyasm to use

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -66,6 +66,11 @@ class ASMPatchPC(PCBase):
         elif backend == "tinyasm":
             if not have_tinyasm:
                 raise ValueError("To use the TinyASM backend you need to install firedrake with TinyASM (firedrake-update --tinyasm)")
+
+            _, P = asmpc.getOperators()
+            lgmap = V.dof_dset.lgmap
+            P.setLGMap(rmap=lgmap, cmap=lgmap)
+
             asmpc.setType("tinyasm")
             # TinyASM wants local numbers, no need to translate
             tinyasm.SetASMLocalSubdomains(


### PR DESCRIPTION
TinyASM needs the local-to-global map on the matrix, but it isn't always set. (For example, it's not set for a fieldsplit within a fieldsplit, at least.) This small patch sets the local-to-global map on the matrix before it is passed in to TinyASM.