### PR TITLE
Annotate functions with PETSc events

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -17,6 +17,18 @@ del sys, config
 
 # Ensure petsc is initialised by us before anything else gets in there.
 import firedrake.petsc as petsc
+
+# Initialise PETSc events for both import and entire duration of program
+_main_event = petsc.PETSc.Log.Event("firedrake")
+_main_event.begin()
+
+_init_event = petsc.PETSc.Log.Event("firedrake.__init__")
+_init_event.begin()
+
+import atexit
+atexit.register(lambda: _main_event.end())
+
+del atexit
 del petsc
 
 # UFL Exprs come with a custom __del__ method, but we hold references
@@ -128,3 +140,6 @@ if (_omp_num_threads is None) or (_omp_num_threads > 1):
     warning('OMP_NUM_THREADS is not set or is set to a value greater than 1,'
             ' we suggest setting OMP_NUM_THREADS=1 to improve performance')
 del _openblas_lib, _openblas_dll, _omp_num_threads, os, cdll, find_library
+
+# Stop profiling Firedrake import
+_init_event.end()

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -11,6 +11,7 @@ from firedrake import (assemble_expressions, matrix, parameters, solving,
                        tsfc_interface, utils)
 from firedrake.adjoint import annotate_assemble
 from firedrake.bcs import DirichletBC, EquationBC, EquationBCSplit
+from firedrake.petsc import PETSc
 from firedrake.slate import slac, slate
 from firedrake.utils import ScalarType
 from pyop2 import op2

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -249,7 +249,6 @@ def _get_assembly_rank(expr, diagonal):
     raise AssertionError
 
 
-@PETSc.Log.EventDecorator()
 def _assemble_scalar(expr, bcs, opts):
     """Assemble a 0-form.
 
@@ -270,7 +269,6 @@ def _assemble_scalar(expr, bcs, opts):
     return scalar.data[0]
 
 
-@PETSc.Log.EventDecorator()
 def _assemble_vector(expr, vector, bcs, opts):
     """Assemble either a 1-form or the diagonal of a 2-form.
 
@@ -306,7 +304,6 @@ def _assemble_vector(expr, vector, bcs, opts):
     return vector
 
 
-@PETSc.Log.EventDecorator()
 def _assemble_matrix(expr, matrix, bcs, opts):
     """Assemble a 2-form into a matrix.
 
@@ -337,7 +334,6 @@ def _assemble_matrix(expr, matrix, bcs, opts):
     return matrix
 
 
-@PETSc.Log.EventDecorator()
 def _make_scalar():
     """Make an empty scalar.
 
@@ -346,7 +342,6 @@ def _make_scalar():
     return op2.Global(1, [0.0], dtype=utils.ScalarType)
 
 
-@PETSc.Log.EventDecorator()
 def _make_vector(V):
     """Make an empty vector.
 
@@ -357,7 +352,6 @@ def _make_vector(V):
     return firedrake.Function(V.function_space())
 
 
-@PETSc.Log.EventDecorator()
 def _make_matrix(expr, bcs, opts):
     """Make an empty matrix.
 
@@ -435,7 +429,6 @@ def _make_matrix(expr, bcs, opts):
                          options_prefix=opts.options_prefix)
 
 
-@PETSc.Log.EventDecorator()
 def _assemble_expr(expr, tensor, bcs, opts, assembly_rank):
     """Assemble an expression into the provided tensor.
 
@@ -501,7 +494,6 @@ def _get_mat_type(mat_type, sub_mat_type, arguments):
     return mat_type, sub_mat_type
 
 
-@PETSc.Log.EventDecorator()
 def _collect_lgmaps(matrix, all_bcs, Vrow, Vcol, row, col):
     """Obtain local to global maps for matrix insertion in the
     presence of boundary conditions.
@@ -537,7 +529,6 @@ def _collect_lgmaps(matrix, all_bcs, Vrow, Vcol, row, col):
     return (rlgmap, clgmap), unroll
 
 
-@PETSc.Log.EventDecorator()
 def _vector_arg(access, get_map, i, *, function, V):
     """Obtain an :class:`~pyop2.op2.Arg` for insertion into a given
     vector (:class:`Function`).
@@ -559,7 +550,6 @@ def _vector_arg(access, get_map, i, *, function, V):
         return function.dat[i](access, map_)
 
 
-@PETSc.Log.EventDecorator()
 def _matrix_arg(access, get_map, row, col, *,
                 all_bcs, matrix, Vrow, Vcol):
     """Obtain an op2.Arg for insertion into the given matrix.
@@ -594,7 +584,6 @@ def _matrix_arg(access, get_map, row, col, *,
                                   unroll_map=unroll)
 
 
-@PETSc.Log.EventDecorator()
 def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
     """Apply Dirichlet boundary conditions to a tensor.
 
@@ -648,7 +637,6 @@ def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
         raise AssertionError
 
 
-@PETSc.Log.EventDecorator()
 @utils.known_pyop2_safe
 def _make_parloops(expr, tensor, bcs, diagonal, fc_params, assembly_rank):
     """Create parloops for the assembly of the expression.

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -50,6 +50,7 @@ Please refer to :func:`assemble` for a description of the options.
 """
 
 
+@PETSc.Log.EventDecorator()
 @annotate_assemble
 def assemble(expr, tensor=None, bcs=None, *,
              diagonal=False,
@@ -132,6 +133,7 @@ def assemble(expr, tensor=None, bcs=None, *,
         raise TypeError(f"Unable to assemble: {expr}")
 
 
+@PETSc.Log.EventDecorator()
 def assemble_form(expr, tensor, bcs, diagonal, assembly_type,
                   form_compiler_parameters,
                   mat_type, sub_mat_type,
@@ -170,6 +172,7 @@ def assemble_form(expr, tensor, bcs, diagonal, assembly_type,
         raise AssertionError
 
 
+@PETSc.Log.EventDecorator()
 def allocate_matrix(expr, bcs=(), form_compiler_parameters=None,
                     mat_type=None, sub_mat_type=None, appctx={},
                     options_prefix=None):
@@ -189,6 +192,7 @@ def allocate_matrix(expr, bcs=(), form_compiler_parameters=None,
     return _make_matrix(expr, bcs, opts)
 
 
+@PETSc.Log.EventDecorator()
 def create_assembly_callable(expr, tensor=None, bcs=None, form_compiler_parameters=None,
                              mat_type=None, sub_mat_type=None, diagonal=False):
     r"""Create a callable object than be used to assemble expr into a tensor.
@@ -245,6 +249,7 @@ def _get_assembly_rank(expr, diagonal):
     raise AssertionError
 
 
+@PETSc.Log.EventDecorator()
 def _assemble_scalar(expr, bcs, opts):
     """Assemble a 0-form.
 
@@ -265,6 +270,7 @@ def _assemble_scalar(expr, bcs, opts):
     return scalar.data[0]
 
 
+@PETSc.Log.EventDecorator()
 def _assemble_vector(expr, vector, bcs, opts):
     """Assemble either a 1-form or the diagonal of a 2-form.
 
@@ -300,6 +306,7 @@ def _assemble_vector(expr, vector, bcs, opts):
     return vector
 
 
+@PETSc.Log.EventDecorator()
 def _assemble_matrix(expr, matrix, bcs, opts):
     """Assemble a 2-form into a matrix.
 
@@ -330,6 +337,7 @@ def _assemble_matrix(expr, matrix, bcs, opts):
     return matrix
 
 
+@PETSc.Log.EventDecorator()
 def _make_scalar():
     """Make an empty scalar.
 
@@ -338,6 +346,7 @@ def _make_scalar():
     return op2.Global(1, [0.0], dtype=utils.ScalarType)
 
 
+@PETSc.Log.EventDecorator()
 def _make_vector(V):
     """Make an empty vector.
 
@@ -348,6 +357,7 @@ def _make_vector(V):
     return firedrake.Function(V.function_space())
 
 
+@PETSc.Log.EventDecorator()
 def _make_matrix(expr, bcs, opts):
     """Make an empty matrix.
 
@@ -425,6 +435,7 @@ def _make_matrix(expr, bcs, opts):
                          options_prefix=opts.options_prefix)
 
 
+@PETSc.Log.EventDecorator()
 def _assemble_expr(expr, tensor, bcs, opts, assembly_rank):
     """Assemble an expression into the provided tensor.
 
@@ -490,6 +501,7 @@ def _get_mat_type(mat_type, sub_mat_type, arguments):
     return mat_type, sub_mat_type
 
 
+@PETSc.Log.EventDecorator()
 def _collect_lgmaps(matrix, all_bcs, Vrow, Vcol, row, col):
     """Obtain local to global maps for matrix insertion in the
     presence of boundary conditions.
@@ -525,6 +537,7 @@ def _collect_lgmaps(matrix, all_bcs, Vrow, Vcol, row, col):
     return (rlgmap, clgmap), unroll
 
 
+@PETSc.Log.EventDecorator()
 def _vector_arg(access, get_map, i, *, function, V):
     """Obtain an :class:`~pyop2.op2.Arg` for insertion into a given
     vector (:class:`Function`).
@@ -546,6 +559,7 @@ def _vector_arg(access, get_map, i, *, function, V):
         return function.dat[i](access, map_)
 
 
+@PETSc.Log.EventDecorator()
 def _matrix_arg(access, get_map, row, col, *,
                 all_bcs, matrix, Vrow, Vcol):
     """Obtain an op2.Arg for insertion into the given matrix.
@@ -580,6 +594,7 @@ def _matrix_arg(access, get_map, row, col, *,
                                   unroll_map=unroll)
 
 
+@PETSc.Log.EventDecorator()
 def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
     """Apply Dirichlet boundary conditions to a tensor.
 
@@ -633,6 +648,7 @@ def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
         raise AssertionError
 
 
+@PETSc.Log.EventDecorator()
 @utils.known_pyop2_safe
 def _make_parloops(expr, tensor, bcs, diagonal, fc_params, assembly_rank):
     """Create parloops for the assembly of the expression.

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -240,7 +240,6 @@ class Assign(object):
         """Coefficients appearing in the rvalue."""
         return extract_coefficients(self.rvalue)
 
-    @PETSc.Log.EventDecorator()
     @cached_property
     def split(self):
         """A tuple of assignment expressions, separated by subspace for mixed spaces."""
@@ -314,7 +313,6 @@ class Assign(object):
         rvalue, = map_expr_dags(self.relabeller, [self.rvalue])
         return (type(self), hash(self.lvalue), hash(rvalue))
 
-    @PETSc.Log.EventDecorator()
     @cached_property
     def par_loop_args(self):
         """Arguments for a parallel loop to evaluate this expression.

--- a/firedrake/assemble_expressions.py
+++ b/firedrake/assemble_expressions.py
@@ -23,6 +23,7 @@ from ufl.corealg.multifunction import MultiFunction
 from ufl.corealg.traversal import unique_pre_traversal as ufl_traversal
 
 import firedrake
+from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType, cached_property, known_pyop2_safe
 
 
@@ -239,6 +240,7 @@ class Assign(object):
         """Coefficients appearing in the rvalue."""
         return extract_coefficients(self.rvalue)
 
+    @PETSc.Log.EventDecorator()
     @cached_property
     def split(self):
         """A tuple of assignment expressions, separated by subspace for mixed spaces."""
@@ -312,6 +314,7 @@ class Assign(object):
         rvalue, = map_expr_dags(self.relabeller, [self.rvalue])
         return (type(self), hash(self.lvalue), hash(rvalue))
 
+    @PETSc.Log.EventDecorator()
     @cached_property
     def par_loop_args(self):
         """Arguments for a parallel loop to evaluate this expression.
@@ -350,6 +353,7 @@ class IDiv(AugmentedAssign):
     symbol = "/="
 
 
+@PETSc.Log.EventDecorator()
 def compile_to_gem(expr, translator):
     """Compile a single pointwise expression to GEM.
 
@@ -399,6 +403,7 @@ def compile_to_gem(expr, translator):
     return preprocess_gem([lvalue, rvalue])
 
 
+@PETSc.Log.EventDecorator()
 def pointwise_expression_kernel(exprs, scalar_type):
     """Compile a kernel for pointwise expressions.
 
@@ -452,6 +457,7 @@ class dereffed(object):
             a.data = weakref.ref(a.data)
 
 
+@PETSc.Log.EventDecorator()
 @known_pyop2_safe
 def evaluate_expression(expr, subset=None):
     """Evaluate a pointwise expression.
@@ -492,6 +498,7 @@ def evaluate_expression(expr, subset=None):
     return lvalue
 
 
+@PETSc.Log.EventDecorator()
 def assemble_expression(expr, subset=None):
     """Evaluate a UFL expression pointwise and assign it to a new
     :class:`~.Function`.

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -9,7 +9,6 @@ from ufl import as_ufl, UFLException, as_tensor, VectorElement
 import finat
 
 import pyop2 as op2
-from pyop2.profiling import timed_function
 from pyop2 import exceptions
 from pyop2.utils import as_tuple
 
@@ -21,6 +20,7 @@ from firedrake import slate
 from firedrake import solving
 from firedrake.formmanipulation import ExtractSubBlock
 from firedrake.adjoint.dirichletbc import DirichletBCMixin
+from firedrake.petsc import PETSc
 
 __all__ = ['DirichletBC', 'homogenize', 'EquationBC']
 
@@ -371,7 +371,7 @@ class DirichletBC(BCBase, DirichletBCMixin):
         self.function_arg = val
         self._original_arg = val
 
-    @timed_function('ApplyBC')
+    @PETSc.Log.EventDecorator('ApplyBC')
     @DirichletBCMixin._ad_annotate_apply
     def apply(self, r, u=None):
         r"""Apply this boundary condition to ``r``.

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -320,7 +320,6 @@ class DirichletBC(BCBase, DirichletBCMixin):
             return self
         return type(self)(V, g, sub_domain)
 
-    @PETSc.Log.EventDecorator()
     @function_arg.setter
     def function_arg(self, g):
         '''Set the value of this boundary condition.'''

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -92,7 +92,6 @@ class BCBase(object):
             raise RuntimeError("This function should only be called when function space is indexed")
         return fs.index
 
-    @PETSc.Log.EventDecorator()
     @utils.cached_property
     def domain_args(self):
         r"""The sub_domain the BC applies to."""
@@ -128,7 +127,6 @@ class BCBase(object):
             s.append((ndim - 1 - i, as_tuple(sd[i])))
         return as_tuple(s)
 
-    @PETSc.Log.EventDecorator()
     @utils.cached_property
     def nodes(self):
         '''The list of nodes at which this boundary condition applies.'''

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -36,6 +36,7 @@ class BCBase(object):
         the ``top`` and ``bottom`` strings are used to flag the bcs application on
         the top and bottom boundaries of the extruded mesh respectively.
     '''
+    @PETSc.Log.EventDecorator()
     def __init__(self, V, sub_domain):
 
         # First, we bail out on zany elements.  We don't know how to do BC's for them.
@@ -91,6 +92,7 @@ class BCBase(object):
             raise RuntimeError("This function should only be called when function space is indexed")
         return fs.index
 
+    @PETSc.Log.EventDecorator()
     @utils.cached_property
     def domain_args(self):
         r"""The sub_domain the BC applies to."""
@@ -126,6 +128,7 @@ class BCBase(object):
             s.append((ndim - 1 - i, as_tuple(sd[i])))
         return as_tuple(s)
 
+    @PETSc.Log.EventDecorator()
     @utils.cached_property
     def nodes(self):
         '''The list of nodes at which this boundary condition applies.'''
@@ -169,6 +172,7 @@ class BCBase(object):
 
         return op2.Subset(self._function_space.node_set, self.nodes)
 
+    @PETSc.Log.EventDecorator()
     def zero(self, r):
         r"""Zero the boundary condition nodes on ``r``.
 
@@ -186,6 +190,7 @@ class BCBase(object):
         except exceptions.MapValueError:
             raise RuntimeError("%r defined on incompatible FunctionSpace!" % r)
 
+    @PETSc.Log.EventDecorator()
     def set(self, r, val):
         r"""Set the boundary nodes to a prescribed (external) value.
         :arg r: the :class:`Function` to which the value should be applied.
@@ -199,6 +204,7 @@ class BCBase(object):
     def integrals(self):
         raise NotImplementedError("integrals() method has to be overwritten")
 
+    @PETSc.Log.EventDecorator()
     def as_subspace(self, field, V, use_split):
         fs = self._function_space
         if fs.parent is not None and isinstance(fs.parent.ufl_element(), VectorElement):
@@ -292,6 +298,7 @@ class DirichletBC(BCBase, DirichletBCMixin):
             self._function_arg_update()
         return self._function_arg
 
+    @PETSc.Log.EventDecorator()
     def reconstruct(self, field=None, V=None, g=None, sub_domain=None, use_split=False):
         fs = self.function_space()
         if V is None:
@@ -315,6 +322,7 @@ class DirichletBC(BCBase, DirichletBCMixin):
             return self
         return type(self)(V, g, sub_domain)
 
+    @PETSc.Log.EventDecorator()
     @function_arg.setter
     def function_arg(self, g):
         '''Set the value of this boundary condition.'''
@@ -451,6 +459,7 @@ class EquationBC(object):
     :arg Jp_eq_J: this flag is used only with the `reconstruct` method
     '''
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, *args, bcs=None, J=None, Jp=None, V=None, is_linear=False, Jp_eq_J=False):
         from firedrake.variational_solver import check_pde_args, is_form_consistent
         if isinstance(args[0], ufl.classes.Equation):
@@ -520,6 +529,7 @@ class EquationBC(object):
         else:
             return getattr(self, f"_{form_type}")
 
+    @PETSc.Log.EventDecorator()
     def reconstruct(self, V, subu, u, field):
         _F = self._F.reconstruct(field=field, V=V, subu=subu, u=u)
         _J = self._J.reconstruct(field=field, V=V, subu=subu, u=u)
@@ -579,6 +589,7 @@ class EquationBCSplit(BCBase):
         bc.increment_bc_depth()
         self.bcs.append(bc)
 
+    @PETSc.Log.EventDecorator()
     def reconstruct(self, field=None, V=None, subu=None, u=None, row_field=None, col_field=None, action_x=None, use_split=False):
         subu = subu or self.u
         row_field = row_field or field
@@ -616,6 +627,7 @@ class EquationBCSplit(BCBase):
         return ebc
 
 
+@PETSc.Log.EventDecorator()
 def homogenize(bc):
     r"""Create a homogeneous version of a :class:`.DirichletBC` object and return it. If
     ``bc`` is an iterable containing one or more :class:`.DirichletBC` objects,

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,6 +1,7 @@
 from firedrake.petsc import PETSc
 from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
 from firedrake.cython import hdf5interface as h5i
+from firedrake.petsc import PETSc
 import firedrake
 import numpy as np
 import os
@@ -63,6 +64,7 @@ class DumbCheckpoint(object):
         self._fidx = 0
         self.new_file()
 
+    @PETSc.Log.EventDecorator()
     def set_timestep(self, t, idx=None):
         r"""Set the timestep for output.
 
@@ -85,6 +87,7 @@ class DumbCheckpoint(object):
         new_steps = np.concatenate((steps, [self._time]))
         self.write_attribute("/", "stored_time_steps", new_steps)
 
+    @PETSc.Log.EventDecorator()
     def get_timesteps(self):
         r"""Return all the time steps (and time indices) in the current
         checkpoint file.
@@ -96,6 +99,7 @@ class DumbCheckpoint(object):
         steps = self.read_attribute("/", "stored_time_steps", [])
         return steps, indices
 
+    @PETSc.Log.EventDecorator()
     def new_file(self, name=None):
         r"""Open a new on-disk file for writing checkpoint data.
 
@@ -165,6 +169,7 @@ class DumbCheckpoint(object):
         self._h5file = h5i.get_h5py_file(self.vwr)
         return self._h5file
 
+    @PETSc.Log.EventDecorator()
     def close(self):
         r"""Close the checkpoint file (flushing any pending writes)"""
         if hasattr(self, "_vwr"):
@@ -190,6 +195,7 @@ class DumbCheckpoint(object):
             self.h5file.require_group(group)
             self.write_attribute(group, "timestep", self._time)
 
+    @PETSc.Log.EventDecorator()
     def store(self, function, name=None):
         r"""Store a function in the checkpoint file.
 
@@ -215,6 +221,7 @@ class DumbCheckpoint(object):
             v.setName(oname)
             self.vwr.popGroup()
 
+    @PETSc.Log.EventDecorator()
     def load(self, function, name=None):
         r"""Store a function from the checkpoint file.
 
@@ -376,6 +383,7 @@ class HDF5File(object):
         r"""Flush any pending writes."""
         self._h5file.flush()
 
+    @PETSc.Log.EventDecorator()
     def write(self, function, path, timestamp=None):
         r"""Store a function in the checkpoint file.
 
@@ -408,6 +416,7 @@ class HDF5File(object):
             attr["timestamp"] = timestamp
             self._set_timestamp(timestamp)
 
+    @PETSc.Log.EventDecorator()
     def read(self, function, path, timestamp=None):
         r"""Store a function from the checkpoint file.
 

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1,4 +1,3 @@
-from firedrake.petsc import PETSc
 from pyop2.mpi import COMM_WORLD, dup_comm, free_comm
 from firedrake.cython import hdf5interface as h5i
 from firedrake.petsc import PETSc

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -3,6 +3,7 @@ import ufl
 
 from pyop2 import op2
 from pyop2.exceptions import DataTypeError, DataValueError
+from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType
 
 import firedrake.utils as utils
@@ -72,6 +73,7 @@ class Constant(ufl.Coefficient, ConstantMixin):
         super(Constant, self).__init__(fs)
         self._repr = 'Constant(%r, %r)' % (self.ufl_element(), self.count())
 
+    @PETSc.Log.EventDecorator()
     def evaluate(self, x, mapping, component, index_values):
         """Return the evaluation of this :class:`Constant`.
 
@@ -116,6 +118,7 @@ class Constant(ufl.Coefficient, ConstantMixin):
             raise RuntimeError("Can't apply boundary conditions to a Constant")
         return None
 
+    @PETSc.Log.EventDecorator()
     @ConstantMixin._ad_annotate_assign
     def assign(self, value):
         """Set the value of this constant.

--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -45,6 +45,7 @@ import firedrake
 from firedrake.petsc import PETSc
 
 
+@PETSc.Log.EventDecorator()
 def get_function_space(dm):
     """Get the :class:`~.FunctionSpace` attached to this DM.
 
@@ -65,6 +66,7 @@ def get_function_space(dm):
     return V
 
 
+@PETSc.Log.EventDecorator()
 def set_function_space(dm, V):
     """Set the :class:`~.FunctionSpace` on this DM.
 
@@ -317,6 +319,7 @@ def create_matrix(dm):
     return ctx._jac.petscmat
 
 
+@PETSc.Log.EventDecorator()
 def create_field_decomposition(dm, *args, **kwargs):
     """Callback to decompose a DM.
 
@@ -349,6 +352,7 @@ def create_field_decomposition(dm, *args, **kwargs):
     return names, W._ises, dms
 
 
+@PETSc.Log.EventDecorator()
 def create_subdm(dm, fields, *args, **kwargs):
     """Callback to create a sub-DM describing the specified fields.
 
@@ -395,6 +399,7 @@ def create_subdm(dm, fields, *args, **kwargs):
         return iset, subspace.dm
 
 
+@PETSc.Log.EventDecorator()
 def coarsen(dm, comm):
     """Callback to coarsen a DM.
 
@@ -434,6 +439,7 @@ def coarsen(dm, comm):
     return cdm
 
 
+@PETSc.Log.EventDecorator()
 def refine(dm, comm):
     """Callback to refine a DM.
 

--- a/firedrake/extrusion_utils.py
+++ b/firedrake/extrusion_utils.py
@@ -4,11 +4,13 @@ import numpy
 import islpy as isl
 
 from pyop2 import op2
+from firedrake.petsc import PETSc
 from firedrake.utils import IntType, RealType, ScalarType
 from tsfc.finatinterface import create_element
 import loopy as lp
 
 
+@PETSc.Log.EventDecorator()
 def make_extruded_coords(extruded_topology, base_coords, ext_coords,
                          layer_height, extrusion_type='uniform', kernel=None):
     """

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -7,6 +7,7 @@ from ufl.classes import Zero, FixedIndex, ListTensor
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.corealg.map_dag import MultiFunction, map_expr_dags
 
+from firedrake.petsc import PETSc
 from firedrake.ufl_expr import Argument
 
 
@@ -32,6 +33,7 @@ class ExtractSubBlock(MultiFunction):
 
     index_inliner = IndexInliner()
 
+    @PETSc.Log.EventDecorator()
     def split(self, form, argument_indices):
         """Split a form.
 
@@ -79,6 +81,7 @@ class ExtractSubBlock(MultiFunction):
         else:
             return self.reuse_if_untouched(o, expr, coefficients, arguments, cds)
 
+    @PETSc.Log.EventDecorator()
     def argument(self, o):
         from ufl import split
         from firedrake import MixedFunctionSpace, FunctionSpace
@@ -127,6 +130,7 @@ class ExtractSubBlock(MultiFunction):
 SplitForm = collections.namedtuple("SplitForm", ["indices", "form"])
 
 
+@PETSc.Log.EventDecorator()
 def split_form(form, diagonal=False):
     """Split a form into a tuple of sub-forms defined on the component spaces.
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -389,7 +389,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             self.dat.zero(subset=subset)
             return self
         elif (isinstance(expr, Function)
-            and expr.function_space() == self.function_space()):
+              and expr.function_space() == self.function_space()):
             expr.dat.copy(self.dat, subset=subset)
             return self
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -14,6 +14,7 @@ from firedrake.logging import warning
 from firedrake import utils
 from firedrake import vector
 from firedrake.adjoint import FunctionMixin
+from firedrake.petsc import PETSc
 try:
     import cachetools
 except ImportError:
@@ -81,6 +82,7 @@ class CoordinatelessFunction(ufl.Coefficient):
         r"""The underlying coordinateless function."""
         return self
 
+    @PETSc.Log.EventDecorator()
     def copy(self, deepcopy=False):
         r"""Return a copy of this CoordinatelessFunction.
 
@@ -106,6 +108,7 @@ class CoordinatelessFunction(ufl.Coefficient):
                      for i, (fs, dat) in
                      enumerate(zip(self.function_space(), self.dat)))
 
+    @PETSc.Log.EventDecorator()
     def split(self):
         r"""Extract any sub :class:`Function`\s defined on the component spaces
         of this this :class:`Function`'s :class:`.FunctionSpace`."""
@@ -120,6 +123,7 @@ class CoordinatelessFunction(ufl.Coefficient):
                                                 name="view[%d](%s)" % (i, self.name()))
                          for i, j in enumerate(np.ndindex(self.dof_dset.dim)))
 
+    @PETSc.Log.EventDecorator()
     def sub(self, i):
         r"""Extract the ith sub :class:`Function` of this :class:`Function`.
 
@@ -222,6 +226,7 @@ class Function(ufl.Coefficient, FunctionMixin):
     the :class:`.FunctionSpace`.
     """
 
+    @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_init
     def __init__(self, function_space, val=None, name=None, dtype=ScalarType):
         r"""
@@ -270,6 +275,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         r"""The underlying coordinateless function."""
         return self._data
 
+    @PETSc.Log.EventDecorator()
     def copy(self, deepcopy=False):
         r"""Return a copy of this Function.
 
@@ -295,6 +301,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         return tuple(type(self)(V, val)
                      for (V, val) in zip(self.function_space(), self.topological.split()))
 
+    @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_split
     def split(self):
         r"""Extract any sub :class:`Function`\s defined on the component spaces
@@ -309,6 +316,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             return tuple(type(self)(self.function_space().sub(i), self.topological.sub(i))
                          for i in range(self.function_space().value_size))
 
+    @PETSc.Log.EventDecorator()
     def sub(self, i):
         r"""Extract the ith sub :class:`Function` of this :class:`Function`.
 
@@ -324,6 +332,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             return self._components[i]
         return self._split[i]
 
+    @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_project
     def project(self, b, *args, **kwargs):
         r"""Project ``b`` onto ``self``. ``b`` must be a :class:`Function` or an
@@ -346,6 +355,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         r"""Return a :class:`.Vector` wrapping the data in this :class:`Function`"""
         return vector.Vector(self)
 
+    @PETSc.Log.EventDecorator()
     def interpolate(self, expression, subset=None):
         r"""Interpolate an expression onto this :class:`Function`.
 
@@ -354,6 +364,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         from firedrake import interpolation
         return interpolation.interpolate(expression, self, subset=subset)
 
+    @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_assign
     @utils.known_pyop2_safe
     def assign(self, expr, subset=None):
@@ -378,7 +389,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             self.dat.zero(subset=subset)
             return self
         elif (isinstance(expr, Function)
-              and expr.function_space() == self.function_space()):
+            and expr.function_space() == self.function_space()):
             expr.dat.copy(self.dat, subset=subset)
             return self
 
@@ -510,6 +521,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             raise NotImplementedError("Unsupported arguments when attempting to evaluate Function.")
         return self.at(coord)
 
+    @PETSc.Log.EventDecorator()
     def at(self, arg, *args, **kwargs):
         r"""Evaluate function at points.
 
@@ -637,6 +649,7 @@ class PointNotInDomainError(Exception):
         return "domain %s does not contain point %s" % (self.domain, self.point)
 
 
+@PETSc.Log.EventDecorator()
 def make_c_evaluate(function, c_name="evaluate", ldargs=None, tolerance=None):
     r"""Generates, compiles and loads a C function to evaluate the
     given Firedrake :class:`Function`."""

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -16,6 +16,7 @@ __all__ = ("MixedFunctionSpace", "FunctionSpace",
            "VectorFunctionSpace", "TensorFunctionSpace")
 
 
+@PETSc.Log.EventDecorator()
 def make_scalar_element(mesh, family, degree, vfamily, vdegree):
     """Build a scalar :class:`ufl.FiniteElement`.
 
@@ -135,6 +136,7 @@ def FunctionSpace(mesh, family, degree=None, name=None, vfamily=None,
         return new
 
 
+@PETSc.Log.EventDecorator()
 def VectorFunctionSpace(mesh, family, degree=None, dim=None,
                         name=None, vfamily=None, vdegree=None):
     """Create a rank-1 :class:`.FunctionSpace`.
@@ -171,6 +173,7 @@ def VectorFunctionSpace(mesh, family, degree=None, dim=None,
     return FunctionSpace(mesh, element, name=name)
 
 
+@PETSc.Log.EventDecorator()
 def TensorFunctionSpace(mesh, family, degree=None, shape=None,
                         symmetry=None, name=None, vfamily=None,
                         vdegree=None):
@@ -208,6 +211,7 @@ def TensorFunctionSpace(mesh, family, degree=None, shape=None,
     return FunctionSpace(mesh, element, name=name)
 
 
+@PETSc.Log.EventDecorator()
 def MixedFunctionSpace(spaces, name=None, mesh=None):
     """Create a :class:`.MixedFunctionSpace`.
 

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -7,9 +7,9 @@ backwards-compatibility, argument checking, and dispatch.
 import ufl
 
 from pyop2.utils import flatten
-from pyop2.profiling import timed_function
 
 from firedrake import functionspaceimpl as impl
+from firedrake.petsc import PETSc
 
 
 __all__ = ("MixedFunctionSpace", "FunctionSpace",
@@ -96,7 +96,7 @@ def check_element(element, top=True):
         check_element(e, top=False)
 
 
-@timed_function("CreateFunctionSpace")
+@PETSc.Log.EventDecorator("CreateFunctionSpace")
 def FunctionSpace(mesh, family, degree=None, name=None, vfamily=None,
                   vdegree=None):
     """Create a :class:`.FunctionSpace`.

--- a/firedrake/functionspacedata.py
+++ b/firedrake/functionspacedata.py
@@ -382,6 +382,7 @@ class FunctionSpaceData(object):
                  "interior_facet_boundary_masks", "offset",
                  "extruded", "mesh", "global_numbering")
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, mesh, finat_element, real_tensorproduct=False):
         entity_dofs = finat_element.entity_dofs()
         nodes_per_entity = tuple(mesh.make_dofs_per_plex_entity(entity_dofs))
@@ -424,6 +425,7 @@ class FunctionSpaceData(object):
     def __str__(self):
         return "FunctionSpaceData(%s, %s)" % (self.mesh, self.node_set)
 
+    @PETSc.Log.EventDecorator()
     def boundary_nodes(self, V, sub_domain):
         if sub_domain in ["bottom", "top"]:
             if not V.extruded:
@@ -440,6 +442,7 @@ class FunctionSpaceData(object):
             key = (entity_dofs_key(V.finat_element.entity_dofs()), sdkey)
             return get_facet_closure_nodes(V.mesh(), key, V)
 
+    @PETSc.Log.EventDecorator()
     def get_map(self, V, entity_set, map_arity, name, offset):
         """Return a :class:`pyop2.Map` from some topological entity to
         degrees of freedom.
@@ -465,6 +468,7 @@ class FunctionSpaceData(object):
         return val
 
 
+@PETSc.Log.EventDecorator()
 def get_shared_data(mesh, finat_element, real_tensorproduct=False):
     """Return the :class:`FunctionSpaceData` for the given
     element.

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -66,6 +66,7 @@ class WithGeometry(ufl.FunctionSpace):
         r"""The :class:`~ufl.classes.Cell` this FunctionSpace is defined on."""
         return self.ufl_domain().ufl_cell()
 
+    @PETSc.Log.EventDecorator()
     def split(self):
         r"""Split into a tuple of constituent spaces."""
         return self._split
@@ -78,6 +79,7 @@ class WithGeometry(ufl.FunctionSpace):
         else:
             return self._split
 
+    @PETSc.Log.EventDecorator()
     def sub(self, i):
         if len(self) == 1:
             bound = self.value_size
@@ -283,6 +285,7 @@ class FunctionSpace(object):
        which provides extra error checking and argument sanitising.
 
     """
+    @PETSc.Log.EventDecorator()
     def __init__(self, mesh, element, name=None):
         super(FunctionSpace, self).__init__()
         if type(element) is ufl.MixedElement:
@@ -535,6 +538,7 @@ class FunctionSpace(object):
         """
         return self._shared_data.boundary_nodes(self, sub_domain)
 
+    @PETSc.Log.EventDecorator()
     def local_to_global_map(self, bcs, lgmap=None):
         r"""Return a map from process local dof numbering to global dof numbering.
 

--- a/firedrake/halo.py
+++ b/firedrake/halo.py
@@ -126,6 +126,7 @@ class Halo(op2.Halo):
         gsec = self.dm.getDefaultGlobalSection()
         return dmcommon.make_global_numbering(lsec, gsec)
 
+    @PETSc.Log.EventDecorator()
     def global_to_local_begin(self, dat, insert_mode):
         assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
         if self.comm.size == 1:
@@ -133,6 +134,7 @@ class Halo(op2.Halo):
         mtype, _ = _get_mtype(dat)
         self.sf.bcastBegin(mtype, dat._data, dat._data, MPI.REPLACE)
 
+    @PETSc.Log.EventDecorator()
     def global_to_local_end(self, dat, insert_mode):
         assert insert_mode is op2.WRITE, "Only WRITE GtoL supported"
         if self.comm.size == 1:
@@ -140,6 +142,7 @@ class Halo(op2.Halo):
         mtype, _ = _get_mtype(dat)
         self.sf.bcastEnd(mtype, dat._data, dat._data, MPI.REPLACE)
 
+    @PETSc.Log.EventDecorator()
     def local_to_global_begin(self, dat, insert_mode):
         assert insert_mode in {op2.INC, op2.MIN, op2.MAX}, "%s LtoG not supported" % insert_mode
         if self.comm.size == 1:
@@ -153,6 +156,7 @@ class Halo(op2.Halo):
               (True, op2.MAX): MPI.MAX}[(builtin, insert_mode)]
         self.sf.reduceBegin(mtype, dat._data, dat._data, op)
 
+    @PETSc.Log.EventDecorator()
     def local_to_global_end(self, dat, insert_mode):
         assert insert_mode in {op2.INC, op2.MIN, op2.MAX}, "%s LtoG not supported" % insert_mode
         if self.comm.size == 1:

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -13,10 +13,12 @@ from tsfc import compile_expression_dual_evaluation
 import firedrake
 from firedrake import utils
 from firedrake.adjoint import annotate_interpolate
+from firedrake.petsc import PETSc
 
 __all__ = ("interpolate", "Interpolator")
 
 
+@PETSc.Log.EventDecorator()
 def interpolate(expr, V, subset=None, access=op2.WRITE):
     """Interpolate an expression onto a new function in V.
 
@@ -83,6 +85,7 @@ class Interpolator(object):
         self.expr = expr
         self.V = V
 
+    @PETSc.Log.EventDecorator()
     @annotate_interpolate
     def interpolate(self, *function, output=None, transpose=False):
         """Compute the interpolation.
@@ -142,6 +145,7 @@ class Interpolator(object):
                     return assembled_interpolator
 
 
+@PETSc.Log.EventDecorator()
 def make_interpolator(expr, V, subset, access):
     assert isinstance(expr, ufl.classes.Expr)
 
@@ -318,6 +322,7 @@ class GlobalWrapper(object):
         self.ufl_domain = lambda: None
 
 
+@PETSc.Log.EventDecorator()
 def compile_python_kernel(expression, to_pts, to_element, fs, coords):
     """Produce a :class:`PyOP2.Kernel` wrapping the eval method on the
     function provided."""

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -18,6 +18,7 @@ class LinearSolver(OptionsManager):
 
     DEFAULT_KSP_PARAMETERS = solving_utils.DEFAULT_KSP_PARAMETERS
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, A, *, P=None, solver_parameters=None,
                  nullspace=None, transpose_nullspace=None,
                  near_nullspace=None, options_prefix=None):
@@ -130,6 +131,7 @@ class LinearSolver(OptionsManager):
         # blift is now b - A u_bc, and satisfies the boundary conditions
         return blift
 
+    @PETSc.Log.EventDecorator()
     def solve(self, x, b):
         if not isinstance(x, (function.Function, vector.Vector)):
             raise TypeError("Provided solution is a '%s', not a Function or Vector" % type(x).__name__)

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -15,6 +15,7 @@ from firedrake.utils import cached_property
 __all__ = ("ImplicitMatrixContext", )
 
 
+@PETSc.Log.EventDecorator()
 def find_sub_block(iset, ises):
     """Determine if iset comes from a concatenation of some subset of
     ises.
@@ -83,6 +84,7 @@ class ImplicitMatrixContext(object):
        preconditioners and the like.
 
     """
+    @PETSc.Log.EventDecorator()
     def __init__(self, a, row_bcs=[], col_bcs=[],
                  fc_params=None, appctx=None):
         from firedrake.assemble import assemble
@@ -198,6 +200,7 @@ class ImplicitMatrixContext(object):
     def missingDiagonal(self, mat):
         return (False, -1)
 
+    @PETSc.Log.EventDecorator()
     def mult(self, mat, X, Y):
         with self._x.dat.vec_wo as v:
             X.copy(v)
@@ -231,6 +234,7 @@ class ImplicitMatrixContext(object):
         with self._y.dat.vec_ro as v:
             v.copy(Y)
 
+    @PETSc.Log.EventDecorator()
     def multTranspose(self, mat, Y, X):
         """
         EquationBC makes multTranspose different from mult.
@@ -334,6 +338,7 @@ class ImplicitMatrixContext(object):
     # extraction for our custom matrix type.  Note that we are splitting UFL
     # and index sets rather than an assembled matrix, keeping matrix
     # assembly deferred as long as possible.
+    @PETSc.Log.EventDecorator()
     def createSubMatrix(self, mat, row_is, col_is, target=None):
         if target is not None:
             # Repeat call, just return the matrix, since we don't
@@ -395,6 +400,7 @@ class ImplicitMatrixContext(object):
 
         return submat
 
+    @PETSc.Log.EventDecorator()
     def duplicate(self, mat, copy):
 
         if copy == 0:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -70,7 +70,7 @@ class _Facets(object):
     .. warning::
 
        The unique_markers argument **must** be the same on all processes."""
-    
+
     @PETSc.Log.EventDecorator()
     def __init__(self, mesh, classes, kind, facet_cell, local_facet_number, markers=None,
                  unique_markers=None):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -70,6 +70,8 @@ class _Facets(object):
     .. warning::
 
        The unique_markers argument **must** be the same on all processes."""
+    
+    @PETSc.Log.EventDecorator()
     def __init__(self, mesh, classes, kind, facet_cell, local_facet_number, markers=None,
                  unique_markers=None):
 
@@ -126,6 +128,7 @@ class _Facets(object):
 
         return op2.Subset(self.set, [])
 
+    @PETSc.Log.EventDecorator()
     def measure_set(self, integral_type, subdomain_id,
                     all_integer_subdomain_ids=None):
         """Return an iteration set appropriate for the requested integral type.
@@ -171,6 +174,7 @@ class _Facets(object):
         else:
             return self.subset(subdomain_id)
 
+    @PETSc.Log.EventDecorator()
     def subset(self, markers):
         """Return the subset corresponding to a given marker value.
 
@@ -202,6 +206,7 @@ class _Facets(object):
                        "facet_to_cell_map")
 
 
+@PETSc.Log.EventDecorator()
 def _from_gmsh(filename, comm=None):
     """Read a Gmsh .msh file from `filename`.
 
@@ -219,6 +224,7 @@ def _from_gmsh(filename, comm=None):
     return gmsh_plex
 
 
+@PETSc.Log.EventDecorator()
 def _from_exodus(filename, comm):
     """Read an Exodus .e or .exo file from `filename`.
 
@@ -229,6 +235,7 @@ def _from_exodus(filename, comm):
     return plex
 
 
+@PETSc.Log.EventDecorator()
 def _from_cgns(filename, comm):
     """Read a CGNS .cgns file from `filename`.
 
@@ -238,6 +245,7 @@ def _from_cgns(filename, comm):
     return plex
 
 
+@PETSc.Log.EventDecorator()
 def _from_triangle(filename, dim, comm):
     """Read a set of triangle mesh files from `filename`.
 
@@ -305,6 +313,7 @@ def _from_triangle(filename, dim, comm):
     return plex
 
 
+@PETSc.Log.EventDecorator()
 def _from_cell_list(dim, cells, coords, comm):
     """
     Create a DMPlex from a list of cells and coords.
@@ -560,6 +569,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     def cell_set(self):
         pass
 
+    @PETSc.Log.EventDecorator()
     def cell_subset(self, subdomain_id, all_integer_subdomain_ids=None):
         """Return a subset over cells with the given subdomain_id.
 
@@ -602,6 +612,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
                                                     subdomain_id)
             return self._subsets.setdefault(key, op2.Subset(self.cell_set, indices))
 
+    @PETSc.Log.EventDecorator()
     def measure_set(self, integral_type, subdomain_id,
                     all_integer_subdomain_ids=None):
         """Return an iteration set appropriate for the requested integral type.
@@ -825,6 +836,7 @@ class MeshTopology(AbstractMeshTopology):
         else:
             raise NotImplementedError("Cell type '%s' not supported." % cell)
 
+    @PETSc.Log.EventDecorator()
     def _facets(self, kind):
         if kind not in ["interior", "exterior"]:
             raise ValueError("Unknown facet type '%s'" % kind)
@@ -921,6 +933,7 @@ class MeshTopology(AbstractMeshTopology):
         size = list(self._entity_classes[self.cell_dimension(), :])
         return op2.Set(size, "Cells", comm=self.comm)
 
+    @PETSc.Log.EventDecorator()
     def set_partitioner(self, distribute, partitioner_type=None):
         """Set partitioner for (re)distributing underlying plex over comm.
 
@@ -969,6 +982,7 @@ class MeshTopology(AbstractMeshTopology):
 class ExtrudedMeshTopology(MeshTopology):
     """Representation of an extruded mesh topology."""
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, mesh, layers):
         """Build an extruded mesh topology from an input mesh topology
 
@@ -1074,6 +1088,7 @@ class ExtrudedMeshTopology(MeshTopology):
             dofs_per_entity[b, v] += len(entities[0])
         return tuplify(dofs_per_entity)
 
+    @PETSc.Log.EventDecorator()
     def node_classes(self, nodes_per_entity, real_tensorproduct=False):
         """Compute node classes given nodes per entity.
 
@@ -1091,6 +1106,7 @@ class ExtrudedMeshTopology(MeshTopology):
             nodes_per_entity = sum(nodes[:, i]*(self.layers - i) for i in range(2))
             return super(ExtrudedMeshTopology, self).node_classes(nodes_per_entity)
 
+    @PETSc.Log.EventDecorator()
     def make_offset(self, entity_dofs, ndofs, real_tensorproduct=False):
         """Returns the offset between the neighbouring cells of a
         column for each DoF.
@@ -1166,6 +1182,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
     another mesh.
     """
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, swarm, parentmesh, name, reorder):
         """
         Half-initialise a mesh topology.
@@ -1472,6 +1489,7 @@ values from f.)"""
         # Build spatial index
         return spatialindex.from_regions(coords_min, coords_max)
 
+    @PETSc.Log.EventDecorator()
     def locate_cell(self, x, tolerance=None):
         """Locate cell containg given point.
 
@@ -1527,6 +1545,7 @@ values from f.)"""
             locator.restype = ctypes.c_int
             return cache.setdefault(tolerance, locator)
 
+    @PETSc.Log.EventDecorator()
     def init_cell_orientations(self, expr):
         """Compute and initialise :attr:`cell_orientations` relative to a specified orientation.
 
@@ -1576,6 +1595,7 @@ values from f.)"""
         return list(OrderedDict.fromkeys(dir(self._topology) + current))
 
 
+@PETSc.Log.EventDecorator()
 def make_mesh_from_coordinates(coordinates):
     """Given a coordinate field build a new mesh, using said coordinate field.
 
@@ -1877,6 +1897,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', kern
     return self
 
 
+@PETSc.Log.EventDecorator()
 def VertexOnlyMesh(mesh, vertexcoords):
     """
     Create a vertex only mesh, immersed in a given mesh, with vertices
@@ -2063,6 +2084,7 @@ def _pic_swarm_in_plex(plex, coords, fields=[]):
     return swarm
 
 
+@PETSc.Log.EventDecorator()
 def SubDomainData(geometric_expr):
     """Creates a subdomain data object from a boolean-valued UFL expression.
 

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -212,6 +212,7 @@ class TransferManager(object):
         except KeyError:
             return cache._work_vec.setdefault(key, V.dof_dset.layout_vec.duplicate())
 
+    @PETSc.Log.EventDecorator()
     def op(self, source, target, transfer_op):
         """Primal transfer (either prolongation or injection).
 

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -1,6 +1,7 @@
 from pyop2 import op2
 
 import firedrake
+from firedrake.petsc import PETSc
 from . import utils
 from . import kernels
 
@@ -23,6 +24,7 @@ def check_arguments(coarse, fine):
         raise ValueError("Mismatching function space shapes")
 
 
+@PETSc.Log.EventDecorator()
 def prolong(coarse, fine):
     check_arguments(coarse, fine)
     Vc = coarse.function_space()
@@ -83,6 +85,7 @@ def prolong(coarse, fine):
     return fine
 
 
+@PETSc.Log.EventDecorator()
 def restrict(fine_dual, coarse_dual):
     check_arguments(coarse_dual, fine_dual)
     Vf = fine_dual.function_space()
@@ -144,6 +147,7 @@ def restrict(fine_dual, coarse_dual):
     return coarse_dual
 
 
+@PETSc.Log.EventDecorator()
 def inject(fine, coarse):
     check_arguments(coarse, fine)
     Vf = fine.function_space()

--- a/firedrake/norms.py
+++ b/firedrake/norms.py
@@ -3,10 +3,12 @@ from ufl import inner, div, grad, curl, dx
 from firedrake.assemble import assemble
 from firedrake import function
 from firedrake.logging import warning
+from firedrake.petsc import PETSc
 
 __all__ = ['errornorm', 'norm']
 
 
+@PETSc.Log.EventDecorator()
 def errornorm(u, uh, norm_type="L2", degree_rise=None, mesh=None):
     """Compute the error :math:`e = u - u_h` in the specified norm.
 
@@ -36,6 +38,7 @@ def errornorm(u, uh, norm_type="L2", degree_rise=None, mesh=None):
     return norm(u - uh, norm_type=norm_type, mesh=mesh)
 
 
+@PETSc.Log.EventDecorator()
 def norm(v, norm_type="L2", mesh=None):
     r"""Compute the norm of ``v``.
 

--- a/firedrake/nullspace.py
+++ b/firedrake/nullspace.py
@@ -50,6 +50,7 @@ class VectorSpaceBasis(object):
         self._constant = constant
         self._ad_orthogonalized = False
 
+    @PETSc.Log.EventDecorator()
     def nullspace(self, comm=None):
         r"""The PETSc NullSpace object for this :class:`.VectorSpaceBasis`.
 
@@ -62,6 +63,7 @@ class VectorSpaceBasis(object):
                                                    comm=comm)
         return self._nullspace
 
+    @PETSc.Log.EventDecorator()
     def orthonormalize(self):
         r"""Orthonormalize the basis.
 
@@ -86,6 +88,7 @@ class VectorSpaceBasis(object):
         self.check_orthogonality()
         self._ad_orthogonalized = True
 
+    @PETSc.Log.EventDecorator()
     def orthogonalize(self, b):
         r"""Orthogonalize ``b`` with respect to this :class:`.VectorSpaceBasis`.
 
@@ -99,6 +102,7 @@ class VectorSpaceBasis(object):
             nullsp.remove(v)
         self._ad_orthogonalized = True
 
+    @PETSc.Log.EventDecorator()
     def check_orthogonality(self, orthonormal=True):
         r"""Check if the basis is orthogonal.
 

--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -5,9 +5,10 @@ import os
 import ufl
 from itertools import chain
 from pyop2.mpi import COMM_WORLD, dup_comm
-from firedrake.utils import IntType
 from pyop2.utils import as_tuple
 from pyadjoint import no_annotations
+from firedrake.petsc import PETSc
+from firedrake.utils import IntType
 
 from .paraview_reordering import vtk_lagrange_tet_reorder,\
     vtk_lagrange_hex_reorder, vtk_lagrange_interval_reorder,\
@@ -115,6 +116,7 @@ def get_sup_element(*elements, continuous=False, max_degree=None):
                              variant="equispaced")
 
 
+@PETSc.Log.EventDecorator()
 def get_topology(coordinates):
     r"""Get the topology for VTU output.
 
@@ -621,6 +623,7 @@ class File(object):
             f.write(b'</VTKFile>\n')
         return fname
 
+    @PETSc.Log.EventDecorator()
     def write(self, *functions, **kwargs):
         """Write functions to this :class:`File`.
 

--- a/firedrake/parloops.py
+++ b/firedrake/parloops.py
@@ -13,6 +13,7 @@ import coffee.base as ast
 
 from firedrake.logging import warning
 from firedrake import constant
+from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType_c
 try:
     from cachetools import LRUCache
@@ -172,6 +173,7 @@ def _form_string_kernel(body, measure, args, **kwargs):
                         "par_loop_kernel", **kwargs)
 
 
+@PETSc.Log.EventDecorator()
 def par_loop(kernel, measure, args, kernel_kwargs=None, is_loopy_kernel=False, **kwargs):
     r"""A :func:`par_loop` is a user-defined operation which reads and
     writes :class:`.Function`\s by looping over the mesh cells or facets

--- a/firedrake/plot.py
+++ b/firedrake/plot.py
@@ -15,6 +15,7 @@ from firedrake import (interpolate, sqrt, inner, Function, SpatialCoordinate,
                        FunctionSpace, VectorFunctionSpace, PointNotInDomainError,
                        Constant, assemble, dx)
 from firedrake.mesh import MeshGeometry
+from firedrake.petsc import PETSc
 
 __all__ = ["plot", "triplot", "tricontourf", "tricontour", "trisurf", "tripcolor",
            "quiver", "streamplot", "FunctionPlotter"]
@@ -71,6 +72,7 @@ def _get_collection_types(gdim, tdim):
     raise ValueError("Geometric dimension must be either 2 or 3!")
 
 
+@PETSc.Log.EventDecorator()
 def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     r"""Plot a mesh colouring marked facet segments
 
@@ -205,6 +207,7 @@ def _plot_2d_field(method_name, function, *args, complex_component="real", **kwa
     return method(triangulation, toreal(values, complex_component), *args, **kwargs)
 
 
+@PETSc.Log.EventDecorator()
 def tricontourf(function, *args, complex_component="real", **kwargs):
     r"""Create a filled contour plot of a 2D Firedrake :class:`~.Function`
 
@@ -220,6 +223,7 @@ def tricontourf(function, *args, complex_component="real", **kwargs):
     return _plot_2d_field("tricontourf", function, *args, complex_component=complex_component, **kwargs)
 
 
+@PETSc.Log.EventDecorator()
 def tricontour(function, *args, complex_component="real", **kwargs):
     r"""Create a contour plot of a 2D Firedrake :class:`~.Function`
 
@@ -235,6 +239,7 @@ def tricontour(function, *args, complex_component="real", **kwargs):
     return _plot_2d_field("tricontour", function, *args, complex_component=complex_component, **kwargs)
 
 
+@PETSc.Log.EventDecorator()
 def tripcolor(function, *args, complex_component="real", **kwargs):
     r"""Create a pseudo-color plot of a 2D Firedrake :class:`~.Function`
 
@@ -274,6 +279,7 @@ def _trisurf_3d(axes, function, *args, complex_component="real", vmin=None, vmax
     return collection
 
 
+@PETSc.Log.EventDecorator()
 def trisurf(function, *args, complex_component="real", **kwargs):
     r"""Create a 3D surface plot of a 2D Firedrake :class:`~.Function`
 
@@ -312,6 +318,7 @@ def trisurf(function, *args, complex_component="real", **kwargs):
     return axes.plot_trisurf(triangulation, values, *args, **_kwargs)
 
 
+@PETSc.Log.EventDecorator()
 def quiver(function, *, complex_component="real", **kwargs):
     r"""Make a quiver plot of a 2D vector Firedrake :class:`~.Function`
 
@@ -348,6 +355,7 @@ def _step_to_boundary(mesh, x, u, dt, loc_tolerance):
     return bracket[0]
 
 
+@PETSc.Log.EventDecorator()
 def streamline(function, point, direction=+1, tolerance=3e-3, loc_tolerance=1e-10,
                complex_component="real"):
     r"""Generate a streamline of a vector field starting from a point
@@ -558,6 +566,7 @@ class Streamplotter(object):
         self.streamlines.append(streamline)
 
 
+@PETSc.Log.EventDecorator()
 def streamplot(function, resolution=None, min_length=None, max_time=None,
                start_width=0.5, end_width=1.5, tolerance=3e-3, loc_tolerance=1e-10,
                seed=None, complex_component="real", **kwargs):
@@ -653,6 +662,7 @@ def streamplot(function, resolution=None, min_length=None, max_time=None,
     return collection
 
 
+@PETSc.Log.EventDecorator()
 def plot(function, *args, bezier=False, num_sample_points=10, complex_component="real", **kwargs):
     r"""Plot a 1D Firedrake :class:`~.Function`
 

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -15,8 +15,10 @@ from tsfc.coffee import generate as generate_coffee
 from tsfc.parameters import default_parameters
 
 from firedrake import utils
+from firedrake.petsc import PETSc
 
 
+@PETSc.Log.EventDecorator()
 def compile_element(expression, coordinates, parameters=None):
     """Generates C code for point evaluations.
 

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -3,9 +3,10 @@ import numpy
 import sympy
 
 from pyop2 import op2
-from firedrake.utils import IntType, as_cstr, ScalarType, ScalarType_c, complex_mode
-
 from pyop2.sequential import generate_single_cell_wrapper
+
+from firedrake.petsc import PETSc
+from firedrake.utils import IntType, as_cstr, ScalarType, ScalarType_c, complex_mode
 
 import ufl
 from ufl.corealg.map_dag import map_expr_dag
@@ -94,6 +95,7 @@ def init_X(fiat_cell, parameters):
     return "\n".join("%s = %s;" % ("X[%d]" % i, formatter(v)) for i, v in enumerate(X))
 
 
+@PETSc.Log.EventDecorator()
 def to_reference_coordinates(ufl_coordinate_element, parameters):
     # Set up UFL form
     cell = ufl_coordinate_element.cell()
@@ -148,6 +150,7 @@ def to_reference_coordinates(ufl_coordinate_element, parameters):
     return body
 
 
+@PETSc.Log.EventDecorator()
 def compile_coordinate_element(ufl_coordinate_element, contains_eps, parameters=None):
     """Generates C code for changing to reference coordinates.
 

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -3,6 +3,7 @@ import functools
 import ufl
 
 import firedrake
+from firedrake.petsc import PETSc
 from firedrake.utils import cached_property, complex_mode, SLATE_SUPPORTS_COMPLEX
 from firedrake import expression
 from firedrake import functionspace
@@ -65,6 +66,7 @@ def check_meshes(source, target):
     return source_mesh, target_mesh
 
 
+@PETSc.Log.EventDecorator()
 @annotate_project
 def project(v, V, bcs=None,
             solver_parameters=None,
@@ -214,6 +216,7 @@ class SupermeshProjector(ProjectorBase):
         return self.residual
 
 
+@PETSc.Log.EventDecorator()
 def Projector(v, v_out, bcs=None, solver_parameters=None,
               form_compiler_parameters=None, constant_jacobian=True,
               use_slate_for_inverse=False):

--- a/firedrake/slate/static_condensation/sc_base.py
+++ b/firedrake/slate/static_condensation/sc_base.py
@@ -1,7 +1,7 @@
 import abc
 
 from firedrake.preconditioners import PCBase
-from pyop2.profiling import timed_region
+from firedrake.petsc import PETSc
 
 
 class SCBase(PCBase):
@@ -49,13 +49,13 @@ class SCBase(PCBase):
         :arg y: A PETSc vector for the result.
         """
 
-        with timed_region("SCForwardElim"):
+        with PETSc.Log.Event("SCForwardElim"):
             self.forward_elimination(pc, x)
 
-        with timed_region("SCSolve"):
+        with PETSc.Log.Event("SCSolve"):
             self.sc_solve(pc)
 
-        with timed_region("SCBackSub"):
+        with PETSc.Log.Event("SCBackSub"):
             self.backward_substitution(pc, y)
 
     def applyTranspose(self, pc, x, y):

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -5,7 +5,6 @@ from firedrake.slate.static_condensation.sc_base import SCBase
 from firedrake.matrix_free.operators import ImplicitMatrixContext
 from firedrake.petsc import PETSc
 from firedrake.slate.slate import Tensor
-from pyop2.profiling import timed_function
 
 
 __all__ = ['SCPC']
@@ -19,7 +18,7 @@ class SCPC(SCBase):
     static condensation for problems with up to three fields.
     """
 
-    @timed_function("SCPCInit")
+    @PETSc.Log.EventDecorator("SCPCInit")
     def initialize(self, pc):
         """Set up the problem context. This takes the incoming
         three-field system and constructs the static
@@ -232,7 +231,7 @@ class SCPC(SCBase):
 
         return local_solvers
 
-    @timed_function("SCPCUpdate")
+    @PETSc.Log.EventDecorator("SCPCUpdate")
     def update(self, pc):
         """Update by assembling into the KSP operator. No
         need to reconstruct symbolic objects.

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -27,10 +27,11 @@ from firedrake import solving_utils
 from firedrake import dmhooks
 import firedrake
 from firedrake.adjoint import annotate_solve
-
+from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType
 
 
+@PETSc.Log.EventDecorator()
 @annotate_solve
 def solve(*args, **kwargs):
     r"""Solve linear system Ax = b or variational problem a == L or F == 0.

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -174,6 +174,7 @@ class _SNESContext(object):
     get the context (which is one of these objects) to find the
     Firedrake level information.
     """
+    @PETSc.Log.EventDecorator()
     def __init__(self, problem, mat_type, pmat_type, appctx=None,
                  pre_jacobian_callback=None, pre_function_callback=None,
                  post_jacobian_callback=None, post_function_callback=None,
@@ -315,6 +316,7 @@ class _SNESContext(object):
         if ises is not None:
             nullspace._apply(ises, transpose=transpose, near=near)
 
+    @PETSc.Log.EventDecorator()
     def split(self, fields):
         from firedrake import replace, as_vector, split
         from firedrake import NonlinearVariationalProblem as NLVP

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -56,6 +56,7 @@ class BlockMatrix(object):
             y.array[start::stride] = yi.array_r
 
 
+@PETSc.Log.EventDecorator()
 def assemble_mixed_mass_matrix(V_A, V_B):
     """
     Construct the mixed mass matrix of two function spaces,

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -26,8 +26,8 @@ from pyop2.op2 import Kernel
 from pyop2.mpi import COMM_WORLD, MPI
 
 from firedrake.formmanipulation import split_form
-
 from firedrake.parameters import parameters as default_parameters
+from firedrake.petsc import PETSc
 from firedrake import utils
 
 # Set TSFC default scalar type at load time
@@ -157,6 +157,7 @@ SplitKernel = collections.namedtuple("SplitKernel", ["indices",
                                                      "kinfo"])
 
 
+@PETSc.Log.EventDecorator()
 def compile_form(form, name, parameters=None, split=True, interface=None, coffee=False, diagonal=False):
     """Compile a form using TSFC.
 

--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -6,6 +6,7 @@ from ufl.algorithms import extract_arguments, extract_coefficients
 
 import firedrake
 from firedrake import utils
+from firedrake.petsc import PETSc
 
 
 __all__ = ['Argument', 'TestFunction', 'TrialFunction',
@@ -70,6 +71,7 @@ class Argument(ufl.argument.Argument):
         return Argument(function_space, number, part=part)
 
 
+@PETSc.Log.EventDecorator()
 def TestFunction(function_space, part=None):
     """Build a test function on the specified function space.
 
@@ -79,6 +81,7 @@ def TestFunction(function_space, part=None):
     return Argument(function_space, 0, part=part)
 
 
+@PETSc.Log.EventDecorator()
 def TrialFunction(function_space, part=None):
     """Build a trial function on the specified function space.
 
@@ -114,6 +117,7 @@ def TrialFunctions(function_space):
     return split(TrialFunction(function_space))
 
 
+@PETSc.Log.EventDecorator()
 def derivative(form, u, du=None, coefficient_derivatives=None):
     """Compute the derivative of a form.
 
@@ -188,6 +192,7 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
     return ufl.derivative(form, u, du, coefficient_derivatives)
 
 
+@PETSc.Log.EventDecorator()
 def action(form, coefficient):
     """Compute the action of a form on a coefficient.
 
@@ -203,6 +208,7 @@ def action(form, coefficient):
         return ufl.action(form, coefficient)
 
 
+@PETSc.Log.EventDecorator()
 def adjoint(form, reordered_arguments=None):
     """Compute the adjoint of a form.
 
@@ -242,6 +248,7 @@ def adjoint(form, reordered_arguments=None):
         return ufl.adjoint(form, reordered_arguments)
 
 
+@PETSc.Log.EventDecorator()
 def CellSize(mesh):
     """A symbolic representation of the cell size of a mesh.
 
@@ -251,6 +258,7 @@ def CellSize(mesh):
     return 2.0 * ufl.Circumradius(mesh)
 
 
+@PETSc.Log.EventDecorator()
 def FacetNormal(mesh):
     """A symbolic representation of the facet normal on a cell in a mesh.
 

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -11,6 +11,7 @@ from firedrake.cython import dmcommon
 from firedrake import mesh
 from firedrake import function
 from firedrake import functionspace
+from firedrake.petsc import PETSc
 
 from pyadjoint.tape import no_annotations
 
@@ -31,6 +32,7 @@ __all__ = ['IntervalMesh', 'UnitIntervalMesh',
            'TorusMesh', 'CylinderMesh']
 
 
+@PETSc.Log.EventDecorator()
 def IntervalMesh(ncells, length_or_left, right=None, distribution_parameters=None, comm=COMM_WORLD):
     """
     Generate a uniform mesh of an interval.
@@ -79,6 +81,7 @@ def IntervalMesh(ncells, length_or_left, right=None, distribution_parameters=Non
     return mesh.Mesh(plex, reorder=False, distribution_parameters=distribution_parameters)
 
 
+@PETSc.Log.EventDecorator()
 def UnitIntervalMesh(ncells, distribution_parameters=None, comm=COMM_WORLD):
     """
     Generate a uniform mesh of the interval [0,1].
@@ -94,6 +97,7 @@ def UnitIntervalMesh(ncells, distribution_parameters=None, comm=COMM_WORLD):
     return IntervalMesh(ncells, length_or_left=1.0, distribution_parameters=distribution_parameters, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicIntervalMesh(ncells, length, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a periodic mesh of an interval.
 
@@ -143,6 +147,7 @@ cells are not currently supported")
     return mesh.Mesh(new_coordinates)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicUnitIntervalMesh(ncells, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a periodic mesh of the unit interval
 
@@ -153,6 +158,7 @@ def PeriodicUnitIntervalMesh(ncells, distribution_parameters=None, comm=COMM_WOR
     return PeriodicIntervalMesh(ncells, length=1.0, distribution_parameters=distribution_parameters, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def OneElementThickMesh(ncells, Lx, Ly, distribution_parameters=None, comm=COMM_WORLD):
     """
     Generate a rectangular mesh in the domain with corners [0,0]
@@ -310,6 +316,7 @@ def OneElementThickMesh(ncells, Lx, Ly, distribution_parameters=None, comm=COMM_
     return mash
 
 
+@PETSc.Log.EventDecorator()
 def UnitTriangleMesh(comm=COMM_WORLD):
     """Generate a mesh of the reference triangle
 
@@ -322,6 +329,7 @@ def UnitTriangleMesh(comm=COMM_WORLD):
     return mesh.Mesh(plex, reorder=False)
 
 
+@PETSc.Log.EventDecorator()
 def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None,
                   diagonal="left", distribution_parameters=None, comm=COMM_WORLD):
     """Generate a rectangular mesh
@@ -414,6 +422,7 @@ def RectangleMesh(nx, ny, Lx, Ly, quadrilateral=False, reorder=None,
     return mesh.Mesh(plex, reorder=reorder, distribution_parameters=distribution_parameters)
 
 
+@PETSc.Log.EventDecorator()
 def SquareMesh(nx, ny, L, reorder=None, quadrilateral=False, diagonal="left", distribution_parameters=None, comm=COMM_WORLD):
     """Generate a square mesh
 
@@ -439,6 +448,7 @@ def SquareMesh(nx, ny, L, reorder=None, quadrilateral=False, diagonal="left", di
                          comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def UnitSquareMesh(nx, ny, reorder=None, diagonal="left", quadrilateral=False, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a unit square mesh
 
@@ -463,6 +473,7 @@ def UnitSquareMesh(nx, ny, reorder=None, diagonal="left", quadrilateral=False, d
                       comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicRectangleMesh(nx, ny, Lx, Ly, direction="both",
                           quadrilateral=False, reorder=None,
                           distribution_parameters=None,
@@ -561,6 +572,7 @@ cells in each direction are not currently supported")
     return mesh.Mesh(new_coordinates)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicSquareMesh(nx, ny, L, direction="both", quadrilateral=False, reorder=None,
                        distribution_parameters=None, diagonal=None, comm=COMM_WORLD):
     """Generate a periodic square mesh
@@ -593,6 +605,7 @@ def PeriodicSquareMesh(nx, ny, L, direction="both", quadrilateral=False, reorder
                                  diagonal=diagonal, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicUnitSquareMesh(nx, ny, direction="both", reorder=None,
                            quadrilateral=False, distribution_parameters=None,
                            diagonal=None, comm=COMM_WORLD):
@@ -625,6 +638,7 @@ def PeriodicUnitSquareMesh(nx, ny, direction="both", reorder=None,
                               diagonal=diagonal, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def CircleManifoldMesh(ncells, radius=1, distribution_parameters=None, comm=COMM_WORLD):
     """Generated a 1D mesh of the circle, immersed in 2D.
 
@@ -650,6 +664,7 @@ def CircleManifoldMesh(ncells, radius=1, distribution_parameters=None, comm=COMM
     return m
 
 
+@PETSc.Log.EventDecorator()
 def UnitDiskMesh(refinement_level=0, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a mesh of the unit disk in 2D
 
@@ -701,6 +716,7 @@ def UnitDiskMesh(refinement_level=0, reorder=None, distribution_parameters=None,
     return m
 
 
+@PETSc.Log.EventDecorator()
 def UnitTetrahedronMesh(comm=COMM_WORLD):
     """Generate a mesh of the reference tetrahedron.
 
@@ -713,6 +729,7 @@ def UnitTetrahedronMesh(comm=COMM_WORLD):
     return mesh.Mesh(plex, reorder=False)
 
 
+@PETSc.Log.EventDecorator()
 def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, distribution_parameters=None, diagonal="default", comm=COMM_WORLD):
     """Generate a mesh of a 3D box.
 
@@ -819,6 +836,7 @@ def BoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, distribution_parameters=None, 
     return mesh.Mesh(plex, reorder=reorder, distribution_parameters=distribution_parameters)
 
 
+@PETSc.Log.EventDecorator()
 def CubeMesh(nx, ny, nz, L, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a mesh of a cube
 
@@ -843,6 +861,7 @@ def CubeMesh(nx, ny, nz, L, reorder=None, distribution_parameters=None, comm=COM
                    comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def UnitCubeMesh(nx, ny, nz, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a mesh of a unit cube
 
@@ -866,6 +885,7 @@ def UnitCubeMesh(nx, ny, nz, reorder=None, distribution_parameters=None, comm=CO
                     comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicBoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a periodic mesh of a 3D box.
 
@@ -961,6 +981,7 @@ def PeriodicBoxMesh(nx, ny, nz, Lx, Ly, Lz, reorder=None, distribution_parameter
     return m1
 
 
+@PETSc.Log.EventDecorator()
 def PeriodicUnitCubeMesh(nx, ny, nz, reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate a periodic mesh of a unit cube
 
@@ -974,6 +995,7 @@ def PeriodicUnitCubeMesh(nx, ny, nz, reorder=None, distribution_parameters=None,
     return PeriodicBoxMesh(nx, ny, nz, 1., 1., 1., reorder=reorder, distribution_parameters=distribution_parameters, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
                           distribution_parameters=None, comm=COMM_WORLD):
     """Generate an icosahedral approximation to the surface of the
@@ -1057,6 +1079,7 @@ def IcosahedralSphereMesh(radius, refinement_level=0, degree=1, reorder=None,
     return m
 
 
+@PETSc.Log.EventDecorator()
 def UnitIcosahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
                               distribution_parameters=None, comm=COMM_WORLD):
     """Generate an icosahedral approximation to the unit sphere.
@@ -1075,6 +1098,7 @@ def UnitIcosahedralSphereMesh(refinement_level=0, degree=1, reorder=None,
 
 # mesh is mainly used as a utility, so it's unnecessary to annotate the construction
 # in this case.
+@PETSc.Log.EventDecorator()
 @no_annotations
 def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
                          hemisphere="both",
@@ -1189,6 +1213,7 @@ def OctahedralSphereMesh(radius, refinement_level=0, degree=1,
     return m
 
 
+@PETSc.Log.EventDecorator()
 def UnitOctahedralSphereMesh(refinement_level=0, degree=1,
                              hemisphere="both", z0=0.8, reorder=None,
                              distribution_parameters=None, comm=COMM_WORLD):
@@ -1341,6 +1366,7 @@ def _cubedsphere_cells_and_coords(radius, refinement_level):
     return cells, coords
 
 
+@PETSc.Log.EventDecorator()
 def CubedSphereMesh(radius, refinement_level=0, degree=1,
                     reorder=None, distribution_parameters=None, comm=COMM_WORLD):
     """Generate an cubed approximation to the surface of the
@@ -1375,6 +1401,7 @@ def CubedSphereMesh(radius, refinement_level=0, degree=1,
     return m
 
 
+@PETSc.Log.EventDecorator()
 def UnitCubedSphereMesh(refinement_level=0, degree=1, reorder=None,
                         distribution_parameters=None, comm=COMM_WORLD):
     """Generate a cubed approximation to the unit sphere.
@@ -1390,6 +1417,7 @@ def UnitCubedSphereMesh(refinement_level=0, degree=1, reorder=None,
                            degree=degree, reorder=reorder, comm=comm)
 
 
+@PETSc.Log.EventDecorator()
 def TorusMesh(nR, nr, R, r, quadrilateral=False, reorder=None,
               distribution_parameters=None, comm=COMM_WORLD):
     """Generate a toroidal mesh
@@ -1435,6 +1463,7 @@ def TorusMesh(nR, nr, R, r, quadrilateral=False, reorder=None,
     return m
 
 
+@PETSc.Log.EventDecorator()
 def CylinderMesh(nr, nl, radius=1, depth=1, longitudinal_direction="z",
                  quadrilateral=False, reorder=None,
                  distribution_parameters=None, diagonal=None, comm=COMM_WORLD):
@@ -1564,6 +1593,7 @@ def CylinderMesh(nr, nl, radius=1, depth=1, longitudinal_direction="z",
     return m
 
 
+@PETSc.Log.EventDecorator()
 def PartiallyPeriodicRectangleMesh(nx, ny, Lx, Ly, direction="x", quadrilateral=False,
                                    reorder=None, distribution_parameters=None, diagonal=None, comm=COMM_WORLD):
     """Generates RectangleMesh that is periodic in the x or y direction.

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -42,6 +42,7 @@ def is_form_consistent(is_linear, bcs):
 class NonlinearVariationalProblem(NonlinearVariationalProblemMixin):
     r"""Nonlinear variational problem F(u; v) = 0."""
 
+    @PETSc.Log.EventDecorator()
     @NonlinearVariationalProblemMixin._ad_annotate_init
     def __init__(self, F, u, bcs=None, J=None,
                  Jp=None,
@@ -104,6 +105,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
     DEFAULT_KSP_PARAMETERS = solving_utils.DEFAULT_KSP_PARAMETERS.copy()
     DEFAULT_KSP_PARAMETERS["ksp_rtol"] = 1e-5
 
+    @PETSc.Log.EventDecorator()
     @NonlinearVariationalSolverMixin._ad_annotate_init
     def __init__(self, problem, *, solver_parameters=None,
                  options_prefix=None,
@@ -237,6 +239,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         """
         self._ctx.transfer_manager = manager
 
+    @PETSc.Log.EventDecorator()
     @NonlinearVariationalSolverMixin._ad_annotate_solve
     def solve(self, bounds=None):
         r"""Solve the variational problem.
@@ -281,6 +284,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 class LinearVariationalProblem(NonlinearVariationalProblem):
     r"""Linear variational problem a(u, v) = L(v)."""
 
+    @PETSc.Log.EventDecorator()
     def __init__(self, a, L, u, bcs=None, aP=None,
                  form_compiler_parameters=None,
                  constant_jacobian=False):


### PR DESCRIPTION
I've added `@PETSc.Log.EventDecorator()` decorators to lots of functions. The idea here is to combine this with the flame graph output that PETSc now supports so we can get some nice, low effort profiling information for Firedrake users.

I've been somewhat arbitrary with the functions that I've labelled. What I intend to do is run all of the demos and look for any big gaps as this will indicate a section where we need extra annotations.

~But. Before any of this gets merged I've identified some [major bugs](https://gitlab.com/petsc/petsc/-/merge_requests/3937) in the flame graph stuff I did in PETSc that should really get fixed beforehand.~
Edit: This is now fixed.

This should ideally get merged with https://github.com/OP2/PyOP2/pull/623.