### PR TITLE
Various annotation fixes for Constant and Function

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -198,7 +198,10 @@ class FunctionSplitBlock(Block, Backend):
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx,
                                prepared=None):
         eval_adj = self.backend.Function(block_variable.output.function_space())
-        eval_adj.sub(self.idx).assign(adj_inputs[0].function)
+        if type(adj_inputs[0]) is self.backend.Function:
+            eval_adj.sub(self.idx).assign(adj_inputs[0])
+        else:
+            eval_adj.sub(self.idx).assign(adj_inputs[0].function)
         return eval_adj.vector()
 
     def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx,

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from pyadjoint.adjfloat import AdjFloat
 from pyadjoint.tape import get_working_tape, annotate_tape
 from pyadjoint.overloaded_type import OverloadedType, create_overloaded_object
 from pyadjoint.reduced_functional_numpy import gather
@@ -24,6 +25,11 @@ class ConstantMixin(OverloadedType):
                                     _ad_outputs=kwargs.pop("_ad_outputs", None),
                                     annotate=kwargs.pop("annotate", True), **kwargs)
             init(self, *args, **kwargs)
+
+            other = args[0]
+            if isinstance(other, int):
+                other = AdjFloat(other)
+            self.assign(other, annotate=annotate_tape(kwargs))
         return wrapper
 
     @staticmethod

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -83,7 +83,11 @@ class ConstantMixin(OverloadedType):
         return self._constant_from_values(self.values() + other.values())
 
     def _ad_dot(self, other, options=None):
-        return sum(self.values() * other.values())
+        from firedrake_adjoint import AdjFloat
+        if type(other) is AdjFloat:
+            return sum(self.values() * other)
+        else:
+            return sum(self.values() * other.values())
 
     @staticmethod
     def _ad_assign_numpy(dst, src, offset):

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -83,7 +83,6 @@ class ConstantMixin(OverloadedType):
         return self._constant_from_values(self.values() + other.values())
 
     def _ad_dot(self, other, options=None):
-        from firedrake_adjoint import AdjFloat
         if type(other) is AdjFloat:
             return sum(self.values() * other)
         else:

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -25,11 +25,6 @@ class ConstantMixin(OverloadedType):
                                     _ad_outputs=kwargs.pop("_ad_outputs", None),
                                     annotate=kwargs.pop("annotate", True), **kwargs)
             init(self, *args, **kwargs)
-
-            other = args[0]
-            if isinstance(other, int):
-                other = AdjFloat(other)
-            self.assign(other, annotate=annotate_tape(kwargs))
         return wrapper
 
     @staticmethod

--- a/firedrake/adjoint/constant.py
+++ b/firedrake/adjoint/constant.py
@@ -16,6 +16,7 @@ class ConstantMixin(OverloadedType):
     def _ad_annotate_init(init):
         @wraps(init)
         def wrapper(self, *args, **kwargs):
+            annotate = kwargs.pop("annotate", True)
             OverloadedType.__init__(self, *args,
                                     block_class=kwargs.pop("block_class", None),
                                     _ad_floating_active=kwargs.pop("_ad_floating_active", False),
@@ -23,8 +24,12 @@ class ConstantMixin(OverloadedType):
                                     output_block_class=kwargs.pop("output_block_class", None),
                                     _ad_output_args=kwargs.pop("_ad_output_args", None),
                                     _ad_outputs=kwargs.pop("_ad_outputs", None),
-                                    annotate=kwargs.pop("annotate", True), **kwargs)
+                                    annotate=annotate, **kwargs)
             init(self, *args, **kwargs)
+
+            other = args[0]
+            if isinstance(other, (type(self), AdjFloat)):
+                self.assign(other, annotate=annotate)
         return wrapper
 
     @staticmethod

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -276,6 +276,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         return self._data
 
     @PETSc.Log.EventDecorator()
+    @FunctionMixin._ad_annotate_copy
     def copy(self, deepcopy=False):
         r"""Return a copy of this Function.
 

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -655,9 +655,9 @@ def test_supermesh_project_hessian(vector):
 def test_init_constant():
     from firedrake_adjoint import ReducedFunctional, Control
     mesh = UnitSquareMesh(1, 1)
-    c1 = Constant(1.0, domain=mesh)
-    c2 = Constant(c1, domain=mesh)
-    J = assemble(c2*dx)
+    c1 = Constant(1.0)
+    c2 = Constant(c1)
+    J = assemble(c2*dx(domain=mesh))
     rf = ReducedFunctional(J, Control(c1))
     assert np.isclose(rf(-1.0), -1.0)
 

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -649,3 +649,27 @@ def test_supermesh_project_hessian(vector):
     assert isinstance(source.block_variable.hessian_value, Vector)
     Hm = source.block_variable.hessian_value.inner(h.vector())
     assert taylor_test(rf, source, h, dJdm=dJdm, Hm=Hm) > 2.9
+
+
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+def test_init_constant():
+    from firedrake_adjoint import ReducedFunctional, Control
+    mesh = UnitSquareMesh(1, 1)
+    c1 = Constant(1.0, domain=mesh)
+    c2 = Constant(c1, domain=mesh)
+    J = assemble(c2*dx)
+    rf = ReducedFunctional(J, Control(c1))
+    assert np.isclose(rf(-1.0), -1.0)
+
+
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+def test_copy_function():
+    from firedrake_adjoint import ReducedFunctional, Control
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+    one = Constant(1.0)
+    f = interpolate(one, V)
+    g = f.copy(deepcopy=True)
+    J = assemble(g*dx)
+    rf = ReducedFunctional(J, Control(f))
+    assert np.isclose(rf(interpolate(-one, V)), -J)


### PR DESCRIPTION
(Most of these fixes thanks to @mc4117 )

We noticed that the code
```
c1 = Constant(1.0)
c2 = Constant(c1)
```
doesn't write to tape, whereas
```
c1 = Constant(1.0)
c2 = Constant(0.0)
c2.assign(c1)
```
does. This is why there is an extra call to `assign` in the wrapper for `Constant.__init__`.

The wrapper for `Function.copy` exists but was unused.