### PR TITLE
expressions: Check that spaces line up via UFL, not FInAT element

### DIFF
--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -362,7 +362,7 @@ def compile_to_gem(expr, translator):
     if any(type(s.ufl_element()) is ufl.MixedElement for s in spaces if s is not None):
         raise ValueError("Not expecting a mixed space at this point, "
                          "did you forget to index a function with .sub(...)?")
-    if len(set(s.finat_element for s in spaces if s is not None)) != 1:
+    if len(set(s.ufl_element() for s in spaces if s is not None)) != 1:
         raise ValueError("All coefficients must be defined on the same space")
     lvalue = expr.lvalue
     rvalue = expr.rvalue


### PR DESCRIPTION
When assembling a pointwise expression, we need to check that the
source and target spaces of the coefficients match. Previously we did
this by checking that the finat_element of the spaces matched. This
turns out not to be safe, because of the way Firedrake (via TSFC)
constructs FInAT elements from UFL elements.

TSFC's finatinterface convert_element function caches with a
WeakKeyDictionary a map from UFL element to matching FInAT element.
Not all objects in Firedrake are collected by the refcounting garbage
collector, so it can happen if we have (say) a
VectorElement(FiniteElement(...)) that the scalar element for this
case is pulled out of the cache via a UFL element that will
subsequently be collected (dropping the scalar finat counterpart from
the cache). When we subsequently make a scalar element we get an
equivalent, but not object-equal FInAT element.

So, we can end up in the situation

V = FunctionSpace(mesh, VectorElement(ScalarElement(...)))
...
Q = FunctionSpace(mesh, ScalarElement(...))

and have V.sub(0).finat_element != Q.finat_element (even though
V.sub(0).ufl_element() == Q.ufl_element()).

The pointwise expression compiler then complains on an assignment

fV.sub(0).assign(fQ)

that the spaces do not match.

To solve this problem, we can instead just assert equality of the UFL
elements, rather than the FInAT elements in the sanity checking.