### PR TITLE
Docs actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,11 +45,7 @@ jobs:
           firedrake-preprocess-bibtex --validate /home/firedrake/firedrake/src/firedrake/docs/source/_static/bibliography.bib
           firedrake-preprocess-bibtex --validate /home/firedrake/firedrake/src/firedrake/docs/source/_static/firedrake-apps.bib
       - name: Build docs
-        # PETSC dir and arch are mock variables
         run: |
           . /home/firedrake/firedrake/bin/activate
           firedrake-status
-          export PETSC_DIR=/home/firedrake/firedrake/src/petsc
-          export PETSC_ARCH=default
-          firedrake-update --honour-petsc-dir 
           make -C /home/firedrake/firedrake/src/firedrake/docs html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as
     # part of the jobs
     steps:
+      - name: Checkout branch
+        run: |
+          git -C /home/firedrake/firedrake/src/firedrake checkout ${GITHUB_HEAD_REF}
       - name: Fix permissions
         # Firedrake's Dockerfile sets USER to firedrake instead of
         # using the default user, so we need to update file
@@ -28,11 +31,10 @@ jobs:
         # (copied from https://help.github.com/en/actions/migrating-to-github-actions/migrating-from-circleci-to-github-actions)
         run: |
           sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
-      - uses: actions/checkout@v2
       - name: Install
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python -m pip install -e .
+          python -m pip install -e /home/firedrake/firedrake/src/firedrake
           python -m pip install sphinx
           python -m pip install sphinxcontrib-bibtex
           python -m pip install bibtexparser
@@ -40,11 +42,14 @@ jobs:
       - name: Check bibtex
         run: |
           . /home/firedrake/firedrake/bin/activate
-          cd docs
-          firedrake-preprocess-bibtex --validate source/_static/bibliography.bib
-          firedrake-preprocess-bibtex --validate source/_static/firedrake-apps.bib
+          firedrake-preprocess-bibtex --validate /home/firedrake/firedrake/src/firedrake/docs/source/_static/bibliography.bib
+          firedrake-preprocess-bibtex --validate /home/firedrake/firedrake/src/firedrake/docs/source/_static/firedrake-apps.bib
       - name: Build docs
+        # PETSC dir and arch are mock variables
         run: |
           . /home/firedrake/firedrake/bin/activate
-          cd docs
-          make html
+          firedrake-status
+          export PETSC_DIR=/home/firedrake/firedrake/src/petsc
+          export PETSC_ARCH=default
+          firedrake-update --honour-petsc-dir 
+          make -C /home/firedrake/firedrake/src/firedrake/docs html


### PR DESCRIPTION
This PR adresses #2070, at least partially.

I have changed the workflow such that it does not work on two separate Firedrakes anymore. Now, the workflow checks out firedrake in the docker container rather than in a separately pulled version of the branch. I found it confusing to understand what is happening in the action beforehand, so the PR is mainly for clarification of the workflow.