### PR TITLE
Python 3.9

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -116,13 +116,7 @@ log = logging.getLogger()
 
 log.info("Running %s" % " ".join(sys.argv))
 
-
-if sys.version_info >= (3, 9):
-    print("""\nCan not install Firedrake with Python 3.9 at the moment:
-wheels are not yet available for Python 3.9 for the required package(s).
-Please install with Python 3.8 (or with earlier versions).""")
-    sys.exit(1)
-elif sys.version_info < (3, 6):
+if sys.version_info < (3, 6):
     if mode == "install":
         print("""\nInstalling Firedrake requires Python 3, at least version 3.6.
 You should run firedrake-install with python3.""")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1534,6 +1534,8 @@ if mode == "install":
             source += "vtk-9.0.1-cp39-cp39-linux_x86_64.whl"
         log.info("Pip installing VTK for Python 3.9 to venv")
         run_pip_install([source])
+        # Also lazy-object-proxy
+        run_pip(["install", "lazy-object-proxy==1.4.*"])
 
     packages = clone_dependencies("firedrake")
     packages = clone_dependencies("PyOP2") + packages

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -116,7 +116,12 @@ log = logging.getLogger()
 
 log.info("Running %s" % " ".join(sys.argv))
 
-if sys.version_info < (3, 6):
+if sys.version_info >= (3, 10):
+    print("""\nCan not install Firedrake with Python 3.10 at the moment:
+Some wheels are not yet available for Python 3.10 for some required package(s).
+Please install with Python 3.9 (or an earlier version >= 3.6).""")
+    sys.exit(1)
+elif sys.version_info < (3, 6):
     if mode == "install":
         print("""\nInstalling Firedrake requires Python 3, at least version 3.6.
 You should run firedrake-install with python3.""")
@@ -1526,7 +1531,7 @@ if mode == "install":
             run_pip_install(package.split())
 
     # Temporary workaround for missing VTK wheel on Python 3.9
-    if sys.version_info >= (3, 9):
+    if sys.version_info[:2] == (3, 9):
         source = "https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20210113/"
         if osname == "Darwin":
             source += "vtk-9.0.1-cp39-cp39-macosx_10_14_x86_64.whl"

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1525,6 +1525,16 @@ if mode == "install":
             log.info("Pip installing %s to venv" % package)
             run_pip_install(package.split())
 
+    # Temporary workaround for missing VTK wheel on Python 3.9
+    if sys.version_info >= (3, 9):
+        source = "https://github.com/firedrakeproject/VTKPythonPackage/releases/download/firedrake_20210113/"
+        if osname == "Darwin":
+            source += "vtk-9.0.1-cp39-cp39-macosx_10_14_x86_64.whl"
+        elif osname == "Linux":
+            source += "vtk-9.0.1-cp39-cp39-linux_x86_64.whl"
+        log.info("Pip installing VTK for Python 3.9 to venv")
+        run_pip_install([source])
+
     packages = clone_dependencies("firedrake")
     packages = clone_dependencies("PyOP2") + packages
     packages += ["firedrake"]


### PR DESCRIPTION
Update the install script to deal with Python version 3.9

Currently installs VTK 9.0.1 from our wheelhouse: https://github.com/firedrakeproject/VTKPythonPackage/releases

We may also have issues with python-lazy-object-proxy, this is confirmed by @JDBetteridge.
Can be reproduced with `pip install --no-build-isolation --no-cache-dir lazy-object-proxy==1.4.*`