### PR TITLE
update documentation dependencies

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1217,10 +1217,10 @@ def install_documentation_dependencies():
     """Just install the required dependencies. There are no provenance
     issues here so no need to record this in the configuration dict."""
     log.info("Installing documentation dependencies")
-    run_pip_install(["sphinx"])
-    run_pip_install(["sphinxcontrib-bibtex"])
-    run_pip_install(["bibtexparser"])
-    run_pip_install(["git+https://github.com/sphinx-contrib/youtube.git"])
+    run_pip(["install", "-U", "sphinx"])
+    run_pip(["install", "-U", "sphinxcontrib-bibtex"])
+    run_pip(["install", "-U", "bibtexparser"])
+    run_pip(["install", "-U", "sphinxcontrib-youtube"])
 
 
 def clean_obsolete_packages():


### PR DESCRIPTION
sphinxcontrib-youtube is now on PyPI. Also set other documentation dependencies to update when `--documentation-dependencies` is run. This is partly to make sure that the sphinx version matches with sphinxcontrib-youtube, and partly because it seems just generally a good idea. Note that the documentation dependencies don't have the same interlinked dependency issues as the rest of Firedrake.