### PR TITLE
Docs: Fix the setSize error for parallel case

### DIFF
--- a/docs/source/petsc-interface.rst
+++ b/docs/source/petsc-interface.rst
@@ -127,7 +127,7 @@ newly defined class to compute the matrix action:
 
    # Set up B
    # B is the same size as A
-   B.setSizes(*A.getSizes())
+   B.setSizes(A.getSizes())
 
    B.setType(B.Type.PYTHON)
    B.setPythonContext(Bctx)


### PR DESCRIPTION
Because the second parameter for setSizes is `blocksize`, we should not unpack the value of `A.getSizes()`.