### PR TITLE
Use UFL coefficient numbering instead of rolling our own

### DIFF
--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -211,9 +211,7 @@ def compile_form(form, name, parameters=None, split=True, interface=None, coffee
         pass
 
     kernels = []
-    # A map from all form coefficients to their number.
-    coefficient_numbers = dict((c, n)
-                               for (n, c) in enumerate(form.coefficients()))
+    coefficient_numbers = form.coefficient_numbering()
     if split:
         iterable = split_form(form, diagonal=diagonal)
     else:


### PR DESCRIPTION
I noticed that we were doing something that UFL already does for us [here](https://github.com/firedrakeproject/ufl/blob/master/ufl/form.py#L454).