### PR TITLE
Small fix to OpenCascadeMeshHierarchy due to API change

### DIFF
--- a/firedrake/mg/opencascade_mh.py
+++ b/firedrake/mg/opencascade_mh.py
@@ -139,7 +139,7 @@ def project_mesh_to_cad_3d(mesh, cad):
     ids = mesh.exterior_facets.unique_markers
 
     filt = lambda arr: arr[numpy.where(arr < mesh.coordinates.dof_dset.size)[0]]
-    boundary_nodes = {id: filt(mesh.coordinates.function_space().boundary_nodes(int(id), "topological")) for id in ids}
+    boundary_nodes = {id: filt(mesh.coordinates.function_space().boundary_nodes(int(id))) for id in ids}
 
     for (id, face) in zip(ids, cad.faces()):
         owned_nodes = boundary_nodes[id]
@@ -214,7 +214,7 @@ def project_mesh_to_cad_2d(mesh, cad):
     ids = mesh.exterior_facets.unique_markers
 
     filt = lambda arr: arr[numpy.where(arr < mesh.coordinates.dof_dset.size)[0]]
-    boundary_nodes = {id: filt(mesh.coordinates.function_space().boundary_nodes(int(id), "topological")) for id in ids}
+    boundary_nodes = {id: filt(mesh.coordinates.function_space().boundary_nodes(int(id))) for id in ids}
 
     for (id, edge) in zip(ids, cad.edges()):
         owned_nodes = boundary_nodes[id]


### PR DESCRIPTION
`FunctionSpace.boundary_nodes` no longer takes in an argument `"topological"`.

It passes the tests that use opencascade on my machine.