### PR TITLE
Add the NotImplementedError for crossed box mesh for Pk (k>1) elements

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -784,6 +784,7 @@ def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, distribution_parameters=None, 
                  v2, v4, v6, v7,
                  v1, v2, v7, v4]
         cells = np.asarray(cells).swapaxes(0, 3).reshape(-1, 4)
+        raise NotImplementedError("The crossed cutting of hexahedra has a broken connectivity issue for Pk (k>1) elements")
     else:
         raise ValueError("Unrecognised value for diagonal '%r'", diagonal)
 

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -435,10 +435,3 @@ def test_changing_default_reorder_works(reorder):
     finally:
         parameters["reorder_meshes"] = old_reorder
 
-
-@pytest.mark.parametrize("kind, num_cells",
-                         [("default", 6), ("crossed", 5)])
-def test_boxmesh_kind(kind, num_cells):
-    m = BoxMesh(1, 1, 1, 1, 1, 1, diagonal=kind)
-    m.init()
-    assert m.num_cells() == num_cells

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -435,6 +435,7 @@ def test_changing_default_reorder_works(reorder):
     finally:
         parameters["reorder_meshes"] = old_reorder
 
+
 @pytest.mark.parametrize("kind, num_cells",
                          [("default", 6)])
 def test_boxmesh_kind(kind, num_cells):

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -435,3 +435,9 @@ def test_changing_default_reorder_works(reorder):
     finally:
         parameters["reorder_meshes"] = old_reorder
 
+@pytest.mark.parametrize("kind, num_cells",
+                         [("default", 6)])
+def test_boxmesh_kind(kind, num_cells):
+    m = BoxMesh(1, 1, 1, 1, 1, 1, diagonal=kind)
+    m.init()
+    assert m.num_cells() == num_cells


### PR DESCRIPTION
The crossed cutting of hexahedra is implemented in PR #1776 

However, as discussed in the reported issue #1923 about using crossed box mesh, there seems to have broken connectivity issues of this mesh.

Hence, this PR is adding a `NotImplementedError` when referring to `diagonal="crossed"` in `BoxMesh`.