### PR TITLE
Build scipy in the Docker container

### DIFF
--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -10,4 +10,4 @@ WORKDIR /home/firedrake
 
 # Now install Firedrake.
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
-RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --remove-build-files"
+RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --remove-build-files --pip-install scipy"


### PR DESCRIPTION
An imminent PR for my FDM preconditioner #2024 , since it requires scipy to build sparse cell matrices. Scipy is also required already by one of the jupyter notebooks.