### PR TITLE
Sharing DM means sharing residual function.

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -250,6 +250,10 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
            If bounds are provided the ``snes_type`` must be set to
            ``vinewtonssls`` or ``vinewtonrsls``.
         """
+        # Make sure the DM has this solver's callback functions
+        self._ctx.set_function(self.snes)
+        self._ctx.set_jacobian(self.snes)
+           
         # Make sure appcontext is attached to the DM before we solve.
         dm = self.snes.getDM()
         for dbc in self._problem.dirichlet_bcs():

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -253,7 +253,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         # Make sure the DM has this solver's callback functions
         self._ctx.set_function(self.snes)
         self._ctx.set_jacobian(self.snes)
-           
+
         # Make sure appcontext is attached to the DM before we solve.
         dm = self.snes.getDM()
         for dbc in self._problem.dirichlet_bcs():


### PR DESCRIPTION
The `DM` is shared between all solvers and so is its `DMSNES` object. This means that the residual function `DMSNESSetFunction` is also shared between all solvers. For the case of several `NonlinearVariationalSolver` it is not a problem because the only difference between solvers is encapsulated in the context `appctx`. It is a problem when using a `TS` that also shares the same `DM`, as it will steal the `DMSNESSetFunction` and set up its own. When an independent and previously setup `NonlinearVariationalSolver` wants to solve again, it finds that its residual function is no longer there, but `TS`'s is.

Let me know if it is a good idea to include a test to show the issue. It might be a bit long because of the `TS`.