### PR TITLE
Only pass Functions to SupermeshProjectBlock

### DIFF
--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -31,10 +31,10 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 bcs = kwargs.get("bcs", [])
-                if isinstance(b, firedrake.Constant) or b.ufl_domain() == self.function_space().mesh():
-                    block = ProjectBlock(b, self.function_space(), self, bcs)
-                else:
+                if isinstance(b, firedrake.Function) and b.ufl_domain() != self.function_space().mesh():
                     block = SupermeshProjectBlock(b, self.function_space(), self, bcs)
+                else:
+                    block = ProjectBlock(b, self.function_space(), self, bcs)
 
                 tape = get_working_tape()
                 tape.add_block(block)

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from firedrake.adjoint.blocks import ProjectBlock, SupermeshProjectBlock
-from firedrake import function, constant
+from firedrake import function
 
 
 def annotate_project(project):

--- a/firedrake/adjoint/projection.py
+++ b/firedrake/adjoint/projection.py
@@ -23,10 +23,10 @@ def annotate_project(project):
                 # block should be created before project because output might also be an input that needs checkpointing
                 output = args[1]
                 V = output.function_space()
-                if args[0].ufl_domain() == V.mesh():
-                    block = ProjectBlock(args[0], V, output, bcs, **sb_kwargs)
-                else:
+                if isinstance(args[0], function.Function) and args[0].ufl_domain() != V.mesh():
                     block = SupermeshProjectBlock(args[0], V, output, bcs, **sb_kwargs)
+                else:
+                    block = ProjectBlock(args[0], V, output, bcs, **sb_kwargs)
 
         with stop_annotating():
             output = project(*args, **kwargs)
@@ -34,10 +34,10 @@ def annotate_project(project):
         if annotate:
             tape = get_working_tape()
             if not isinstance(args[1], function.Function):
-                if isinstance(args[0], constant.Constant) or args[0].ufl_domain() == args[1].mesh():
-                    block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
-                else:
+                if isinstance(args[0], function.Function) and args[0].ufl_domain() != args[1].mesh():
                     block = SupermeshProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
+                else:
+                    block = ProjectBlock(args[0], args[1], output, bcs, **sb_kwargs)
             tape.add_block(block)
             block.add_output(output.create_block_variable())
 


### PR DESCRIPTION
PR #2063 causes issues in Thetis-adjoint because SupermeshProjectBlock can receive unsupported arguments such as expressions. This fix makes sure that it only receives Functions as input.