### PR TITLE
Disable x11 for petsc installs.

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -555,6 +555,9 @@ petsc_options = {"--with-fortran-bindings=0",
                  # For superlu_dist amongst others.
                  "--with-cxx-dialect=C++11"}
 
+if osname == "Darwin":
+    petsc_options.add("--with-x=0")
+
 if not options["minimal_petsc"]:
     petsc_options.add("--with-zlib")
     # File formats


### PR DESCRIPTION
Addresses the issue #2045