### PR TITLE
setup.py: add firedrake.adjoint to package list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup
+from setuptools import find_packages
 from glob import glob
 from os import environ as env, path
 from Cython.Distutils import build_ext
@@ -82,11 +83,7 @@ setup(name='firedrake',
       author="Imperial College London and others",
       author_email="firedrake@imperial.ac.uk",
       url="http://firedrakeproject.org",
-      packages=["firedrake", "firedrake.mg", "firedrake.slope_limiter",
-                "firedrake.matrix_free", "firedrake.preconditioners",
-                "firedrake.cython",
-                "firedrake.slate", "firedrake.slate.slac", "firedrake.slate.static_condensation",
-                "firedrake_configuration", "firedrake_citations"],
+      packages=find_packages(),
       package_data={"firedrake": ["evaluate.h",
                                   "locate.c",
                                   "icons/*.png"]},


### PR DESCRIPTION
Fixes import error:

	>>> import firedrake
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/.../usr/lib/python3.8/site-packages/firedrake/__init__.py", line 59, in <module>
	    from firedrake.assemble import *
	...
	  File "/.../usr/lib/python3.8/site-packages/firedrake/interpolation.py", line 15, in <module>
	    from firedrake.adjoint import annotate_interpolate
	ModuleNotFoundError: No module named 'firedrake.adjoint'

Signed-off-by: Alexei Colin <acolin@isi.edu>