### PR TITLE
M1 fixes

### DIFF
--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -96,29 +96,39 @@ def get_petsc_variables():
     return {k.strip(): v.strip() for k, v in splitlines}
 
 
-def get_blas_library():
-    """Get the path to the BLAS library that PETSc links to"""
+def _get_dependencies(filename):
+    """Get all the dependencies of a shared object library"""
     # Linux uses `ldd` to look at shared library linkage, MacOS uses `otool`
     try:
         program = ["ldd"]
-        cmd = subprocess.run([*program, PETSc.__file__], stdout=subprocess.PIPE)
+        cmd = subprocess.run([*program, filename], stdout=subprocess.PIPE)
+        # Filter out the VDSO and the ELF interpreter on Linux
+        results = [line for line in cmd.stdout.decode("utf-8").split("\n") if "=>" in line]
+        return [line.split()[2] for line in results]
     except FileNotFoundError:
         program = ["otool", "-L"]
-        cmd = subprocess.run([*program, PETSc.__file__], stdout=subprocess.PIPE)
+        cmd = subprocess.run([*program, filename], stdout=subprocess.PIPE)
+        # Meanwhile MacOS puts garbage at the beginning and end of `otool` output
+        return [line.split()[0] for line in cmd.stdout.decode("utf-8").split("\n")[1:-1]]
 
+
+def get_blas_library():
+    """Get the path to the BLAS library that PETSc links to"""
+    petsc_py_dependencies = _get_dependencies(PETSc.__file__)
     library_names = ["blas", "libmkl"]
-    entries = [
-        entry for entry in cmd.stdout.decode("utf-8").split("\n")
-        if any(name in entry for name in library_names)
-    ]
-    if not entries:
-        return None
+    for filename in petsc_py_dependencies:
+        if any(name in filename for name in library_names):
+            return filename
 
-    # `ldd` puts a bunch of garbage before the library name in the output, so
-    # we have to split the result on whitespace and get the 3rd word, whereas
-    # `otool` puts it right at the beginning.
-    index = 2 if program[0] == "ldd" else 0
-    return entries[0].split()[index]
+    # On newer MacOS versions, the PETSc Python extension library doesn't link
+    # to BLAS or MKL directly, so we check the PETSc C library.
+    petsc_c_library = [f for f in petsc_py_dependencies if "libpetsc" in f][0]
+    petsc_c_dependencies = _get_dependencies(petsc_c_library)
+    for filename in petsc_c_dependencies:
+        if any(name in filename for name in library_names):
+            return filename
+
+    return None
 
 
 class OptionsManager(object):

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -618,12 +618,14 @@ elif options.get("with_blas") is not None:
     else:
         petsc_options.add("--CFLAGS=-I{}/include".format(options["with_blas"]))
 elif osname == "Darwin":
-    brew_prefix = check_output(['brew', '--prefix'])[:-1]
-    brew_gcc_prefix = brew_prefix+"/opt/gcc/lib/gcc/11"
-    mac_blas = brew_prefix+"/opt/openblas"
-    petsc_options.add("--with-blaslapack-dir={}".format(mac_blas))
-    petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(mac_blas))
-    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(mac_blas, brew_gcc_prefix))
+    brew_gcc_prefix = check_output(["brew", "--prefix", "gcc"])[:-1]
+    brew_gcc_info = json.loads(check_output(["brew", "info", "--json", "gcc"])[:-1])
+    gcc_major_version = brew_gcc_info[0]["installed"][0]["version"].split(".")[0]
+    brew_gcc_libdir = brew_gcc_prefix + "/lib/gcc/" + gcc_major_version
+    brew_blas_prefix = check_output(["brew", "--prefix", "openblas"])[:-1]
+    petsc_options.add("--with-blaslapack-dir={}".format(brew_blas_prefix))
+    petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(brew_blas_prefix))
+    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(brew_blas_prefix, brew_gcc_libdir))
 
 for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
     if option.startswith("--with-hdf5-dir"):
@@ -1434,8 +1436,7 @@ if mode == "install" or not args.update_script:
                     brew_install(package)
 
             if args.with_blas is None and mode == "install":
-                blas_location = brew_prefix+"/opt/openblas"
-                config["with_blas"] = blas_location
+                config["with_blas"] = brew_blas_prefix
         else:
             log.info("Xcode and homebrew installation disabled. Proceeding on the rash assumption that packaged dependencies are in place.")
             log.info("Please use the --show-dependencies for more information.")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -619,10 +619,11 @@ elif options.get("with_blas") is not None:
         petsc_options.add("--CFLAGS=-I{}/include".format(options["with_blas"]))
 elif osname == "Darwin":
     brew_prefix = check_output(['brew', '--prefix'])[:-1]
+    brew_gcc_prefix = brew_prefix+"/opt/gcc/lib/gcc/11"
     mac_blas = brew_prefix+"/opt/openblas"
     petsc_options.add("--with-blaslapack-dir={}".format(mac_blas))
     petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(mac_blas))
-    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib".format(mac_blas))
+    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(mac_blas, brew_gcc_prefix))
 
 for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
     if option.startswith("--with-hdf5-dir"):


### PR DESCRIPTION
Resolves #2196 (thanks to omarjamil for figuring this out).

Also, the code that I had added to find the BLAS library that PETSc links to didn't work properly on MacOS 11.x. In MacOS 10.x, the PETSc extension library for Python (`PETSc.cpython-blah-blah.dylib`) directly links to BLAS and all the other transitive dependencies of PETSc. In 11.x this is no longer true and we have to instead have to look for BLAS among all the shared object dependencies of the PETSc C library (`libpetsc.dylib`). This patch fixes this problem as well.