### PR TITLE
Fixed warning generated by if L is 0

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -298,7 +298,7 @@ class LinearVariationalProblem(NonlinearVariationalProblem):
         # In the linear case, the Jacobian is the equation LHS.
         J = a
         # Jacobian is checked in superclass, but let's check L here.
-        if L is 0:  # noqa: F632
+        if not isinstance(L, (ufl.Form, slate.slate.TensorBase)) and L == 0:
             F = ufl_expr.action(J, u)
         else:
             if not isinstance(L, (ufl.Form, slate.slate.TensorBase)):


### PR DESCRIPTION
My logs are full of 
```
firedrake/src/firedrake/firedrake/variational_solver.py:301: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if L is 0:  # noqa: F632
```
so I'm fixing it (hopefully)