### PR TITLE
io: change quad facet traversal logic

### DIFF
--- a/tests/extrusion/test_variable_layers_numbering.py
+++ b/tests/extrusion/test_variable_layers_numbering.py
@@ -370,8 +370,8 @@ def test_numbering_quad():
     assert numpy.equal(V.cell_node_map().values,
                        [[0, 1, 3, 4, 9, 10, 6, 7],
                         [9, 10, 6, 7, 15, 16, 12, 13],
-                        [3, 4, 6, 7, 17, 18, 19, 20],
-                        [6, 7, 12, 13, 19, 20, 22, 23]]).all()
+                        [3, 4, 17, 18, 6, 7, 19, 20],
+                        [6, 7, 19, 20, 12, 13, 22, 23]]).all()
 
     assert numpy.equal(DirichletBC(V, 0, "bottom").nodes,
                        [0, 3, 6, 9, 12, 15, 17, 19, 22]).all()


### PR DESCRIPTION
`plex` quad cell in general can be oriented in 8 different ways relative to the FInAT reference cell, but FInAT quad cell is represented as a tensor product of two intervals, so it is only aware of 2 x 2 = 4 orientations. Thus we need to construct the `cell_closure`, which basically represents the FInAT reference cell, so that `plex` cell would never be mapped to the FInAT cell "wrongly" oriented, and we need to do so in a way that we can recover the correct ordering of the cell DoFs after save/load cycles.