### PR TITLE
improve BLAS threads checking

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -123,7 +123,7 @@ del get_versions
 # - MKL_NUM_THREADS: mkl,
 # - VECLIB_MAXIMUM_THREADS: accelerate,
 # - NUMEXPR_NUM_THREADS: numexpr
-# We only handle the first two cases
+# We only handle the first three cases
 from ctypes import cdll
 try:
     _blas_lib = cdll.LoadLibrary(_blas_lib_path)

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -140,6 +140,8 @@ try:
             warning("Cannot set number of threads in BLAS library!")
 except OSError:
     warning("Could not load BLAS library!")
+except TypeError:
+    warning("Could not find BLAS library!")
 
 # OMP_NUM_THREADS can be set to a comma-separated list of positive integers
 try:

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -106,16 +106,19 @@ def get_blas_library():
         program = ["otool", "-L"]
         cmd = subprocess.run([*program, PETSc.__file__], stdout=subprocess.PIPE)
 
-    entries = cmd.stdout.decode("utf-8").split("\n")
-    entry = next((e for e in entries if "blas" in e or "libmkl" in e), None)
-    if entry is None:
+    library_names = ["blas", "libmkl"]
+    entries = [
+        entry for entry in cmd.stdout.decode("utf-8").split("\n")
+        if any(name in entry for name in library_names)
+    ]
+    if not entries:
         return None
 
     # `ldd` puts a bunch of garbage before the library name in the output, so
     # we have to split the result on whitespace and get the 3rd word, whereas
     # `otool` puts it right at the beginning.
     index = 2 if program[0] == "ldd" else 0
-    return entry.split()[index]
+    return entries[0].split()[index]
 
 
 class OptionsManager(object):

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -104,7 +104,7 @@ def get_blas_library():
         cmd = subprocess.run(["otool", "-L", PETSc.__file__], stdout=subprocess.PIPE)
 
     entries = cmd.stdout.decode("utf-8").split("\n")
-    entry = next((entry for entry in entries if "blas" in entry), None)
+    entry = next((entry for entry in entries if "blas" in entry or "libmkl" in entry), None)
     if entry is None:
         return None
 


### PR DESCRIPTION
The current code in `__init__.py` checks for the presence of OpenBLAS and sets the number of threads to 1 in order to prevent awful performance regressions. This does the right thing in some setups but not others:

1. You have regular old Netlib BLAS.
2. You're linking to the Intel MKL library for BLAS.
3. You installed OpenBLAS via the `--with-blas=download` option when building PETSc.

You still get the warning even in the last case because the current code uses `find_library` to look for OpenBLAS, which only looks in places like `/usr/lib/`, and not in the PETSc build tree. This patch handles the other cases as well by parsing the output of either `ldd` or `otool` (platform depending) on `firedrake.petsc.PETSc.__file__`.

I've tested it on my Mac and in Docker images with Netlib BLAS, Intel MKL, OpenBLAS installed via apt-get, and OpenBLAS installed via PETSc.