### PR TITLE
Firedrake-update: Reset loopy remote to branch main

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -757,16 +757,23 @@ def git_update(name, url=None):
         git_sha = check_output(["git", "rev-parse", "HEAD"])
         # Ensure remotes get updated if and when we move repositories.
         if url:
-            plain_url = split_requirements_url(url)[1]
+            _, plain_url, branch = split_requirements_url(url)
             current_url = check_output(["git", "remote", "-v"]).split()[1]
+            current_branch = check_output(["git", "branch", "--show-current"]).strip()
             protocol = "https" if current_url.startswith("https") else "ssh"
             new_url = git_url(plain_url, protocol)
             # Ensure we only change from bitbucket to github and not the reverse.
-            if new_url != current_url and "bitbucket.org" in current_url \
-               and ("github.com/firedrakeproject" in plain_url
-                    or "github.com/dolfin-adjoint" in plain_url):
+            if (new_url != current_url
+                and ("bitbucket.org" in current_url)
+                and ("github.com/firedrakeproject" in plain_url
+                     or "github.com/dolfin-adjoint" in plain_url)):
                 log.info("Updating git remote for %s" % name)
                 check_call(["git", "remote", "set-url", "origin", new_url])
+            # Ensure we only switch loopy branch if loopy is on firedrake and not on a feature branch.
+            elif name == "loopy" and current_branch != branch and current_branch == "firedrake":
+                log.info("Updating loopy branch to main")
+                check_call(["git", "checkout", "-q", branch])
+
         check_call(["git", "pull", "--recurse-submodules"])
         git_sha_new = check_output(["git", "rev-parse", "HEAD"])
     return git_sha != git_sha_new


### PR DESCRIPTION
Adresses https://github.com/firedrakeproject/firedrake/issues/2113

https://github.com/OP2/PyOP2/pull/627 needs to be merged first.

After we have merged all that, we want to change the default branch of our loopy fork.