### PR TITLE
Add guard to starting PETSc logging

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -19,17 +19,17 @@ del sys, config
 import firedrake.petsc as petsc
 
 # Initialise PETSc events for both import and entire duration of program
-petsc.PETSc.Log.begin()
-_main_event = petsc.PETSc.Log.Event("firedrake")
-_main_event.begin()
+_is_logging = "log_view" in petsc.OptionsManager.commandline_options
+if _is_logging:
+    _main_event = petsc.PETSc.Log.Event("firedrake")
+    _main_event.begin()
 
-_init_event = petsc.PETSc.Log.Event("firedrake.__init__")
-_init_event.begin()
+    _init_event = petsc.PETSc.Log.Event("firedrake.__init__")
+    _init_event.begin()
 
-import atexit
-atexit.register(lambda: _main_event.end())
-
-del atexit
+    import atexit
+    atexit.register(lambda: _main_event.end())
+    del atexit
 del petsc
 
 # UFL Exprs come with a custom __del__ method, but we hold references
@@ -143,4 +143,7 @@ if (_omp_num_threads is None) or (_omp_num_threads > 1):
 del _openblas_lib, _openblas_dll, _omp_num_threads, os, cdll, find_library
 
 # Stop profiling Firedrake import
-_init_event.end()
+if _is_logging:
+    _init_event.end()
+    del _init_event
+del _is_logging


### PR DESCRIPTION
This fix is necessary because the [previous solution](https://github.com/firedrakeproject/firedrake/pull/2126), needed to stop
PETSc complaining when the user passes `PETSc.Log.begin` themselves,
would break nested profiling since `PETSc.Log.begin` calls
`PetscLogDefaultBegin` internally instead of `PetscLogNestedBegin`.

When the `-log_view` flag is passed PETSc checks and calls the right
`Begin` function hence why I've added this guard.

I have also observed that nested profiling does not work properly if the
user writes `PETSc.Log.begin` in their code but I don't think we can do
much about this.