### PR TITLE
Allow variable-height mesh extrusion

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1754,8 +1754,10 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
                          ``[a, b]`` where ``a`` indicates the starting
                          cell layer of the column and ``b`` the number
                          of cell layers in that column.
-    :arg layer_height:   the layer height, assuming all layers are evenly
-                         spaced. If this is omitted, the value defaults to
+    :arg layer_height:   the layer height.  A scalar value will result in
+                         evenly-spaced layers, whereas an array of values
+                         will vary the layer height through the extrusion.
+                         If this is omitted, the value defaults to
                          1/layers (i.e. the extruded mesh has total height 1.0)
                          unless a custom kernel is used.  Must be
                          provided if using a variable number of layers.
@@ -1805,14 +1807,30 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
                              mesh.cell_set.total_size, layers.shape)
         if layer_height is None:
             raise ValueError("Must provide layer height for variable layers")
+
+        # variable-height layers need to be present for the maximum number
+        # of extruded layers
+        num_layers = layers.sum(axis=1).max() if mesh.cell_set.total_size else 0
+        num_layers = mesh.comm.allreduce(num_layers, op=MPI.MAX)
+
         # Convert to internal representation
         layers[:, 1] += 1 + layers[:, 0]
+
     else:
         if layer_height is None:
             # Default to unit
             layer_height = 1 / layers
+
+        num_layers = layers
+
         # All internal logic works with layers of base mesh (not layers of cells)
         layers = layers + 1
+
+    try:
+        assert num_layers == len(layer_height)
+    except TypeError:
+        # layer_height is a scalar; equi-distant layers are fine
+        pass
 
     topology = ExtrudedMeshTopology(mesh.topology, layers)
 

--- a/tests/extrusion/test_layer_height_mesh_volume.py
+++ b/tests/extrusion/test_layer_height_mesh_volume.py
@@ -1,0 +1,32 @@
+import numpy
+from firedrake import *
+
+
+def test_extrude_uniform_mesh_volume():
+    mesh = UnitSquareMesh(4, 4)
+
+    extmesh = ExtrudedMesh(mesh, 4, layer_height=[0.1, 0.2, 0.3, 0.4], extrusion_type="uniform")
+
+    assert numpy.allclose(assemble(1*dx(domain=extmesh)), 1.0)
+
+
+def test_extrude_variable_uniform_mesh_volume():
+    mesh = IntervalMesh(2, 2)
+    mesh.coordinates.dat.data[2] = 3
+    extmesh = ExtrudedMesh(mesh, layers=[[0, 2], [2, 3]],
+                           layer_height=[0.1, 0.2, 0.3, 0.4, 0.5])
+
+    assert numpy.allclose(assemble(1*dx(domain=extmesh)), (0.1 + 0.2) + 2 * (0.3 + 0.4 + 0.5))
+
+
+def test_extrude_radial_mesh_volume():
+    radius = 1000
+
+    mesh = IcosahedralSphereMesh(radius=radius, refinement_level=4)
+
+    # layer heights sum to 1.5 / radius
+    layer_heights = np.array([0.2] * 5 + [0.1] * 5) / radius
+    extmesh = ExtrudedMesh(mesh, 10, layer_height=layer_heights, extrusion_type="radial")
+
+    exact = 4 * pi * ((radius + 1.5/radius)**3 - radius**3) / 3
+    assert numpy.allclose(assemble(1*dx(domain=extmesh)), exact, rtol=4e-3)


### PR DESCRIPTION
The "layer_height" parameter for mesh extrusion was a single scalar that gave a uniform thickness for all extruded layers. This is extended to allow for an array to be used instead, which gives the thickness for the individual layers.

I thought this might be useful after I just hacked it together for my own use. Probably needs:
- [x] tests
- [x] ensure that `layer_heights == layers` (I assume that's available on the `extruded_topology` somewhere?)

Definitely happy to tidy things up if this seems like it would be desired!