### PR TITLE
firedrake-update installs petsc4py if not yet installed

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -15,6 +15,7 @@ import shlex
 from glob import iglob
 from itertools import chain
 import re
+import importlib
 
 osname = platform.uname().system
 arch = platform.uname().machine
@@ -1514,6 +1515,17 @@ with open(config_location, "w") as f:
     f.write(json_output)
 log.info("Configuration saved to " + config_location)
 
+
+def is_installed(name):
+    # Return if package `name` is installed.
+    try:
+        importlib.import_module(name)
+    except ModuleNotFoundError:
+        return False
+    else:
+        return True
+
+
 if mode == "install":
     os.mkdir("src")
     os.chdir("src")
@@ -1638,15 +1650,20 @@ else:
 
     # update packages.
     if not args.honour_petsc_dir:
-        petsc_changed = git_update("petsc", deps["petsc"])
+        update_petsc = git_update("petsc", deps["petsc"])
     else:
-        petsc_changed = False
+        update_petsc = False
     if os.path.exists(os.path.join(firedrake_env, "src/petsc4py")):
         clean("petsc4py/")
         shutil.move("petsc4py", "petsc4py_old")
-        petsc4py_changed = True
+        update_petsc4py = True
     else:
-        petsc4py_changed = False
+        # Even if petsc has been installed, petsc4py might not, in
+        # which case we need to make sure that we install it.
+        # This situation occurs, e.g., when `firedrake-install`
+        # fails somewhere after successfully installing petsc,
+        # and the user continues installation with `firedrake-update`.
+        update_petsc4py = not is_installed("petsc4py")
     if os.path.exists(os.path.join(firedrake_env, "src/slepc4py")):
         clean("slepc4py")
         shutil.move("slepc4py", "slepc4py_old")
@@ -1662,7 +1679,7 @@ else:
             pip_uninstall("petsc4py")
 
     # If there is a petsc package to remove, then we're an old installation which will need to rebuild PETSc.
-    petsc_changed = pip_uninstall("petsc") or petsc_changed
+    update_petsc = pip_uninstall("petsc") or update_petsc
 
     for p in packages:
         try:
@@ -1677,7 +1694,7 @@ else:
     with pipargs("--no-deps"):
         with environment(**compiler_env):
             # Only rebuild petsc if it has changed.
-            if not args.honour_petsc_dir and (args.rebuild or petsc_changed):
+            if not args.honour_petsc_dir and (args.rebuild or update_petsc):
                 clean("petsc/")
                 install("petsc/")
         if not args.honour_petsc_dir:
@@ -1699,7 +1716,7 @@ else:
         pip_requirements(p, compiler_env)
 
     with pipargs("--no-deps"):
-        if args.rebuild or petsc_changed or petsc4py_changed:
+        if args.rebuild or update_petsc or update_petsc4py:
             # If not honour_petsc_dir, we have a version of petsc that contains
             # petsc4py in its source tree (old petsc must have been updated
             # in the above).


### PR DESCRIPTION
This PR is to let `firedrake-update` install `petsc4py` if not yet installed.