### PR TITLE
Don't change the user in the Firedrake env container

### DIFF
--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -34,5 +34,3 @@ RUN useradd -m -s /bin/bash -G sudo jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     ldconfig
 
-USER firedrake
-WORKDIR /home/firedrake


### PR DESCRIPTION
First step towards having Actions-compatible docker files.

I think this doesn't break anything because:

* All the downstream containers explicitly set the user
* Jenkins runs as its own user anyway.