### PR TITLE
Demo fixes

### DIFF
--- a/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
+++ b/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
@@ -40,7 +40,7 @@ After numerous manipulations (described in detail in :cite:`Salwa:2017`) and eva
 
     \begin{align}
     & \int v \phi^{n+1} \, {\mathrm d} S_f = \int v (\phi^n - \Delta t \eta^n) \, {\mathrm d} S_f \\
-    & \int \rho_0 {\bf v} \cdot {\bf U}^{n+1} \, {\mathrm d} x_S \underline{ + \int {\bf n} \cdot {\bf v} \, \phi^{n+1} \, {\mathrm d} s_s} = \rho_0 \int {\bf v} \cdot {\bf U}^n \, {\mathrm d} x_S \nonumber\\ 
+    & \int \rho_0 {\bf v} \cdot {\bf U}^{n+1} \, {\mathrm d} x_S \underline{ + \int {\bf n} \cdot {\bf v} \, \phi^{n+1} \, {\mathrm d} s_s} = \rho_0 \int {\bf v} \cdot {\bf U}^n \, {\mathrm d} x_S \nonumber\\
     & \hspace{5cm}  - \Delta t \int \left( \lambda \nabla \cdot {\bf v} \nabla \cdot {\bf X}^n + \mu \frac{\partial X^n_j}{\partial x_i}  \left( \frac{\partial v_i}{\partial x_j}  + \frac{\partial v_j}{\partial x_i} \right) \right) \, {\mathrm d} x_S \underline{ + \int {\bf n} \cdot {\bf v} \, \phi^n \, {\mathrm d} s_s }
     \\
     & \int \nabla v \cdot \nabla \phi^{n+1} \, {\mathrm d} x_F \underline{ - \int v {\bf n} \cdot {\bf U}^{n+1} \, {\mathrm d} s_s }= 0 \\ %\hspace{1cm} (+ \text{Dirichlet BC at } \partial \Omega_f)\\
@@ -65,42 +65,42 @@ Now we present the code used to solve the system of equations above. We start wi
 Then, we set parameters of the simulation::
 
     # parameters in SI units
-    t_end = 5. # time of simulation [s]
-    dt = 0.005 # time step [s]
-    g = 9.8 # gravitational acceleration
+    t_end = 5.0  # time of simulation [s]
+    dt = 0.005  # time step [s]
+    g = 9.8  # gravitational acceleration
     # water
-    Lx = 20. # length of the tank [m] in x-direction; needed for computing initial condition
-    Lz = 10. # height of the tank [m]; needed for computing initial condition
-    rho = 1000. # fluid density in kg/m^2 in 2D [water]
+    Lx = 20.0  # length of the tank [m] in x-direction; needed for computing initial condition
+    Lz = 10.0  # height of the tank [m]; needed for computing initial condition
+    rho = 1000.0  # fluid density in kg/m^2 in 2D [water]
     # solid parameters
     #  - we use a sufficiently soft material to be able to see noticeable structural displacement
-    rho_B = 7700. # structure density in kg/m^2 in 2D
-    lam = 1e7 # N/m in 2D - first Lame constant
-    mu = 1e7 # N/m in 2D - second Lame constant
+    rho_B = 7700.0  # structure density in kg/m^2 in 2D
+    lam = 1e7  # N/m in 2D - first Lame constant
+    mu = 1e7  # N/m in 2D - second Lame constant
     # mesh
     mesh = Mesh("L_domain.msh")
     # these numbers must match the ones defined in the mesh file
-    fluid_id = 1 # fluid subdomain
-    structure_id = 2 # structure subdomain
-    bottom_id = 1 # structure bottom
-    top_id = 6 # fluid surface
-    interface_id = 9 # fluid-structure interface
+    fluid_id = 1  # fluid subdomain
+    structure_id = 2  # structure subdomain
+    bottom_id = 1  # structure bottom
+    top_id = 6  # fluid surface
+    interface_id = 9  # fluid-structure interface
     # control parameters
-    output_data_every_x_time_steps = 20 # to avoid saving data every time step
-    coupling = True # turn on coupling terms
+    output_data_every_x_time_steps = 20  # to avoid saving data every time step
+    coupling = True  # turn on coupling terms
 
 The equations are in nondimensional units, hence we transform::
 
     L = Lz
-    T = L/math.sqrt(g*L)
+    T = L / math.sqrt(g * L)
     t_end /= T
     dt /= T
     Lx /= L
     Lz /= L
     rho_B /= rho
-    lam /= g*rho*L
-    mu /= g*rho*L
-    rho = 1. # or equivalently rho /= rho
+    lam /= g * rho * L
+    mu /= g * rho * L
+    rho = 1.0  # or equivalently rho /= rho
 
 Let us define function spaces, including the mixed one::
 
@@ -108,10 +108,10 @@ Let us define function spaces, including the mixed one::
     V_B = VectorFunctionSpace(mesh, "CG", 1)
     mixed_V = V_W * V_B
 
-Then, we define functions. First, in the fluid domain:: 
+Then, we define functions. First, in the fluid domain::
 
     phi = Function(V_W, name="phi")
-    phi_f = Function(V_W, name="phi_f") # at the free surface
+    phi_f = Function(V_W, name="phi_f")  # at the free surface
     eta = Function(V_W, name="eta")
     trial_W = TrialFunction(V_W)
     v_W = TestFunction(V_W)
@@ -137,20 +137,28 @@ We need auxiliary indicator functions, that are 0 in one subdomain and 1 in the 
     V_DG0_B = FunctionSpace(mesh, "DG", 0)
 
     # Heaviside step function in fluid
-    I_W = Function( V_DG0_W )
-    par_loop(('{[i] : 0 <= i < f.dofs}', 'f[i, 0] = 1.0'),
-             dx(fluid_id), {'f': (I_W, WRITE)}, is_loopy_kernel=True)
+    I_W = Function(V_DG0_W)
+    par_loop(("{[i] : 0 <= i < f.dofs}", "f[i, 0] = 1.0"),
+             dx(fluid_id),
+             {"f": (I_W, WRITE)},
+             is_loopy_kernel=True)
     I_cg_W = Function(V_W)
-    par_loop(('{[i] : 0 <= i < A.dofs}', 'A[i, 0] = fmax(A[i, 0], B[0, 0])'),
-             dx, {'A' : (I_cg_W, RW), 'B': (I_W, READ)}, is_loopy_kernel=True)
+    par_loop(("{[i] : 0 <= i < A.dofs}", "A[i, 0] = fmax(A[i, 0], B[0, 0])"),
+             dx,
+             {"A": (I_cg_W, RW), "B": (I_W, READ)},
+             is_loopy_kernel=True)
 
     # Heaviside step function in solid
-    I_B = Function( V_DG0_B )
-    par_loop(('{[i] : 0 <= i < f.dofs}', 'f[i, 0] = 1.0'),
-             dx(structure_id), {'f': (I_B, WRITE)}, is_loopy_kernel=True)
+    I_B = Function(V_DG0_B)
+    par_loop(("{[i] : 0 <= i < f.dofs}", "f[i, 0] = 1.0"),
+             dx(structure_id),
+             {"f": (I_B, WRITE)},
+             is_loopy_kernel=True)
     I_cg_B = Function(V_B)
-    par_loop(('{[i, j] : 0 <= i < A.dofs and 0 <= j < 2}', 'A[i, j] = fmax(A[i, j], B[0, 0])'),
-             dx, {'A' : (I_cg_B, RW), 'B': (I_B, READ)}, is_loopy_kernel=True)
+    par_loop(("{[i, j] : 0 <= i < A.dofs and 0 <= j < 2}", "A[i, j] = fmax(A[i, j], B[0, 0])"),
+             dx,
+             {"A": (I_cg_B, RW), "B": (I_B, READ)},
+             is_loopy_kernel=True)
 
 We use indicator functions to construct normal unit vector outward to the fluid domain at the fluid-structure interface::
 
@@ -159,6 +167,7 @@ We use indicator functions to construct normal unit vector outward to the fluid 
 
 Now we can construct special boundary conditions that limit the solvers only to the appropriate subdomains of our interest::
 
+
     class MyBC(DirichletBC):
         def __init__(self, V, value, markers):
             # Call superclass init
@@ -166,98 +175,105 @@ Now we can construct special boundary conditions that limit the solvers only to 
             super(MyBC, self).__init__(V, value, 0)
             # Override the "nodes" property which says where the boundary
             # condition is to be applied.
-            self.nodes = np.unique(np.where(markers.dat.data_ro_with_halos == 0)[0])   
+            self.nodes = np.unique(np.where(markers.dat.data_ro_with_halos == 0)[0])
 
-    def surface_BC():      
+
+    def surface_BC():
         # This will set nodes on the top boundary to 1.
-        bc = DirichletBC( V_W, 1, top_id )
+        bc = DirichletBC(V_W, 1, top_id)
         # We will use this function to determine the new BC nodes (all those
         # that aren't on the boundary)
-        f = Function( V_W, dtype=np.int32 )
+        f = Function(V_W, dtype=np.int32)
         # f is now 0 everywhere, except on the boundary
         bc.apply(f)
         # Now I can use MyBC to create a "boundary condition" to zero out all
         # the nodes that are *not* on the top boundary:
-        return MyBC( V_W, 0, f )
+        return MyBC(V_W, 0, f)
+
 
     # same as above, but in the mixed space
-    def surface_BC_mixed(): 
-        bc_mixed = DirichletBC( mixed_V.sub(0), 1, top_id )
-        f_mixed = Function( mixed_V.sub(0), dtype=np.int32 )
+    def surface_BC_mixed():
+        bc_mixed = DirichletBC(mixed_V.sub(0), 1, top_id)
+        f_mixed = Function(mixed_V.sub(0), dtype=np.int32)
         bc_mixed.apply(f_mixed)
-        return MyBC( mixed_V.sub(0), 0, f_mixed )
-        
+        return MyBC(mixed_V.sub(0), 0, f_mixed)
+
+
     BC_exclude_beyond_surface = surface_BC()
     BC_exclude_beyond_surface_mixed = surface_BC_mixed()
-    BC_exclude_beyond_solid = MyBC( V_B, 0, I_cg_B )
+    BC_exclude_beyond_solid = MyBC(V_B, 0, I_cg_B)
     BC_exclude_beyond_water_mixed = MyBC(mixed_V.sub(0), 0, I_cg_W)
     BC_exclude_beyond_solid_mixed = MyBC(mixed_V.sub(1), 0, I_cg_B)
 
 Finally, we are ready to define the solvers of our equations. First, equation for :math:`\phi` at the free surface::
 
     a_phi_f = trial_W * v_W * ds(top_id)
-    L_phi_f = ( phi_f - dt * eta ) * v_W * ds(top_id)
-    LVP_phi_f = LinearVariationalProblem( a_phi_f, L_phi_f, phi_f, bcs=BC_exclude_beyond_surface )
-    LVS_phi_f = LinearVariationalSolver( LVP_phi_f )
+    L_phi_f = (phi_f - dt * eta) * v_W * ds(top_id)
+    LVP_phi_f = LinearVariationalProblem(a_phi_f, L_phi_f, phi_f, bcs=BC_exclude_beyond_surface)
+    LVS_phi_f = LinearVariationalSolver(LVP_phi_f)
 
 Second, equation for the beam displacement :math:`{\bf X}`, where we also fix it to the bottom by applying zero Dirichlet boundary condition::
 
-    a_X = dot( trial_B, v_B ) * dx(structure_id)
-    L_X = dot( (X + dt * U), v_B ) * dx(structure_id)
+    a_X = dot(trial_B, v_B) * dx(structure_id)
+    L_X = dot((X + dt * U), v_B) * dx(structure_id)
     # no-motion beam bottom boundary condition
-    BC_bottom = DirichletBC( V_B, as_vector([0.,0.]), bottom_id)
-    LVP_X = LinearVariationalProblem(a_X, L_X, X, bcs = [BC_bottom, BC_exclude_beyond_solid])
-    LVS_X = LinearVariationalSolver( LVP_X )
+    BC_bottom = DirichletBC(V_B, as_vector([0.0, 0.0]), bottom_id)
+    LVP_X = LinearVariationalProblem(a_X, L_X, X, bcs=[BC_bottom, BC_exclude_beyond_solid])
+    LVS_X = LinearVariationalSolver(LVP_X)
 
 Finally, we define solvers for :math:`\phi`, :math:`{\bf U}` and :math:`\eta` in the mixed domain. In particular, value of :math:`\phi` at the free surface is used as a boundary condition. Note that avg(...) is necessary for terms in expressions containing n_int, which is built in "DG" space::
 
     # phi-U
     # no-motion beam bottom boundary condition in the mixed space
-    BC_bottom_mixed = DirichletBC( mixed_V.sub(1), as_vector([0.,0.]), bottom_id )
+    BC_bottom_mixed = DirichletBC(mixed_V.sub(1), as_vector([0.0, 0.0]), bottom_id)
     # boundary condition to set phi_f at the free surface
-    BC_phi_f = DirichletBC( mixed_V.sub(0), phi_f, top_id )
+    BC_phi_f = DirichletBC(mixed_V.sub(0), phi_f, top_id)
     delX = nabla_grad(X)
     delv_B = nabla_grad(v_s)
-    T_x_dv = lam * div(X) * div(v_s) + mu * ( inner( delX, delv_B + transpose(delv_B) ) )
-    a_U = rho_B * dot( trial_s, v_s ) * dx(structure_id)
-    L_U = ( rho_B * dot( U, v_s ) - dt * T_x_dv ) * dx(structure_id)
-    a_phi = dot( grad(trial_f), grad(v_f) ) * dx(fluid_id)
+    T_x_dv = lam * div(X) * div(v_s) + mu * (inner(delX, delv_B + transpose(delv_B)))
+    a_U = rho_B * dot(trial_s, v_s) * dx(structure_id)
+    L_U = (rho_B * dot(U, v_s) - dt * T_x_dv) * dx(structure_id)
+    a_phi = dot(grad(trial_f), grad(v_f)) * dx(fluid_id)
     if coupling:
-        a_U += dot( avg(v_s), n_int ) * avg(trial_f) * dS       # avg(...) necessary here and below
-        L_U += dot( avg(v_s), n_int ) * avg(phi) * dS
-        a_phi += - dot( n_int, avg(trial_s) ) * avg(v_f) * dS
-    LVP_U_phi = LinearVariationalProblem( a_U + a_phi, L_U, result_mixed, bcs = [BC_phi_f, BC_bottom_mixed, BC_exclude_beyond_solid_mixed, BC_exclude_beyond_water_mixed] )
-    LVS_U_phi = LinearVariationalSolver( LVP_U_phi )
+        a_U += dot(avg(v_s), n_int) * avg(trial_f) * dS  # avg(...) necessary here and below
+        L_U += dot(avg(v_s), n_int) * avg(phi) * dS
+        a_phi += -dot(n_int, avg(trial_s)) * avg(v_f) * dS
+    LVP_U_phi = LinearVariationalProblem(a_U + a_phi, L_U, result_mixed,
+                                         bcs=[BC_phi_f,
+                                              BC_bottom_mixed,
+                                              BC_exclude_beyond_solid_mixed,
+                                              BC_exclude_beyond_water_mixed])
+    LVS_U_phi = LinearVariationalSolver(LVP_U_phi)
 
     # eta
     a_eta = trial_W * v_W * ds(top_id)
-    L_eta = eta * v_W * ds(top_id) + dt * dot( grad(v_W), grad(phi) ) * dx(fluid_id)
+    L_eta = eta * v_W * ds(top_id) + dt * dot(grad(v_W), grad(phi)) * dx(fluid_id)
     if coupling:
-        L_eta += - dt * dot( n_int, avg(U) ) * avg(v_W) * dS
-    LVP_eta = LinearVariationalProblem( a_eta, L_eta, eta, bcs=BC_exclude_beyond_surface )
-    LVS_eta = LinearVariationalSolver( LVP_eta )
+        L_eta += -dt * dot(n_int, avg(U)) * avg(v_W) * dS
+    LVP_eta = LinearVariationalProblem(a_eta, L_eta, eta, bcs=BC_exclude_beyond_surface)
+    LVS_eta = LinearVariationalSolver(LVP_eta)
 
 Let us set the initial condition. We choose no motion at the beginning in both fluid and structure, zero displacement in the structure and deflected free surface in the fluid. The shape of the deflection is computed from the analytical solution::
 
     # initial condition in fluid based on analytical solution
     # compute analytical initial phi and eta
     n_mode = 1
-    a = 0. * T / L**2 # in nondim units
-    b = 5. * T / L**2 # in nondim units
-    lambda_x = np.pi*n_mode/Lx
-    omega = np.sqrt( lambda_x*np.tanh(lambda_x*Lz) )
+    a = 0.0 * T / L ** 2  # in nondim units
+    b = 5.0 * T / L ** 2  # in nondim units
+    lambda_x = np.pi * n_mode / Lx
+    omega = np.sqrt(lambda_x * np.tanh(lambda_x * Lz))
     x = mesh.coordinates
-    phi_exact_expr = a * cos(lambda_x*x[0]) * cosh(lambda_x*x[1])
-    eta_exact_expr = - omega * b * cos(lambda_x*x[0]) * cosh(lambda_x*Lz)
+    phi_exact_expr = a * cos(lambda_x * x[0]) * cosh(lambda_x * x[1])
+    eta_exact_expr = -omega * b * cos(lambda_x * x[0]) * cosh(lambda_x * Lz)
 
     bc_top = DirichletBC(V_W, 0, top_id)
-    eta.assign(0.)
-    phi.assign(0.)
+    eta.assign(0.0)
+    phi.assign(0.0)
     eta_exact = Function(V_W)
-    eta_exact.interpolate( eta_exact_expr )
-    eta.assign( eta_exact, bc_top.node_set )
-    phi.interpolate( phi_exact_expr )
-    phi_f.assign( phi, bc_top.node_set)
+    eta_exact.interpolate(eta_exact_expr)
+    eta.assign(eta_exact, bc_top.node_set)
+    phi.interpolate(phi_exact_expr)
+    phi_f.assign(phi, bc_top.node_set)
 
 A file to store data for visualization::
 
@@ -265,24 +281,28 @@ A file to store data for visualization::
 
 To save data for visualization, we change the position of the nodes in the mesh, so that they represent the computed dynamic position of the free surface and the structure::
 
+
     def output_data():
         output_data.counter += 1
-        if output_data.counter % output_data_every_x_time_steps != 0: return
+        if output_data.counter % output_data_every_x_time_steps != 0:
+            return
         mesh_static = mesh.coordinates.vector().get_local()
-        mesh.coordinates.vector().set_local( mesh_static + X.vector().get_local() )
-        mesh.coordinates.dat.data[:,1] += eta.dat.data_ro
-        outfile_phi.write( phi )
-        mesh.coordinates.vector().set_local( mesh_static )
-    output_data.counter = -1 # -1 to exclude counting print of initial state
+        mesh.coordinates.vector().set_local(mesh_static + X.vector().get_local())
+        mesh.coordinates.dat.data[:, 1] += eta.dat.data_ro
+        outfile_phi.write(phi)
+        mesh.coordinates.vector().set_local(mesh_static)
+
+
+    output_data.counter = -1  # -1 to exclude counting print of initial state
 
 In the end, we proceed with the actual computation loop::
 
-    t = 0.
+    t = 0.0
     output_data()
 
     while t <= t_end + dt:
         t += dt
-        print('time = ', t * T)
+        print("time = ", t * T)
         # symplectic Euler scheme
         LVS_phi_f.solve()
         LVS_U_phi.solve()

--- a/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
+++ b/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
@@ -118,9 +118,9 @@ x-axis. ::
 
 We define function spaces::
 
-  Vdg = FunctionSpace(mesh,"DG",1)               # DG elements for Potential Vorticity (PV)
+  Vdg = FunctionSpace(mesh,"DQ",1)               # DQ elements for Potential Vorticity (PV)
   Vcg = FunctionSpace(mesh,"CG",1)               # CG elements for Streamfunction
-  Vu  = VectorFunctionSpace(mesh,"DG",1)          # DG elements for velocity
+  Vu  = VectorFunctionSpace(mesh,"DQ",0)          # DQ elements for velocity
 
 and initial conditions for the potential vorticity, here we use
 Firedrake's ability to :doc:`interpolate UFL expressions <../interpolation>`. ::
@@ -159,11 +159,11 @@ function at the top and bottom of the domain. ::
 
   bc1 = DirichletBC(Vcg, 0., (1, 2))
 
-  psi_problem = LinearVariationalProblem(Apsi,Lpsi,psi0,bcs=bc1)
+  psi_problem = LinearVariationalProblem(Apsi,Lpsi,psi0,bcs=bc1,constant_jacobian=True)
   psi_solver = LinearVariationalSolver(psi_problem,
                                        solver_parameters={
           'ksp_type':'cg',
-          'pc_type':'sor'
+          'pc_type':'hypre'
           })
 
 Next we'll set up the advection equation, for which we need an
@@ -221,8 +221,6 @@ execute the time loop. ::
   T = 10.
   dumpfreq = 5
   tdump = 0
-
-  v0 = Function(Vu)
 
   while(t < (T-Dt/2)):
 

--- a/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
+++ b/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
@@ -111,38 +111,38 @@ Next we define the domain we will solve the equations on, square
 domain with 50 cells in each direction that is periodic along the
 x-axis. ::
 
-  Lx   = 2.*pi                                     # Zonal length
-  Ly   = 2.*pi                                     # Meridonal length
-  n0   = 50                                        # Spatial resolution
-  mesh = PeriodicRectangleMesh(n0, n0, Lx, Ly,  direction="x", quadrilateral=True)
+  Lx = 2.0 * pi  # Zonal length
+  Ly = 2.0 * pi  # Meridonal length
+  n0 = 50  # Spatial resolution
+  mesh = PeriodicRectangleMesh(n0, n0, Lx, Ly, direction="x", quadrilateral=True)
 
 We define function spaces::
 
-  Vdg = FunctionSpace(mesh,"DQ",1)               # DQ elements for Potential Vorticity (PV)
-  Vcg = FunctionSpace(mesh,"CG",1)               # CG elements for Streamfunction
-  Vu  = VectorFunctionSpace(mesh,"DQ",0)          # DQ elements for velocity
+  Vdg = FunctionSpace(mesh, "DQ", 1)  # DQ elements for Potential Vorticity (PV)
+  Vcg = FunctionSpace(mesh, "CG", 1)  # CG elements for Streamfunction
+  Vu = VectorFunctionSpace(mesh, "DQ", 0)  # DQ elements for velocity
 
 and initial conditions for the potential vorticity, here we use
 Firedrake's ability to :doc:`interpolate UFL expressions <../interpolation>`. ::
 
   x = SpatialCoordinate(mesh)
-  q0 = Function(Vdg).interpolate(0.1*sin(x[0])*sin(x[1]))
+  q0 = Function(Vdg).interpolate(0.1 * sin(x[0]) * sin(x[1]))
 
 We define some :class:`~.Function`\s to store the fields::
 
-  dq1 = Function(Vdg)       # PV fields for different time steps
-  qh  = Function(Vdg)
-  q1  = Function(Vdg)
+  dq1 = Function(Vdg)  # PV fields for different time steps
+  qh = Function(Vdg)
+  q1 = Function(Vdg)
 
-  psi0 = Function(Vcg)      # Streamfunctions for different time steps
+  psi0 = Function(Vcg)  # Streamfunctions for different time steps
   psi1 = Function(Vcg)
 
 along with the physical parameters of the model. ::
 
-  F    = Constant(1.0)         # Rotational Froude number
-  beta = Constant(0.1)         # beta plane coefficient
-  Dt   = 0.1                   # Time step
-  dt   = Constant(Dt)
+  F = Constant(1.0)  # Rotational Froude number
+  beta = Constant(0.1)  # beta plane coefficient
+  Dt = 0.1  # Time step
+  dt = Constant(Dt)
 
 Next, we define the variational problems.  First the elliptic problem
 for the stream function. ::
@@ -151,20 +151,16 @@ for the stream function. ::
   phi = TestFunction(Vcg)
 
   # Build the weak form for the inversion
-  Apsi = (inner(grad(psi),grad(phi)) + F*psi*phi)*dx
-  Lpsi = -q1*phi*dx
+  Apsi = (inner(grad(psi), grad(phi)) + F * psi * phi) * dx
+  Lpsi = -q1 * phi * dx
 
 We impose homogeneous dirichlet boundary conditions on the stream
 function at the top and bottom of the domain. ::
 
-  bc1 = DirichletBC(Vcg, 0., (1, 2))
+  bc1 = DirichletBC(Vcg, 0.0, (1, 2))
 
-  psi_problem = LinearVariationalProblem(Apsi,Lpsi,psi0,bcs=bc1,constant_jacobian=True)
-  psi_solver = LinearVariationalSolver(psi_problem,
-                                       solver_parameters={
-          'ksp_type':'cg',
-          'pc_type':'hypre'
-          })
+  psi_problem = LinearVariationalProblem(Apsi, Lpsi, psi0, bcs=bc1, constant_jacobian=True)
+  psi_solver = LinearVariationalSolver(psi_problem, solver_parameters={"ksp_type": "cg", "pc_type": "hypre"})
 
 Next we'll set up the advection equation, for which we need an
 operator :math:`\vec\nabla^\perp`, defined as a python anonymouus
@@ -176,29 +172,27 @@ For upwinding, we'll need a representation of the normal to a facet,
 and a way of selecting the upwind side::
 
   n = FacetNormal(mesh)
-  un = 0.5*(dot(gradperp(psi0), n) + abs(dot(gradperp(psi0), n)))
+  un = 0.5 * (dot(gradperp(psi0), n) + abs(dot(gradperp(psi0), n)))
 
 Now the variational problem for the advection equation itself. ::
 
   q = TrialFunction(Vdg)
   p = TestFunction(Vdg)
-  a_mass = p*q*dx
-  a_int  = (dot(grad(p), -gradperp(psi0)*q) + beta*p*psi0.dx(0))*dx
-  a_flux = (dot(jump(p), un('+')*q('+') - un('-')*q('-')) )*dS
-  arhs   = a_mass - dt*(a_int + a_flux)
+  a_mass = p * q * dx
+  a_int = (dot(grad(p), -gradperp(psi0) * q) + beta * p * psi0.dx(0)) * dx
+  a_flux = (dot(jump(p), un("+") * q("+") - un("-") * q("-"))) * dS
+  arhs = a_mass - dt * (a_int + a_flux)
 
-  q_problem = LinearVariationalProblem(a_mass, action(arhs,q1), dq1)
+  q_problem = LinearVariationalProblem(a_mass, action(arhs, q1), dq1)
 
 Since the operator is a mass matrix in a discontinuous space, it can
 be inverted exactly using an incomplete LU factorisation with zero
 fill. ::
 
-  q_solver  = LinearVariationalSolver(q_problem,
-                                      solver_parameters={
-          'ksp_type':'preonly',
-          'pc_type':'bjacobi',
-          'sub_pc_type': 'ilu'
-          })
+  q_solver = LinearVariationalSolver(q_problem,
+                                     solver_parameters={"ksp_type": "preonly",
+                                                        "pc_type": "bjacobi",
+                                                        "sub_pc_type": "ilu"})
 
 To visualise the output of the simulation, we create a :class:`~.File`
 object.  To which we can store multiple :class:`~.Function`\s.  So
@@ -217,40 +211,39 @@ names. ::
 Now all that is left is to define the timestepping parameters and
 execute the time loop. ::
 
-  t = 0.
-  T = 10.
+  t = 0.0
+  T = 10.0
   dumpfreq = 5
   tdump = 0
 
-  while(t < (T-Dt/2)):
+  while t < (T - Dt / 2):
+      # Compute the streamfunction for the known value of q0
+      q1.assign(q0)
+      psi_solver.solve()
+      q_solver.solve()
 
-    # Compute the streamfunction for the known value of q0
-    q1.assign(q0)
-    psi_solver.solve()
-    q_solver.solve()
+      # Find intermediate solution q^(1)
+      q1.assign(dq1)
+      psi_solver.solve()
+      q_solver.solve()
 
-    # Find intermediate solution q^(1)
-    q1.assign(dq1)
-    psi_solver.solve()
-    q_solver.solve()
+      # Find intermediate solution q^(2)
+      q1.assign(0.75 * q0 + 0.25 * dq1)
+      psi_solver.solve()
+      q_solver.solve()
 
-    # Find intermediate solution q^(2)
-    q1.assign(0.75*q0 + 0.25*dq1)
-    psi_solver.solve()
-    q_solver.solve()
+      # Find new solution q^(n+1)
+      q0.assign(q0 / 3 + 2 * dq1 / 3)
 
-    # Find new solution q^(n+1)
-    q0.assign(q0/3 + 2*dq1/3)
+      # Store solutions to xml and pvd
+      t += Dt
+      print(t)
 
-    # Store solutions to xml and pvd
-    t += Dt
-    print(t)
-
-    tdump += 1
-    if tdump == dumpfreq:
-        tdump -= dumpfreq
-        v.project(gradperp(psi0))
-        output.write(q0, psi0, v, time=t)
+      tdump += 1
+      if tdump == dumpfreq:
+          tdump -= dumpfreq
+          v.project(gradperp(psi0))
+          output.write(q0, psi0, v, time=t)
 
 A python script version of this demo can be found `here <qg_1layer_wave.py>`__.
 

--- a/tests/demos/test_demos_run.py
+++ b/tests/demos/test_demos_run.py
@@ -35,6 +35,9 @@ def py_file(rst_file, tmpdir, monkeypatch):
     geos = glob.glob("%s/*.geo" % dirname(rst_file))
     for geo in geos:
         name = "%s.msh" % splitext(basename(geo))[0]
+        if os.path.exists(name):
+            # No need to generate if it's already there
+            continue
         try:
             subprocess.check_call(["gmsh", geo, "-format", "msh2", "-3", "-o", str(tmpdir.join(name))])
         except (subprocess.CalledProcessError, OSError):


### PR DESCRIPTION
It turns out the FSI demo had been broken since the merge of #1471 since it had a load of singular operators that were previously being inverted with jacobi (which just ignores those rows). We never noticed because despite the mesh living in the repo, the tests would skip if we can't use GMSH (which is not installed in the docker containers).

Fix the singular operators and clean up the code formatting.

While I'm here, also do some minor cleanups in the one layer QG demo.