### PR TITLE
Specify is_input and is_output for loopy.GlobalArg objects

### DIFF
--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -425,8 +425,8 @@ def pointwise_expression_kernel(exprs, scalar_type):
             except KeyError:
                 continue
             plargs.append(arg)
-            is_input = arg.access in [op2.INC, op2.READ, op2.RW]
-            is_output = arg.access in [op2.INC, op2.RW, op2.WRITE]
+            is_input = arg.access in [op2.INC, op2.MAX, op2.MIN, op2.READ, op2.RW]
+            is_output = arg.access in [op2.INC, op2.MAX, op2.MIN, op2.RW, op2.WRITE]
             args.append(loopy.GlobalArg(var.name, shape=var.shape, dtype=c.dat.dtype, is_input=is_input, is_output=is_output))
     assert len(coefficients) == 0
     name = "expression_kernel"

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -425,7 +425,9 @@ def pointwise_expression_kernel(exprs, scalar_type):
             except KeyError:
                 continue
             plargs.append(arg)
-            args.append(loopy.GlobalArg(var.name, shape=var.shape, dtype=c.dat.dtype))
+            is_input = arg.access in [op2.INC, op2.READ, op2.RW]
+            is_output = arg.access in [op2.INC, op2.RW, op2.WRITE]
+            args.append(loopy.GlobalArg(var.name, shape=var.shape, dtype=c.dat.dtype, is_input=is_input, is_output=is_output))
     assert len(coefficients) == 0
     name = "expression_kernel"
     knl = generate(impero_c, args, scalar_type, kernel_name=name,


### PR DESCRIPTION
I'm worried about getting the correct access modifiers here. `op2.MIN` and `op2.MAX` have been omitted because I don't know how those work. This now passes `test_expressions.py` though!