### PR TITLE
Test notebooks

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -9,3 +9,4 @@ vtk==9.0.1
 pkgconfig
 cached_property
 requests
+nbval

--- a/tests/demos/test_notebooks_run.py
+++ b/tests/demos/test_notebooks_run.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+import subprocess
+import glob
+
+
+cwd = os.path.abspath(os.path.dirname(__file__))
+nb_dir = os.path.join(cwd, "..", "..", "docs", "notebooks")
+
+
+# Discover the notebook files by globbing the notebook directory
+@pytest.fixture(params=glob.glob(os.path.join(nb_dir, "*.ipynb")),
+                ids=lambda x: os.path.basename(x))
+def ipynb_file(request):
+    return os.path.abspath(request.param)
+
+
+@pytest.mark.skipcomplex  # Will need to add a seperate case for a complex tutorial.
+def test_notebook_runs(ipynb_file, tmpdir, monkeypatch):
+    monkeypatch.chdir(tmpdir)
+    pytest = os.path.join(os.environ.get("VIRTUAL_ENV"), "bin", "pytest")
+    subprocess.check_call([pytest, "--nbval-lax", ipynb_file])


### PR DESCRIPTION
[PR 2131](https://github.com/firedrakeproject/firedrake/pull/2131) fixes some broken notebooks.
[Issue 2135](https://github.com/firedrakeproject/firedrake/issues/2135) points out that no one noticed they were broken.

This PR hooks the tests (back?) up.

Note that it is based off of the previous PR; the only changes are in `requirements-ext.txt` and `tests/demos/test_notebooks_run.py`.