### PR TITLE
REVERT WHEN HAVE NEW BUILD HW: temp demo test skip

### DIFF
--- a/tests/demos/test_demos_run.py
+++ b/tests/demos/test_demos_run.py
@@ -27,6 +27,10 @@ def env():
 
 @pytest.fixture
 def py_file(rst_file, tmpdir, monkeypatch):
+
+    if basename(rst_file) == 'qg_1layer_wave.py.rst':
+        pytest.skip("This test occasionally fails due to presumed build hardware issues")
+
     # Change to the temporary directory (monkeypatch ensures that this
     # is undone when the fixture usage disappears)
     monkeypatch.chdir(tmpdir)


### PR DESCRIPTION
Temporarily skip an occasionally failing demo test.

This failure is assumed to be due to build hardware issues and is not
reproduced locally - we assume it is because of issues with build
hardware. Revert when have new build hardware.