### PR TITLE
mg: Fix grid transfer on extruded mesh hierarchies that refine in the extruded direction

### DIFF
--- a/firedrake/cython/mgimpl.pyx
+++ b/firedrake/cython/mgimpl.pyx
@@ -110,7 +110,7 @@ def fine_to_coarse_nodes(Vf, Vc, np.ndarray[PetscInt, ndim=2, mode="c"] fine_to_
     cdef:
         np.ndarray[PetscInt, ndim=2, mode="c"] fine_map, coarse_map, fine_to_coarse_map
         np.ndarray[PetscInt, ndim=1, mode="c"] coarse_offset, fine_offset
-        PetscInt i, j, k, node, layer, layers
+        PetscInt i, j, k, node, fine_layer, fine_layers, coarse_layer, coarse_layers, ratio
         PetscInt coarse_per_cell, fine_per_cell, coarse_cell, fine_cells
         bint extruded
 

--- a/firedrake/cython/mgimpl.pyx
+++ b/firedrake/cython/mgimpl.pyx
@@ -61,7 +61,7 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray[PetscInt, ndim=2, mode="c"] coarse_t
         np.ndarray[PetscInt, ndim=1, mode="c"] coarse_offset, fine_offset
         PetscInt i, j, k, l, m, node, fine, layer
         PetscInt coarse_per_cell, fine_per_cell, fine_cell_per_coarse_cell, coarse_cells
-        PetscInt layers
+        PetscInt fine_layer, fine_layers, coarse_layer, coarse_layers, ratio
         bint extruded
 
     fine_map = Vf.cell_node_map().values
@@ -73,26 +73,36 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray[PetscInt, ndim=2, mode="c"] coarse_t
     if extruded:
         coarse_offset = Vc.offset
         fine_offset = Vf.offset
-        layers = Vc.mesh().layers - 1
+        coarse_layers = Vc.mesh().layers - 1
+        fine_layers = Vf.mesh().layers - 1
+
+        ratio = fine_layers // coarse_layers
+        assert ratio * coarse_layers == fine_layers # check ratio is an int
     coarse_cells = coarse_map.shape[0]
     coarse_per_cell = coarse_map.shape[1]
     fine_per_cell = fine_map.shape[1]
+
+    ndof = fine_per_cell * fine_cell_per_coarse_cell
+    if extruded:
+        ndof *= ratio
     coarse_to_fine_map = np.full((Vc.dof_dset.total_size,
-                                  fine_per_cell * fine_cell_per_coarse_cell),
+                                  ndof),
                                  -1,
                                  dtype=IntType)
     for i in range(coarse_cells):
         for j in range(coarse_per_cell):
             node = coarse_map[i, j]
             if extruded:
-                for layer in range(layers):
+                for coarse_layer in range(coarse_layers):
                     k = 0
                     for l in range(fine_cell_per_coarse_cell):
                         fine = coarse_to_fine_cells[i, l]
-                        for m in range(fine_per_cell):
-                            coarse_to_fine_map[node + coarse_offset[j]*layer, k] = (fine_map[fine, m] +
-                                                                                    fine_offset[m]*layer)
-                            k += 1
+                        for layer in range(ratio):
+                            fine_layer = coarse_layer * ratio + layer
+                            for m in range(fine_per_cell):
+                                coarse_to_fine_map[node + coarse_offset[j]*coarse_layer, k] = (fine_map[fine, m] +
+                                                                                               fine_offset[m]*fine_layer)
+                                k += 1
             else:
                 k = 0
                 for l in range(fine_cell_per_coarse_cell):

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -200,11 +200,18 @@ def compile_element(expression, dual_space=None, parameters=None,
 
 
 def prolong_kernel(expression):
+    meshc = expression.ufl_domain()
     hierarchy, level = utils.get_level(expression.ufl_domain())
     levelf = level + Fraction(1 / hierarchy.refinements_per_level)
     cache = hierarchy._shared_data_cache["transfer_kernels"]
     coordinates = expression.ufl_domain().coordinates
-    key = (("prolong", )
+    if meshc.cell_set._extruded:
+        idx = levelf * hierarchy.refinements_per_level
+        assert idx == int(idx)
+        level_ratio = (hierarchy._meshes[int(idx)].layers - 1) // (meshc.layers - 1)
+    else:
+        level_ratio = 1
+    key = (("prolong", level_ratio)
            + expression.ufl_element().value_shape()
            + entity_dofs_key(expression.function_space().finat_element.entity_dofs())
            + entity_dofs_key(coordinates.function_space().finat_element.entity_dofs()))
@@ -273,7 +280,7 @@ def prolong_kernel(expression):
                "R": R,
                "spacedim": element.cell.get_spatial_dimension(),
                "coarse": coarse,
-               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
+               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1] * level_ratio,
                "Rdim": numpy.prod(element.value_shape),
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "compute_celldist": compute_celldist(element.cell, X="Xref", celldist="celldist"),
@@ -289,7 +296,12 @@ def restrict_kernel(Vf, Vc):
     levelf = level + Fraction(1 / hierarchy.refinements_per_level)
     cache = hierarchy._shared_data_cache["transfer_kernels"]
     coordinates = Vc.ufl_domain().coordinates
-    key = (("restrict", )
+    if Vf.extruded:
+        assert Vc.extruded
+        level_ratio = (Vf.mesh().layers - 1) // (Vc.mesh().layers - 1)
+    else:
+        level_ratio = 1
+    key = (("restrict", level_ratio)
            + Vf.ufl_element().value_shape()
            + entity_dofs_key(Vf.finat_element.entity_dofs())
            + entity_dofs_key(Vc.finat_element.entity_dofs())
@@ -356,7 +368,7 @@ def restrict_kernel(Vf, Vc):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": str(evaluate_kernel),
-               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
+               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1]*level_ratio,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "compute_celldist": compute_celldist(element.cell, X="Xref", celldist="celldist"),
                "Xc_cell_inc": coords_element.space_dimension(),
@@ -374,7 +386,12 @@ def inject_kernel(Vf, Vc):
     hierarchy, level = utils.get_level(Vc.ufl_domain())
     cache = hierarchy._shared_data_cache["transfer_kernels"]
     coordinates = Vf.ufl_domain().coordinates
-    key = (("inject", )
+    if Vf.extruded:
+        assert Vc.extruded
+        level_ratio = (Vf.mesh().layers - 1) // (Vc.mesh().layers - 1)
+    else:
+        level_ratio = 1
+    key = (("inject", level_ratio)
            + Vf.ufl_element().value_shape()
            + entity_dofs_key(Vc.finat_element.entity_dofs())
            + entity_dofs_key(Vf.finat_element.entity_dofs())
@@ -383,7 +400,7 @@ def inject_kernel(Vf, Vc):
     try:
         return cache[key]
     except KeyError:
-        ncandidate = hierarchy.coarse_to_fine_cells[level].shape[1]
+        ncandidate = hierarchy.coarse_to_fine_cells[level].shape[1] * level_ratio
         if Vc.finat_element.entity_dofs() == Vc.finat_element.entity_closure_dofs():
             return cache.setdefault(key, (dg_injection_kernel(Vf, Vc, ncandidate), True))
 

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -109,22 +109,27 @@ def coarse_cell_to_fine_node_map(Vc, Vf):
         assert Vc.extruded == Vf.extruded
         if Vc.mesh().variable_layers or Vf.mesh().variable_layers:
             raise NotImplementedError("Not implemented for variable layers, sorry")
-        if Vc.extruded and Vc.mesh().layers != Vf.mesh().layers:
-            raise ValueError("Coarse and fine meshes must have same number of layers")
-
+        if Vc.extruded:
+            level_ratio = (Vf.mesh().layers - 1) // (Vc.mesh().layers - 1)
+        else:
+            level_ratio = 1
         coarse_to_fine = hierarchy.coarse_to_fine_cells[levelc]
         _, ncell = coarse_to_fine.shape
         iterset = Vc.mesh().cell_set
         arity = Vf.finat_element.space_dimension() * ncell
-        coarse_to_fine_nodes = numpy.full((iterset.total_size, arity), -1, dtype=IntType)
+        coarse_to_fine_nodes = numpy.full((iterset.total_size, arity*level_ratio), -1, dtype=IntType)
         values = Vf.cell_node_map().values[coarse_to_fine, :].reshape(iterset.size, arity)
 
-        coarse_to_fine_nodes[:Vc.mesh().cell_set.size, :] = values
+        if Vc.extruded:
+            off = numpy.tile(Vf.offset, ncell)
+            coarse_to_fine_nodes[:Vc.mesh().cell_set.size, :] = numpy.hstack([values + off*i for i in range(level_ratio)])
+        else:
+            coarse_to_fine_nodes[:Vc.mesh().cell_set.size, :] = values
         offset = Vf.offset
         if offset is not None:
-            offset = numpy.tile(offset, ncell)
+            offset = numpy.tile(offset*level_ratio, ncell*level_ratio)
         return cache.setdefault(key, op2.Map(iterset, Vf.node_set,
-                                             arity=arity, values=coarse_to_fine_nodes,
+                                             arity=arity*level_ratio, values=coarse_to_fine_nodes,
                                              offset=offset))
 
 

--- a/tests/multigrid/test_inject_refined_extruded.py
+++ b/tests/multigrid/test_inject_refined_extruded.py
@@ -1,0 +1,31 @@
+from firedrake import *
+import pytest
+
+
+@pytest.mark.parametrize("element", ["P", "DQ"])
+def test_inject_mesh(element):
+    Nx = Ny = Nz = 8
+    Lx = Ly = Lz = 4
+    nref = 1
+    k = 2
+
+    # mesh hierarchy
+    quadbasemesh = RectangleMesh(Nx, Ny, Lx, Ly, quadrilateral=True)
+    quadbasemh = MeshHierarchy(quadbasemesh, nref)
+    mh = ExtrudedMeshHierarchy(quadbasemh, height=Lz, base_layer=Nz)
+
+    horiz_elt = FiniteElement("CG", quadrilateral, k)
+    vert_elt = FiniteElement("CG", interval, k)
+    elt = TensorProductElement(horiz_elt, vert_elt)
+
+    xf, *_ = SpatialCoordinate(mh[1])
+    Vf = FunctionSpace(mh[1], elt)
+    uf = Function(Vf)
+    uf.interpolate(xf)
+
+    xc, *_ = SpatialCoordinate(mh[0])
+    Vc = FunctionSpace(mh[0], elt)
+    uc = Function(Vc)
+    inject(uf, uc)
+
+    assert norm(uc - xc) < 1e-10

--- a/tests/multigrid/test_inject_refined_extruded.py
+++ b/tests/multigrid/test_inject_refined_extruded.py
@@ -1,21 +1,38 @@
 from firedrake import *
+from firedrake.utils import complex_mode
 import pytest
 
 
-@pytest.mark.parametrize("element", ["P", "DQ"])
-def test_inject_mesh(element):
+@pytest.fixture(params=[False, True],
+                ids=["prism", "hex"])
+def quadrilateral(request):
+    return request.param
+
+
+@pytest.fixture(params=[False, True],
+                ids=["continuous", "discontinuous"])
+def dg(request):
+    return request.param
+
+
+def test_inject_refined_extmesh(quadrilateral, dg):
     Nx = Ny = Nz = 8
     Lx = Ly = Lz = 4
     nref = 1
     k = 2
 
     # mesh hierarchy
-    quadbasemesh = RectangleMesh(Nx, Ny, Lx, Ly, quadrilateral=True)
-    quadbasemh = MeshHierarchy(quadbasemesh, nref)
-    mh = ExtrudedMeshHierarchy(quadbasemh, height=Lz, base_layer=Nz)
+    basemesh = RectangleMesh(Nx, Ny, Lx, Ly, quadrilateral=quadrilateral)
+    basemh = MeshHierarchy(basemesh, nref)
+    mh = ExtrudedMeshHierarchy(basemh, height=Lz, base_layer=Nz)
 
-    horiz_elt = FiniteElement("CG", quadrilateral, k)
-    vert_elt = FiniteElement("CG", interval, k)
+    if dg:
+        name = "DQ" if quadrilateral else "DG"
+        horiz_elt = FiniteElement(name, basemesh.ufl_cell(), k)
+        vert_elt = FiniteElement("DG", interval, k)
+    else:
+        horiz_elt = FiniteElement("CG", basemesh.ufl_cell(), k)
+        vert_elt = FiniteElement("CG", interval, k)
     elt = TensorProductElement(horiz_elt, vert_elt)
 
     xf, *_ = SpatialCoordinate(mh[1])
@@ -26,6 +43,9 @@ def test_inject_mesh(element):
     xc, *_ = SpatialCoordinate(mh[0])
     Vc = FunctionSpace(mh[0], elt)
     uc = Function(Vc)
-    inject(uf, uc)
-
-    assert norm(uc - xc) < 1e-10
+    if dg and complex_mode:
+        with pytest.raises(NotImplementedError):
+            inject(uf, uc)
+    else:
+        inject(uf, uc)
+        assert norm(uc - xc) < 1e-10


### PR DESCRIPTION
I augmented @MelodyShih's test, but now the discontinuous injections fail.