### PR TITLE
Set the right communicators when building transfer matrices in p-MG.

### DIFF
--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -934,7 +934,7 @@ def prolongation_matrix_matfree(Vf, Vc, Vf_bcs, Vc_bcs):
         ctx = StandaloneInterpolationMatrix(Vf, Vc, Vf_bcs, Vc_bcs)
 
     sizes = (Vc.dof_dset.layout_vec.getSizes(), Vf.dof_dset.layout_vec.getSizes())
-    M_shll = PETSc.Mat().createPython(sizes, ctx)
+    M_shll = PETSc.Mat().createPython(sizes, ctx, comm=Vf.mesh().comm)
     M_shll.setUp()
 
     return M_shll


### PR DESCRIPTION
I tried to use `firedrake.P1PC` inside defcon and it hung. This patch fixes it.