### PR TITLE
Refactor assemble

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -94,10 +94,11 @@ def assemble(expr, tensor=None, bcs=None, *,
 
     :returns: See below.
 
-    If expr is a :class:`~ufl.classes.Form` then this evaluates the corresponding
-    integral(s) and returns a :class:`float` for 0-forms, a
-    :class:`.Function` for 1-forms and a :class:`.Matrix` or :class:`.ImplicitMatrix`
-    for 2-forms. Similarly if it is a Slate tensor expression.
+    If expr is a :class:`~ufl.classes.Form` or Slate tensor expression then
+    this evaluates the corresponding integral(s) and returns a :class:`float`
+    for 0-forms, a :class:`.Function` for 1-forms and a :class:`.Matrix` or
+    :class:`.ImplicitMatrix` for 2-forms. In the case of 2-forms the rows
+    correspond to the test functions and the columns to the trial functions.
 
     If expr is an expression other than a form, it will be evaluated
     pointwise on the :class:`.Function`\s in the expression. This will
@@ -298,7 +299,8 @@ def _assemble_matrix(expr, matrix, bcs, opts):
     :arg bcs: Iterable of boundary conditions.
     :arg opts: :class:`_AssemblyOpts` containing the assembly options.
 
-    :returns: The assembled :class:`.Matrix` or :class:`.ImplicitMatrix`.
+    :returns: The assembled :class:`.Matrix` or :class:`.ImplicitMatrix`. For
+        more information about this object refer to :func:`assemble`.
 
     This function does the matrix-specific initialisation of the output tensor
     before calling the generic function :func:`_assemble_expr`.

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -521,9 +521,9 @@ def _vector_arg(access, get_map, i, *, function, V):
     vector (:class:`Function`).
 
     :arg access: :mod:`~pyop2` access descriptor (e.g. :class:`~pyop2.op2.READ`).
-    :arg get_map: callable of one argument that obtains :class:`~pyop2.op2.Map`
+    :arg get_map: Callable of one argument that obtains :class:`~pyop2.op2.Map`
         objects from :class:`FunctionSpace` objects.
-    :arg i: index of block (may be None).
+    :arg i: Index of block (subspace of a mixed function), may be ``None``.
     :arg function: :class:`Function` to insert into.
     :arg V: :class:`FunctionSpace` corresponding to ``function``.
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -116,7 +116,10 @@ class TensorBase(object, metaclass=ABCMeta):
     _id = count()
 
     def __init__(self, *_):
-        # A cache to stash results in. Mirrors :class:`ufl.form.Form`.
+        """Initialise a cache for stashing results.
+
+        Mirrors :class:`~ufl.form.Form`.
+        """
         self._cache = {}
 
     @cached_property

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -115,6 +115,10 @@ class TensorBase(object, metaclass=ABCMeta):
 
     _id = count()
 
+    def __init__(self, *_):
+        # A cache to stash results in. Mirrors :class:`ufl.form.Form`.
+        self._cache = {}
+
     @cached_property
     def id(self):
         return next(TensorBase._id)


### PR DESCRIPTION
This pull request:

- Lifts zeroing the tensor out of `_assemble()`. This means that `get_scalar()`, `get_vector()` and `get_matrix()` only need to return `tensor`, rather than `tensor, zeros, lambda: tensor`.
- Caches parloops on the form instead of constructing a monolithic assembly 'thunk'. This makes it straightforward to pass arguments into the parloops at execution time and will speed `assemble()` up significantly.

The changes will introduce a small amount of overhead where `create_assembly_callable()` is used because we do more logic every time the assembly callable is called. If this overhead is problematic we could also cache the callables that apply the boundary conditions.

What do people think? I know the code needs documenting and the caching does not yet work but I wanted to check before spending more time on this.