### PR TITLE
Add shape, dtype and intent to parloop cache key

### DIFF
--- a/firedrake/parloops.py
+++ b/firedrake/parloops.py
@@ -113,6 +113,13 @@ def _form_loopy_kernel(kernel_domains, instructions, measure, args, **kwargs):
         kernel_domains = "[] -> {[]}"
     try:
         key = (kernel_domains, tuple(instructions), tuple(map(tuple, kwargs.items())))
+        # Add shape, dtype and intent to the cache key
+        for func, intent in args.values():
+            if isinstance(func, Indexed):
+                for dat in func.ufl_operands[0].dat.split:
+                    key += (dat.shape, dat.dtype, intent)
+            else:
+                key += (func.dat.shape, func.dat.dtype, intent)
         if kernel_cache is not None:
             return kernel_cache[key]
         else:

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -288,4 +288,3 @@ def test_par_loop_respects_shape():
     par_loop((domain, instructions), dx, {'A': (f_scalar, WRITE)},
              is_loopy_kernel=True)
     assert np.allclose(f_scalar.dat.data, 1.0)
-

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -271,3 +271,21 @@ def test_walk_facets_rt():
              is_loopy_kernel=True)
 
     assert errornorm(f1, f2, degree_rise=0) < 1e-10
+
+
+def test_par_loop_respects_shape():
+    m = UnitSquareMesh(2, 2)
+    f_scalar = Function(FunctionSpace(m, "CG", 1))
+    f_vector = Function(VectorFunctionSpace(m, "CG", 1))
+
+    domain = "{[i] : 0 <= i < A.dofs}"
+    instructions = "A[i, 0] = 1"
+
+    par_loop((domain, instructions), dx, {'A': (f_vector, WRITE)},
+             is_loopy_kernel=True)
+    assert np.allclose(f_vector.dat.data[:, 0], 1.0)
+
+    par_loop((domain, instructions), dx, {'A': (f_scalar, WRITE)},
+             is_loopy_kernel=True)
+    assert np.allclose(f_scalar.dat.data, 1.0)
+


### PR DESCRIPTION
This fixes #2075.

Also added a test to check we don't hit this bug again.