### PR TITLE
Rckirby/mg serendipity 3d

### DIFF
--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -28,6 +28,9 @@ class TransferManager(object):
             degree = element.degree()
             family = lambda c: "DG" if c.is_simplex() else "DQ"
             if isinstance(cell, ufl.TensorProductCell):
+                if type(degree) is int:
+                    degree = [degree] * len(cell.sub_cells())
+
                 scalar_element = ufl.TensorProductElement(*(ufl.FiniteElement(family(c), cell=c, degree=d)
                                                             for (c, d) in zip(cell.sub_cells(), degree)))
             else:

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -109,8 +109,6 @@ def coarse_cell_to_fine_node_map(Vc, Vf):
         assert Vc.extruded == Vf.extruded
         if Vc.mesh().variable_layers or Vf.mesh().variable_layers:
             raise NotImplementedError("Not implemented for variable layers, sorry")
-        if Vc.extruded and Vc.mesh().layers != Vf.mesh().layers:
-            raise ValueError("Coarse and fine meshes must have same number of layers")
 
         coarse_to_fine = hierarchy.coarse_to_fine_cells[levelc]
         _, ncell = coarse_to_fine.shape

--- a/tests/multigrid/test_poisson_gmg_extruded_serendipity.py
+++ b/tests/multigrid/test_poisson_gmg_extruded_serendipity.py
@@ -1,0 +1,45 @@
+from firedrake import *
+import pytest
+
+
+def run_poisson():
+    parameters = {"snes_type": "ksponly",
+                  "ksp_type": "preonly",
+                  "pc_type": "mg",
+                  "pc_mg_type": "full",
+                  "mg_levels_ksp_type": "chebyshev",
+                  "mg_levels_ksp_max_it": 2,
+                  "mg_levels_pc_type": "jacobi"}
+
+    N = 4
+    base = UnitSquareMesh(N, N, quadrilateral=True)
+    basemh = MeshHierarchy(base, 2)
+    mh = ExtrudedMeshHierarchy(basemh, height=1, base_layer=N)
+
+    V = FunctionSpace(mh[-1], 'S', 2)
+
+    u = Function(V)
+    v = TestFunction(V)
+
+    x, y, z = SpatialCoordinate(V.mesh())
+
+    uex = x*(1-x) * y*(1-x) * z*(1-z) * exp(x)
+    f = -div(grad(uex))
+    F = inner(grad(u), grad(v))*dx - inner(f, v)*dx
+    bcs = [DirichletBC(V, 0, "on_boundary"),
+           DirichletBC(V, 0, "top"),
+           DirichletBC(V, 0, "bottom")]
+
+    # Choose a forcing function such that the exact solution is not an
+    # eigenmode.  This stresses the preconditioner much more.  e.g. 10
+    # iterations of ilu fails to converge this problem sufficiently.
+
+    solve(F == 0, u, bcs=bcs, solver_parameters=parameters)
+
+    return errornorm(uex, u)
+
+
+@pytest.mark.parallel
+def test_poisson_gmg():
+    print(run_poisson())
+    assert run_poisson() < 1e-3


### PR DESCRIPTION
Multigrid is breaking on 3d extruded meshes when we use serendipity elements.  These are non-tensor-product elements on tensor product domains.  These are minimal fixes (and a test) that confirm MG now works.