### PR TITLE
Website: add Thetis river plume animation on front page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,8 +41,10 @@ Features:
 
   .. container:: youtube
 
-    .. youtube:: xhxvM1N8mDQ?modestbranding=1;controls=0;rel=0
-       :width: 400px
+    .. youtube:: K6ggbbfVWpc?modestbranding=1;controls=0;rel=0
+       :width: 450px
+
+    River plume simulated with the Firedrake-based `Thetis ocean model <https://thetisproject.org>`_.
 
 .. only:: latex
 


### PR DESCRIPTION
Replaces the double slit wave animation on the Firedrake front page by a Thetis 3D river plume simulation. Perhaps better suited to highlight the capabilities of Firedrake. The animation also shows the movement of the 3D mesh.

![fd_frontpage](https://user-images.githubusercontent.com/7586775/111747544-1b569e00-8898-11eb-8221-66068fa3a879.png)
