### PR TITLE
Don't install Python on OSX

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1284,7 +1284,6 @@ if mode == "install" or not args.update_script:
     if osname == "Darwin":
         package_manager = "brew"
         required_packages = ["gcc",
-                             "python3",
                              "autoconf",
                              "make",
                              "automake",


### PR DESCRIPTION
Installing Python can never fix any problems, but can cause them. Let's just not.