### PR TITLE
Fix form splitting of derivatives

### DIFF
--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -72,11 +72,13 @@ class ExtractSubBlock(MultiFunction):
         return self.expr(o, *map_expr_dags(self.index_inliner, operands))
 
     def coefficient_derivative(self, o, expr, coefficients, arguments, cds):
-        # If we're only taking a derivative wrt part of an argument in
-        # a mixed space other bits might come back as zero. We want to
-        # propagate a zero in that case.
         argument, = arguments
-        if all(isinstance(a, Zero) for a in argument.ufl_operands):
+        if (isinstance(argument, Zero)
+            or (isinstance(argument, ListTensor)
+                and all(isinstance(a, Zero) for a in argument.ufl_operands))):
+            # If we're only taking a derivative wrt part of an argument in
+            # a mixed space other bits might come back as zero. We want to
+            # propagate a zero in that case.
             return Zero(o.ufl_shape, o.ufl_free_indices, o.ufl_index_dimensions)
         else:
             return self.reuse_if_untouched(o, expr, coefficients, arguments, cds)


### PR DESCRIPTION
If we were taking a coordinate derivative, or the derivative direction
was a Function (rather than an Argument), the simplifications in the
handler for CoefficientDerivatives would just return Zero, rather than
an appropriate split thing. Fix by guarding the zero return more
tightly.