### PR TITLE
Fix caching of physical node locations for MG

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1330,6 +1330,7 @@ class MeshGeometry(ufl.Mesh, MeshGeometryMixin):
         coordinates._as_mesh_geometry = weakref.ref(self)
 
         self._coordinates = coordinates
+        self._geometric_shared_data_cache = defaultdict(dict)
 
     def init(self):
         """Finish the initialisation of the mesh.  Most of the time

--- a/firedrake/mg/opencascade_mh.py
+++ b/firedrake/mg/opencascade_mh.py
@@ -47,12 +47,6 @@ def OpenCascadeMeshHierarchy(stepfile, element_size, levels, comm=COMM_WORLD, di
             Function(VFS(mesh, "CG", order)).interpolate(mesh.coordinates)
             for mesh in mh]
         ho_meshes = [Mesh(T) for T in Ts]
-        from collections import defaultdict
-        for i, m in enumerate(ho_meshes):
-            m._shared_data_cache = defaultdict(dict)
-            for k in mh[i]._shared_data_cache:
-                if k != "hierarchy_physical_node_locations":
-                    m._shared_data_cache[k] = mh[i]._shared_data_cache[k]
         mh = HierarchyBase(
             ho_meshes, mh.coarse_to_fine_cells,
             mh.fine_to_coarse_cells,

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -134,7 +134,9 @@ def physical_node_locations(V):
         assert isinstance(element, (ufl.VectorElement, ufl.TensorElement))
         element = element.sub_elements()[0]
     mesh = V.mesh()
-    cache = mesh._shared_data_cache["hierarchy_physical_node_locations"]
+    # This is a defaultdict, so the first time we access the key we
+    # get a fresh dict for the cache.
+    cache = mesh._geometric_shared_data_cache["hierarchy_physical_node_locations"]
     key = element
     try:
         return cache[key]


### PR DESCRIPTION
We can't cache on the topology!

@florianwechsung `git annotate` says that you're responsible for the opencascade code that I'm removing. I think that one doesn't need to copy the topological `shared_data_cache` because the topologies remain the same.