### PR TITLE
Slate: fix make indexing of blocks with too few indices legal.

### DIFF
--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -74,7 +74,9 @@ class BlockIndexer(object):
 
         block_shape = tuple(len(V) for V in self.tensor.arg_function_spaces)
         # Convert slice indices to tuple of indices.
-        blocks = tuple(as_tuple(range(k.stop)[k] if isinstance(k, slice) else k)
+        blocks = tuple(tuple(range(k.start or 0, k.stop or n, k.step or 1))
+                       if isinstance(k, slice)
+                       else (k,)
                        for k, n in zip(key, block_shape))
 
         if blocks == tuple(tuple(range(n)) for n in block_shape):

--- a/tests/slate/test_slate_infrastructure.py
+++ b/tests/slate/test_slate_infrastructure.py
@@ -246,6 +246,9 @@ def test_blocks(zero_rank_tensor, mixed_matrix, mixed_vector):
     F01 = _F[:2]
     F12 = _F[1:3]
 
+    # Test make indexing with too few indices legal
+    assert _M[2] == _M[2, :3]
+
     # Test index checking
     with pytest.raises(ValueError):
         S.blocks[0]


### PR DESCRIPTION
@thomasgibson wrote Slate so that if tensors on mixed function space are indexed with blocks, but with too few indices, Slate will fix that under the hood.

When I translated the Slate compiler to produce Loo.py not Eigen (via GEM) in this commit https://github.com/firedrakeproject/firedrake/commit/710f8af6057185596cdedfcebfca81be0bb69536, I made a mistake that breaks what I said above. Since indexing with too few indices was not tested, I did not realise until a discussion with Lawrence today.

This PR is a fix so that indexing with too few indices works and also introduces a test for that.