### PR TITLE
Enable any rank constants

### DIFF
--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -17,12 +17,8 @@ def _globalify(value):
     rank = len(shape)
     if rank == 0:
         dat = op2.Global(1, data)
-    elif rank == 1:
-        dat = op2.Global(shape, data)
-    elif rank == 2:
-        dat = op2.Global(shape, data)
     else:
-        raise RuntimeError("Don't know how to make Constant from data with rank %d" % rank)
+        dat = op2.Global(shape, data)
     return dat, rank, shape
 
 
@@ -65,7 +61,7 @@ class Constant(ufl.Coefficient, ConstantMixin):
             e = ufl.FiniteElement("Real", cell, 0)
         elif rank == 1:
             e = ufl.VectorElement("Real", cell, 0, shape[0])
-        elif rank == 2:
+        else:
             e = ufl.TensorElement("Real", cell, 0, shape=shape)
 
         fs = ufl.FunctionSpace(domain, e)


### PR DESCRIPTION
Need higher than order two rank tensors.

Just enabling appears to be supported by ufl

Not sure we actually need to limit the rank at all here.

Run tested to generate alternative to PerturbationSymbol(3) (on which firedrake appears to crash)

Hmm. Some errors in jenkins... Wonder what they are about.

Updated to allow any rank.