### PR TITLE
Melina97/fix ad annotate solve

### DIFF
--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -63,8 +63,7 @@ class NonlinearVariationalSolverMixin:
                                                        solver_kwargs=self._ad_kwargs,
                                                        **sb_kwargs)
                 if not self._ad_nlvs:
-                    from firedrake import NonlinearVariationalSolver
-                    self._ad_nlvs = NonlinearVariationalSolver(self._ad_problem_clone(self._ad_problem,
+                    self._ad_nlvs = type(self)(self._ad_problem_clone(self._ad_problem,
                                                                                       block.get_dependencies()),
                                                                **self._ad_kwargs)
 

--- a/firedrake/adjoint/variational_solver.py
+++ b/firedrake/adjoint/variational_solver.py
@@ -63,9 +63,10 @@ class NonlinearVariationalSolverMixin:
                                                        solver_kwargs=self._ad_kwargs,
                                                        **sb_kwargs)
                 if not self._ad_nlvs:
-                    self._ad_nlvs = type(self)(self._ad_problem_clone(self._ad_problem,
-                                                                                      block.get_dependencies()),
-                                                               **self._ad_kwargs)
+                    self._ad_nlvs = type(self)(
+                        self._ad_problem_clone(self._ad_problem, block.get_dependencies()),
+                        **self._ad_kwargs
+                    )
 
                 block._ad_nlvs = self._ad_nlvs
                 tape.add_block(block)


### PR DESCRIPTION
Call `type(self)` instead of an explicit class name in order to handle subclasses correctly.