### PR TITLE
Docs - debug install failures

### DIFF
--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -11,6 +11,8 @@ digraph triage {
     python_version [label="Python 3.5?"];
     using_macos [label="Using\nMacOS?"];
     using_homebrew [label="Using\nHomebrew?"];
+    url_error [label="URL Error with SSL\ncertificate failure?"];
+    which_python [label="which python3 points\nat /usr/local/bin/python3?"];
 
     activate_venv [label="Activate the\nvenv first."];
     uninstall_anaconda [label="Deactivate\nAnaconda."];
@@ -18,6 +20,7 @@ digraph triage {
     update_install_script [label="Fetch new\ninstall script"];
     get_homebrew [label="Use Homebrew."];
     brew_doctor [label="brew doctor"];
+    change_path [label="Modify PATH variable"];
 
     can_install -> install_succeeded;
     install_succeeded -> can_import;
@@ -32,4 +35,7 @@ digraph triage {
     using_macos -> using_homebrew [label="yes"];
     using_homebrew -> get_homebrew [label="no"];
     using_homebrew -> brew_doctor [label="yes"];
+    using_macos -> url_error [label="yes"];
+    url_error -> which_python [label="yes"];
+    which_python -> change_path [label="no"];
 }

--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -12,7 +12,7 @@ digraph triage {
     using_macos [label="Using\nMacOS?"];
     using_homebrew [label="Using\nHomebrew?"];
     url_error [label="URL Error with SSL\ncertificate failure?"];
-    which_python [label="which python3 points\nat /usr/local/bin/python3?"];
+    which_python [label="<which python3> points\nat <$(brew --prefix)/bin/python3>?"];
 
     activate_venv [label="Activate the\nvenv first."];
     uninstall_anaconda [label="Deactivate\nAnaconda."];
@@ -20,7 +20,7 @@ digraph triage {
     update_install_script [label="Fetch new\ninstall script"];
     get_homebrew [label="Use Homebrew."];
     brew_doctor [label="brew doctor"];
-    change_path [label="Modify PATH variable"];
+    explicit_path [label="Run <$(brew --prefix)/bin/python3\n firedrake-install>"];
 
     can_install -> install_succeeded;
     install_succeeded -> can_import;
@@ -37,5 +37,5 @@ digraph triage {
     using_homebrew -> brew_doctor [label="yes"];
     using_macos -> url_error [label="yes"];
     url_error -> which_python [label="yes"];
-    which_python -> change_path [label="no"];
+    which_python -> explicit_path [label="no"];
 }


### PR DESCRIPTION
Hi. I have extended the diagram on how to debug install failures with an additional branch. The branch considers the case where Firedrake install fails with an SSL certificate error. The error says `urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed ...>`.

I keep running into this and I *think* it is because I code in VSCode and VSCode modifies my PATH variable (which is probably my fault). I get the install working by removing `/Library/Frameworks/Python.framework/Versions/3.8/bin` from my PATH variable so that `which python3` points at `/usr/local/bin/python3`.

Because my brain is a sieve, I always have to look for the closed issue where we talked about this. I thought adding this into the diagram might be the better thing to do as it will increase the visibility of the solution. LMKWYT, maybe this error is not common enough for being put into that diagram?
