### PR TITLE
Annotate supermesh projection

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -597,13 +597,13 @@ class SupermeshProjectBlock(Block, Backend):
     Projecting a source from :math:`V_A` to :math:`V_B` amounts to solving the
     linear system
 
-  ..math::
+ .. math::
         M_B * v_B = M_{AB} * v_A,
 
     where :math:`M_B` is the mass matrix on :math:`V_B`, :math:`M_{AB}` is the
     mixed mass matrix for :math:`V_A` and :math:`V_B` and :math:`v_A` and
     :math:`v_B` are vector representations of the source and target
-    :class:`Function`s.
+    :class:`.Function`s.
 
     This can be broken into two steps:
       Step 1. form RHS, multiplying the source with the mixed mass matrix;

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -636,7 +636,6 @@ class SupermeshProjectBlock(Block, Backend):
         mesh = kwargs.pop("mesh", None)
         if mesh is None:
             mesh = target_space.mesh()
-        self.source = source
         self.source_space = source.function_space()
         self.target_space = target_space
 
@@ -683,8 +682,8 @@ class SupermeshProjectBlock(Block, Backend):
         if not isinstance(inputs[0], self.backend.Function):
             raise NotImplementedError(f"Source function must be a Function, not {type(inputs[0])}.")
         target = self.backend.Function(self.target_space)
-        rhs = self.apply_mixedmass(self.source)  # Step 1
-        self.apply_massinv(target, rhs)          # Step 2
+        rhs = self.apply_mixedmass(inputs[0])  # Step 1
+        self.apply_massinv(target, rhs)        # Step 2
         return target
 
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -587,3 +587,29 @@ class InterpolateBlock(Block, Backend):
 
     def recompute_component(self, inputs, block_variable, idx, prepared):
         return self.backend.interpolate(prepared, self.V)
+
+
+class SupermeshProjectBlock(Block):
+    """
+    Annotates supermesh projection.
+    """
+    def __init__(self, source, V, target, bcs=[], *args, **kwargs):
+        target_mesh = kwargs.pop("mesh", None)
+        if target_mesh is None:
+            target_mesh = V.mesh()
+        source_mesh = source.function_space().mesh()
+        raise NotImplementedError  # TODO
+
+    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
+        raise NotImplementedError  # TODO
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
+        raise NotImplementedError  # TODO
+
+    def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs,
+                                   block_variable, idx,
+                                   relevant_dependencies, prepared=None):
+        raise NotImplementedError  # TODO
+
+    def recompute_component(self, inputs, block_variable, idx, prepared):
+        return self.backend.project(prepared, self.V)

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -663,8 +663,8 @@ class SupermeshProjectBlock(Block, Backend):
           Adjoint of step 1. multiply :math:`v_S^{adj} := M_{ST}^T * w^{tmp}`.
         """
         from firedrake.petsc import PETSc
-        if len(adj_inputs) > 1:
-            raise(NotImplementedError("SupermeshProjectBlock must have a single output"))
+        if len(adj_inputs) != 1:
+            raise NotImplementedError("SupermeshProjectBlock must have a single output")
 
         # Seed vector, intermediate and output
         seed = adj_inputs[0]
@@ -694,6 +694,6 @@ class SupermeshProjectBlock(Block, Backend):
     def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs,
                                    block_variable, idx,
                                    relevant_dependencies, prepared=None):
-        if len(adj_inputs) > 1:
-            raise(NotImplementedError("SupermeshProjectBlock must have a single output"))
+        if len(adj_inputs) != 1:
+            raise NotImplementedError("SupermeshProjectBlock must have a single output")
         raise NotImplementedError  # TODO

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -687,6 +687,8 @@ class SupermeshProjectBlock(Block, Backend):
         return target
 
     def _recompute_component_transpose(self, inputs):
+        if not isinstance(inputs[0], (self.backend.Function, self.backend.Vector)):
+            raise NotImplementedError(f"Source function must be a Function, not {type(inputs[0])}.")
         out = self.backend.Function(self.source_space)
         with inputs[0].dat.vec_ro as vin, out.dat.vec_wo as vout:
             vtmp = vin.copy()
@@ -706,7 +708,7 @@ class SupermeshProjectBlock(Block, Backend):
         """
         if len(adj_inputs) != 1:
             raise NotImplementedError("SupermeshProjectBlock must have a single output")
-        return self._recompute_component_transpose(adj_inputs)
+        return self._recompute_component_transpose(adj_inputs).vector()
 
     def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
         """
@@ -723,6 +725,6 @@ class SupermeshProjectBlock(Block, Backend):
     def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs,
                                    block_variable, idx,
                                    relevant_dependencies, prepared=None):
-        if len(adj_inputs) != 1:
+        if len(hessian_inputs) != 1:
             raise NotImplementedError("SupermeshProjectBlock must have a single output")
-        raise NotImplementedError("Hessian for SuperProjectBlock not yet considered")  # TODO
+        return self.evaluate_adj_component(inputs, hessian_inputs, block_variable, idx).vector()

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -612,13 +612,12 @@ class SupermeshProjectBlock(Block, Backend):
     def __init__(self, source, target_space, target, bcs=[], **kwargs):
         super(SupermeshProjectBlock, self).__init__()
         import firedrake.supermeshing as supermesh
-        from firedrake.utils import complex_mode, SLATE_SUPPORTS_COMPLEX
 
         # Process args and kwargs
         if not isinstance(source, self.backend.Function):
             raise NotImplementedError(f"Source function must be a Function, not {type(source)}.")
         if bcs != []:
-            raise NotImplementedError(f"Boundary conditions not yet considered.")
+            raise NotImplementedError("Boundary conditions not yet considered.")
 
         # Store spaces
         mesh = kwargs.pop("mesh", None)

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -31,7 +31,7 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 bcs = kwargs.get("bcs", [])
-                if b.ufl_domain() == self.function_space().mesh():
+                if isinstance(b, firedrake.Constant) or b.ufl_domain() == self.function_space().mesh():
                     block = ProjectBlock(b, self.function_space(), self, bcs)
                 else:
                     block = SupermeshProjectBlock(b, self.function_space(), self, bcs)

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -2,7 +2,7 @@ from functools import wraps
 import ufl
 from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape, no_annotations
-from firedrake.adjoint.blocks import FunctionAssignBlock, ProjectBlock, FunctionSplitBlock, FunctionMergeBlock
+from firedrake.adjoint.blocks import FunctionAssignBlock, ProjectBlock, FunctionSplitBlock, FunctionMergeBlock, SupermeshProjectBlock
 import firedrake
 
 
@@ -31,7 +31,10 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 bcs = kwargs.get("bcs", [])
-                block = ProjectBlock(b, self.function_space(), self, bcs)
+                if b.function_space().mesh() != self.function_space().mesh():
+                    block = SupermeshProjectBlock(b, self.function_space(), self, bcs)
+                else:
+                    block = ProjectBlock(b, self.function_space(), self, bcs)
 
                 tape = get_working_tape()
                 tape.add_block(block)

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -31,10 +31,10 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 bcs = kwargs.get("bcs", [])
-                if b.ufl_domain() != self.function_space().mesh():
-                    block = SupermeshProjectBlock(b, self.function_space(), self, bcs)
-                else:
+                if b.ufl_domain() == self.function_space().mesh():
                     block = ProjectBlock(b, self.function_space(), self, bcs)
+                else:
+                    block = SupermeshProjectBlock(b, self.function_space(), self, bcs)
 
                 tape = get_working_tape()
                 tape.add_block(block)

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -31,7 +31,7 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 bcs = kwargs.get("bcs", [])
-                if b.function_space().mesh() != self.function_space().mesh():
+                if b.ufl_domain() != self.function_space().mesh():
                     block = SupermeshProjectBlock(b, self.function_space(), self, bcs)
                 else:
                     block = ProjectBlock(b, self.function_space(), self, bcs)

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -23,7 +23,7 @@ def annotate_project(project):
                 # block should be created before project because output might also be an input that needs checkpointing
                 output = args[1]
                 V = output.function_space()
-                if args[0].function_space().mesh() != V.mesh():
+                if args[0].ufl_domain() != V.mesh():
                     block = SupermeshProjectBlock(args[0], V, output, bcs, **sb_kwargs)
                 else:
                     block = ProjectBlock(args[0], V, output, bcs, **sb_kwargs)
@@ -34,7 +34,7 @@ def annotate_project(project):
         if annotate:
             tape = get_working_tape()
             if not isinstance(args[1], function.Function):
-                if args[0].function_space().mesh() != args[1].mesh():
+                if args[0].ufl_domain() != args[1].mesh():
                     block = SupermeshProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
                 else:
                     block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from firedrake.adjoint.blocks import ProjectBlock, SupermeshProjectBlock
-from firedrake import function
+from firedrake import function, constant
 
 
 def annotate_project(project):
@@ -34,7 +34,7 @@ def annotate_project(project):
         if annotate:
             tape = get_working_tape()
             if not isinstance(args[1], function.Function):
-                if args[0].ufl_domain() == args[1].mesh():
+                if isinstance(args[0], constant.Constant) or args[0].ufl_domain() == args[1].mesh():
                     block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
                 else:
                     block = SupermeshProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -23,10 +23,10 @@ def annotate_project(project):
                 # block should be created before project because output might also be an input that needs checkpointing
                 output = args[1]
                 V = output.function_space()
-                if args[0].ufl_domain() != V.mesh():
-                    block = SupermeshProjectBlock(args[0], V, output, bcs, **sb_kwargs)
-                else:
+                if args[0].ufl_domain() == V.mesh():
                     block = ProjectBlock(args[0], V, output, bcs, **sb_kwargs)
+                else:
+                    block = SupermeshProjectBlock(args[0], V, output, bcs, **sb_kwargs)
 
         with stop_annotating():
             output = project(*args, **kwargs)
@@ -34,10 +34,10 @@ def annotate_project(project):
         if annotate:
             tape = get_working_tape()
             if not isinstance(args[1], function.Function):
-                if args[0].ufl_domain() != args[1].mesh():
-                    block = SupermeshProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
-                else:
+                if args[0].ufl_domain() == args[1].mesh():
                     block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
+                else:
+                    block = SupermeshProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
             tape.add_block(block)
             block.add_output(output.create_block_variable())
 

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -42,6 +42,19 @@ class BlockMatrix(object):
             self.mat.mult(xi, yi)
             y.array[start::stride] = yi.array_r
 
+    def multTranspose(self, mat, x, y):
+        sizes = self.mat.getSizes()
+        for i in range(self.dimension):
+            start = i
+            stride = self.dimension
+
+            xa = x.array_r[start::stride]
+            ya = y.array_r[start::stride]
+            xi = PETSc.Vec().createWithArray(xa, size=sizes[0], comm=x.comm)
+            yi = PETSc.Vec().createWithArray(ya, size=sizes[1], comm=y.comm)
+            self.mat.multTranspose(xi, yi)
+            y.array[start::stride] = yi.array_r
+
 
 def assemble_mixed_mass_matrix(V_A, V_B):
     """

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -593,8 +593,7 @@ def test_supermesh_project_gradient(vector):
     rf = ReducedFunctional(J, control)
 
     # Taylor test
-    m = Function(source)
     h = Function(source_space)
     h.vector()[:] = rand(source_space.dim())
-    minconv = taylor_test(rf, m, h)
+    minconv = taylor_test(rf, source, h)
     assert minconv > 1.9


### PR DESCRIPTION
This PR annotates the supermesh projection operator under the assumption that the input is a `Function`. A `SupermeshProjectBlock` is created whenever source and target spaces of a projection operator live on different meshes.