### PR TITLE
Interpolation onto a Vertex Only Mesh

### DIFF
--- a/docs/notebooks/10-sum-factorisation.ipynb
+++ b/docs/notebooks/10-sum-factorisation.ipynb
@@ -219,7 +219,7 @@
     "    fiat_make_rule = FIAT.quadrature.GaussLobattoLegendreQuadratureLineRule\n",
     "    fiat_rule = fiat_make_rule(FIAT.ufc_simplex(1), degree + 1)\n",
     "    finat_ps = finat.point_set.GaussLobattoLegendrePointSet\n",
-    "    finat_qr = finat.quadrature.QuadratureRule\n",
+    "    finat_qr = finat.quadrature.make_quadrature\n",
     "    return finat_qr(finat_ps(fiat_rule.get_points()), fiat_rule.get_weights())\n",
     "\n",
     "def gauss_lobatto_legendre_cube_rule(dimension, degree):\n",

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2637,33 +2637,39 @@ def remove_ghosts_pic(PETSc.DM swarm, PETSc.DM plex):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def label_pic_parent_cell_nums(PETSc.DM swarm, parentmesh):
+def label_pic_parent_cell_info(PETSc.DM swarm, parentmesh):
     """
     For each PIC in the input swarm, label its `parentcellnum` field with
-    the relevant cell number from the `parentmesh` in which is it emersed.
-    The cell numbering is that given by the `parentmesh.locate_cell`
-    method.
+    the relevant cell number from the `parentmesh` in which is it emersed
+    and the `refcoord` field with the relevant cell reference coordinate.
+    This information is given by the
+    `parentmesh.locate_cell_and_reference_coordinate` method.
+
+    For a swarm with N PICs emersed in `parentmesh`
+    the `parentcellnum` field is N long and
+    the `refcoord` field is N*parentmesh.topological_dimension() long.
 
     :arg swarm: The DMSWARM which contains the PICs immersed in
         `parentmesh`
     :arg parentmesh: The mesh within with the `swarm` PICs are immersed.
 
     ..note:: All PICs must be within the parentmesh or this will try to
-             assign `None` (returned by `parentmesh.locate_cell`) to a
-             `PetscReal`.
+             assign `None` (returned by
+             `parentmesh.locate_cell_and_reference_coordinate`) to the
+             `parentcellnum` or `refcoord` fields.
+
+
     """
     cdef:
-        PetscInt num_vertices, i, dim, parent_cell_num
+        PetscInt num_vertices, i, gdim, tdim
+        PetscInt parent_cell_num
         np.ndarray[PetscReal, ndim=2, mode="c"] swarm_coords
         np.ndarray[PetscInt, ndim=1, mode="c"] parent_cell_nums
+        np.ndarray[PetscReal, ndim=2, mode="c"] reference_coords
+        np.ndarray[PetscReal, ndim=1, mode="c"] reference_coord
 
-    if type(swarm) is not PETSc.DMSwarm:
-        raise ValueError("swarm must be a DMSwarm")
-
-    if parentmesh.topology_dm.handle != swarm.getCellDM().handle:
-        raise ValueError("parentmesh.topology_dm is not the swarm's CellDM")
-
-    dim = parentmesh.geometric_dimension()
+    gdim = parentmesh.geometric_dimension()
+    tdim = parentmesh.topological_dimension()
 
     num_vertices = swarm.getLocalSize()
 
@@ -2673,21 +2679,33 @@ def label_pic_parent_cell_nums(PETSc.DM swarm, parentmesh):
     max_num_vertices = comm.allreduce(num_vertices, op=MPI.MAX)
 
     # Create an out of mesh point to use in locate_cell when needed
-    out_of_mesh_point = np.full((1, dim), np.inf)
+    out_of_mesh_point = np.full((1, gdim), np.inf)
 
     # get fields - NOTE this isn't copied so make sure
     # swarm.restoreField is called for each field too!
-    swarm_coords = swarm.getField("DMSwarmPIC_coor").reshape((num_vertices, dim))
+    swarm_coords = swarm.getField("DMSwarmPIC_coor").reshape((num_vertices, gdim))
     parent_cell_nums = swarm.getField("parentcellnum")
+    reference_coords = swarm.getField("refcoord").reshape((num_vertices, tdim))
 
     # find parent cell numbers
+    # TODO We should be able to do this for all the points in in one call to
+    # the parent mesh's _c_locator.
+    # SUGGESTED API 1:
+    #   parent_cell_nums, reference_coords = parentmesh.locate_cell_and_reference_coordinates(swarm_coords)
+    # with second call for collectivity.
+    # SUGGESTED API 2:
+    #   parent_cell_nums, reference_coords = parentmesh.locate_cell_and_reference_coordinates(swarm_coords, local_num_vertices)
+    # with behaviour changing inside locate_cell_and_reference_coordinates to
+    # ensure collectivity.
     for i in range(max_num_vertices):
         if i < num_vertices:
-            parent_cell_num = parentmesh.locate_cell(swarm_coords[i])
+            parent_cell_num, reference_coord = parentmesh.locate_cell_and_reference_coordinate(swarm_coords[i])
             parent_cell_nums[i] = parent_cell_num
+            reference_coords[i] = reference_coord
         else:
             parentmesh.locate_cell(out_of_mesh_point)  # should return None
 
     # have to restore fields once accessed to allow access again
+    swarm.restoreField("refcoord")
     swarm.restoreField("parentcellnum")
     swarm.restoreField("DMSwarmPIC_coor")

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2709,3 +2709,46 @@ def label_pic_parent_cell_info(PETSc.DM swarm, parentmesh):
     swarm.restoreField("refcoord")
     swarm.restoreField("parentcellnum")
     swarm.restoreField("DMSwarmPIC_coor")
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def fill_reference_coordinates_function(reference_coordinates_f):
+    """
+    Fill the PyOP2 dat of an input vector valued function on a
+    VertexOnlyMesh `reference_coordinates_f` with the reference
+    coordinates of each vertex in their relevant reference cells.
+
+    :arg reference_coordinates_f: A vector valued function on a
+        VertexOnlyMesh (with vector dimension the topological dimension
+        of the parent mesh) which will have its dat modified.
+
+    :returns: The updated `reference_coordinates_f`.
+    """
+    cdef:
+        PetscInt num_vertices, i, gdim, parent_tdim
+        PETSc.DM swarm
+        np.ndarray[PetscReal, ndim=2, mode="c"] reference_coords
+
+    from firedrake.mesh import VertexOnlyMeshTopology
+    assert isinstance(reference_coordinates_f.function_space().mesh().topology, VertexOnlyMeshTopology)
+
+    gdim = reference_coordinates_f.function_space().mesh()._parent_mesh.geometric_dimension()
+    parent_tdim = reference_coordinates_f.function_space().mesh()._parent_mesh.topological_dimension()
+
+    swarm = reference_coordinates_f.function_space().mesh().topology_dm
+
+    num_vertices = swarm.getLocalSize()
+
+    assert reference_coordinates_f.dat.shape == (num_vertices, parent_tdim)
+
+    # get reference coord field - NOTE isn't copied so could have GC issues!
+    reference_coords = swarm.getField("refcoord").reshape((num_vertices, parent_tdim))
+
+    # store reference coord field in Function Dat.
+    reference_coordinates_f.dat.data[:] = reference_coords[:]
+
+    # have to restore fields once accessed to allow access again
+    swarm.restoreField("refcoord")
+
+    return reference_coordinates_f

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -374,11 +374,12 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
             m_ = coefficient.cell_node_map()
             parloop_args.append(coefficient.dat(op2.READ, m_))
 
-    parloop = op2.ParLoop(*parloop_args).compute
+    parloop = op2.ParLoop(*parloop_args)
+    parloop_compute_callable = parloop.compute
     if isinstance(tensor, op2.Mat):
-        return parloop, tensor.assemble
+        return parloop_compute_callable, tensor.assemble
     else:
-        return copyin + (parloop, ) + copyout
+        return copyin + (parloop_compute_callable, ) + copyout
 
 
 @singledispatch

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -180,6 +180,8 @@ def make_interpolator(expr, V, subset, access):
                 raise ValueError("Cannot interpolate onto a mesh of a different geometric dimension")
             if not hasattr(target_mesh, "_parent_mesh") or target_mesh._parent_mesh is not source_mesh:
                 raise ValueError("Can only interpolate across meshes where the source mesh is the parent of the target")
+            if not argfs_map:
+                raise NotImplementedError("Source function space must advertise a cell node map to interpolate cross-mesh")
             # Since the par_loop is over the target mesh cells we need to
             # compose a map that takes us from target mesh cells to the
             # function space nodes on the source mesh.
@@ -368,6 +370,8 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
             # a Real space
             m_ = coefficient.cell_node_map()
         elif coeff_mesh is source_mesh:
+            if not coefficient.cell_node_map():
+                raise NotImplementedError("Source function space must advertise a cell node map to interpolate cross-mesh")
             # Since the par_loop is over the target mesh cells we need to
             # compose a map that takes us from target mesh cells to the
             # function space nodes on the source mesh.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1,5 +1,5 @@
 import numpy
-from functools import partial
+from functools import partial, singledispatch
 
 import FIAT
 import ufl
@@ -7,8 +7,11 @@ from ufl.algorithms import extract_arguments
 
 from pyop2 import op2
 
-from tsfc.finatinterface import create_base_element
+from tsfc.finatinterface import create_base_element, as_fiat_cell
 from tsfc import compile_expression_dual_evaluation
+
+import gem
+import finat
 
 import firedrake
 from firedrake import utils
@@ -166,10 +169,14 @@ def make_interpolator(expr, V, subset, access):
     elif len(arguments) == 1:
         if isinstance(V, firedrake.Function):
             raise ValueError("Cannot interpolate an expression with an argument into a Function")
-
         argfs = arguments[0].function_space()
+        argfs_map = argfs.cell_node_map()
+        if argfs_map is None or argfs_map.iterset != V.cell_node_map().iterset:
+            if isinstance(V.ufl_domain().topology, firedrake.mesh.VertexOnlyMeshTopology):
+                # Compose a vertex-cell to parent-cell-function-space-node map
+                argfs_map = compose_map_and_cache(V.ufl_domain().cell_parent_cell_map, argfs_map)
         sparsity = op2.Sparsity((V.dof_dset, argfs.dof_dset),
-                                ((V.cell_node_map(), argfs.cell_node_map()),),
+                                ((V.cell_node_map(), argfs_map),),
                                 name="%s_%s_sparsity" % (V.name, argfs.name),
                                 nest=False,
                                 block_sparse=True)
@@ -227,17 +234,48 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
         raise RuntimeError('Shape mismatch: Expression shape %r, FunctionSpace shape %r'
                            % (expr.ufl_shape, V.ufl_element().value_shape()))
 
-    mesh = V.ufl_domain()
-    coords = mesh.coordinates
+    target_mesh = V.ufl_domain()
+    try:
+        trans_mesh = (
+            expr.ufl_domain() is not None  # Constant expr
+            and expr.ufl_domain() != V.mesh()  # Coming from a different domain
+        )
+    except AttributeError:
+        # Have python Expression
+        trans_mesh = False
+
+    if trans_mesh:
+        if target_mesh.geometric_dimension() != expr.ufl_domain().geometric_dimension():
+            raise ValueError("Cannot interpolate onto a mesh of a different geometric dimension")
+        # For trans-mesh interpolation we use a FInAT QuadratureElement as the
+        # (base) target element with runtime point set expressions as their
+        # quadrature rule point set and weights from their dual basis.
+        # NOTE: This setup is useful for thinking about future design - in the
+        # future this `rebuild` function can be absorbed into FInAT as a
+        # transformer that eats an element and gives you an equivalent (which
+        # may or may not be a QuadratureElement) that lets you do run time
+        # tabulation. Alternatively (and this all depends on future design
+        # decision about FInAT how dual evaluation should work) the
+        # to_element's dual basis (which look rather like quadrature rules) can
+        # have their pointset(s) directly replaced with run-time tabulated
+        # equivalent(s) (i.e. finat.point_set.UnknownPointSet(s))
+        to_element = rebuild(to_element, expr)
+        # The source domain is on the expression not the FunctionSpace/Function
+        # we are interpolating into/onto
+        source_coords_coeff = expr.ufl_domain().coordinates
+        source_domain = expr.ufl_domain()
+    else:
+        # The source domain is that of the FunctionSpace/Function we are
+        # interpolating into/onto
+        source_coords_coeff = target_mesh.coordinates
+        source_domain = V.mesh()
 
     parameters = {}
     parameters['scalar_type'] = utils.ScalarType
 
     if not isinstance(expr, firedrake.Expression):
-        if expr.ufl_domain() and expr.ufl_domain() != V.mesh():
-            raise NotImplementedError("Interpolation onto another mesh not supported.")
         kernel = compile_expression_dual_evaluation(expr, to_element,
-                                                    domain=V.mesh(),
+                                                    domain=source_domain,
                                                     parameters=parameters,
                                                     coffee=False)
         ast = kernel.ast
@@ -254,20 +292,34 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
                 raise NotImplementedError("Can only interpolate Python kernels with Lagrange elements")
             pts, = dual.pt_dict.keys()
             to_pts.append(pts)
-        kernel, oriented, needs_cell_sizes, coefficients = compile_python_kernel(expr, to_pts, to_element, V, coords)
+        kernel, oriented, needs_cell_sizes, coefficients = compile_python_kernel(expr, to_pts, to_element, V, source_coords_coeff)
         first_coeff_fake_coords = False
     else:
         raise RuntimeError("Attempting to evaluate an Expression which has no value.")
 
-    cell_set = coords.cell_set
+    cell_set = target_mesh.coordinates.cell_set
     if subset is not None:
         assert subset.superset == cell_set
         cell_set = subset
     parloop_args = [kernel, cell_set]
 
     if first_coeff_fake_coords:
-        # Replace with real coords coefficient
-        coefficients[0] = coords
+        # Replace with real source_coords_coeff
+        coefficients[0] = source_coords_coeff
+
+    if trans_mesh:
+        # Add the coordinates of the target mesh quadrature points in the
+        # source mesh's reference cell as an extra argument for the inner loop.
+        # (with a vertex only mesh this is a single point for each vertex cell)
+        coefficients = coefficients + [target_mesh.reference_coordinates]
+        # In the trans-mesh case we loop over the target mesh cells so we need
+        # to compose a map that takes us from their cells to the source mesh
+        # cells, and (where necessary) to the function space nodes on the
+        # source mesh.
+        if isinstance(target_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology):
+            target_mesh_source_mesh_map = target_mesh.cell_parent_cell_map
+        else:
+            raise NotImplementedError("Can only interpolate onto a Vertex Only Mesh")
 
     if tensor in set((c.dat for c in coefficients)):
         output = tensor
@@ -286,28 +338,130 @@ def _interpolator(V, tensor, expr, subset, arguments, access):
         parloop_args.append(tensor(access, V.cell_node_map()))
     else:
         assert access == op2.WRITE  # Other access descriptors not done for Matrices.
-        parloop_args.append(tensor(op2.WRITE, (V.cell_node_map(),
-                                               arguments[0].function_space().cell_node_map())))
+        rows_map = V.cell_node_map()
+        columns_map = arguments[0].function_space().cell_node_map()
+        if trans_mesh:
+            # We have to map to the source mesh cells before mapping to nodes
+            columns_map = compose_map_and_cache(target_mesh_source_mesh_map,
+                                                columns_map)
+        parloop_args.append(tensor(op2.WRITE, (rows_map, columns_map)))
     if oriented:
-        co = mesh.cell_orientations()
+        co = target_mesh.cell_orientations()
         parloop_args.append(co.dat(op2.READ, co.cell_node_map()))
     if needs_cell_sizes:
-        cs = mesh.cell_sizes
+        cs = target_mesh.cell_sizes
         parloop_args.append(cs.dat(op2.READ, cs.cell_node_map()))
     for coefficient in coefficients:
-        m_ = coefficient.cell_node_map()
-        parloop_args.append(coefficient.dat(op2.READ, m_))
-
-    for o in coefficients:
-        domain = o.ufl_domain()
-        if domain is not None and domain.topology != mesh.topology:
-            raise NotImplementedError("Interpolation onto another mesh not supported.")
+        if coefficient.ufl_domain() == source_domain and trans_mesh:
+            m_ = compose_map_and_cache(target_mesh_source_mesh_map, coefficient.cell_node_map())
+            parloop_args.append(coefficient.dat(op2.READ, m_))
+        else:
+            m_ = coefficient.cell_node_map()
+            parloop_args.append(coefficient.dat(op2.READ, m_))
 
     parloop = op2.ParLoop(*parloop_args).compute
     if isinstance(tensor, op2.Mat):
         return parloop, tensor.assemble
     else:
         return copyin + (parloop, ) + copyout
+
+
+@singledispatch
+def rebuild(element, expr):
+    raise NotImplementedError(f"Cross mesh interpolation not implemented for a {element} element.")
+
+
+@rebuild.register(finat.DiscontinuousLagrange)
+def rebuild_dg(element, expr):
+    # To tabulate on the given element (which is on a different mesh to the
+    # expression) we must do so at runtime. We therefore create a quadrature
+    # element with runtime points to evaluate for each point in the element's
+    # dual basis. This exists on the same reference cell as the input element
+    # and we can interpolate onto it before mapping the result back onto the
+    # target space.
+    expr_tdim = expr.ufl_domain().topological_dimension()
+    # Need point evaluations and matching weights from dual basis.
+    # This could use FIAT's dual basis as below:
+    # num_points = sum(len(dual.get_point_dict()) for dual in element.fiat_equivalent.dual_basis())
+    # weights = []
+    # for dual in element.fiat_equivalent.dual_basis():
+    #     pts = dual.get_point_dict().keys()
+    #     for p in pts:
+    #         for w, _ in dual.get_point_dict()[p]:
+    #             weights.append(w)
+    # assert len(weights) == num_points
+    # but for now we just fix the values to what we know works:
+    if element.degree != 0 or not isinstance(element.cell, FIAT.reference_element.Point):
+        raise NotImplementedError("Cross mesh interpolation only implemented for P0DG on vertex cells.")
+    num_points = 1
+    weights = [1.]*num_points
+    # gem.Variable name starting with rt_ forces TSFC runtime tabulation
+    runtime_points_expr = gem.Variable('rt_X', (num_points, expr_tdim))
+    rule_pointset = finat.point_set.UnknownPointSet(runtime_points_expr)
+    try:
+        expr_fiat_cell = as_fiat_cell(expr.ufl_element().cell())
+    except AttributeError:
+        # expression must be pure function of spatial coordinates so
+        # domain has correct ufl cell
+        expr_fiat_cell = as_fiat_cell(expr.ufl_domain().ufl_cell())
+    rule = finat.quadrature.QuadratureRule(rule_pointset, weights=weights)
+    return finat.QuadratureElement(expr_fiat_cell, rule)
+
+
+@rebuild.register(finat.TensorFiniteElement)
+def rebuild_te(element, expr):
+    return finat.TensorFiniteElement(rebuild(element.base_element. expr),
+                                     element.shape,
+                                     transpose=element._transpose)
+
+
+def composed_map(map1, map2):
+    """
+    Manually build a :class:`PyOP2.Map` from the iterset of map1 to the
+    toset of map2.
+
+    :arg map1: The map with the desired iterset
+    :arg map2: The map with the desired toset
+
+    :returns:  The composed map
+
+    Requires that `map1.toset == map2.iterset`.
+    Only currently implemented for `map1.arity == 1`
+    """
+    if map1.toset != map2.iterset:
+        raise ValueError("Cannot compose a map where the intermediate sets do not match!")
+    if map1.arity != 1:
+        raise NotImplementedError("Can only currently build composed maps where map1.arity == 1")
+    iterset = map1.iterset
+    toset = map2.toset
+    arity = map2.arity
+    values = map2.values[map1.values].reshape(iterset.size, arity)
+    assert values.shape == (iterset.size, arity)
+    return op2.Map(iterset, toset, arity, values)
+
+
+def compose_map_and_cache(map1, map2):
+    """
+    Retrieve a composed :class:`PyOP2.Map` map from the cache of map1
+    using map2 as the cache key. The composed map maps from the iterset
+    of map1 to the toset of map2. Calls `composed_map` and caches the
+    result on map1 if the composed map is not found.
+
+    :arg map1: The map with the desired iterset from which the result is
+        retrieved or cached
+    :arg map2: The map with the desired toset
+
+    :returns:  The composed map
+
+    See also `composed_map`.
+    """
+    cache_key = hash((map2, "composed"))
+    try:
+        cmap = map1._cache[cache_key]
+    except KeyError:
+        cmap = composed_map(map1, map2)
+        map1._cache[cache_key] = cmap
+    return cmap
 
 
 class GlobalWrapper(object):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1966,9 +1966,9 @@ def VertexOnlyMesh(mesh, vertexcoords):
     if pdim != gdim:
         raise ValueError(f"Mesh geometric dimension {gdim} must match point list dimension {pdim}")
 
-    swarm = _pic_swarm_in_plex(mesh.topology.topology_dm, vertexcoords, fields=[("parentcellnum", 1, IntType)])
+    swarm = _pic_swarm_in_plex(mesh.topology.topology_dm, vertexcoords, fields=[("parentcellnum", 1, IntType), ("refcoord", tdim, RealType)])
 
-    dmcommon.label_pic_parent_cell_nums(swarm, mesh)
+    dmcommon.label_pic_parent_cell_info(swarm, mesh)
 
     # Topology
     topology = VertexOnlyMeshTopology(swarm, mesh.topology, name="swarmmesh", reorder=False)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1488,9 +1488,10 @@ values from f.)"""
         if not np.allclose(x.imag, 0):
             raise ValueError("Point coordinates must have zero imaginary part")
         x = x.real.copy()
-
+        X = np.empty_like(x)
         cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
-                                                    x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
+                                                    x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         if cell == -1:
             return None
         else:
@@ -1508,10 +1509,14 @@ values from f.)"""
         except KeyError:
             src = pq_utils.src_locate_cell(self, tolerance=tolerance)
             src += """
-    int locator(struct Function *f, double *x)
+    int locator(struct Function *f, double *x, double *X)
     {
         struct ReferenceCoords reference_coords;
-        return locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &reference_coords);
+        int cell = locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &reference_coords);
+        for(int i=0; i<%(geometric_dimension)d; i++) {
+            X[i] = reference_coords.X[i];
+        }
+        return cell;
     }
     """ % dict(geometric_dimension=self.geometric_dimension())
 
@@ -1524,6 +1529,7 @@ values from f.)"""
                                                "-Wl,-rpath,%s/lib" % sys.prefix])
 
             locator.argtypes = [ctypes.POINTER(function._CFunction),
+                                ctypes.POINTER(ctypes.c_double),
                                 ctypes.POINTER(ctypes.c_double)]
             locator.restype = ctypes.c_int
             return cache.setdefault(tolerance, locator)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1998,6 +1998,10 @@ def VertexOnlyMesh(mesh, vertexcoords):
 
     vmesh.__init__(coordinates)
 
+    # Save vertex reference coordinate (within reference cell) in function
+    reference_coordinates_fs = functionspace.VectorFunctionSpace(vmesh, "DG", 0, dim=tdim)
+    vmesh.reference_coordinates = dmcommon.fill_reference_coordinates_function(function.Function(reference_coordinates_fs))
+
     return vmesh
 
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1479,27 +1479,10 @@ values from f.)"""
         :arg x: point coordinates
         :kwarg tolerance: for checking if a point is in a cell. Default
             is None.
-        :returns: cell number (int), or None (if the point is not 
+        :returns: cell number (int), or None (if the point is not
             in the domain)
         """
-
-        if self.variable_layers:
-            raise NotImplementedError("Cell location not implemented for variable layers")
-
-        x = np.asarray(x, dtype=utils.ScalarType)
-        if not np.allclose(x.imag, 0):
-            raise ValueError("Point coordinates must have zero imaginary part")
-        x = x.real.copy()
-        if x.size != self.geometric_dimension():
-            raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
-        X = np.empty_like(x)
-        cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
-                                                    x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
-        if cell == -1:
-            return None
-        else:
-            return cell
+        return self.locate_cell_and_reference_coordinate(x, tolerance=tolerance)[0]
 
     def locate_reference_coordinate(self, x, tolerance=None):
         """Get reference coordinates of a given point in its cell. Which
@@ -1511,9 +1494,24 @@ values from f.)"""
         :returns: reference coordinates within cell (numpy array) or
             None (if the point is not in the domain)
         """
+        return self.locate_cell_and_reference_coordinate(x, tolerance=tolerance)[1]
+
+    def locate_cell_and_reference_coordinate(self, x, tolerance=None):
+        """Locate cell containing a given point and the reference
+        coordinates of the point within the cell.
+
+        :arg x: point coordinates
+        :kwarg tolerance: for checking if a point is in a cell. Default
+            is None.
+        :returns: tuple either (cell number, reference coordinates)
+            (int, numpy array), or (None, None) (point is not in the domain)
+        """
         if self.variable_layers:
-            raise NotImplementedError("Cell reference coordinates not implemented for variable layers")
+            raise NotImplementedError("Cell location not implemented for variable layers")
         x = np.asarray(x, dtype=utils.ScalarType)
+        if not np.allclose(x.imag, 0):
+            raise ValueError("Point coordinates must have zero imaginary part")
+        x = x.real.copy()
         if x.size != self.geometric_dimension():
             raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
         X = np.empty_like(x)
@@ -1521,9 +1519,9 @@ values from f.)"""
                                                     x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
                                                     X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         if cell == -1:
-            return None
+            return (None, None)
         else:
-            return X
+            return cell, X
 
     def _c_locator(self, tolerance=None):
         from pyop2 import compilation

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1501,6 +1501,30 @@ values from f.)"""
         else:
             return cell
 
+    def locate_reference_coordinate(self, x, tolerance=None):
+        """Get reference coordinates of a given point in its cell. Which
+        cell the point is in can be queried with the locate_cell method.
+
+        :arg x: point coordinates
+        :kwarg tolerance: for checking if a point is in a cell. Default
+            is None.
+        :returns: reference coordinates within cell (numpy array) or
+            None (if the point is not in the domain)
+        """
+        if self.variable_layers:
+            raise NotImplementedError("Cell reference coordinates not implemented for variable layers")
+        x = np.asarray(x, dtype=utils.ScalarType)
+        if x.size != self.geometric_dimension():
+            raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
+        X = np.empty_like(x)
+        cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
+                                                    x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
+        if cell == -1:
+            return None
+        else:
+            return X
+
     def _c_locator(self, tolerance=None):
         from pyop2 import compilation
         from pyop2.utils import get_petsc_dir

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1299,6 +1299,23 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         size = list(self._entity_classes[self.cell_dimension(), :])
         return op2.Set(size, "Cells", comm=self.comm)
 
+    @property
+    def cell_parent_cell_list(self):
+        """Return a list of parent mesh cells numbers in vertex only
+        mesh cell order.
+        """
+        cell_parent_cell_list = np.copy(self.topology_dm.getField("parentcellnum"))
+        self.topology_dm.restoreField("parentcellnum")
+        return cell_parent_cell_list
+
+    @property
+    def cell_parent_cell_map(self):
+        """Return the :class:`pyop2.Map` from vertex only mesh cells to
+        parent mesh cells.
+        """
+        return op2.Map(self.cell_set, self._parent_mesh.cell_set, 1,
+                       self.cell_parent_cell_list, "cell_parent_cell")
+
 
 class MeshGeometry(ufl.Mesh, MeshGeometryMixin):
     """A representation of mesh topology and geometry."""

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1206,25 +1206,19 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         cell = ufl.Cell("vertex")
         self._ufl_mesh = ufl.Mesh(ufl.VectorElement("DG", cell, 0, dim=cell.topological_dimension()))
 
-        def callback(self):
-            """Finish initialisation."""
-            del self._callback
+        # Mark OP2 entities and derive the resulting Swarm numbering
+        with timed_region("Mesh: numbering"):
+            dmcommon.mark_entity_classes(self.topology_dm)
+            self._entity_classes = dmcommon.get_entity_classes(self.topology_dm).astype(int)
 
-            # Mark OP2 entities and derive the resulting Swarm numbering
-            with timed_region("Mesh: numbering"):
-                dmcommon.mark_entity_classes(self.topology_dm)
-                self._entity_classes = dmcommon.get_entity_classes(self.topology_dm).astype(int)
+            # Derive a cell numbering from the Swarm numbering
+            entity_dofs = np.zeros(tdim+1, dtype=IntType)
+            entity_dofs[-1] = 1
 
-                # Derive a cell numbering from the Swarm numbering
-                entity_dofs = np.zeros(tdim+1, dtype=IntType)
-                entity_dofs[-1] = 1
-
-                self._cell_numbering = self.create_section(entity_dofs)
-                entity_dofs[:] = 0
-                entity_dofs[0] = 1
-                self._vertex_numbering = self.create_section(entity_dofs)
-
-        self._callback = callback
+            self._cell_numbering = self.create_section(entity_dofs)
+            entity_dofs[:] = 0
+            entity_dofs[0] = 1
+            self._vertex_numbering = self.create_section(entity_dofs)
 
     @property
     def comm(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1474,11 +1474,13 @@ values from f.)"""
         return spatialindex.from_regions(coords_min, coords_max)
 
     def locate_cell(self, x, tolerance=None):
-        """Locate cell containg given point.
+        """Locate cell containing a given point.
 
         :arg x: point coordinates
-        :kwarg tolerance: for checking if a point is in a cell.
-        :returns: cell number (int), or None (if the point is not in the domain)
+        :kwarg tolerance: for checking if a point is in a cell. Default
+            is None.
+        :returns: cell number (int), or None (if the point is not 
+            in the domain)
         """
 
         if self.variable_layers:
@@ -1488,6 +1490,8 @@ values from f.)"""
         if not np.allclose(x.imag, 0):
             raise ValueError("Point coordinates must have zero imaginary part")
         x = x.real.copy()
+        if x.size != self.geometric_dimension():
+            raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
         X = np.empty_like(x)
         cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
                                                     x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -538,12 +538,13 @@ def dg_injection_kernel(Vf, Vc, ncell):
                      quadrature_rule=macro_quadrature_rule,
                      scalar_type=parameters["scalar_type"])
 
-    fexpr, = fem.compile_ufl(f, **macro_cfg)
+    macro_context = fem.PointSetContext(**macro_cfg)
+    fexpr, = fem.compile_ufl(f, macro_context)
     X = ufl.SpatialCoordinate(Vf.mesh())
-    C_a, = fem.compile_ufl(X, **macro_cfg)
+    C_a, = fem.compile_ufl(X, macro_context)
     detJ = ufl_utils.preprocess_expression(abs(ufl.JacobianDeterminant(f.ufl_domain())),
                                            complex_mode=complex_mode)
-    macro_detJ, = fem.compile_ufl(detJ, **macro_cfg)
+    macro_detJ, = fem.compile_ufl(detJ, macro_context)
 
     Vce = create_element(Vc.ufl_element())
 
@@ -568,8 +569,9 @@ def dg_injection_kernel(Vf, Vc, ncell):
     X = ufl.SpatialCoordinate(Vc.mesh())
     K = ufl_utils.preprocess_expression(ufl.JacobianInverse(Vc.mesh()),
                                         complex_mode=complex_mode)
-    C_0, = fem.compile_ufl(X, **coarse_cfg)
-    K, = fem.compile_ufl(K, **coarse_cfg)
+    coarse_context = fem.PointSetContext(**coarse_cfg)
+    C_0, = fem.compile_ufl(X, coarse_context)
+    K, = fem.compile_ufl(K, coarse_context)
 
     i = gem.Index()
     j = gem.Index()

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -1,0 +1,293 @@
+from firedrake import *
+import pytest
+import numpy as np
+from functools import reduce
+from operator import add
+
+
+# Utility Functions and Fixtures
+
+# NOTE we don't include interval mesh since many of the function spaces
+# here are not defined on it.
+@pytest.fixture(params=[pytest.param("interval", marks=pytest.mark.xfail(reason="swarm not implemented in 1d")),
+                        "square",
+                        "squarequads",
+                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "cube",
+                        "tetrahedron",
+                        pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
+                        pytest.param("periodicrectangle", marks=pytest.mark.xfail(reason="meshes made from coordinate fields are not supported"))],
+                ids=lambda x: f"{x}-mesh")
+def parentmesh(request):
+    if request.param == "interval":
+        return UnitIntervalMesh(1)
+    elif request.param == "square":
+        return UnitSquareMesh(1, 1)
+    elif request.param == "squarequads":
+        return UnitSquareMesh(2, 2, quadrilateral=True)
+    elif request.param == "extruded":
+        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+    elif request.param == "cube":
+        return UnitCubeMesh(1, 1, 1)
+    elif request.param == "tetrahedron":
+        return UnitTetrahedronMesh()
+    elif request.param == "immersedsphere":
+        return UnitIcosahedralSphereMesh()
+    elif request.param == "periodicrectangle":
+        return PeriodicRectangleMesh(3, 3, 1, 1)
+
+
+@pytest.fixture(params=[0, 1, 100], ids=lambda x: f"{x}-coords")
+def vertexcoords(request, parentmesh):
+    size = (request.param, parentmesh.geometric_dimension())
+    return pseudo_random_coords(size)
+
+
+@pytest.fixture(params=[("CG", 2, FunctionSpace),
+                        ("DG", 2, FunctionSpace)],
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def fs(request):
+    return request.param
+
+
+@pytest.fixture(params=[("CG", 2, VectorFunctionSpace),
+                        ("N1curl", 2, FunctionSpace),
+                        ("N2curl", 2, FunctionSpace),
+                        ("N1div", 2, FunctionSpace),
+                        ("N2div", 2, FunctionSpace),
+                        pytest.param(("RTCE", 2, FunctionSpace), marks=pytest.mark.xfail(raises=AttributeError)),  # fiat equivalent missing point_dict
+                        pytest.param(("RTCF", 2, FunctionSpace), marks=pytest.mark.xfail(raises=AttributeError))],  # fiat equivalent missing point_dict
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def vfs(request):
+    return request.param
+
+
+@pytest.fixture(params=[("CG", 2, TensorFunctionSpace),
+                        ("BDM", 2, VectorFunctionSpace),
+                        ("Regge", 2, FunctionSpace)],
+                ids=lambda x: f"{x[2].__name__}({x[0]}{x[1]})")
+def tfs(request):
+    return request.param
+
+
+def pseudo_random_coords(size):
+    """
+    Get an array of pseudo random coordinates with coordinate elements
+    between -0.5 and 1.5. The random numbers are consistent for any
+    given `size` since `numpy.random.seed(0)` is called each time this
+    is used.
+    """
+    np.random.seed(0)
+    a, b = -0.5, 1.5
+    return (b - a) * np.random.random_sample(size=size) + a
+
+
+# Tests
+
+# NOTE: these _spatialcoordinate tests should be equivalent to some kind of
+# interpolation from a CG1 VectorFunctionSpace (I think)
+def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = FunctionSpace(vm, "DG", 0)
+    expr = reduce(add, SpatialCoordinate(parentmesh))
+    w_expr = interpolate(expr, W)
+    assert np.allclose(w_expr.dat.data_ro, np.sum(vertexcoords, axis=1))
+
+
+def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    fs_fam, fs_deg, fs_typ = fs
+    V = fs_typ(parentmesh, fs_fam, fs_deg)
+    W = FunctionSpace(vm, "DG", 0)
+    expr = reduce(add, SpatialCoordinate(parentmesh))
+    v = Function(V).interpolate(expr)
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
+    # try and make reusable Interpolator from V to W
+    A_w = Interpolator(TestFunction(V), W)
+    w_v = Function(W)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
+    # use it again for a different Function in V
+    v = Function(V).assign(Constant(2))
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, 2)
+
+
+def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = VectorFunctionSpace(vm, "DG", 0)
+    expr = 2 * SpatialCoordinate(parentmesh)
+    w_expr = interpolate(expr, W)
+    assert np.allclose(w_expr.dat.data_ro, 2*np.asarray(vertexcoords))
+
+
+def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
+    vfs_fam, vfs_deg, vfs_typ = vfs
+    # skip where the element doesn't support the cell type
+    if vfs_fam != "CG":
+        if parentmesh.ufl_cell().cellname() == "quadrilateral":
+            if not (vfs_fam == "RTCE" or vfs_fam == "RTCF"):
+                pytest.skip(f"{vfs_fam} does not support {parentmesh.ufl_cell()} cells")
+            # TODO: Remove this else when fixed
+            else:
+                pytest.skip(f"Some complex merge related problem for {vfs_fam}, get this from loopy: TypeError: unsupported type for persistent hash keying: <class 'complex'>")
+        elif parentmesh.ufl_cell().cellname() == "triangle" or parentmesh.ufl_cell().cellname() == "tetrahedron":
+            if (not (vfs_fam == "N1curl" or vfs_fam == "N2curl"
+                     or vfs_fam == "N1div" or vfs_fam == "N2div")):
+                pytest.skip(f"{vfs_fam} does not support {parentmesh.ufl_cell()} cells")
+            # TODO: Remove this else when fixed
+            else:
+                if parentmesh.ufl_cell().cellname() == "tetrahedron" and vfs_fam == "N2div":
+                    pytest.skip("N2div on tetrahedron cells is broken upstream - causes hanging (try tests/regression/test_interpolation_nodes.py and see!)")
+        else:
+            pytest.skip(f"{vfs_fam} does not support {parentmesh.ufl_cell()} cells")
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    V = vfs_typ(parentmesh, vfs_fam, vfs_deg)
+    W = VectorFunctionSpace(vm, "DG", 0)
+    expr = 2 * SpatialCoordinate(parentmesh)
+    v = Function(V).interpolate(expr)
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, 2*np.asarray(vertexcoords))
+    # try and make reusable Interpolator from V to W
+    A_w = Interpolator(TestFunction(V), W)
+    w_v = Function(W)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, 2*np.asarray(vertexcoords))
+    # use it again for a different Function in V
+    expr = 4 * SpatialCoordinate(parentmesh)
+    v = Function(V).interpolate(expr)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, 4*np.asarray(vertexcoords))
+
+
+def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = TensorFunctionSpace(vm, "DG", 0)
+    x = SpatialCoordinate(parentmesh)
+    gdim = parentmesh.geometric_dimension()
+    expr = 2 * as_tensor([x]*gdim)
+    assert W.shape == expr.ufl_shape
+    w_expr = interpolate(expr, W)
+    result = 2 * np.asarray([[vertexcoords[i]]*gdim for i in range(len(vertexcoords))])
+    if len(result) == 0:
+        result = result.reshape(vertexcoords.shape + (gdim,))
+    assert np.allclose(w_expr.dat.data_ro, result)
+
+
+def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
+    tfs_fam, tfs_deg, tfs_typ = tfs
+    # skip where the element doesn't support the cell type
+    if (tfs_fam != "CG" and parentmesh.ufl_cell().cellname() != "triangle"
+            and parentmesh.ufl_cell().cellname() != "tetrahedron"):
+        pytest.skip(f"{tfs_fam} does not support {parentmesh.ufl_cell()} cells")
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    V = tfs_typ(parentmesh, tfs_fam, tfs_deg)
+    W = TensorFunctionSpace(vm, "DG", 0)
+    x = SpatialCoordinate(parentmesh)
+    # use outer product to check Regge works
+    expr = outer(x, x)
+    assert W.shape == expr.ufl_shape
+    v = Function(V).interpolate(expr)
+    result = np.asarray([np.outer(vertexcoords[i], vertexcoords[i]) for i in range(len(vertexcoords))])
+    if len(result) == 0:
+        result = result.reshape(vertexcoords.shape + (parentmesh.geometric_dimension(),))
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, result)
+    # try and make reusable Interpolator from V to W
+    A_w = Interpolator(TestFunction(V), W)
+    w_v = Function(W)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, result)
+    # use it again for a different Function in V
+    expr = 2*outer(x, x)
+    v = Function(V).interpolate(expr)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, 2*result)
+
+
+# "UFL expressions for mixed functions are not yet supported."
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
+    tfs_fam, tfs_deg, tfs_typ = tfs
+    # skip where the element doesn't support the cell type
+    if (tfs_fam != "CG" and parentmesh.ufl_cell().cellname() != "triangle"
+            and parentmesh.ufl_cell().cellname() != "tetrahedron"):
+        pytest.skip(f"{tfs_fam} does not support {parentmesh.ufl_cell()} cells")
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    V1 = tfs_typ(parentmesh, tfs_fam, tfs_deg)
+    V2 = FunctionSpace(parentmesh, "CG", 1)
+    V = V1 * V2
+    W1 = TensorFunctionSpace(vm, "DG", 0)
+    W2 = FunctionSpace(vm, "DG", 0)
+    W = W1 * W2
+    x = SpatialCoordinate(parentmesh)
+    v = Function(V)
+    v1, v2 = v.split()
+    # Get Function in V1
+    # use outer product to check Regge works
+    expr1 = outer(x, x)
+    assert W1.shape == expr1.ufl_shape
+    interpolate(expr1, v1)
+    result1 = np.asarray([np.outer(vertexcoords[i], vertexcoords[i]) for i in range(len(vertexcoords))])
+    if len(result1) == 0:
+        result1 = result1.reshape(vertexcoords.shape + (parentmesh.geometric_dimension(),))
+    # Get Function in V2
+    expr2 = reduce(add, SpatialCoordinate(parentmesh))
+    interpolate(expr2, v2)
+    result2 = np.sum(vertexcoords, axis=1)
+    # Interpolate Function in V into W
+    w_v = interpolate(v, W)
+    # Split result and check
+    w_v1, w_v2 = w_v.split()
+    assert np.allclose(w_v1.dat.data_ro, result1)
+    assert np.allclose(w_v2.dat.data_ro, result2)
+    # try and make reusable Interpolator from V to W
+    A_w = Interpolator(TestFunction(V), W)
+    w_v = Function(W)
+    A_w.interpolate(v, output=w_v)
+    # Split result and check
+    w_v1, w_v2 = w_v.split()
+    assert np.allclose(w_v1.dat.data_ro, result1)
+    assert np.allclose(w_v2.dat.data_ro, result2)
+    # Enough tests - don't both using it again for a different Function in V
+
+
+@pytest.mark.parallel
+def test_scalar_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.parallel
+def test_vector_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.skip(reason="Skipping parallel tests using in-test logic is buggy")
+@pytest.mark.parallel
+def test_vector_function_interpolation_parallel(parentmesh, vertexcoords, vfs):
+    test_vector_function_interpolation(parentmesh, vertexcoords, vfs)
+
+
+@pytest.mark.parallel
+def test_tensor_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
+    test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords)
+
+
+@pytest.mark.skip(reason="Skipping parallel tests using in-test logic is buggy")
+@pytest.mark.parallel
+def test_tensor_function_interpolation_parallel(parentmesh, vertexcoords, tfs):
+    test_tensor_function_interpolation(parentmesh, vertexcoords, tfs)
+
+
+@pytest.mark.skip(reason="Skipping parallel tests using in-test logic is buggy")
+@pytest.mark.parallel
+def test_mixed_function_interpolation_parallel(parentmesh, vertexcoords, tfs):
+    test_mixed_function_interpolation(parentmesh, vertexcoords, tfs)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -260,8 +260,6 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     # Enough tests - don't both using it again for a different Function in V
 
 
-# "Source function space must advertise a cell node map to interpolate cross-mesh"
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_scalar_real_interpolation(parentmesh, vertexcoords):
     if parentmesh.ufl_cell().cellname() == "quadrilateral":
         pytest.skip("Interpolation onto real spaces on quadrilaterals is broken")
@@ -272,7 +270,19 @@ def test_scalar_real_interpolation(parentmesh, vertexcoords):
     v = interpolate(Constant(1.0), V)
     w_v = interpolate(v, W)
     assert np.allclose(w_v.dat.data_ro, 1.)
+
+
+# TODO: Remove this skip when fixed
+@pytest.mark.skip("Some complex merge related problem, get this from loopy: TypeError: unsupported type for persistent hash keying: <class 'complex'>")
+def test_scalar_real_interpolator(parentmesh, vertexcoords):
     # try and make reusable Interpolator from V to W
+    if parentmesh.ufl_cell().cellname() == "quadrilateral":
+        pytest.skip("Interpolation onto real spaces on quadrilaterals is broken")
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = FunctionSpace(vm, "DG", 0)
+    V = FunctionSpace(parentmesh, "Real", 0)
+    v = interpolate(Constant(1.0), V)
     A_w = Interpolator(TestFunction(V), W)
     w_v = Function(W)
     A_w.interpolate(v, output=w_v)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -263,6 +263,8 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
 # "Source function space must advertise a cell node map to interpolate cross-mesh"
 @pytest.mark.xfail(raises=NotImplementedError)
 def test_scalar_real_interpolation(parentmesh, vertexcoords):
+    if parentmesh.ufl_cell().cellname() == "quadrilateral":
+        pytest.skip("Interpolation onto real spaces on quadrilaterals is broken")
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     vertexcoords = vm.coordinates.dat.data_ro
     W = FunctionSpace(vm, "DG", 0)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -260,6 +260,23 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     # Enough tests - don't both using it again for a different Function in V
 
 
+# "Source function space must advertise a cell node map to interpolate cross-mesh"
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_scalar_real_interpolation(parentmesh, vertexcoords):
+    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vertexcoords = vm.coordinates.dat.data_ro
+    W = FunctionSpace(vm, "DG", 0)
+    V = FunctionSpace(parentmesh, "Real", 0)
+    v = interpolate(Constant(1.0), V)
+    w_v = interpolate(v, W)
+    assert np.allclose(w_v.dat.data_ro, 1.)
+    # try and make reusable Interpolator from V to W
+    A_w = Interpolator(TestFunction(V), W)
+    w_v = Function(W)
+    A_w.interpolate(v, output=w_v)
+    assert np.allclose(w_v.dat.data_ro, 1.)
+
+
 @pytest.mark.parallel
 def test_scalar_spatialcoordinate_interpolation_parallel(parentmesh, vertexcoords):
     test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords)

--- a/tests/vertexonly/test_poisson_inverse_conductivity.py
+++ b/tests/vertexonly/test_poisson_inverse_conductivity.py
@@ -1,0 +1,92 @@
+from firedrake import *
+from pyadjoint.tape import get_working_tape, pause_annotation, annotate_tape
+import pytest
+import numpy as np
+
+
+@pytest.fixture(autouse=True)
+def handle_taping():
+    yield
+    tape = get_working_tape()
+    tape.clear_tape()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def handle_exit_annotation():
+    yield
+    # Since importing firedrake_adjoint modifies a global variable, we need to
+    # pause annotations at the end of the module
+    annotate = annotate_tape()
+    if annotate:
+        pause_annotation()
+
+
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+def test_poisson_inverse_conductivity():
+    # Have to import inside test to make sure cleanup fixtures work as intended
+    from firedrake_adjoint import Control, ReducedFunctional, minimize
+
+    # Use pyadjoint to estimate an unknown conductivity in a
+    # poisson-like forward model from point measurements
+    m = UnitSquareMesh(2, 2)
+    V = FunctionSpace(m, family='CG', degree=2)
+    Q = FunctionSpace(m, family='CG', degree=2)
+
+    # generate random "true" conductivity with beta distribution
+    pcg = PCG64(seed=0)
+    rg = RandomGenerator(pcg)
+    # beta distribution
+    q_true = rg.beta(Q, 1.0, 2.0)
+
+    # Compute the true solution of the PDE.
+    u_true = Function(V)
+    v = TestFunction(V)
+    f = Constant(1.0)
+    k0 = Constant(0.5)
+    bc = DirichletBC(V, 0, 'on_boundary')
+    F = (k0 * exp(q_true) * inner(grad(u_true), grad(v)) - f * v) * dx
+    solve(F == 0, u_true, bc)
+
+    # Generate random point cloud
+    num_points = 2
+    np.random.seed(0)
+    xs = np.random.random_sample((num_points, 2))
+    point_cloud = VertexOnlyMesh(m, xs)
+
+    # Prove the the point cloud coordinates are correct
+    assert((point_cloud.coordinates.dat.data_ro == xs).all())
+
+    # Generate "observed" data
+    generator = np.random.default_rng(0)
+    signal_to_noise = 20
+    U = u_true.dat.data_ro[:]
+    u_range = U.max() - U.min()
+    σ = Constant(u_range / signal_to_noise)
+    ζ = generator.standard_normal(len(xs))
+    u_obs_vals = np.array(u_true.at(xs)) + float(σ) * ζ
+
+    # Store data on the point_cloud
+    P0DG = FunctionSpace(point_cloud, 'DG', 0)
+    u_obs = Function(P0DG)
+    u_obs.dat.data[:] = u_obs_vals
+
+    # Run the forward model
+    get_working_tape().clear_tape()
+    u = Function(V)
+    q = Function(Q)
+    bc = DirichletBC(V, 0, 'on_boundary')
+    F = (k0 * exp(q) * inner(grad(u), grad(v)) - f * v) * dx
+    solve(F == 0, u, bc)
+
+    # Two terms in the functional
+    misfit_expr = 0.5 * ((u_obs - interpolate(u, P0DG)) / σ)**2
+    α = Constant(0.5)
+    regularisation_expr = 0.5 * α**2 * inner(grad(q), grad(q))
+
+    # Form functional and reduced functional
+    J = assemble(misfit_expr * dx) + assemble(regularisation_expr * dx)
+    q̂ = Control(q)
+    Ĵ = ReducedFunctional(J, q̂)
+
+    # Estimate q using Newton-CG which evaluates the hessian action
+    minimize(Ĵ, method='Newton-CG', options={'disp': True})


### PR DESCRIPTION
Adds changes needed to allow interpolation from an arbitrary function function space onto a P0DG function space on a Firedrake `VertexOnlyMesh`

This replaces #1815 and sits on top of master, avoiding dependency on #1743 (dual evaluation with FInAT which needs lots of work).

The features added here will eventually be absorbed into #1743 when that is complete.

Linked PRs
 - https://github.com/firedrakeproject/tsfc/pull/247
 - https://github.com/FInAT/FInAT/pull/81

Generated Issues:
 -  #2069 
 - #2095 

Fixes #1795 

Status:

 * Parent mesh cell number:
   * Added functionality to find and store the parent mesh cell for each vertex cell of the Vertex Only Mesh (saved in swarm field `"parentcellnum"`)
   * Added `VertexOnlyMeshTopology.cell_parent_cell_list` and `VertexOnlyMeshTopology.cell_parent_cell_map` properties containing the parent cell number information
 * Vertex reference coordinate location in parent mesh cells:
   * Added functionality to find and store the reference cell locations of each Vertex Only Mesh vertex cell in their parent mesh cells (saved in swarm field `"refcoord"`)
   * Saved these values in cell order in a `mesh.reference_coordinates` function in a P0DG vector function space on the Vertex Only Mesh.
 * Resolved #1796 by removing unnecessary callbacks in Vertex Only Mesh creation
 * Create interpolation kernel from the parent mesh onto the Vertex Only Mesh by
   1. Modifying the FInAT `QuadratureElement` to allow a custom rule with runtime tabulated point to use as the `to_element` for going from the parent mesh function space to P0DG on the `VertexOnlyMesh` (see https://github.com/FInAT/FInAT/pull/81). 
   2. Create a suitable custom FInAT `QuadratureElement` for a runtime point tabulated point (expression `gem.Variable('X', (tdim,))`) with weight 1 to represent the runtime tabulated point, on the expression's mesh reference cell, onto which we interpolate in interpolation code in `firedrake/interpolate.py`.
   3. Switch the interpolation domain and domain coordinates coords to interpolated expression's mesh and mesh coordinates for feeding into `compile_expression_dual_evaluation`
   4. Modify TSFC's `compile_expression_dual_evaluation` so that the dual evaluation of this element will create create a kernel for interpolating from the parent mesh reference cell at an unknown point onto the vertex only mesh (see https://github.com/firedrakeproject/tsfc/pull/247). This has a coefficient defined in P0DG on the `VertexOnlyMesh` as the input argument for "unknown point" - the point location is defined on the reference cell of the parent mesh.
 * Create outer loop to run interpolation kernel over
   * Use the P0DG `FunctionSpace` on the `VertexOnlyMesh`'s `cell_set` as the `iterset` for iterating over.
   * Create a double indirection PyOP2 `Map` to get from `VertexOnlyMesh` cells to their parent cell function space nodes as defined on the parent mesh reference cell - a so-called `cell_parent_cell_fs_node_map`
      * The `Map` is made with a `composed_map` function using the `cell_node_map` of the expression we are interpolating and the `cell_parent_cell_map` of the Vertex Only Mesh: `composed_map(mesh.cell_parent_cell_map, cell_node_map)`
   * Use the double indirection map to register the "unknown point" coefficient as a par loop argument and appropriate space of `op2.Sparsity` when making an `Interpolator`

To do:
 - [x] Fix failing test if it's my fault
 - [x] Test mixed spaces
 - [x] Consider (again?) if a the FInAT `QuadratureElement` is really a suitable basis for doing this instead of some dedicated runtime tabulation FInAT element
 - [x] stash the composed map on cell_parent_cell_map using caching
 - [x] Work out what I was doing in the `get_composed_map` if statement in `interpolate.py` and maybe replace with actually getting the `composed_map`? It looks like a create it again
    - [x] ~move some of the composed map creation into cython? See code~ Not worth it for a reshape
 - [x] Check through above description carefully to make sure it's accurate
    - [x] In particular, explain what goes on with the use of `cell_parent_cell_fs_node_map` in the creation of an `op2.Sparsity` when you make an `Interpolator` object.
 - [x] Squash
 - [x] Check and make issue about broken real interpolation onto Quadrature elements - done see #2093
 - [x] Make issue about not being able to make an interpolator for Real onto V.O.M.s - done see #2095