### PR TITLE
Add FEMlium to firedrake apps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
               sh 'mkdir tmp'
               dir('tmp') {
                 timestamps {
-                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --no-package-manager || (cat firedrake-install.log && /bin/false)'
+                  sh '../scripts/firedrake-install $COMPLEX --tinyasm --disable-ssh --minimal-petsc --slepc --documentation-dependencies --install thetis --install gusto --install icepack --install irksome --install femlium --no-package-manager || (cat firedrake-install.log && /bin/false)'
                 }
               }
             }

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -9,4 +9,4 @@ USER firedrake
 WORKDIR /home/firedrake
 
 # Now install extra Firedrake components.
-RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --tinyasm --slepc --install thetis --install gusto --install icepack"
+RUN bash -c "source firedrake/bin/activate; firedrake-update --documentation-dependencies --tinyasm --slepc --install thetis --install gusto --install icepack --install irksome --install femlium"

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -35,6 +35,8 @@ firedrake_apps = {
                 "git+ssh://github.com/icepack/icepack.git#egg=icepack"),
     "irksome": ("""Implicit Runge-Kutta methods. https://github.com/firedrakeproject/Irksome/""",
                 "git+ssh://github.com/firedrakeproject/Irksome.git#egg=Irksome"),
+    "femlium": ("""Interactive visualization of finite element simulations on geographic maps with folium. https://femlium.github.io/""",
+                "git+ssh://github.com/FEMlium/FEMlium.git@main#egg=FEMlium"),
 }
 
 

--- a/tests/regression/test_import_applications.py
+++ b/tests/regression/test_import_applications.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack"])
+@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack", "femlium"])
 def app(request):
     return request.param
 


### PR DESCRIPTION
Hi,

@dham on slack suggested to add [FEMlium](https://femlium.github.io/) among the apps installable with `firedrake-install --install femlium`.

I have tested myself this change running `firedrake-install` on a `firedrakeproject/firedrake-env` docker image.

Do you want me to change `Jenkinsfile` and `tests/regression/test_import_applications.py` too, in a similar way to what was done in #1751?