### PR TITLE
use randomgen via numpy

### DIFF
--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -1,5 +1,6 @@
 import enum
 import numpy as np
+import numpy.random as randomgen
 import matplotlib.pyplot as plt
 import matplotlib.colors
 import matplotlib.patches
@@ -563,8 +564,6 @@ def streamplot(function, resolution=None, min_length=None, max_time=None,
         component? (``'real'`` or ``'imag'``). Default is ``'real'``.
     :kwarg kwargs: same as for matplotlib :class:`~matplotlib.collections.LineCollection`
     """
-    import randomgen
-
     if function.ufl_shape != (2,):
         raise ValueError("Streamplot only defined for 2D vector fields!")
 
@@ -599,7 +598,7 @@ def streamplot(function, resolution=None, min_length=None, max_time=None,
     start_points = np.vstack((X.ravel(), Y.ravel())).T
 
     # Randomly shuffle the start points
-    generator = randomgen.MT19937(seed).generator
+    generator = randomgen.Generator(randomgen.MT19937(seed))
     for x in generator.permutation(np.array(start_points)):
         streamplotter.add_streamline(x)
 

--- a/firedrake/randomfunctiongen.py
+++ b/firedrake/randomfunctiongen.py
@@ -1,25 +1,89 @@
 """
 
-This module wraps `randomgen <https://pypi.org/project/randomgen/>`__
-and enables users to generate a randomised :class:`.Function`
-from a :class:`.FunctionSpace`.
-This module inherits all attributes from `randomgen <https://pypi.org/project/randomgen/>`__.
+This module wraps `numpy.random <https://numpy.org/doc/stable/reference/random/index.html>`__,
+and enables users to generate a randomised :class:`.Function` from a :class:`.FunctionSpace`.
+This module inherits almost all attributes from `numpy.random <https://numpy.org/doc/stable/reference/random/index.html>`__ with the following changes:
+
+**Generator**
+
+:class:`.Generator` wraps `numpy.random.Generator <https://numpy.org/doc/stable/reference/random/generator.html>`__.
+:class:`.Generator` inherits almost all distribution methods from `numpy.random.Generator <https://numpy.org/doc/stable/reference/random/generator.html>`__,
+and they can be used to generate a randomised :class:`.Function` by passing a :class:`.FunctionSpace` as the first argument.
+
+Example:
+
+.. code-block:: python3
+
+    from firedrake import *
+
+    mesh = UnitSquareMesh(2, 2)
+    V = FunctionSpace(mesh, 'CG', 1)
+    pcg = PCG64(seed=123456789)
+    rg = Generator(pcg)
+    f_beta = rg.beta(V, 1.0, 2.0)
+    print(f_beta.dat.data)
+    # prints:
+    # [0.0075147 0.40893448 0.18390776 0.46192167 0.20055854 0.02231147 0.47424777 0.24177973 0.55937075]
+
+**BitGenerator**
+
+:class:`.BitGenerator` is the base class for bit generators; see `numpy.random.BitGenerator <https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.BitGenerator.html#numpy.random.BitGenerator>`__.
+A :class:`.BitGenerator` takes an additional keyword argument `comm` (=`pyop2.mpi.COMM_WORLD` by default).
+If `comm.Get_rank() > 1`, :class:`.PCG64` or :class:`.Philox` must be used, as these bit generators are known to be prallel-safe.
+
+*PCG64*
+
+:class:`.PCG64` wraps `numpy.random.PCG64 <https://numpy.org/doc/stable/reference/random/bit_generators/pcg64.html>`__.
+If `seed` keyword is not provided by the user, it is set using `numpy.random.SeedSequence <https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html>`__.
+To make :class:`.PCG64` automatically generate multiple streams in parallel, Firedrake preprocesses the `seed` as the following before
+passing it to `numpy.random.PCG64 <https://numpy.org/doc/stable/reference/random/bit_generators/pcg64.html>`__:
+
+.. code-block:: python3
+
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    sg = numpy.random.SeedSequence(seed)
+    seed = sg.spawn(size)[rank]
+
+.. note::
+
+    `inc` is no longer a valid keyword for :class:`.PCG64` constructor. However, one can reset "state" after construction as:
+
+    .. code-block:: python3
+
+        pcg = PCG64()
+        state = pcg.state
+        state['state'] = {'state': seed, 'inc': inc}
+        pcg.state = state
+
+*Philox*
+
+:class:`.Philox` wraps `numpy.random.Philox <https://numpy.org/doc/stable/reference/random/bit_generators/philox.html>`__.
+If `key` keyword is not provided by the user, :class:`.Philox` computes the default key as:
+
+.. code-block:: python3
+
+    key = np.zeros(2, dtype=np.uint64)
+    key[0] = comm.Get_rank()
 
 """
-from mpi4py import MPI
 
-import numpy as np
 import inspect
-import randomgen
+import warnings
+import numpy as np
+import numpy.random as randomgen
 
 from firedrake.function import Function
+from pyop2.mpi import COMM_WORLD
 from ufl import FunctionSpace
 
-__all__ = [item for item in randomgen.__all__ if item not in ('hypergeometric', 'multinomial', 'random_sample')]
+_deprecated_attributes = ['RandomGenerator', ]
 
-_class_names = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass)]
-_method_names = [name for name, _ in inspect.getmembers(randomgen.RandomGenerator)
-                 if not name.startswith('_') and name not in ('state', 'poisson_lam_max')]
+__all__ = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass)] + _deprecated_attributes
+
+
+_known_attributes = ['beta', 'binomial', 'bytes', 'chisquare', 'choice', 'dirichlet', 'exponential', 'f', 'gamma', 'geometric', 'get_state', 'gumbel', 'hypergeometric', 'laplace', 'logistic', 'lognormal', 'logseries', 'multinomial', 'multivariate_normal', 'negative_binomial', 'noncentral_chisquare', 'noncentral_f', 'normal', 'pareto', 'permutation', 'poisson', 'power', 'rand', 'randint', 'randn', 'random', 'random_integers', 'random_sample', 'ranf', 'rayleigh', 'sample', 'seed', 'set_state', 'shuffle', 'standard_cauchy', 'standard_exponential', 'standard_gamma', 'standard_normal', 'standard_t', 'triangular', 'uniform', 'vonmises', 'wald', 'weibull', 'zipf', 'Generator', 'RandomState', 'SeedSequence', 'MT19937', 'Philox', 'PCG64', 'SFC64', 'default_rng', 'BitGenerator']
+_known_generator_attributes = ['beta', 'binomial', 'bit_generator', 'bytes', 'chisquare', 'choice', 'dirichlet', 'exponential', 'f', 'gamma', 'geometric', 'gumbel', 'hypergeometric', 'integers', 'laplace', 'logistic', 'lognormal', 'logseries', 'multinomial', 'multivariate_hypergeometric', 'multivariate_normal', 'negative_binomial', 'noncentral_chisquare', 'noncentral_f', 'normal', 'pareto', 'permutation', 'poisson', 'power', 'random', 'rayleigh', 'shuffle', 'standard_cauchy', 'standard_exponential', 'standard_gamma', 'standard_normal', 'standard_t', 'triangular', 'uniform', 'vonmises', 'wald', 'weibull', 'zipf']
 
 
 def __getattr__(module_attr):
@@ -119,7 +183,7 @@ def __getattr__(module_attr):
                 st += sp + 'Generate a :class:`.Function` f = Function(V), randomise it by calling the original method *' + name + '* (...) with given arguments, and return f.\n\n'
                 st += sp + ':arg V: :class:`.FunctionSpace`\n\n'
                 st += sp + ':returns: :class:`.Function`\n\n'
-                st += sp + "The original documentation is found at `<https://bashtage.github.io/randomgen/generated/randomgen.legacy.legacy.LegacyGenerator." + name + ".html>`__, which is reproduced below with appropriate changes.\n\n"
+                st += sp + "The original documentation is found at `<https://numpy.org/doc/stable/reference/random/generated/numpy.random." + name + ".html>`__, which is reproduced below with appropriate changes.\n\n"
                 st += sp + s.replace('(', '(*').replace(')', '*)') + '\n\n'
             elif '.. math::' in s:
                 st += '\n' + sp + s + '\n\n'
@@ -127,15 +191,13 @@ def __getattr__(module_attr):
                 st += sp + s + '\n'
 
         return st
-
-    if module_attr == 'RandomGenerator':
-
+    if module_attr == 'Generator':
         _Base = getattr(randomgen, module_attr)
-
         _dict = {}
-
         _dict["__doc__"] = ("\n"
                             "    Container for the Basic Random Number Generators.\n"
+                            "\n"
+                            "    The original documentation is found at `<https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.Generator>`__, which is reproduced below with appropriate changes.\n"
                             "\n"
                             "    Users can pass to many of the available distribution methods\n"
                             "    a :class:`.FunctionSpace` as the first argument to obtain a randomised :class:`.Function`.\n"
@@ -150,29 +212,36 @@ def __getattr__(module_attr):
                             "        mesh = UnitSquareMesh(2,2)\n"
                             "        V = FunctionSpace(mesh, 'CG', 1)\n"
                             "        pcg = PCG64(seed=123456789)\n"
-                            "        rg = RandomGenerator(pcg)\n"
+                            "        rg = Generator(pcg)\n"
                             "        f_beta = rg.beta(V, 1.0, 2.0)\n"
                             "        print(f_beta.dat.data)\n"
-                            "        # produces:\n"
-                            "        # [0.56462514 0.11585311 0.01247943 0.398984 0.19097059 0.5446709 0.1078666 0.2178807 0.64848515]\n"
+                            "        # prints:\n"
+                            "        # [0.0075147 0.40893448 0.18390776 0.46192167 0.20055854 0.02231147 0.47424777 0.24177973 0.55937075]\n"
                             "\n")
+
+        def __init__(self, bit_generator=None):
+            if bit_generator is None:
+                from firedrake.randomfunctiongen import PCG64
+                bit_generator = PCG64()
+            super(_Wrapper, self).__init__(bit_generator)
+        _dict['__init__'] = __init__
 
         # Use decorator to add doc strings to
         # auto generated methods
         def add_doc_string(doc_string):
-
             def f(func):
                 func.__doc__ = _reformat_doc(doc_string)
                 return func
-
             return f
 
         # To have Sphinx generate docs, make the following methods "static"
-        for class_attr, _ in inspect.getmembers(getattr(randomgen, module_attr)):
-
-            # These methods are not to be used with V
-            if class_attr in ('bytes', 'shuffle', 'permutation', 'dirichlet', 'multinomial', 'multivariate_normal', 'complex_normal'):
-
+        for class_attr, _ in inspect.getmembers(randomgen.Generator):
+            if class_attr.startswith('_'):
+                continue
+            elif class_attr in ['bit_generator', ]:
+                continue
+            elif class_attr in ['bytes', 'dirichlet', 'integers', 'multinomial', 'multivariate_hypergeometric', 'multivariate_normal', 'shuffle', 'permutation']:
+                # These methods are not to be used with V.
                 # class_attr is mutable, so we have to wrap func with
                 # another function to lock the value of class_attr
                 def funcgen(c_a):
@@ -187,38 +256,10 @@ def __getattr__(module_attr):
                     return func
 
                 _dict[class_attr] = funcgen(class_attr)
-
-            # Arguments for these two are slightly different
-            elif class_attr in ('rand', 'randn'):
-
-                # Here, too, wrap func with funcgen.
-                def funcgen(c_a):
-
-                    @add_doc_string(getattr(_Base, c_a).__doc__)
-                    def func(self, *args, **kwargs):
-                        if len(args) > 0 and isinstance(args[0], FunctionSpace):
-                            # Extract size from V
-                            if 'size' in kwargs.keys():
-                                raise TypeError("Cannot specify 'size' when generating a random function from 'V'")
-                            V = args[0]
-                            f = Function(V)
-                            with f.dat.vec_wo as v:
-                                v.array[:] = getattr(self, c_a)(v.local_size, **kwargs)
-                            return f
-                        else:
-                            # forward to the original implementation
-                            return getattr(super(_Wrapper, self), c_a)(*args, **kwargs)
-
-                    return func
-
-                _dict[class_attr] = funcgen(class_attr)
-
             # Other methods here
-            elif class_attr in _method_names:
-
+            elif class_attr in _known_generator_attributes:
                 # Here, too, wrap func with funcgen.
                 def funcgen(c_a):
-
                     @add_doc_string(getattr(_Base, c_a).__doc__)
                     def func(self, *args, **kwargs):
                         if len(args) > 0 and isinstance(args[0], FunctionSpace):
@@ -235,103 +276,83 @@ def __getattr__(module_attr):
                         else:
                             # forward to the original implementation
                             return getattr(super(_Wrapper, self), c_a)(*args, **kwargs)
-
                     return func
-
                 _dict[class_attr] = funcgen(class_attr)
-
+            else:
+                warnings.warn("Unknown attribute: Firedrake needs to wrap numpy.random.Generator.%s." % class_attr)
         _Wrapper = type(module_attr, (_Base,), _dict)
-
         return _Wrapper
-
-    elif module_attr in _class_names:
-
+    elif module_attr == "RandomGenerator":
+        from firedrake.randomfunctiongen import Generator
+        return Generator
+    elif module_attr in ['MT19937', 'Philox', 'PCG64', 'SFC64']:
         _Base = getattr(randomgen, module_attr)
 
         def __init__(self, *args, **kwargs):
-            self._comm = kwargs.pop('comm', MPI.COMM_WORLD)
-            # Remember args, kwargs as these are changed in super().__init__
-            _args = args
-            _kwargs = kwargs
-            self._initialized = False
-            super(_Wrapper, self).__init__(*args, **kwargs)
-            self._initialized = True
-            self.seed(*_args, **_kwargs)
-            self._generator = None
+            _kwargs = kwargs.copy()
+            self._comm = _kwargs.pop('comm', COMM_WORLD)
+            if self._comm.Get_size() > 1 and module_attr not in ['PCG64', 'Philox']:
+                raise TypeError("Use 'PCG64', 'Philox', for parallel RNG")
+            self._init(*args, **_kwargs)
 
-        @property
-        def generator(self):
-            if self._generator is None:
-                from . import RandomGenerator
-                self._generator = RandomGenerator(brng=self)
-            return self._generator
+        def seed(self, *args, **kwargs):
+            raise AttributeError("`seed` method is not available in `numpy.random`; if reseeding, create a new bit generator with the new seed.")
 
         if module_attr == 'PCG64':
-
-            # Use examples in https://bashtage.github.io/randomgen/parallel.html
-            # with appropriate changes.
-            def seed(self, seed=None, inc=None):
-
-                if self._comm.Get_size() == 1:
-                    super(_Wrapper, self).seed(seed=seed, inc=0 if inc is None else inc)
-                else:
-                    rank = self._comm.Get_rank()
-                    if seed is None:
-                        if rank == 0:
-                            # generate a 128bit seed
-                            entropy = randomgen.entropy.random_entropy(4)
-                            seed = sum([int(entropy[i]) * 2 ** (32 * i) for i in range(4)])
-                        else:
-                            seed = None
-                        # All processes have to have the same seed
-                        seed = self._comm.bcast(seed, root=0)
-                    # Use rank to generate multiple streams.
-                    # If 'inc' is to be passed, it is users' responsibility
-                    # to provide an appropriate value.
-                    inc = inc or rank
-                    super(_Wrapper, self).seed(seed=seed, inc=inc)
-
-        elif module_attr in ('Philox', 'ThreeFry'):
-
-            def seed(self, seed=None, counter=None, key=None):
-
+            def _init(self, *args, **kwargs):
+                if 'inc' in kwargs:
+                    raise RuntimeError("'inc' is no longer a valid keyword; see <https://www.firedrakeproject.org/firedrake.html#module-firedrake.randomfunctiongen>")
+                rank = self._comm.Get_rank()
+                size = self._comm.Get_size()
+                _kwargs = kwargs.copy()
+                seed = _kwargs.get("seed")
+                if seed is None:
+                    if rank == 0:
+                        # generate a 128bit seed
+                        seed = randomgen.SeedSequence().entropy
+                    else:
+                        seed = None
+                    seed = self._comm.bcast(seed, root=0)
+                # Create multiple streams
+                sg = randomgen.SeedSequence(seed)
+                _kwargs["seed"] = sg.spawn(size)[rank]
+                super(_Wrapper, self).__init__(*args, **_kwargs)
+        elif module_attr == 'Philox':
+            def _init(self, *args, **kwargs):
+                seed = kwargs.get("seed")
+                # counter = kwargs.get("counter")
+                key = kwargs.get("key")
                 if self._comm.Get_size() > 1:
                     rank = self._comm.Get_rank()
                     if seed is not None:
-                        raise TypeError("'seed' should not be used when using 'Philox'/'ThreeFry' in parallel.  A random 'key' is automatically generated and used unless specified.")
+                        raise TypeError("'seed' should not be used when using 'Philox' in parallel.  A random 'key' is automatically generated and used unless specified.")
                     # if 'key' is to be passed, it is users' responsibility
                     # to provide an appropriate one
                     if key is None:
                         # Use rank to generate multiple streams
-                        key = np.zeros(2 if module_attr == 'Philox' else 4, dtype=np.uint64)
+                        key = np.zeros(2, dtype=np.uint64)
                         key[0] = rank
-
-                super(_Wrapper, self).seed(seed=seed, counter=counter, key=key)
-
+                _kwargs = kwargs.copy()
+                _kwargs["key"] = key
+                super(_Wrapper, self).__init__(*args, **_kwargs)
         else:
-
-            def seed(self, *args, **kwargs):
-
-                if self._comm.Get_size() > 1:
-                    raise TypeError("Use 'PCG64', 'Philox', 'ThreeFry' for parallel RNG")
-
-                super(_Wrapper, self).seed(*args, **kwargs)
-
+            def _init(self, *args, **kwargs):
+                super(_Wrapper, self).__init__(*args, **kwargs)
         _dict = {"__init__": __init__,
+                 "_init": _init,
                  "seed": seed,
-                 "generator": generator,
                  "__doc__": _reformat_doc(getattr(randomgen, module_attr).__doc__)}
-
         _Wrapper = type(module_attr, (_Base,), _dict)
-
         return _Wrapper
-
-    else:
-
+    elif module_attr in ['BitGenerator', 'RandomState', 'SeedSequence', 'default_rng', 'get_state', 'seed', 'set_state']:
+        return getattr(randomgen, module_attr)
+    elif not module_attr.startswith('_'):
+        # module_attr not in _known_attributes + _deprecated_attributes
+        warnings.warn("Found unknown attribute: Falling back to numpy.random.%s, but Firedrake might need to wrap this attribute." % module_attr)
         return getattr(randomgen, module_attr)
 
 
-# __getattr__ on module level only works for 3.7+
+# Module level __getattr__ is only available with 3.7+
 
 import sys
 

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -5,7 +5,6 @@ pytest-xdist
 ipython
 matplotlib
 pylint
-randomgen==1.16.4
 vtk==9.0.1
 pkgconfig
 cached_property

--- a/tests/randomfunctiongen/test_randomfunction.py
+++ b/tests/randomfunctiongen/test_randomfunction.py
@@ -5,11 +5,11 @@ import pytest
 
 import inspect
 import numpy as np
-import randomgen
+import numpy.random as randomgen
 
 
-brng_list = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass) if name not in ('RandomGenerator', 'RandomState')]
-meth_list = [name for name, _ in inspect.getmembers(randomgen.RandomGenerator) if not name.startswith('_') and name not in ('state', 'poisson_lam_max', 'seed', 'random_integers', 'bytes', 'permutation', 'shuffle', 'dirichlet', 'multinomial', 'multivariate_normal', 'complex_normal', 'brng')]
+brng_list = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass) if name not in ('BitGenerator', 'Generator', 'RandomState', 'SeedSequence')]
+meth_list = [name for name, _ in inspect.getmembers(randomgen.Generator) if not name.startswith('_') and name not in ('bit_generator', 'bytes', 'dirichlet', 'integers', 'multinomial', 'multivariate_hypergeometric', 'multivariate_normal', 'shuffle', 'permutation')]
 
 
 @pytest.mark.parametrize("brng", brng_list)
@@ -22,132 +22,91 @@ def test_randomfunc(brng, meth):
     V = V0 * V1
 
     seed = 123456789
-
-    # original
-    rg_base = getattr(randomgen, brng)(seed=seed).generator
-
+    # Original
+    bgen = getattr(randomgen, brng)(seed=seed)
+    if brng == 'PCG64':
+        state = bgen.state
+        state['state'] = {'state': seed, 'inc': V.comm.Get_rank()}
+        bgen.state = state
+    rg_base = randomgen.Generator(bgen)
     # Firedrake wrapper
-    rg_wrap = getattr(randomfunctiongen, brng)(seed=seed).generator
+    fgen = getattr(randomfunctiongen, brng)(seed=seed)
+    if brng == 'PCG64':
+        state = fgen.state
+        state['state'] = {'state': seed, 'inc': V.comm.Get_rank()}
+        fgen.state = state
+    rg_wrap = randomfunctiongen.Generator(fgen)
 
     if meth == 'beta':
         args = (0.3, 0.5)
-
     elif meth == 'binomial':
         args = (7, 0.3)
-
     elif meth == 'chisquare':
         args = (7,)
-
     elif meth == 'choice':
         args = (1234 * 5678,)
-
     elif meth == 'exponential':
         args = ()
-
     elif meth == 'f':
         args = (7, 17)
-
     elif meth == 'gamma':
         args = (3.14,)
-
     elif meth == 'geometric':
         args = (0.5,)
-
     elif meth == 'gumbel':
         args = ()
-
     elif meth == 'hypergeometric':
         args = (17, 2 * 17, 3 * 17 - 1)
-
     elif meth == 'laplace':
         args = ()
-
     elif meth == 'logistic':
         args = ()
-
     elif meth == 'lognormal':
         args = ()
-
     elif meth == 'logseries':
         args = (0.3,)
-
     elif meth == 'negative_binomial':
         args = (7, 0.3)
-
     elif meth == 'noncentral_chisquare':
         args = (7, 3.14)
-
     elif meth == 'noncentral_f':
         args = (7, 17, 3.14)
-
     elif meth == 'normal':
         args = ()
-
     elif meth == 'pareto':
         args = (3.14,)
-
     elif meth == 'poisson':
         args = ()
-
     elif meth == 'power':
         args = (3.14,)
-
-    elif meth == 'rand':
+    elif meth == 'random':
         args = ()
-
-    elif meth == 'randint':
-        args = (7,)
-
-    elif meth == 'randn':
-        args = ()
-
-    elif meth == 'random_raw':
-        args = ()
-
-    elif meth == 'random_sample':
-        args = ()
-
-    elif meth == 'random_uintegers':
-        args = ()
-
     elif meth == 'rayleigh':
         args = ()
-
     elif meth == 'standard_cauchy':
         args = ()
-
     elif meth == 'standard_exponential':
         args = ()
-
     elif meth == 'standard_gamma':
         args = (3.14,)
-
     elif meth == 'standard_normal':
         args = ()
-
     elif meth == 'standard_t':
         args = (7,)
-
-    elif meth == 'tomaxint':
-        args = ()
-
     elif meth == 'triangular':
         args = (2.71, 3.14, 10.)
-
     elif meth == 'uniform':
         args = ()
-
     elif meth == 'vonmises':
         args = (2.71, 3.14)
-
     elif meth == 'wald':
         args = (2.71, 3.14)
-
     elif meth == 'weibull':
         args = (3.14,)
-
     elif meth == 'zipf':
         args = (3.14,)
+    else:
+        raise RuntimeError("Unknown method: add test for %s." % meth)
 
     for i in range(1, 10):
         f = getattr(rg_wrap, meth)(V, *args)
@@ -155,34 +114,30 @@ def test_randomfunc(brng, meth):
             if meth in ('rand', 'randn'):
                 assert np.allclose(getattr(rg_base, meth)(v.local_size), v.array[:])
             else:
-                kwargs = {'size': (v.local_size,)}
+                kwargs = {'size': (v.local_size, )}
                 assert np.allclose(getattr(rg_base, meth)(*args, **kwargs), v.array[:])
 
 
 @pytest.mark.parallel
 def test_randomfunc_parallel_pcg64():
-
     mesh = UnitSquareMesh(10, 10)
     V0 = VectorFunctionSpace(mesh, "CG", 1)
     V1 = FunctionSpace(mesh, "CG", 1)
     V = V0 * V1
 
     seed = 123456789
-
-    # original
-    from mpi4py import MPI
-    rg_base = randomgen.PCG64(seed=seed, inc=MPI.COMM_WORLD.rank).generator
-
+    # Original
+    bgen = randomgen.PCG64(seed=seed)
+    state = bgen.state
+    state['state'] = {'state': seed, 'inc': V.comm.Get_rank()}
+    bgen.state = state
+    rg_base = randomgen.Generator(bgen)
     # Firedrake wrapper
-    rg_wrap = PCG64(seed=seed).generator
-
-    for i in range(1, 10):
-        f = rg_wrap.beta(V, 0.3, 0.5)
-        with f.dat.vec_ro as v:
-            assert np.allclose(rg_base.beta(0.3, 0.5, size=(v.local_size,)), v.array[:])
-
-    rg_base.seed(seed=12345678910, inc=MPI.COMM_WORLD.rank)
-    rg_wrap.seed(seed=12345678910)
+    fgen = randomfunctiongen.PCG64(seed=seed)
+    state = fgen.state
+    state['state'] = {'state': seed, 'inc': V.comm.Get_rank()}
+    fgen.state = state
+    rg_wrap = randomfunctiongen.Generator(fgen)
     for i in range(1, 10):
         f = rg_wrap.beta(V, 0.3, 0.5)
         with f.dat.vec_ro as v:
@@ -190,33 +145,19 @@ def test_randomfunc_parallel_pcg64():
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize("brng", ['Philox', 'ThreeFry'])
-def test_randomfunc_parallel_philox_threefry(brng):
-
+def test_randomfunc_parallel_philox():
     mesh = UnitSquareMesh(10, 10)
     V0 = VectorFunctionSpace(mesh, "CG", 1)
     V1 = FunctionSpace(mesh, "CG", 1)
     V = V0 * V1
 
-    key_size = 2 if brng == 'Philox' else 4
-
-    # original
-    from mpi4py import MPI
+    key_size = 2
+    # Original
     key = np.zeros(key_size, dtype=np.uint64)
-    key[0] = MPI.COMM_WORLD.rank
-    rg_base = getattr(randomgen, brng)(counter=12345678910, key=key).generator
-
+    key[0] = V.comm.Get_rank()
+    rg_base = randomgen.Generator(randomgen.Philox(counter=12345678910, key=key))
     # Firedrake wrapper
-    rg_wrap = getattr(randomfunctiongen, brng)(counter=12345678910).generator
-
-    for i in range(1, 10):
-        f = rg_wrap.beta(V, 0.3, 0.5)
-        with f.dat.vec_ro as v:
-            assert np.allclose(rg_base.beta(0.3, 0.5, size=(v.local_size,)), v.array[:])
-
-    rg_base.seed(counter=1234567, key=key)
-    rg_wrap.seed(counter=1234567)
-
+    rg_wrap = randomfunctiongen.Generator(randomfunctiongen.Philox(counter=12345678910))
     for i in range(1, 10):
         f = rg_wrap.beta(V, 0.3, 0.5)
         with f.dat.vec_ro as v:

--- a/tests/randomfunctiongen/test_randomgen_compatibility.py
+++ b/tests/randomfunctiongen/test_randomgen_compatibility.py
@@ -3,11 +3,11 @@ import pytest
 
 import inspect
 import numpy as np
-import randomgen
+import numpy.random as randomgen
 
 
-brng_list = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass) if name not in ('RandomGenerator', 'RandomState')]
-meth_list = [name for name, _ in inspect.getmembers(randomgen.RandomGenerator) if not name.startswith('_') and name not in ('state', 'poisson_lam_max', 'seed', 'random_integers', 'brng')]
+brng_list = [name for name, _ in inspect.getmembers(randomgen, inspect.isclass) if name not in ('BitGenerator', 'Generator', 'RandomState', 'SeedSequence')]
+meth_list = [name for name, _ in inspect.getmembers(randomgen.Generator) if not name.startswith('_') and name not in ('bit_generator', 'integers')]
 
 
 @pytest.mark.parametrize("brng", brng_list)
@@ -15,151 +15,116 @@ meth_list = [name for name, _ in inspect.getmembers(randomgen.RandomGenerator) i
 def test_randomgen_brng(brng, meth):
 
     seed = 123456789
-
-    # original
-    rg_base = getattr(randomgen, brng)(seed=seed).generator
-
+    # Original
+    bgen = getattr(randomgen, brng)(seed=seed)
+    if brng == 'PCG64':
+        state = bgen.state
+        state['state'] = {'state': seed, 'inc': 0}
+        bgen.state = state
+    rg_base = randomgen.Generator(bgen)
     # Firedrake wrapper
-    rg_wrap = getattr(randomfunctiongen, brng)(seed=seed).generator
+    fgen = getattr(randomfunctiongen, brng)(seed=seed)
+    if brng == 'PCG64':
+        state = fgen.state
+        state['state'] = {'state': seed, 'inc': 0}
+        fgen.state = state
+    rg_wrap = randomfunctiongen.Generator(fgen)
 
     if meth == 'beta':
         args = (0.3, 0.5)
         kwargs = {'size': 17}
-
     elif meth == 'binomial':
         args = (7, 0.3)
         kwargs = {'size': 17}
-
     elif meth == 'bytes':
         a0 = getattr(rg_base, meth)(17 + 1)
         a1 = getattr(rg_wrap, meth)(17 + 1)
         assert a0 == a1
         return
-
     elif meth == 'chisquare':
         args = (7,)
         kwargs = {'size': 17}
-
     elif meth == 'choice':
         args = (17,)
         kwargs = {'size': 17}
-
     elif meth == 'complex_normal':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'dirichlet':
         args = (np.arange(1, 17+1),)
         kwargs = {'size': 17}
-
     elif meth == 'exponential':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'f':
         args = (7, 17)
         kwargs = {'size': 17}
-
     elif meth == 'gamma':
         args = (3.14,)
         kwargs = {'size': 17}
-
     elif meth == 'geometric':
         args = (0.5,)
         kwargs = {'size': 17}
-
     elif meth == 'gumbel':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'hypergeometric':
         args = (17, 2 * 17, 3 * 17 - 1)
         kwargs = {'size': 17}
-
     elif meth == 'laplace':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'logistic':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'lognormal':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'logseries':
         args = (0.3,)
         kwargs = {'size': 17}
-
     elif meth == 'multinomial':
         args = (17, [0.1, 0.2, 0.3, 0.4])
         kwargs = {'size': 17}
-
+    elif meth == 'multivariate_hypergeometric':
+        args = ([16, 8, 4], 6)
+        kwargs = {'size': 3}
     elif meth == 'multivariate_normal':
         args = ([3.14, 2.71], [[1.00, 0.01], [0.01, 2.00]])
         kwargs = {'size': 17}
-
     elif meth == 'negative_binomial':
         args = (7, 0.3)
         kwargs = {'size': 17}
-
     elif meth == 'noncentral_chisquare':
         args = (7, 3.14)
         kwargs = {'size': 17}
-
     elif meth == 'noncentral_f':
         args = (7, 17, 3.14)
         kwargs = {'size': 17}
-
     elif meth == 'normal':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'pareto':
         args = (3.14,)
         kwargs = {'size': 17}
-
     elif meth == 'permutation':
         args = (10 * 17,)
         kwargs = {}
-
     elif meth == 'poisson':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'power':
         args = (3.14,)
         kwargs = {'size': 17}
-
     elif meth == 'rand':
         args = (17,)
         kwargs = {}
-
-    elif meth == 'randint':
-        args = (7,)
-        kwargs = {'size': 17}
-
-    elif meth == 'randn':
-        args = (17,)
-        kwargs = {}
-
-    elif meth == 'random_raw':
+    elif meth == 'random':
         args = ()
         kwargs = {'size': 17}
-
-    elif meth == 'random_sample':
-        args = ()
-        kwargs = {'size': 17}
-
-    elif meth == 'random_uintegers':
-        args = (7,)
-        kwargs = {}
-
     elif meth == 'rayleigh':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'shuffle':
         arr0 = np.arange(17 + 10)
         arr1 = np.arange(17 + 10)
@@ -167,54 +132,44 @@ def test_randomgen_brng(brng, meth):
         getattr(rg_wrap, meth)(arr1)
         assert np.allclose(arr0, arr1)
         return
-
     elif meth == 'standard_cauchy':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'standard_exponential':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'standard_gamma':
         args = (3.14,)
         kwargs = {'size': 17}
-
     elif meth == 'standard_normal':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'standard_t':
         args = (7,)
         kwargs = {'size': 17}
-
     elif meth == 'tomaxint':
         args = (7,)
         kwargs = {}
-
     elif meth == 'triangular':
         args = (2.71, 3.14, 10.)
         kwargs = {'size': 17}
-
     elif meth == 'uniform':
         args = ()
         kwargs = {'size': 17}
-
     elif meth == 'vonmises':
         args = (2.71, 3.14)
         kwargs = {'size': 17}
-
     elif meth == 'wald':
         args = (2.71, 3.14)
         kwargs = {'size': 17}
-
     elif meth == 'weibull':
         args = (3.14,)
         kwargs = {'size': 17}
-
     elif meth == 'zipf':
         args = (3.14,)
         kwargs = {'size': 17}
+    else:
+        raise RuntimeError("Unknown method: add test for %s." % meth)
 
     for i in range(1, 10):
         assert np.allclose(getattr(rg_base, meth)(*args, **kwargs), getattr(rg_wrap, meth)(*args, **kwargs))


### PR DESCRIPTION
Use `randomgen` via `numpy.random`.

Documentation of `randomfunctiongen` seems to have been broken (`https://www.firedrakeproject.org/firedrake.html#module-firedrake.randomfunctiongen`), though `randomfunctiongen.PCG64.__doc__`, for instance, contains correct doc string. 