### PR TITLE
Deprecate create_assembly_callable

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -174,8 +174,6 @@ def allocate_matrix(expr, bcs=(), form_compiler_parameters=None,
                     options_prefix=None):
     r"""Allocate a matrix given an expression.
 
-    To be used with :func:`create_assembly_callable`.
-
     .. warning::
 
        Do not use this function unless you know what you're doing.
@@ -197,6 +195,10 @@ def create_assembly_callable(expr, tensor=None, bcs=None, form_compiler_paramete
     This is really only designed to be used inside residual and
     jacobian callbacks, since it always assembles back into the
     initially provided tensor.  See also :func:`allocate_matrix`.
+
+    .. warning::
+
+        This function is now deprecated.
 
     .. warning::
 

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -202,6 +202,12 @@ def create_assembly_callable(expr, tensor=None, bcs=None, form_compiler_paramete
 
        Really do not use this function unless you know what you're doing.
     """
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn("create_assembly_callable is now deprecated. Please use assemble instead.",
+                      DeprecationWarning)
+
     if tensor is None:
         raise ValueError("Have to provide tensor to write to")
     return functools.partial(assemble, expr,

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -206,7 +206,7 @@ def create_assembly_callable(expr, tensor=None, bcs=None, form_compiler_paramete
     """
     import warnings
     with warnings.catch_warnings():
-        warnings.simplefilter("always", DeprecationWarning)
+        warnings.simplefilter("once", DeprecationWarning)
         warnings.warn("create_assembly_callable is now deprecated. Please use assemble instead.",
                       DeprecationWarning)
 

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -110,12 +110,12 @@ class LinearSolver(OptionsManager):
 
     @cached_property
     def _rhs(self):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
 
         u = function.Function(self.trial_space)
         b = function.Function(self.test_space)
         expr = -action(self.A.a, u)
-        return u, functools.partial(assemble, expr, tensor=b), b
+        return u, functools.partial(assemble, expr, tensor=b, assembly_type="residual"), b
 
     def _lifted(self, b):
         u, update, blift = self._rhs

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -1,3 +1,5 @@
+import functools
+
 from firedrake.exceptions import ConvergenceError
 import firedrake.function as function
 import firedrake.vector as vector
@@ -108,11 +110,12 @@ class LinearSolver(OptionsManager):
 
     @cached_property
     def _rhs(self):
-        from firedrake.assemble import create_assembly_callable
+        from firedrake import assemble
+
         u = function.Function(self.trial_space)
         b = function.Function(self.test_space)
         expr = -action(self.A.a, u)
-        return u, create_assembly_callable(expr, tensor=b), b
+        return u, functools.partial(assemble, expr, tensor=b), b
 
     def _lifted(self, b):
         u, update, blift = self._rhs

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -85,7 +85,7 @@ class ImplicitMatrixContext(object):
     """
     def __init__(self, a, row_bcs=[], col_bcs=[],
                  fc_params=None, appctx=None):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
 
         self.a = a
         self.aT = adjoint(a)
@@ -141,7 +141,8 @@ class ImplicitMatrixContext(object):
                                                   self.action,
                                                   tensor=self._y,
                                                   bcs=self.bcs_action,
-                                                  form_compiler_parameters=self.fc_params)
+                                                  form_compiler_parameters=self.fc_params,
+                                                  assembly_type="residual")
 
         # For assembling action(adjoint(f), self._y)
         # Sorted list of equation bcs
@@ -159,14 +160,16 @@ class ImplicitMatrixContext(object):
                                       action(adjoint(ebc.f), self._y),
                                       tensor=self._xbc,
                                       bcs=None,
-                                      form_compiler_parameters=self.fc_params))
+                                      form_compiler_parameters=self.fc_params,
+                                      assembly_type="residual"))
         # Domain last
         self._assemble_actionT.append(
             functools.partial(assemble,
                               self.actionT,
                               tensor=self._x if len(self.bcs) == 0 else self._xbc,
                               bcs=None,
-                              form_compiler_parameters=self.fc_params))
+                              form_compiler_parameters=self.fc_params,
+                              assembly_type="residual"))
 
     @cached_property
     def _diagonal(self):
@@ -176,12 +179,13 @@ class ImplicitMatrixContext(object):
 
     @cached_property
     def _assemble_diagonal(self):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
         return functools.partial(assemble,
                                  self.a,
                                  tensor=self._diagonal,
                                  form_compiler_parameters=self.fc_params,
-                                 diagonal=True)
+                                 diagonal=True,
+                                 assembly_type="residual")
 
     def getDiagonal(self, mat, vec):
         self._assemble_diagonal()

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -1,11 +1,13 @@
 from collections import OrderedDict
+import functools
+import itertools
+
 from mpi4py import MPI
 import numpy
-import itertools
+
 from firedrake.ufl_expr import adjoint, action
 from firedrake.formmanipulation import ExtractSubBlock
 from firedrake.bcs import DirichletBC, EquationBCSplit
-
 from firedrake.petsc import PETSc
 from firedrake.utils import cached_property
 
@@ -83,6 +85,8 @@ class ImplicitMatrixContext(object):
     """
     def __init__(self, a, row_bcs=[], col_bcs=[],
                  fc_params=None, appctx=None):
+        from firedrake import assemble
+
         self.a = a
         self.aT = adjoint(a)
         self.fc_params = fc_params
@@ -125,8 +129,6 @@ class ImplicitMatrixContext(object):
         self.action = action(self.a, self._x)
         self.actionT = action(self.aT, self._y)
 
-        from firedrake.assemble import create_assembly_callable
-
         # For assembling action(f, self._x)
         self.bcs_action = []
         for bc in self.bcs:
@@ -135,8 +137,11 @@ class ImplicitMatrixContext(object):
             elif isinstance(bc, EquationBCSplit):
                 self.bcs_action.append(bc.reconstruct(action_x=self._x))
 
-        self._assemble_action = create_assembly_callable(self.action, tensor=self._y, bcs=self.bcs_action,
-                                                         form_compiler_parameters=self.fc_params)
+        self._assemble_action = functools.partial(assemble,
+                                                  self.action,
+                                                  tensor=self._y,
+                                                  bcs=self.bcs_action,
+                                                  form_compiler_parameters=self.fc_params)
 
         # For assembling action(adjoint(f), self._y)
         # Sorted list of equation bcs
@@ -149,15 +154,19 @@ class ImplicitMatrixContext(object):
         # Deepest EquationBCs first
         for bc in self.bcs:
             for ebc in bc.sorted_equation_bcs():
-                self._assemble_actionT.append(create_assembly_callable(action(adjoint(ebc.f), self._y),
-                                              tensor=self._xbc,
-                                              bcs=None,
-                                              form_compiler_parameters=self.fc_params))
+                self._assemble_actionT.append(
+                    functools.partial(assemble,
+                                      action(adjoint(ebc.f), self._y),
+                                      tensor=self._xbc,
+                                      bcs=None,
+                                      form_compiler_parameters=self.fc_params))
         # Domain last
-        self._assemble_actionT.append(create_assembly_callable(self.actionT,
-                                                               tensor=self._x if len(self.bcs) == 0 else self._xbc,
-                                                               bcs=None,
-                                                               form_compiler_parameters=self.fc_params))
+        self._assemble_actionT.append(
+            functools.partial(assemble,
+                              self.actionT,
+                              tensor=self._x if len(self.bcs) == 0 else self._xbc,
+                              bcs=None,
+                              form_compiler_parameters=self.fc_params))
 
     @cached_property
     def _diagonal(self):
@@ -167,11 +176,12 @@ class ImplicitMatrixContext(object):
 
     @cached_property
     def _assemble_diagonal(self):
-        from firedrake.assemble import create_assembly_callable
-        return create_assembly_callable(self.a,
-                                        tensor=self._diagonal,
-                                        form_compiler_parameters=self.fc_params,
-                                        diagonal=True)
+        from firedrake import assemble
+        return functools.partial(assemble,
+                                 self.a,
+                                 tensor=self._diagonal,
+                                 form_compiler_parameters=self.fc_params,
+                                 diagonal=True)
 
     def getDiagonal(self, mat, vec):
         self._assemble_diagonal()

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 
 from firedrake.preconditioners.base import PCBase
 from firedrake.functionspace import FunctionSpace, MixedFunctionSpace
@@ -20,7 +21,7 @@ class AssembledPC(PCBase):
     _prefix = "assembled_"
 
     def initialize(self, pc):
-        from firedrake.assemble import allocate_matrix, create_assembly_callable
+        from firedrake.assemble import allocate_matrix, assemble
         _, P = pc.getOperators()
 
         if pc.getType() != "python":
@@ -55,10 +56,12 @@ class AssembledPC(PCBase):
                                  form_compiler_parameters=fcp,
                                  mat_type=mat_type,
                                  options_prefix=options_prefix)
-        self._assemble_P = create_assembly_callable(a, tensor=self.P,
-                                                    bcs=bcs,
-                                                    form_compiler_parameters=fcp,
-                                                    mat_type=mat_type)
+        self._assemble_P = functools.partial(assemble,
+                                             a,
+                                             tensor=self.P,
+                                             bcs=bcs,
+                                             form_compiler_parameters=fcp,
+                                             mat_type=mat_type)
         self._assemble_P()
 
         # Transfer nullspace over

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -61,7 +61,8 @@ class AssembledPC(PCBase):
                                              tensor=self.P,
                                              bcs=bcs,
                                              form_compiler_parameters=fcp,
-                                             mat_type=mat_type)
+                                             mat_type=mat_type,
+                                             assembly_type="residual")
         self._assemble_P()
 
         # Transfer nullspace over

--- a/firedrake/preconditioners/gtmg.py
+++ b/firedrake/preconditioners/gtmg.py
@@ -1,3 +1,5 @@
+import functools
+
 from firedrake.petsc import PETSc
 from firedrake.preconditioners.base import PCBase
 import firedrake.dmhooks as dmhooks
@@ -14,7 +16,7 @@ class GTMGPC(PCBase):
     def initialize(self, pc):
 
         from firedrake import TestFunction, parameters
-        from firedrake.assemble import allocate_matrix, create_assembly_callable
+        from firedrake.assemble import allocate_matrix, assemble
         from firedrake.interpolation import Interpolator
         from firedrake.solving_utils import _SNESContext
         from firedrake.matrix_free.operators import ImplicitMatrixContext
@@ -56,11 +58,12 @@ class GTMGPC(PCBase):
                                            form_compiler_parameters=fcp,
                                            mat_type=fine_mat_type,
                                            options_prefix=options_prefix)
-            self._assemble_fine_op = create_assembly_callable(fine_operator,
-                                                              tensor=self.fine_op,
-                                                              bcs=fine_bcs,
-                                                              form_compiler_parameters=fcp,
-                                                              mat_type=fine_mat_type)
+            self._assemble_fine_op = functools.partial(assemble,
+                                                       fine_operator,
+                                                       tensor=self.fine_op,
+                                                       bcs=fine_bcs,
+                                                       form_compiler_parameters=fcp,
+                                                       mat_type=fine_mat_type)
             self._assemble_fine_op()
             fine_petscmat = self.fine_op.petscmat
         else:
@@ -98,10 +101,11 @@ class GTMGPC(PCBase):
                                          form_compiler_parameters=fcp,
                                          mat_type=coarse_mat_type,
                                          options_prefix=coarse_options_prefix)
-        self._assemble_coarse_op = create_assembly_callable(coarse_operator,
-                                                            tensor=self.coarse_op,
-                                                            bcs=coarse_space_bcs,
-                                                            form_compiler_parameters=fcp)
+        self._assemble_coarse_op = functools.partial(assemble,
+                                                     coarse_operator,
+                                                     tensor=self.coarse_op,
+                                                     bcs=coarse_space_bcs,
+                                                     form_compiler_parameters=fcp)
         self._assemble_coarse_op()
         coarse_opmat = self.coarse_op.petscmat
 

--- a/firedrake/preconditioners/gtmg.py
+++ b/firedrake/preconditioners/gtmg.py
@@ -15,8 +15,8 @@ class GTMGPC(PCBase):
 
     def initialize(self, pc):
 
-        from firedrake import TestFunction, parameters
-        from firedrake.assemble import allocate_matrix, assemble
+        from firedrake import TestFunction, assemble, parameters
+        from firedrake.assemble import allocate_matrix
         from firedrake.interpolation import Interpolator
         from firedrake.solving_utils import _SNESContext
         from firedrake.matrix_free.operators import ImplicitMatrixContext
@@ -63,7 +63,8 @@ class GTMGPC(PCBase):
                                                        tensor=self.fine_op,
                                                        bcs=fine_bcs,
                                                        form_compiler_parameters=fcp,
-                                                       mat_type=fine_mat_type)
+                                                       mat_type=fine_mat_type,
+                                                       assembly_type="residual")
             self._assemble_fine_op()
             fine_petscmat = self.fine_op.petscmat
         else:
@@ -105,7 +106,8 @@ class GTMGPC(PCBase):
                                                      coarse_operator,
                                                      tensor=self.coarse_op,
                                                      bcs=coarse_space_bcs,
-                                                     form_compiler_parameters=fcp)
+                                                     form_compiler_parameters=fcp,
+                                                     assembly_type="residual")
         self._assemble_coarse_op()
         coarse_opmat = self.coarse_op.petscmat
 

--- a/firedrake/preconditioners/pcd.py
+++ b/firedrake/preconditioners/pcd.py
@@ -1,3 +1,5 @@
+import functools
+
 from firedrake.preconditioners.base import PCBase
 from firedrake.petsc import PETSc
 
@@ -41,7 +43,7 @@ class PCDPC(PCBase):
     def initialize(self, pc):
         from firedrake import TrialFunction, TestFunction, dx, \
             assemble, inner, grad, split, Constant, parameters
-        from firedrake.assemble import allocate_matrix, create_assembly_callable
+        from firedrake.assemble import allocate_matrix
         if pc.getType() != "python":
             raise ValueError("Expecting PC type python")
         prefix = pc.getOptionsPrefix() + "pcd_"
@@ -113,9 +115,11 @@ class PCDPC(PCBase):
         self.Fp = allocate_matrix(fp, form_compiler_parameters=context.fc_params,
                                   mat_type=self.Fp_mat_type,
                                   options_prefix=prefix + "Fp_")
-        self._assemble_Fp = create_assembly_callable(fp, tensor=self.Fp,
-                                                     form_compiler_parameters=context.fc_params,
-                                                     mat_type=self.Fp_mat_type)
+        self._assemble_Fp = functools.partial(assemble,
+                                              fp,
+                                              tensor=self.Fp,
+                                              form_compiler_parameters=context.fc_params,
+                                              mat_type=self.Fp_mat_type)
         self._assemble_Fp()
         Fpmat = self.Fp.petscmat
         self.workspace = [Fpmat.createVecLeft() for i in (0, 1)]

--- a/firedrake/preconditioners/pcd.py
+++ b/firedrake/preconditioners/pcd.py
@@ -119,7 +119,8 @@ class PCDPC(PCBase):
                                               fp,
                                               tensor=self.Fp,
                                               form_compiler_parameters=context.fc_params,
-                                              mat_type=self.Fp_mat_type)
+                                              mat_type=self.Fp_mat_type,
+                                              assembly_type="residual")
         self._assemble_Fp()
         Fpmat = self.Fp.petscmat
         self.workspace = [Fpmat.createVecLeft() for i in (0, 1)]

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 import ufl
 
 import firedrake
@@ -186,9 +187,9 @@ class BasicProjector(ProjectorBase):
 
     @cached_property
     def assembler(self):
-        from firedrake.assemble import create_assembly_callable
-        return create_assembly_callable(self.rhs_form, tensor=self.residual,
-                                        form_compiler_parameters=self.form_compiler_parameters)
+        from firedrake import assemble
+        return functools.partial(assemble, self.rhs_form, tensor=self.residual,
+                                 form_compiler_parameters=self.form_compiler_parameters)
 
     @property
     def rhs(self):

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -187,9 +187,12 @@ class BasicProjector(ProjectorBase):
 
     @cached_property
     def assembler(self):
-        from firedrake import assemble
-        return functools.partial(assemble, self.rhs_form, tensor=self.residual,
-                                 form_compiler_parameters=self.form_compiler_parameters)
+        from firedrake.assemble import assemble
+        return functools.partial(assemble,
+                                 self.rhs_form,
+                                 tensor=self.residual,
+                                 form_compiler_parameters=self.form_compiler_parameters,
+                                 assembly_type="residual")
 
     @property
     def rhs(self):

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -1,8 +1,10 @@
-import ufl
+import functools
 import numbers
-import numpy as np
-import firedrake.dmhooks as dmhooks
 
+import numpy as np
+import ufl
+
+import firedrake.dmhooks as dmhooks
 from firedrake.slate.static_condensation.sc_base import SCBase
 from firedrake.matrix_free.operators import ImplicitMatrixContext
 from firedrake.petsc import PETSc
@@ -38,9 +40,8 @@ class HybridizationPC(SCBase):
         """
         from firedrake import (FunctionSpace, Function, Constant,
                                TrialFunction, TrialFunctions, TestFunction,
-                               DirichletBC)
-        from firedrake.assemble import (allocate_matrix,
-                                        create_assembly_callable)
+                               DirichletBC, assemble)
+        from firedrake.assemble import allocate_matrix
         from firedrake.formmanipulation import split_form
         from ufl.algorithms.replace import replace
 
@@ -201,7 +202,8 @@ class HybridizationPC(SCBase):
 
         # Assemble the Schur complement operator and right-hand side
         self.schur_rhs = Function(TraceSpace)
-        self._assemble_Srhs = create_assembly_callable(
+        self._assemble_Srhs = functools.partial(
+            assemble,
             K * Atilde.inv * AssembledVector(self.broken_residual),
             tensor=self.schur_rhs,
             form_compiler_parameters=self.ctx.fc_params)
@@ -214,11 +216,12 @@ class HybridizationPC(SCBase):
                                  mat_type=mat_type,
                                  options_prefix=prefix,
                                  appctx=self.get_appctx(pc))
-        self._assemble_S = create_assembly_callable(schur_comp,
-                                                    tensor=self.S,
-                                                    bcs=trace_bcs,
-                                                    form_compiler_parameters=self.ctx.fc_params,
-                                                    mat_type=mat_type)
+        self._assemble_S = functools.partial(assemble,
+                                             schur_comp,
+                                             tensor=self.S,
+                                             bcs=trace_bcs,
+                                             form_compiler_parameters=self.ctx.fc_params,
+                                             mat_type=mat_type)
 
         with timed_region("HybridOperatorAssembly"):
             self._assemble_S()
@@ -279,7 +282,7 @@ class HybridizationPC(SCBase):
         :arg split_trace_op: a ``dict`` of split forms that make up the trace
                              contribution in the hybridized mixed system.
         """
-        from firedrake.assemble import create_assembly_callable
+        from firedrake import assemble
 
         # We always eliminate the velocity block first
         id0, id1 = (self.vidx, self.pidx)
@@ -307,15 +310,17 @@ class HybridizationPC(SCBase):
         R = K_1.T - C * A.inv * K_0.T
         u_rec = M.solve(f - C * A.inv * g - R * lambdar,
                         decomposition="PartialPivLU")
-        self._sub_unknown = create_assembly_callable(u_rec,
-                                                     tensor=u,
-                                                     form_compiler_parameters=self.ctx.fc_params)
+        self._sub_unknown = functools.partial(assemble,
+                                              u_rec,
+                                              tensor=u,
+                                              form_compiler_parameters=self.ctx.fc_params)
 
         sigma_rec = A.solve(g - B * AssembledVector(u) - K_0.T * lambdar,
                             decomposition="PartialPivLU")
-        self._elim_unknown = create_assembly_callable(sigma_rec,
-                                                      tensor=sigma,
-                                                      form_compiler_parameters=self.ctx.fc_params)
+        self._elim_unknown = functools.partial(assemble,
+                                               sigma_rec,
+                                               tensor=sigma,
+                                               form_compiler_parameters=self.ctx.fc_params)
 
     @timed_function("HybridUpdate")
     def update(self, pc):

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -88,11 +88,11 @@ class SCPC(SCBase):
         r_expr = reduced_sys.rhs
 
         # Construct the condensed right-hand side
-        self._assemble_Srhs = functools.partial(
-            assemble,
-            r_expr,
-            tensor=self.condensed_rhs,
-            form_compiler_parameters=self.cxt.fc_params)
+        self._assemble_Srhs = functools.partial(assemble,
+                                                r_expr,
+                                                tensor=self.condensed_rhs,
+                                                form_compiler_parameters=self.cxt.fc_params,
+                                                assembly_type="residual")
 
         # Allocate and set the condensed operator
         self.S = allocate_matrix(S_expr,
@@ -102,13 +102,13 @@ class SCPC(SCBase):
                                  options_prefix=prefix,
                                  appctx=self.get_appctx(pc))
 
-        self._assemble_S = functools.partial(
-            assemble,
-            S_expr,
-            tensor=self.S,
-            bcs=bcs,
-            form_compiler_parameters=self.cxt.fc_params,
-            mat_type=mat_type)
+        self._assemble_S = functools.partial(assemble,
+                                             S_expr,
+                                             tensor=self.S,
+                                             bcs=bcs,
+                                             form_compiler_parameters=self.cxt.fc_params,
+                                             mat_type=mat_type,
+                                             assembly_type="residual")
 
         self._assemble_S()
         Smat = self.S.petscmat
@@ -132,13 +132,13 @@ class SCPC(SCBase):
                                         options_prefix=prefix,
                                         appctx=self.get_appctx(pc))
 
-            self._assemble_S_pc = functools.partial(
-                assemble,
-                S_pc_expr,
-                tensor=self.S_pc,
-                bcs=bcs,
-                form_compiler_parameters=self.cxt.fc_params,
-                mat_type=mat_type)
+            self._assemble_S_pc = functools.partial(assemble,
+                                                    S_pc_expr,
+                                                    tensor=self.S_pc,
+                                                    bcs=bcs,
+                                                    form_compiler_parameters=self.cxt.fc_params,
+                                                    mat_type=mat_type,
+                                                    assembly_type="residual")
 
             self._assemble_S_pc()
             Smat_pc = self.S_pc.petscmat
@@ -223,11 +223,11 @@ class SCPC(SCBase):
             be = local_system.rhs
             i, = local_system.field_idx
             local_solve = Ae.solve(be, decomposition="PartialPivLU")
-            solve_call = functools.partial(
-                assemble,
-                local_solve,
-                tensor=fields[i],
-                form_compiler_parameters=self.cxt.fc_params)
+            solve_call = functools.partial(assemble,
+                                           local_solve,
+                                           tensor=fields[i],
+                                           form_compiler_parameters=self.cxt.fc_params,
+                                           assembly_type="residual")
             local_solvers.append(solve_call)
 
         return local_solvers

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,6 +1,7 @@
-import numpy
-
+import functools
 from itertools import chain
+
+import numpy
 
 from pyop2 import op2
 from firedrake_configuration import get_config
@@ -178,7 +179,8 @@ class _SNESContext(object):
                  post_jacobian_callback=None, post_function_callback=None,
                  options_prefix=None,
                  transfer_manager=None):
-        from firedrake.assemble import create_assembly_callable
+        from firedrake import assemble
+
         if pmat_type is None:
             pmat_type = mat_type
         self.mat_type = mat_type
@@ -231,10 +233,10 @@ class _SNESContext(object):
         self.bcs_F = tuple(bc.extract_form('F') for bc in problem.bcs)
         self.bcs_J = tuple(bc.extract_form('J') for bc in problem.bcs)
         self.bcs_Jp = tuple(bc.extract_form('Jp') for bc in problem.bcs)
-        self._assemble_residual = create_assembly_callable(self.F,
-                                                           tensor=self._F,
-                                                           bcs=self.bcs_F,
-                                                           form_compiler_parameters=self.fcp)
+        self._assemble_residual = functools.partial(assemble, self.F,
+                                                    tensor=self._F,
+                                                    bcs=self.bcs_F,
+                                                    form_compiler_parameters=self.fcp)
 
         self._jacobian_assembled = False
         self._splits = {}
@@ -508,12 +510,13 @@ class _SNESContext(object):
 
     @cached_property
     def _assemble_jac(self):
-        from firedrake.assemble import create_assembly_callable
-        return create_assembly_callable(self.J,
-                                        tensor=self._jac,
-                                        bcs=self.bcs_J,
-                                        form_compiler_parameters=self.fcp,
-                                        mat_type=self.mat_type)
+        from firedrake import assemble
+        return functools.partial(assemble,
+                                 self.J,
+                                 tensor=self._jac,
+                                 bcs=self.bcs_J,
+                                 form_compiler_parameters=self.fcp,
+                                 mat_type=self.mat_type)
 
     @cached_property
     def is_mixed(self):
@@ -534,12 +537,13 @@ class _SNESContext(object):
 
     @cached_property
     def _assemble_pjac(self):
-        from firedrake.assemble import create_assembly_callable
-        return create_assembly_callable(self.Jp,
-                                        tensor=self._pjac,
-                                        bcs=self.bcs_Jp,
-                                        form_compiler_parameters=self.fcp,
-                                        mat_type=self.pmat_type)
+        from firedrake import assemble
+        return functools.partial(assemble,
+                                 self.Jp,
+                                 tensor=self._pjac,
+                                 bcs=self.bcs_Jp,
+                                 form_compiler_parameters=self.fcp,
+                                 mat_type=self.pmat_type)
 
     @cached_property
     def _F(self):

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -179,7 +179,7 @@ class _SNESContext(object):
                  post_jacobian_callback=None, post_function_callback=None,
                  options_prefix=None,
                  transfer_manager=None):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
 
         if pmat_type is None:
             pmat_type = mat_type
@@ -233,10 +233,13 @@ class _SNESContext(object):
         self.bcs_F = tuple(bc.extract_form('F') for bc in problem.bcs)
         self.bcs_J = tuple(bc.extract_form('J') for bc in problem.bcs)
         self.bcs_Jp = tuple(bc.extract_form('Jp') for bc in problem.bcs)
-        self._assemble_residual = functools.partial(assemble, self.F,
+
+        self._assemble_residual = functools.partial(assemble,
+                                                    self.F,
                                                     tensor=self._F,
                                                     bcs=self.bcs_F,
-                                                    form_compiler_parameters=self.fcp)
+                                                    form_compiler_parameters=self.fcp,
+                                                    assembly_type="residual")
 
         self._jacobian_assembled = False
         self._splits = {}
@@ -510,13 +513,14 @@ class _SNESContext(object):
 
     @cached_property
     def _assemble_jac(self):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
         return functools.partial(assemble,
                                  self.J,
                                  tensor=self._jac,
                                  bcs=self.bcs_J,
                                  form_compiler_parameters=self.fcp,
-                                 mat_type=self.mat_type)
+                                 mat_type=self.mat_type,
+                                 assembly_type="residual")
 
     @cached_property
     def is_mixed(self):
@@ -537,13 +541,14 @@ class _SNESContext(object):
 
     @cached_property
     def _assemble_pjac(self):
-        from firedrake import assemble
+        from firedrake.assemble import assemble
         return functools.partial(assemble,
                                  self.Jp,
                                  tensor=self._pjac,
                                  bcs=self.bcs_Jp,
                                  form_compiler_parameters=self.fcp,
-                                 mat_type=self.pmat_type)
+                                 mat_type=self.pmat_type,
+                                 assembly_type="residual")
 
     @cached_property
     def _F(self):


### PR DESCRIPTION
I've added a deprecation warning to `create_assembly_callable` and replaced all occurrences with `functools.partial(assemble, ...)`.