### PR TITLE
Annotate LinearSolver

### DIFF
--- a/firedrake/adjoint/__init__.py
+++ b/firedrake/adjoint/__init__.py
@@ -1,6 +1,7 @@
 from firedrake.adjoint.function import *               # noqa: F401
 from firedrake.adjoint.assembly import *               # noqa: F401
 from firedrake.adjoint.projection import *             # noqa: F401
+from firedrake.adjoint.linear_solver import *          # noqa: F401
 from firedrake.adjoint.variational_solver import *     # noqa: F401
 from firedrake.adjoint.solving import *                # noqa: F401
 from firedrake.adjoint.mesh import *                   # noqa: F401

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -73,8 +73,8 @@ class GenericSolveBlock(blocks.GenericSolveBlock, Backend):
 class SolveLinearSystemBlock(GenericSolveBlock):
     def __init__(self, A, u, b, *args, **kwargs):
         lhs = A.form
-        func = u.function
-        rhs = b.form
+        func = u if isinstance(u, self.backend.Function) else u.function
+        rhs = b.form if hasattr(b, 'form') else b
         bcs = A.bcs if hasattr(A, "bcs") else []
         super().__init__(lhs, rhs, func, bcs, *args, **kwargs)
 

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -73,8 +73,8 @@ class GenericSolveBlock(blocks.GenericSolveBlock, Backend):
 class SolveLinearSystemBlock(GenericSolveBlock):
     def __init__(self, A, u, b, *args, **kwargs):
         lhs = A.form
-        func = u if isinstance(u, self.backend.Function) else u.function
-        rhs = b.form if hasattr(b, 'form') else b
+        func = u.function if hasattr(u, "function") else u
+        rhs = b.form if hasattr(b, "form") else b
         bcs = A.bcs if hasattr(A, "bcs") else []
         super().__init__(lhs, rhs, func, bcs, *args, **kwargs)
 

--- a/firedrake/adjoint/linear_solver.py
+++ b/firedrake/adjoint/linear_solver.py
@@ -1,0 +1,55 @@
+import copy
+from firedrake.constant import Constant
+from functools import wraps
+from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
+from firedrake.adjoint.blocks import SolveLinearSystemBlock
+from ufl import replace
+
+
+class LinearSolverMixin:
+    @staticmethod
+    def _ad_annotate_init(init):
+        @no_annotations
+        @wraps(init)
+        def wrapper(self, A, *args, **kwargs):
+            self.ad_block_tag = kwargs.pop("ad_block_tag", None)
+            init(self, A, *args, **kwargs)
+            self._ad_A = A
+            self._ad_args = args
+            self._ad_kwargs = kwargs
+            self._ad_ls = None
+
+        return wrapper
+
+    @staticmethod
+    def _ad_annotate_solve(solve):
+        @wraps(solve)
+        def wrapper(self, x, b, **kwargs):
+            """To disable the annotation, just pass :py:data:`annotate=False` to this routine, and it acts exactly like the
+            Firedrake solve call. This is useful in cases where the solve is known to be irrelevant or diagnostic
+            for the purposes of the adjoint computation (such as projecting fields to other function spaces
+            for the purposes of visualisation)."""
+
+            annotate = annotate_tape(kwargs)
+            if annotate:
+                tape = get_working_tape()
+                A = self._ad_A
+                sb_kwargs = SolveLinearSystemBlock.pop_kwargs(kwargs)
+                sb_kwargs.update(kwargs)
+
+                block = SolveLinearSystemBlock(self._ad_A, x, b,
+                                               solver_params=self.parameters,
+                                               solver_kwargs=self._ad_kwargs,
+                                               ad_block_tag=self.ad_block_tag,
+                                               **sb_kwargs)
+                tape.add_block(block)
+
+            with stop_annotating():
+                out = solve(self, x, b, **kwargs)
+
+            if annotate:
+                block.add_output(x.create_block_variable())
+
+            return out
+
+        return wrapper

--- a/firedrake/adjoint/linear_solver.py
+++ b/firedrake/adjoint/linear_solver.py
@@ -1,9 +1,6 @@
-import copy
-from firedrake.constant import Constant
 from functools import wraps
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
 from firedrake.adjoint.blocks import SolveLinearSystemBlock
-from ufl import replace
 
 
 class LinearSolverMixin:
@@ -37,7 +34,7 @@ class LinearSolverMixin:
                 sb_kwargs = SolveLinearSystemBlock.pop_kwargs(kwargs)
                 sb_kwargs.update(kwargs)
 
-                block = SolveLinearSystemBlock(self._ad_A, x, b,
+                block = SolveLinearSystemBlock(A, x, b,
                                                solver_params=self.parameters,
                                                solver_kwargs=self._ad_kwargs,
                                                ad_block_tag=self.ad_block_tag,

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -9,6 +9,7 @@ from firedrake import dmhooks
 from firedrake.petsc import PETSc, OptionsManager
 from firedrake.utils import cached_property
 from firedrake.ufl_expr import action
+from firedrake.adjoint import LinearSolverMixin
 
 
 __all__ = ["LinearSolver"]
@@ -19,6 +20,7 @@ class LinearSolver(OptionsManager):
     DEFAULT_KSP_PARAMETERS = solving_utils.DEFAULT_KSP_PARAMETERS
 
     @PETSc.Log.EventDecorator()
+    @LinearSolverMixin._ad_annotate_init
     def __init__(self, A, *, P=None, solver_parameters=None,
                  nullspace=None, transpose_nullspace=None,
                  near_nullspace=None, options_prefix=None):
@@ -132,6 +134,7 @@ class LinearSolver(OptionsManager):
         return blift
 
     @PETSc.Log.EventDecorator()
+    @LinearSolverMixin._ad_annotate_solve
     def solve(self, x, b):
         if not isinstance(x, (function.Function, vector.Vector)):
             raise TypeError("Provided solution is a '%s', not a Function or Vector" % type(x).__name__)


### PR DESCRIPTION
When adding Pyadjoing tags to Thetis solves using `ad_block_tag` in [PR261](https://github.com/thetisproject/thetis/pull/261), I noticed that `LinearSolver` is not annotated. Hopefully this should do the trick.