### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+cff-version: 1.2.0
+message: |
+    "If you publish results using Firedrake, we would be grateful if you would cite it using the following metadata.
+    Please visit https://www.firedrakeproject.org/citing.html for extended instructions."
+title: "Firedrake"
+url: "https://github.com/firedrakeproject/firedrake"
+preferred-citation:
+  type: article
+  reference: Rathgeber2016
+  authors:
+    family-names: "Rathgeber"
+    given-names: "Florian"
+    family-names: "Ham"
+    given-names: "David A."
+    family-names: "Lawrence"
+    given-names: "Mitchell"
+    family-names: "Lange"
+    given-names: "Michael"
+    family-names: "Luporini"
+    given-names: "Fabio"
+    family-names: "Mcrae"
+    given-names: "Andrew T. T."
+    family-names: "Bercea"
+    given-names: "Gheorghe-Teodor"
+    family-names: "Markall"
+    given-names: "Graham R."
+    family-names: "Kelly"
+    given-names: "Paul H. J."
+  doi: "10.1145/2998441"
+  url: "http://arxiv.org/abs/1501.01809"
+  journal: "ACM Trans. Math. Softw."
+  start: 1 # First page number
+  end: 27 # Last page number
+  title: "Firedrake: Automating the Finite Element Method by Composing Abstractions"
+  volume: 43
+  issue: 3
+  year: 2016
+


### PR DESCRIPTION
I don't know if you'd like to use this feature or not, but GitHub has recently added "Cite this repository" button. For more details see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files.

This PR adds a `CITATION.cff` file. When present in the repository GitHub adds the "Cite this repository" button with generated APA and BibTeX citations.
![image](https://user-images.githubusercontent.com/19621411/130213869-138ef816-25bf-44ec-b424-018919719792.png)

Clicking "View citation file" opens the` CITATION.cff` file.
GitHub uses https://github.com/citation-file-format/ruby-cff to generate the APA and BibTeX. Here is the output:
```
Rathgeber, F., Ham, D. A., Lawrence, M., Lange, M., Luporini, F., Mcrae, A. T. T., Bercea, G., Markall, G. R., & Kelly, P. H. J. Firedrake: Automating the Finite Element Method by Composing Abstractions. ACM Trans. Math. Softw., 43(3), 1. https://doi.org/10.1145/2998441
```
```
@article{Rathgeber_Firedrake_Automating_the,
author = {Rathgeber, Florian and Ham, David A. and Lawrence, Mitchell and Lange, Michael and Luporini, Fabio and Mcrae, Andrew T. T. and Bercea, Gheorghe-Teodor and Markall, Graham R. and Kelly, Paul H. J.},
doi = {10.1145/2998441},
journal = {ACM Trans. Math. Softw.},
number = {3},
pages = {1--27},
title = {{Firedrake: Automating the Finite Element Method by Composing Abstractions}},
url = {http://arxiv.org/abs/1501.01809},
volume = {43}}
```
Unfortunately, it's not possible to change the reference tag of the generated BibTeX to match https://github.com/firedrakeproject/firedrake/blob/c0912a406323e742466cb77500abc8e15c4287f5/docs/source/_static/bibliography.bib#L281

"message" from CITATION.cff seems not to be used currently by GitHub, maybe this will change in the future, but still, I added a link to the citation webpage of Firedrake.
