### PR TITLE
Allow different meshes at different vtu exports

### DIFF
--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -352,7 +352,7 @@ class File(object):
                b'</VTKFile>\n')
 
     def __init__(self, filename, project_output=False, comm=None, mode="w",
-                 target_degree=None, target_continuity=None):
+                 target_degree=None, target_continuity=None, adaptive=False):
         """Create an object for outputting data for visualisation.
 
         This produces output in VTU format, suitable for visualisation
@@ -369,6 +369,7 @@ class File(object):
         :kwarg target_continuity: override the continuity of the output space;
             A UFL :class:`~.SobolevSpace` object: `H1` for a
             continuous output and `L2` for a discontinuous output.
+        :kwarg adaptive: allow different meshes at different exports if `True`.
 
         .. note::
 
@@ -433,6 +434,7 @@ class File(object):
 
         self._fnames = None
         self._topology = None
+        self._adaptive = adaptive
 
     def _prepare_output(self, function, max_elem):
         from firedrake import FunctionSpace, VectorFunctionSpace, \
@@ -515,7 +517,7 @@ class File(object):
         functions = tuple(self._prepare_output(f, max_elem)
                           for f in functions)
 
-        if self._topology is None:
+        if self._topology is None or self._adaptive:
             self._topology = get_topology(coordinates.function)
 
         basename = "%s_%s" % (self.basename, next(self.counter))

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -7,6 +7,7 @@ from itertools import chain
 from pyop2.mpi import COMM_WORLD, dup_comm
 from firedrake.utils import IntType
 from pyop2.utils import as_tuple
+from pyadjoint import no_annotations
 
 from .paraview_reordering import vtk_lagrange_tet_reorder,\
     vtk_lagrange_hex_reorder, vtk_lagrange_interval_reorder,\
@@ -436,6 +437,7 @@ class File(object):
         self._topology = None
         self._adaptive = adaptive
 
+    @no_annotations
     def _prepare_output(self, function, max_elem):
         from firedrake import FunctionSpace, VectorFunctionSpace, \
             TensorFunctionSpace, Function


### PR DESCRIPTION
This might be viewer-dependent, but my Paraview doesn't like subsequent exports on different meshes, unless the `_topology` attribute of `File` is manually set to `None` each time. This PR avoids having to do so, at the expense of re-extracting the topology every export.


Consider the following example:

```
from firedrake import *

outfile = File('broken.pvd')
outfile.write(UnitSquareMesh(1, 1, diagonal='left').coordinates)
outfile.write(UnitSquareMesh(1, 1, diagonal='right').coordinates)

outfile = File('fixed.pvd', adaptive=True)
outfile.write(UnitSquareMesh(1, 1, diagonal='left').coordinates)
outfile.write(UnitSquareMesh(1, 1, diagonal='right').coordinates)
```

The second outputs of 'broken.pvd' and 'fixed.pvd' are shown on the left and right, respectively.

![multi_mesh_io](https://user-images.githubusercontent.com/22053413/115530465-b2de5080-a28b-11eb-9473-c651e55d65c5.jpeg)
