### PR TITLE
patch: Use correct "fake" subset

### DIFF
--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -183,7 +183,7 @@ def matrix_funptr(form, state):
             arg = test.ufl_domain().interior_facets.local_facet_dat(op2.READ)
             arg.position = len(args)
             args.append(arg)
-        iterset = op2.Subset(iterset, [0])
+        iterset = op2.Subset(iterset, [])
         mod = seq.JITModule(kinfo.kernel, iterset, *args)
         kernels.append(CompiledKernel(mod._fun, kinfo))
     return cell_kernels, int_facet_kernels
@@ -275,7 +275,7 @@ def residual_funptr(form, state):
             arg = test.ufl_domain().interior_facets.local_facet_dat(op2.READ)
             arg.position = len(args)
             args.append(arg)
-        iterset = op2.Subset(iterset, [0])
+        iterset = op2.Subset(iterset, [])
         mod = seq.JITModule(kinfo.kernel, iterset, *args)
         kernels.append(CompiledKernel(mod._fun, kinfo))
     return cell_kernels, int_facet_kernels


### PR DESCRIPTION
If the local subdomain contains no elements, then producing a subset
with one element will fail. But the codegeneration just needs to know
that it is a subset, so use an empty one.