### PR TITLE
Allow iadd vectors

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -407,6 +407,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         if np.isscalar(expr):
             self.dat += expr
             return self
+        if isinstance(expr, vector.Vector):
+            expr = expr.function
         if isinstance(expr, Function) and \
            expr.function_space() == self.function_space():
             self.dat += expr.dat
@@ -425,6 +427,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         if np.isscalar(expr):
             self.dat -= expr
             return self
+        if isinstance(expr, vector.Vector):
+            expr = expr.function
         if isinstance(expr, Function) and \
            expr.function_space() == self.function_space():
             self.dat -= expr.dat
@@ -443,6 +447,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         if np.isscalar(expr):
             self.dat *= expr
             return self
+        if isinstance(expr, vector.Vector):
+            expr = expr.function
         if isinstance(expr, Function) and \
            expr.function_space() == self.function_space():
             self.dat *= expr.dat
@@ -461,6 +467,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         if np.isscalar(expr):
             self.dat /= expr
             return self
+        if isinstance(expr, vector.Vector):
+            expr = expr.function
         if isinstance(expr, Function) and \
            expr.function_space() == self.function_space():
             self.dat /= expr.dat

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -221,6 +221,15 @@ def test_iadd_combination(sfs):
     assert np.allclose(f.dat.data_ro, 2 + 2)
 
 
+def test_iadd_vector(sfs):
+    f = Function(sfs)
+    g = Function(sfs)
+    g.assign(1)
+    f.assign(2)
+    f += g.vector()
+    assert np.allclose(f.dat.data_ro, 3)
+
+
 def test_different_fs_asign_fails(fs_combinations):
     """Assigning to a Function on a different function space should raise
     ValueError."""


### PR DESCRIPTION
I find that sometimes Pyadjoint does `+=` on a Function and a vector from the corresponding space, which raises an error. I haven't been able to figure out why it does this. This PR allows it to happen, provided the Functions are indeed from the same space. The test below fails without these changes.