### PR TITLE
slate: IndexCreator dicts should be per-instance

### DIFF
--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -766,8 +766,9 @@ class SlateWrapperBag(object):
 
 
 class IndexCreator(object):
-    inames = OrderedDict()  # pym variable -> extent
-    namer = UniqueNameGenerator(forced_prefix="i_")
+    def __init__(self):
+        self.inames = OrderedDict()  # pym variable -> extent
+        self.namer = UniqueNameGenerator(forced_prefix="i_")
 
     def __call__(self, extents):
         """Create new indices with specified extents.


### PR DESCRIPTION
Previously we had one iname dict for all IndexCreator instances, so we
would end up with many unused inames in the loopy kernel. Fixes #2108.