### PR TITLE
Change assembly of Slate blocks

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -793,11 +793,13 @@ def _make_parloops(expr, tensor, bcs, diagonal, fc_params, assembly_rank):
             o = m.cell_sizes
             args.append(o.dat(op2.READ, get_map(o)))
 
-        for n in coeff_map:
+        for n, split_map in coeff_map:
             c = coefficients[n]
-            for c_ in c.split():
+            split_c = c.split()
+            for c_ in (split_c[i] for i in split_map):
                 m_ = get_map(c_)
                 args.append(c_.dat(op2.READ, m_))
+
         if needs_cell_facets:
             assert integral_type == "cell"
             extra_args.append(m.cell_to_facets(op2.READ))

--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -26,7 +26,7 @@ class Parameters(dict):
 
     def __setitem__(self, key, value):
         super(Parameters, self).__setitem__(key, value)
-        if self._update_function:
+        if hasattr(self, "_update_function") and self._update_function:
             self._update_function(key, value)
 
     def name(self):
@@ -86,6 +86,9 @@ parameters["default_matrix_type"] = "aij"
 parameters["default_sub_matrix_type"] = "baij"
 
 parameters["type_check_safe_par_loops"] = False
+
+parameters.add(Parameters("slate_compiler"))
+parameters["slate_compiler"]["optimise"] = True
 
 
 def disable_performance_optimisations():

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -167,7 +167,7 @@ def matrix_funptr(form, state):
             arg = c.dat(op2.READ, get_map(c))
             arg.position = len(args)
             args.append(arg)
-        for n in kinfo.coefficient_map:
+        for n, _ in kinfo.coefficient_map:
             c = form.coefficients()[n]
             if c is state:
                 statearg.position = len(args)
@@ -259,7 +259,7 @@ def residual_funptr(form, state):
             arg = c.dat(op2.READ, get_map(c))
             arg.position = len(args)
             args.append(arg)
-        for n in kinfo.coefficient_map:
+        for n, _ in kinfo.coefficient_map:
             c = form.coefficients()[n]
             if c is state:
                 statearg.position = len(args)
@@ -479,7 +479,7 @@ def make_c_arguments(form, kernel, state, get_map, require_state=False,
         coeffs.append(form.ufl_domain().cell_orientations())
     if kernel.kinfo.needs_cell_sizes:
         coeffs.append(form.ufl_domain().cell_sizes)
-    for n in kernel.kinfo.coefficient_map:
+    for n, _ in kernel.kinfo.coefficient_map:
         coeffs.append(form.coefficients()[n])
     if require_state:
         assert state in coeffs, "Couldn't find state vector in form coefficients"

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -187,7 +187,7 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
                        oriented=builder.bag.needs_cell_orientations,
                        subdomain_id="otherwise",
                        domain_number=0,
-                       coefficient_map=tuple(range(len(slate_expr.coefficients()))),
+                       coefficient_map=slate_expr.coeff_map,
                        needs_cell_facets=builder.bag.needs_cell_facets,
                        pass_layer_arg=builder.bag.needs_mesh_layers,
                        needs_cell_sizes=builder.bag.needs_cell_sizes)
@@ -354,7 +354,7 @@ def generate_kernel_ast(builder, statements, declared_temps):
                        oriented=builder.oriented,
                        subdomain_id="otherwise",
                        domain_number=0,
-                       coefficient_map=tuple(range(len(expr_coeffs))),
+                       coefficient_map=slate_expr.coeff_map,
                        needs_cell_facets=builder.needs_cell_facets,
                        pass_layer_arg=builder.needs_mesh_layers,
                        needs_cell_sizes=builder.needs_cell_sizes)

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -263,7 +263,7 @@ class LocalKernelBuilder(object):
                 kint_type = kinfo.integral_type
                 needs_cell_sizes = needs_cell_sizes or kinfo.needs_cell_sizes
 
-                args = [c for i in kinfo.coefficient_map
+                args = [c for i, _ in kinfo.coefficient_map
                         for c in self.coefficient(local_coefficients[i])]
 
                 if kinfo.oriented:
@@ -483,7 +483,7 @@ class LocalLoopyKernelBuilder(object):
                                 self.cell_size_arg))
 
         # Pick the coefficients associated with a Tensor()/TSFC kernel
-        tsfc_coefficients = [tsfc_coefficients[i] for i in kinfo.coefficient_map]
+        tsfc_coefficients = [tsfc_coefficients[i] for i, _ in kinfo.coefficient_map]
         for c, cinfo in wrapper_coefficients.items():
             if c in tsfc_coefficients:
                 if isinstance(cinfo, tuple):

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -598,6 +598,7 @@ class LocalLoopyKernelBuilder(object):
         tensor2temp = OrderedDict()
         inits = []
         for gem_tensor, slate_tensor in var2terminal.items():
+            assert slate_tensor.terminal, "Only terminal tensors need to be initialised in Slate kernels."
             (_, dtype), = assign_dtypes([gem_tensor], self.tsfc_parameters["scalar_type"])
             loopy_tensor = loopy.TemporaryVariable(gem_tensor.name,
                                                    dtype=dtype,
@@ -605,19 +606,21 @@ class LocalLoopyKernelBuilder(object):
                                                    address_space=loopy.AddressSpace.LOCAL)
             tensor2temp[slate_tensor] = loopy_tensor
 
-            if isinstance(slate_tensor, slate.Tensor):
+            if not slate_tensor.assembled:
                 indices = self.bag.index_creator(self.shape(slate_tensor))
                 inames = {var.name for var in indices}
                 var = pym.Subscript(pym.Variable(loopy_tensor.name), indices)
                 inits.append(loopy.Assignment(var, "0.", id="init%d" % len(inits),
                                               within_inames=frozenset(inames)))
 
-            elif isinstance(slate_tensor, slate.AssembledVector):
-                f = slate_tensor._function
-                coeff = coefficients[f]
+            else:
+                f = slate_tensor.form if isinstance(slate_tensor.form, tuple) else (slate_tensor.form,)
+                coeff = tuple(coefficients[c] for c in f)
                 offset = 0
-                ismixed = (type(f.ufl_element()) == MixedElement)
-                names = [name for (name, ext) in coeff.values()] if ismixed else coeff[0]
+                ismixed = tuple((type(c.ufl_element()) == MixedElement) for c in f)
+                names = []
+                for (im, c) in zip(ismixed, coeff):
+                    names += [name for (name, ext) in c.values()] if im else [c[0]]
 
                 # Mixed coefficients come as seperate parameter (one per space)
                 for i, shp in enumerate(*slate_tensor.shapes.values()):

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -653,7 +653,7 @@ class LocalLoopyKernelBuilder(object):
         insn = loopy.CallInstruction((slate_kernel_call_output,), call, id="slate_kernel_call")
         return insn
 
-    def generate_wrapper_kernel_args(self, tensor2temp, templated_subkernels):
+    def generate_wrapper_kernel_args(self, tensor2temp):
         coords_extent = self.extent(self.expression.ufl_domain().coordinates)
         args = [loopy.GlobalArg(self.coordinates_arg, shape=coords_extent,
                                 dtype=self.tsfc_parameters["scalar_type"])]

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -1,0 +1,85 @@
+from gem.node import MemoizerArg
+from functools import singledispatch
+from itertools import repeat
+import firedrake.slate.slate as sl
+
+
+def optimise(expression):
+    """Optimises a Slate expression, e.g. by pushing blocks inside the expression.
+
+    :arg expression: A (potentially unoptimised) Slate expression.
+
+    Returns: An optimised Slate expression
+    """
+    return push_block(expression)
+
+
+def push_block(expression):
+    """Executes a Slate compiler optimisation pass.
+    The optimisation is achieved by pushing blocks from the outside to the inside of an expression.
+    Without the optimisation the local TSFC kernels are assembled first
+    and then the result of the assembly kernel gets indexed in the Slate kernel
+    (and further linear algebra operations maybe done on it).
+    The optimisation pass essentially changes the order of assembly and indexing.
+
+    :arg expression: A (potentially unoptimised) Slate expression.
+
+    Returns: An optimised Slate expression, where Blocks are terminal whereever possible.
+    """
+    mapper = MemoizerArg(_push_block)
+    ret = mapper(expression, ())
+    return ret
+
+
+@singledispatch
+def _push_block(expr, self, indices):
+    raise AssertionError("Cannot handle terminal type: %s" % type(expr))
+
+
+@_push_block.register(sl.Transpose)
+def _push_block_transpose(expr, self, indices):
+    """Indices of the Blocks are transposed if Block is pushed into a Transpose."""
+    return sl.Transpose(*map(self, expr.children, repeat(indices[::-1]))) if indices else expr
+
+
+@_push_block.register(sl.Add)
+@_push_block.register(sl.Negative)
+def _push_block_distributive(expr, self, indices):
+    """Distributes Blocks for these nodes"""
+    return type(expr)(*map(self, expr.children, repeat(indices))) if indices else expr
+
+
+@_push_block.register(sl.Factorization)
+@_push_block.register(sl.Inverse)
+@_push_block.register(sl.Solve)
+@_push_block.register(sl.Mul)
+def _push_block_stop(expr, self, indices):
+    """Blocks cannot be pushed further into this set of nodes."""
+    return sl.Block(expr, indices) if indices else expr
+
+
+@_push_block.register(sl.Tensor)
+def _push_block_tensor(expr, self, indices):
+    """Turns a Block on a Tensor into a Tensor of an indexed form."""
+    return sl.Tensor(sl.Block(expr, indices).form) if indices else expr
+
+
+@_push_block.register(sl.AssembledVector)
+def _push_block_assembled_vector(expr, self, indices):
+    """Turns a Block on an AssembledVector into the  specialized node BlockAssembledVector."""
+    return sl.BlockAssembledVector(expr._function, sl.Block(expr, indices).form, indices) if indices else expr
+
+
+@_push_block.register(sl.Block)
+def _push_block_block(expr, self, indices):
+    """Inlines Blocks into each other.
+    Note that the indices are inlined from the ouside.
+    Example: If we have got the Slate expression A.blocks[:3,:3].blocks[0,0], we encounter the (0,0)-blocks first.
+    The first time round the indices are empty and the (0,0) are in expr._indices.
+    The second time round, (0,0) is stored in indices and the slices are in expr._indices.
+    So in the following line we basically say indices = ((0,1,2)[0], (0,1,2)[0])
+    """
+    reindexed = tuple(big[slice(small[0], small[-1]+1)] for big, small in zip(expr._indices, indices))
+    indices = expr._indices if not indices else reindexed
+    block, = map(self, expr.children, repeat(indices))
+    return block

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -2,7 +2,6 @@ import collections
 
 from functools import partial
 
-from firedrake.slate.slate import Tensor
 from firedrake.slate.slac.utils import RemoveRestrictions
 from firedrake.tsfc_interface import compile_form as tsfc_compile
 
@@ -44,7 +43,7 @@ def compile_terminal_form(tensor, prefix, *, tsfc_parameters=None, coffee=True):
     Returns: A `ContextKernel` containing all relevant information.
     """
 
-    assert isinstance(tensor, Tensor), (
+    assert tensor.terminal, (
         "Only terminal tensors have forms associated with them!"
     )
     # Sets a default name for the subkernel prefix.

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -300,7 +300,7 @@ def merge_loopy(slate_loopy, output_arg, builder, var2terminal, name):
         tsfc_kernels = ()
 
     # Construct args
-    args = [output_arg] + builder.generate_wrapper_kernel_args(tensor2temp, tsfc_kernels)
+    args = [output_arg] + builder.generate_wrapper_kernel_args(tensor2temp)
     # Munge instructions
     insns = inits
     insns.extend(tsfc_calls)

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -167,6 +167,7 @@ def _slate2gem(expr, self):
 
 @_slate2gem.register(sl.Tensor)
 @_slate2gem.register(sl.AssembledVector)
+@_slate2gem.register(sl.BlockAssembledVector)
 def _slate2gem_tensor(expr, self):
     shape = expr.shape if not len(expr.shape) == 0 else (1, )
     name = f"T{len(self.var2terminal)}"

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -118,6 +118,7 @@ class TensorBase(object, metaclass=ABCMeta):
     that one can assemble a tensor."""
 
     terminal = False
+    assembled = False
 
     _id = count()
 
@@ -149,6 +150,8 @@ class TensorBase(object, metaclass=ABCMeta):
                 data = (type(op).__name__, op.arg_function_spaces[0].ufl_element()._ufl_signature_data_(), )
             elif isinstance(op, Block):
                 data = (type(op).__name__, op._indices, )
+            elif isinstance(op, BlockAssembledVector):
+                data = (type(op).__name__, op._indices, op._original_function, op._function)
             elif isinstance(op, Factorization):
                 data = (type(op).__name__, op.decomposition, )
             elif isinstance(op, Tensor):
@@ -388,6 +391,7 @@ class AssembledVector(TensorBase):
 
     operands = ()
     terminal = True
+    assembled = True
 
     def __new__(cls, function):
         if isinstance(function, AssembledVector):
@@ -451,6 +455,74 @@ class AssembledVector(TensorBase):
     def _key(self):
         """Returns a key for hash and equality."""
         return (type(self), self._function)
+
+
+class BlockAssembledVector(AssembledVector):
+    """This class is a symbolic representation of an assembled
+    vector of data contained in a set of :class:`firedrake.Function`s
+    defined on pieces of a split mixed function space.
+
+    :arg functions: A tuple of firedrake functions.
+    """
+    def __new__(cls, function, split_functions, indices):
+        if isinstance(split_functions, tuple) \
+           and all(isinstance(f, Coefficient) for f in split_functions):
+            self = TensorBase.__new__(cls)
+            self._function = split_functions
+            self._indices = indices
+            self._original_function = function
+            return self
+        else:
+            raise TypeError("Expecting a tuple of Coefficients (not a %r)" %
+                            type(split_functions))
+
+    @cached_property
+    def form(self):
+        return self._function
+
+    @cached_property
+    def arg_function_spaces(self):
+        """Returns a tuple of function spaces that the tensor is defined on.
+        """
+        return tuple(f.ufl_function_space() for f in self._function)
+
+    @cached_property
+    def _argument(self):
+        """Generates a tuple of 'test function' associated with this class."""
+        from firedrake.ufl_expr import TestFunction
+        return tuple(TestFunction(fs) for fs in self.arg_function_spaces)
+
+    def arguments(self):
+        """Returns a tuple of arguments associated with the tensor."""
+        return self._argument
+
+    def coefficients(self):
+        """Returns a tuple of coefficients associated with the tensor."""
+        return self._function
+
+    def ufl_domains(self):
+        """Returns the integration domains of the integrals associated with the tensor.
+        """
+        return tuple(domain for fs in self.arg_function_spaces for domain in fs.ufl_domains())
+
+    def subdomain_data(self):
+        """Returns mappings on the tensor:
+        ``{domain:{integral_type: subdomain_data}}``.
+        """
+        return tuple({domain: {"cell": None}} for domain in self.ufl_domain())
+
+    def _output_string(self, prec=None):
+        """Creates a string representation of the tensor."""
+        return "BAV_%d" % self.id
+
+    def __repr__(self):
+        """Slate representation of the tensor object."""
+        return "BlockAssembledVector(%r)" % self._function
+
+    @cached_property
+    def _key(self):
+        """Returns a key for hash and equality."""
+        return (type(self), self._function, self._original_function, self._indices)
 
 
 class Block(TensorBase):
@@ -581,6 +653,11 @@ class Block(TensorBase):
             # turns the Block on an AssembledVector into a set off coefficients
             # corresponding to the indices of the Block
             return tuple(tensor._function.split()[i] for i in chain(*self._indices))
+
+    @cached_property
+    def assembled(self):
+        tensor, = self.operands
+        return tensor.assembled
 
     def coefficients(self):
         """Returns a tuple of coefficients associated with the tensor."""

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -18,7 +18,7 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 
 from collections import OrderedDict
 
-from ufl import Coefficient
+from ufl import Coefficient, Constant
 
 from firedrake.function import Function
 from firedrake.utils import cached_property
@@ -200,6 +200,17 @@ class TensorBase(object, metaclass=ABCMeta):
     @abstractmethod
     def coefficients(self):
         """Returns a tuple of coefficients associated with the tensor."""
+
+    @property
+    def coeff_map(self):
+        """A map from local coefficient numbers
+        to the split global coefficient numbers.
+        The split coefficients are defined on the pieces of the originally mixed function spaces.
+        """
+        return tuple((n, tuple(range(len(c.split()))))
+                     if isinstance(c, Function) or isinstance(c, Constant)
+                     else (n, (0,))
+                     for n, c in enumerate(self.coefficients()))
 
     def ufl_domain(self):
         """This function returns a single domain of integration occuring
@@ -475,10 +486,6 @@ class BlockAssembledVector(AssembledVector):
         else:
             raise TypeError("Expecting a tuple of Coefficients (not a %r)" %
                             type(split_functions))
-
-    @cached_property
-    def form(self):
-        return self._function
 
     @cached_property
     def arg_function_spaces(self):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -115,6 +115,8 @@ class TensorBase(object, metaclass=ABCMeta):
     """A mock object that provides enough compatibility with ufl.Form
     that one can assemble a tensor."""
 
+    terminal = False
+
     _id = count()
 
     def __init__(self, *_):
@@ -383,6 +385,7 @@ class AssembledVector(TensorBase):
         raise ValueError("AssembledVector has no integrals")
 
     operands = ()
+    terminal = True
 
     def __new__(cls, function):
         if isinstance(function, AssembledVector):
@@ -518,6 +521,12 @@ class Block(TensorBase):
         self.operands = (tensor,)
         self._blocks = dict(enumerate(indices))
         self._indices = indices
+
+    @cached_property
+    def terminal(self):
+        """Blocks are only terminal when they sit on Tensors or AssembledVectors"""
+        tensor, = self.operands
+        return tensor.terminal
 
     @cached_property
     def _split_arguments(self):
@@ -701,6 +710,7 @@ class Tensor(TensorBase):
     """
 
     operands = ()
+    terminal = True
 
     def __init__(self, form):
         """Constructor for the Tensor class."""

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -16,6 +16,8 @@ import collections
 
 import ufl
 from ufl import Form, conj
+from firedrake.constant import Constant
+from firedrake.function import Function
 from .ufl_expr import TestFunction
 
 from tsfc import compile_form as tsfc_compile_form
@@ -126,7 +128,8 @@ class TSFCKernel(Cached):
         :arg form: the :class:`~ufl.classes.Form` from which to compile the kernels.
         :arg name: a prefix to be applied to the compiled kernel names. This is primarily useful for debugging.
         :arg parameters: a dict of parameters to pass to the form compiler.
-        :arg number_map: a map from local coefficient numbers to global ones (useful for split forms).
+        :arg number_map: a map from local coefficient numbers
+                         to the split global coefficient numbers.
         :arg interface: the KernelBuilder interface for TSFC (may be None)
         """
         if self._initialized:
@@ -222,8 +225,10 @@ def compile_form(form, name, parameters=None, split=True, interface=None, coffee
     for idx, f in iterable:
         f = _real_mangle(f)
         # Map local coefficient numbers (as seen inside the
-        # compiler) to the global coefficient numbers
-        number_map = dict((n, coefficient_numbers[c])
+        # compiler) to the split global coefficient numbers
+        number_map = dict((n, (coefficient_numbers[c], tuple(range(len(c.split())))))
+                          if isinstance(c, Function) or isinstance(c, Constant)
+                          else (n, (coefficient_numbers[c], (0,)))
                           for (n, c) in enumerate(f.coefficients()))
         prefix = name + "".join(map(str, (i for i in idx if i is not None)))
         kinfos = TSFCKernel(f, prefix, parameters,

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -1,0 +1,157 @@
+import pytest
+from firedrake import *
+import numpy as np
+
+
+@pytest.fixture
+def mesh():
+    return UnitSquareMesh(2, 2, True)
+
+
+@pytest.fixture
+def A(mesh):
+    U = FunctionSpace(mesh, "RT", 1)
+    V = FunctionSpace(mesh, "DG", 0)
+    T = FunctionSpace(mesh, "HDiv Trace", 0)
+    n = FacetNormal(mesh)
+    W = U * V * T
+    u, p, lambdar = TrialFunctions(W)
+    w, q, gammar = TestFunctions(W)
+
+    return Tensor(inner(u, w)*dx + p*q*dx - div(w)*p*dx + q*div(u)*dx
+                  + lambdar('+')*jump(w, n=n)*dS + gammar('+')*jump(u, n=n)*dS
+                  + lambdar*gammar*ds)
+
+
+@pytest.fixture
+def KF(mesh):
+    V = VectorFunctionSpace(mesh, "DG", 1)
+    U = FunctionSpace(mesh, "DG", 1)
+    T = FunctionSpace(mesh, "DG", 0)
+    W = V * U * T
+    x = SpatialCoordinate(mesh)
+    q = Function(V).project(grad(sin(pi*x[0])*cos(pi*x[1])))
+    p = Function(U).interpolate(-x[0]*exp(-x[1]**2))
+    r = Function(T).assign(42.0)
+    u, phi, eta = TrialFunctions(W)
+    v, psi, nu = TestFunctions(W)
+
+    K = Tensor(inner(u, v)*dx + inner(phi, psi)*dx + inner(eta, nu)*dx)
+    F = Tensor(inner(q, v)*dx + inner(p, psi)*dx + inner(r, nu)*dx)
+    return K, K.inv * F
+
+
+@pytest.fixture
+def TC(mesh):
+    V = VectorFunctionSpace(mesh, "DG", 1)
+    U = FunctionSpace(mesh, "DG", 1)
+    T = FunctionSpace(mesh, "DG", 0)
+    W = V * U * T
+    x = SpatialCoordinate(mesh)
+    q = Function(V).project(grad(sin(pi*x[0])*cos(pi*x[1])))
+    p = Function(U).interpolate(-x[0]*exp(-x[1]**2))
+    r = Function(T).assign(42.0)
+    u, phi, eta = TrialFunctions(W)
+    v, psi, nu = TestFunctions(W)
+
+    K = Tensor(inner(u, v)*dx + inner(phi, psi)*dx + inner(eta, nu)*dx)
+    f = assemble(inner(q, v)*dx + inner(p, psi)*dx + inner(r, nu)*dx)
+    return K, AssembledVector(f)
+
+
+def test_push_tensor_blocks_individual(A):
+    """Test Optimisers's ability to handle individual blocks of 2-Tensors."""
+    expressions = [(A+A).blocks[0, 0], (A*A).blocks[0, 0], (-A).blocks[0, 0],
+                   (A.T).blocks[0, 0], (A.inv).blocks[0, 0]]
+    compare_tensor_expressions(expressions)
+
+
+def test_push_tensor_blocks_mixed(A):
+    """Test Optimisers's ability to handle mixed blocks of 2-Tensors."""
+    expressions = [(A+A).blocks[:2, :2], (A*A).blocks[:2, :2], (-A).blocks[:2, :2],
+                   (A.T).blocks[:2, :2], (A.inv).blocks[:2, :2],
+                   (A+A).blocks[1:3, 1:3], (A*A).blocks[1:3, 1:3],
+                   (-A).blocks[1:3, 1:3], (A.T).blocks[1:3, 1:3], (A.inv).blocks[1:3, 1:3]]
+    compare_tensor_expressions(expressions)
+
+
+def test_push_tensor_blocks_on_blocks(A):
+    """Test Optimisers's ability to handle blocks of blocks of 2-Tensors."""
+    expressions = [(A+A).blocks[:2, :2].blocks[0, 0], (A*A).blocks[:2, :2].blocks[0, 0],
+                   (-A).blocks[:2, :2].blocks[0, 0], (A.T).blocks[:2, :2].blocks[0, 0],
+                   (A.inv).blocks[:2, :2].blocks[0, 0]]
+    # test for blocks with too few indices too
+    expressions += [(A+A).blocks[:2].blocks[0, 0]]
+    compare_tensor_expressions(expressions)
+
+
+def test_push_vector_block_individual(KF):
+    """Test Optimisers's ability to handle individual blocks of 1-Tensors."""
+    K, F = KF
+    expressions = [(F+F).blocks[0], (K*F).blocks[0], (-F).blocks[0]]
+    compare_vector_expressions(expressions)
+
+
+def test_push_vector_block_mixed(KF):
+    """Test Optimisers's ability to handle mixed blocks of 1-Tensors."""
+    K, F = KF
+    expressions = [(F+F).blocks[:2], (K*F).blocks[:2], (-F).blocks[:2],
+                   (F+F).blocks[1:3], (K*F).blocks[1:3], (-F).blocks[1:3]]
+    compare_vector_expressions_mixed(expressions)
+
+
+def test_push_vector_blocks_on_blocks(KF):
+    """Test Optimisers's ability to handle blocks of blocks of 1-Tensors."""
+    K, F = KF
+    expressions = [(F+F).blocks[:2].blocks[0], (K*F).blocks[:2].blocks[0],
+                   (-F).blocks[:2].blocks[0]]
+    compare_vector_expressions(expressions)
+
+
+def test_push_assembled_vector_blocks_individual(TC):
+    """Test Optimisers's ability to handle individual blocks of AssembledVectors."""
+    T, C = TC
+    expressions = [C.blocks[0], (C+C).blocks[0], (T*C).blocks[0], (-C).blocks[0], (C.T).blocks[0]]
+    compare_vector_expressions(expressions)
+
+
+def test_push_block_aggressive_unaryop_nesting():
+    """Test Optimisers's ability to handle extremely nested expressions."""
+    V = FunctionSpace(UnitSquareMesh(1, 1), "DG", 3)
+    f = Function(V)
+    g = Function(V)
+    f.assign(1.0)
+    g.assign(0.5)
+    F = AssembledVector(f)
+    G = AssembledVector(g)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    A = Tensor(inner(u, v)*dx)
+    B = Tensor(2.0*inner(u, v)*dx)
+
+    # This is a very silly way to write the vector of ones
+    expressions = [((B.T*A.inv).T*G + (-A.inv.T*B.T).inv*F + B.inv*(A.T).T*F).blocks[0]]
+    compare_vector_expressions(expressions)
+
+
+def compare_tensor_expressions(expressions):
+    for expr in expressions:
+        ref = assemble(expr, form_compiler_parameters={"optimise": False}).M.values
+        opt = assemble(expr, form_compiler_parameters={"optimise": True}).M.values
+        assert np.allclose(opt, ref, rtol=1e-14)
+
+
+def compare_vector_expressions(expressions):
+    for expr in expressions:
+        ref = assemble(expr, form_compiler_parameters={"optimise": False}).dat.data
+        opt = assemble(expr, form_compiler_parameters={"optimise": True}).dat.data
+        assert np.allclose(opt, ref, rtol=1e-14)
+
+
+def compare_vector_expressions_mixed(expressions):
+    for expr in expressions:
+        ref = assemble(expr, form_compiler_parameters={"optimise": False}).dat.data
+        opt = assemble(expr, form_compiler_parameters={"optimise": True}).dat.data
+        for r, o in zip(ref, opt):
+            assert np.allclose(o, r, rtol=1e-14)


### PR DESCRIPTION
Hi all. In this PR I am changing how we deal with the assembly of blocks in Slate.

Generally these blocks are used to index into Tensor which are defined on MixedFunctionSpaces. So for example if we have a form defined a form defined on` W x W` and `W = U x V` and we build `A = Tensor(form)`, then we can get the contributions of, for example, the `U x U` block by asking for `A._blocks[0,0]`.

 The way we used to assemble the kernels corresponding to the blocks was in the order assemble first, index later. So we were assembling the local TSFC kernels (corresponding to A in my example) and then index the result of the assembly kernel in the Slate kernel (and may do further linear algebra operations on it).

In this PR I am changing the order of assembly and indexing to the following: first index the ufl form (with `split`), then assemble the ufl form locally with TSFC.

This would have been the right thing to do in first place so that we don't assemble the whole local tensor, when we only need bits of it. But I also need it for my project, so that local actions on blocks can be expressed easily.

I introduced a `terminal` property which helps me to avoid some checks like `isinstance(tensor, Block)` and so forth later in the compiler pipeline. The main contribution is the new `form` property. We already have this property on Tensors, but I have introduced it on Blocks and AssembledVectors, too. (The reason I introduced it on AssembledVectors too, is the same as for the introduction of `terminal` property).

Because Blocks can sit on top of AssembledVectors or Tensors, they can be rank 1 or rank 2 and depending on that, we either get a form back or a tuple of coefficients. This is not ideal because then later I need to check if form is a tuple or not. I don't really want to tuplify all `form`s (including the forms on Tensors) because it might break backward compatibility. If anyone's got a suggestion how can deal better with this, let me know.