### PR TITLE
Fix tsfc_interface cache key mismatch

### DIFF
--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -87,7 +87,7 @@ class TSFCKernel(Cached):
 
         if val is None:
             raise KeyError("Object with key %s not found" % key)
-        return cls._cache.setdefault(key, pickle.loads(val))
+        return cls._cache.setdefault((key, comm.py2f()), pickle.loads(val))
 
     @classmethod
     def _cache_store(cls, key, val):

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -92,7 +92,7 @@ class TSFCKernel(Cached):
     @classmethod
     def _cache_store(cls, key, val):
         key, comm = key
-        cls._cache[key] = val
+        cls._cache[(key, comm.py2f())] = val
         _ensure_cachedir(comm=comm)
         if comm.rank == 0:
             val._key = key


### PR DESCRIPTION
The cache key is being stored in a different format (`key`) to how it is getting looked up (`(key, commkey)`). This means that it misses every time and gets read from disk instead.

This is a hacky fix, but I feel like that the caching implementation here could be tidied up a lot. Should I try and do that or are you happy to just merge this?