### PR TITLE
Change solver params for this test.

### DIFF
--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -116,7 +116,11 @@ def test_nullspace_mixed():
     # Null space is constant functions in DG and empty in BDM.
     nullspace = MixedVectorSpaceBasis(W, [W.sub(0), VectorSpaceBasis(constant=True)])
 
-    solve(a == L, w, bcs=bcs, nullspace=nullspace)
+    solve(a == L, w, bcs=bcs, nullspace=nullspace,
+          solver_parameters={
+              'ksp_type': 'minres',
+              'ksp_converged_reason': None,
+              'pc_type': 'none'})
 
     exact = Function(DG)
     exact.interpolate(x[1] - 0.5)


### PR DESCRIPTION
The first solve of test_nullspace_mixed() keeps failing on Jenkins and
the suspicion is that this might be due to mumps being flaky. Try to
workaround by changing to iterative solver.