### PR TITLE
Fix parameter handling in Slate compiler

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -695,7 +695,7 @@ def _make_parloops(expr, tensor, bcs, diagonal, fc_params, assembly_rank):
     if isinstance(expr, slate.TensorBase):
         if diagonal:
             raise NotImplementedError("Diagonal + slate not supported")
-        kernels = slac.compile_expression(expr, tsfc_parameters=form_compiler_parameters)
+        kernels = slac.compile_expression(expr, compiler_parameters=form_compiler_parameters)
     else:
         kernels = tsfc_interface.compile_form(expr, "form", parameters=form_compiler_parameters, diagonal=diagonal)
 

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -99,7 +99,7 @@ class SlateKernel(TSFCKernel):
         self._initialized = True
 
 
-def compile_expression(slate_expr, tsfc_parameters=None, coffee=False):
+def compile_expression(slate_expr, compiler_parameters=None, coffee=False):
     """Takes a Slate expression `slate_expr` and returns the appropriate
     :class:`firedrake.op2.Kernel` object representing the Slate expression.
 
@@ -117,8 +117,10 @@ def compile_expression(slate_expr, tsfc_parameters=None, coffee=False):
     # Update default parameters with passed parameters
     # The deepcopy is needed because parameters is a nested dict
     params = copy.deepcopy(parameters)
-    if tsfc_parameters is not None:
-        params["form_compiler"].update(tsfc_parameters)
+    if compiler_parameters and "slate_compiler" in compiler_parameters.keys():
+        params["slate_compiler"].update(compiler_parameters.pop("slate_compiler"))
+    if compiler_parameters:
+        params["form_compiler"].update(compiler_parameters)
 
     # If the expression has already been symbolically compiled, then
     # simply reuse the produced kernel.

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -137,21 +137,21 @@ def test_push_block_aggressive_unaryop_nesting():
 
 def compare_tensor_expressions(expressions):
     for expr in expressions:
-        ref = assemble(expr, form_compiler_parameters={"optimise": False}).M.values
-        opt = assemble(expr, form_compiler_parameters={"optimise": True}).M.values
+        ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).M.values
+        opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).M.values
         assert np.allclose(opt, ref, rtol=1e-14)
 
 
 def compare_vector_expressions(expressions):
     for expr in expressions:
-        ref = assemble(expr, form_compiler_parameters={"optimise": False}).dat.data
-        opt = assemble(expr, form_compiler_parameters={"optimise": True}).dat.data
+        ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).dat.data
+        opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).dat.data
         assert np.allclose(opt, ref, rtol=1e-14)
 
 
 def compare_vector_expressions_mixed(expressions):
     for expr in expressions:
-        ref = assemble(expr, form_compiler_parameters={"optimise": False}).dat.data
-        opt = assemble(expr, form_compiler_parameters={"optimise": True}).dat.data
+        ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).dat.data
+        opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).dat.data
         for r, o in zip(ref, opt):
             assert np.allclose(o, r, rtol=1e-14)


### PR DESCRIPTION
I have screwed up when we merged the optimisation for blocks in Slate in this PR https://github.com/firedrakeproject/firedrake/pull/2111. I have changed the way parameters are handled at the end and introduced a bug.

The testing of blocks on master only tests optimised vs. optimised tests so they would never fail, because the assembly parameter, which specifies that an expression should not be optimised, does not reach the Slate compiler.

I am changing this in a minimally invasive way in this PR, where I treat `form_compiler_parameters` as
`form_compiler_parameters = {tsfc_param1, tsfc_param2, "slate_compiler": {slate_param1, ... }}`

The second option would be to pass everywhere `form_compiler_parameters` AND `slate_compiler_parameters`. This involves a lot of interface changes (especially in assembly), so I opted against it.

The third option would be to handle the parameters as
`compiler_parameters = {"form_compiler": {tsfc_param1, ...}, "slate_compiler": {slate_param1, ... }}`. This also needs changes wherever we pass the `form_compiler_parameters` to assemble, so we need to touch a lot of tests e.g.

So I am in favour of option one, but other opinions are welcome.