### PR TITLE
New Slate optimisation pass

### DIFF
--- a/firedrake/parameters.py
+++ b/firedrake/parameters.py
@@ -89,6 +89,8 @@ parameters["type_check_safe_par_loops"] = False
 
 parameters.add(Parameters("slate_compiler"))
 parameters["slate_compiler"]["optimise"] = True
+# Should a Slate multiplication be replaced by an action?
+parameters["slate_compiler"]["replace_mul"] = False
 
 
 def disable_performance_optimisations():

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -162,7 +162,7 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
 
     # Optimise slate expr, e.g. push blocks as far inward as possible
     if compiler_parameters["slate_compiler"]["optimise"]:
-        slate_expr = optimise(slate_expr)
+        slate_expr = optimise(slate_expr, compiler_parameters["slate_compiler"])
 
     # Create a loopy builder for the Slate expression,
     # e.g. contains the loopy kernels coming from TSFC

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -160,6 +160,7 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
 
     Citations().register("Gibson2018")
 
+    orig_expr = slate_expr
     # Optimise slate expr, e.g. push blocks as far inward as possible
     if compiler_parameters["slate_compiler"]["optimise"]:
         slate_expr = optimise(slate_expr, compiler_parameters["slate_compiler"])
@@ -184,12 +185,18 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
                              include_dirs=BLASLAPACK_INCLUDE.split(),
                              ldargs=BLASLAPACK_LIB.split())
 
+    # map the coefficients in the order that PyOP2 needs
+    new_coeffs = slate_expr.coefficients()
+    orig_coeffs = orig_expr.coefficients()
+    get_index = lambda n: orig_coeffs.index(new_coeffs[n]) if new_coeffs[n] in orig_coeffs else n
+    coeff_map = tuple((get_index(n), split_map) for (n, split_map) in slate_expr.coeff_map)
+
     kinfo = KernelInfo(kernel=loopykernel,
                        integral_type="cell",  # slate can only do things as contributions to the cell integrals
                        oriented=builder.bag.needs_cell_orientations,
                        subdomain_id="otherwise",
                        domain_number=0,
-                       coefficient_map=slate_expr.coeff_map,
+                       coefficient_map=coeff_map,
                        needs_cell_facets=builder.bag.needs_cell_facets,
                        pass_layer_arg=builder.bag.needs_mesh_layers,
                        needs_cell_sizes=builder.bag.needs_cell_sizes)

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -1,17 +1,43 @@
 from gem.node import MemoizerArg
 from functools import singledispatch
 from itertools import repeat
-import firedrake.slate.slate as sl
+from firedrake.slate.slate import *
+from collections import namedtuple
+
+""" ActionBag class
+:arg coeff:     what we contract with.
+:arg pick_op:   decides which argument in Tensor is exchanged against the coefficient
+                and also in which operand the action has to be pushed,
+                basically determins if we pre or postmultiply
+"""
+ActionBag = namedtuple("ActionBag", ["coeff", "pick_op"])
 
 
-def optimise(expression):
-    """Optimises a Slate expression, e.g. by pushing blocks inside the expression.
+def flip(pick_op):
+    """Flip an index. Using this function essentially reverses the order of multiplication."""
+    return pick_op ^ 1
+
+
+def optimise(expression, parameters):
+    """Optimises a Slate expression, by pushing blocks and multiplications
+    inside the expression and by removing double transposes.
 
     :arg expression: A (potentially unoptimised) Slate expression.
+    :arg parameters: A dict of compiler parameters.
 
     Returns: An optimised Slate expression
     """
-    return push_block(expression)
+    # 1) Block optimisation
+    expression = push_block(expression)
+
+    # 2) Multiplication optimisation
+    if expression.rank < 2:
+        expression = push_mul(expression, parameters)
+
+    # 3) Transpose optimisation
+    expression = drop_double_transpose(expression)
+
+    return expression
 
 
 def push_block(expression):
@@ -36,41 +62,41 @@ def _push_block(expr, self, indices):
     raise AssertionError("Cannot handle terminal type: %s" % type(expr))
 
 
-@_push_block.register(sl.Transpose)
+@_push_block.register(Transpose)
 def _push_block_transpose(expr, self, indices):
     """Indices of the Blocks are transposed if Block is pushed into a Transpose."""
-    return sl.Transpose(*map(self, expr.children, repeat(indices[::-1]))) if indices else expr
+    return Transpose(*map(self, expr.children, repeat(indices[::-1]))) if indices else expr
 
 
-@_push_block.register(sl.Add)
-@_push_block.register(sl.Negative)
+@_push_block.register(Add)
+@_push_block.register(Negative)
 def _push_block_distributive(expr, self, indices):
     """Distributes Blocks for these nodes"""
     return type(expr)(*map(self, expr.children, repeat(indices))) if indices else expr
 
 
-@_push_block.register(sl.Factorization)
-@_push_block.register(sl.Inverse)
-@_push_block.register(sl.Solve)
-@_push_block.register(sl.Mul)
+@_push_block.register(Factorization)
+@_push_block.register(Inverse)
+@_push_block.register(Solve)
+@_push_block.register(Mul)
 def _push_block_stop(expr, self, indices):
     """Blocks cannot be pushed further into this set of nodes."""
-    return sl.Block(expr, indices) if indices else expr
+    return Block(expr, indices) if indices else expr
 
 
-@_push_block.register(sl.Tensor)
+@_push_block.register(Tensor)
 def _push_block_tensor(expr, self, indices):
     """Turns a Block on a Tensor into a Tensor of an indexed form."""
-    return sl.Tensor(sl.Block(expr, indices).form) if indices else expr
+    return Tensor(Block(expr, indices).form) if indices else expr
 
 
-@_push_block.register(sl.AssembledVector)
+@_push_block.register(AssembledVector)
 def _push_block_assembled_vector(expr, self, indices):
     """Turns a Block on an AssembledVector into the  specialized node BlockAssembledVector."""
-    return sl.BlockAssembledVector(expr._function, sl.Block(expr, indices).form, indices) if indices else expr
+    return BlockAssembledVector(expr._function, Block(expr, indices).form, indices) if indices else expr
 
 
-@_push_block.register(sl.Block)
+@_push_block.register(Block)
 def _push_block_block(expr, self, indices):
     """Inlines Blocks into each other.
     Note that the indices are inlined from the ouside.
@@ -83,3 +109,211 @@ def _push_block_block(expr, self, indices):
     indices = expr._indices if not indices else reindexed
     block, = map(self, expr.children, repeat(indices))
     return block
+
+
+def push_mul(tensor, options):
+    """Executes a Slate compiler optimisation pass.
+    The optimisation is achieved by pushing coefficients from
+    the outside to the inside of an expression.
+    The optimisation pass essentially changes the order of operations
+    in the expressions so that only matrix-vector products are executed.
+
+    :arg tensor: A (potentially unoptimised) Slate expression.
+    :arg options: Optimisation pass options,
+                  e.g. if the multiplication should be replaced by an action.
+
+    Returns: An optimised Slate expression,
+             where only matrix-vector products are executed whereever possible.
+    """
+
+    from gem.node import MemoizerArg
+    mapper = MemoizerArg(_push_mul)
+    mapper.action = options["replace_mul"]
+    a = mapper(tensor, ActionBag(None, 1))
+    return a
+
+
+@singledispatch
+def _push_mul(expr, self, state):
+    raise AssertionError("Cannot handle terminal type: %s" % type(expr))
+
+
+@_push_mul.register(Tensor)
+@_push_mul.register(Block)
+def _push_mul_tensor(expr, self, state):
+    if not self.action:
+        if state.coeff:
+            return Mul(expr, state.coeff) if state.pick_op == 1 else Mul(state.coeff, expr)
+        else:
+            return expr
+    else:
+        raise NotImplementedError("Actions in Slate are not yet supported.")
+
+
+@_push_mul.register(AssembledVector)
+def _push_mul_vector(expr, self, state):
+    """Do not push into AssembledVectors."""
+    return expr
+
+
+@_push_mul.register(Negative)
+@_push_mul.register(Add)
+def _push_mul_distributive(expr, self, state):
+    """Distribute the multiplication into the children of the expression. """
+    return type(expr)(*map(self, expr.children, (state,)*len(expr.children)))
+
+
+@_push_mul.register(Inverse)
+def _push_mul_inverse(expr, self, state):
+    """ Rewrites the multiplication of Inverse
+    with a coefficient into a Solve via A.inv*b = A.solve(b)
+    or b*A^{-1}= (A.T.inv*b.T).T = A.T.solve(b.T).T ."""
+    child, = expr.children
+    return (Solve(child, state.coeff) if state.pick_op
+            else Transpose(Solve(Transpose(child), Transpose(state.coeff))))
+
+
+@_push_mul.register(Transpose)
+def _push_mul_transpose(expr, self, state):
+    """ Pushes a multiplication through a transpose.
+        This works with help of A.T*x = (x.T*A).T.
+        Another example for  expr:=C*A.solve(B.T) : (C*A.solve(B.T)).T * y = (y.T * (C*A.solve(B.T))).T
+
+        :arg expr: a Transpose
+        :arg self: a MemoizerArg object.
+        :arg state: state carries a coefficient in .coeff,
+                    and information if multiply from front (0) or back (1) in .pick_op
+        :returns: an optimised transposed expression
+    """
+    if expr.rank == 2:
+        # switch the multiplication order with pick_op
+        transposed_state = ActionBag(Transpose(state.coeff), flip(state.pick_op))
+        # push mul into A with new state
+        pushed_expr = self(*expr.children, transposed_state)
+        # transpose the end result
+        return self(Transpose(pushed_expr), state)
+    else:
+        return expr
+
+
+@_push_mul.register(Solve)
+def _push_mul_solve(expr, self, state):
+    """ Pushes a multiplication through a solve.
+        case 1) child 1 is matrix, child2 is vector
+        case 2) child 1 is matrix, child2 is matrix
+                a) multiplication from front
+                b) multiplication from back
+    """
+    if expr.rank == 2 and state.pick_op == 0:
+        """
+        case 2) child 1 is matrix, child2 is matrix and a coefficient is passed through
+                a)  multiplication from front
+                    We exploit A.T*x = (x.T*A).T and previously used A.inv*b=A.solve(b).
+                    e.g.            (1) T3*T3.inv*T3.T
+                    transforms to   (2) T3.T.solve(C3.T).T*T3.T
+                                    (3) (T_3*T3.T.solve(C3.T)).T
+                    From (2) to (3) we need to swap rhs of the solve with the coefficient.
+
+                    or              (1) (C*(A.solve(A.solve(A))))
+                    is              (2) (A.solve(A).T*A.T.solve(C.T)).T
+                    transforms to   (3) (A.T.solve(C.T)).T*A.solve(A)).T.T
+                                    (4) (A.T*A.T.solve((A.T.solve(C.T)))
+                                    (5) (A.T*A.T.solve(A.T.solve(C.T))).T
+                                    (6) A.T.solve(A.T.solve(C.T)).T*A
+        """
+        mat = Transpose(expr.children[state.pick_op])
+        swapped_op = Transpose(expr.children[flip(state.pick_op)])
+        new_rhs = Transpose(state.coeff)
+        pushed_child = self(Solve(mat, new_rhs), ActionBag(None, flip(state.pick_op)))
+        return Transpose(self(swapped_op, ActionBag(pushed_child, flip(state.pick_op))))
+    else:
+        """
+        case 1) a)  child 1 is matrix, child2 is vector and there is no coefficient passed through
+                b)  child 2 is matrix, child2 is matrix and there is a coefficient passed through
+                    ->  multiplication from back
+                        A.solve(B)*x = A.inv*B*x = A.inv*(B*x) = A.solve(Bx)
+                We always push into the right hand side of the solve.
+        """
+        mat, rhs = expr.children
+        return (expr if (rhs.rank == 1 and state.coeff)
+                else Solve(mat, self(self(rhs, state), state)))
+
+
+@_push_mul.register(Mul)
+def _push_mul_mul(expr, self, state):
+    """ Pushes an multiplication by a coefficent through a multiplication to the innermost node.
+        e.g. (A1*A2)*b = A1*(A2*b)
+
+--------case 1) child 1 is matrix, child2 is vector or other way around
+In this case the Mul expression is already partially optimised.
+
+a) The child with rank 1 must contain the coefficient.
+Both childs may still leave space for optimisation.
+Optimise child of rank 1 first and use result as coefficient
+to push the Mul into the other child.
+No coefficient would be multiplied on the outside of the Mul.
+e.g. (A0*A1)*((A2+A3)*y) = (A0*A1)*(A2*y+A3*y) = A0*(A1*(A2*y+A3*y))
+
+b) A coefficient is multiplied from the outside.
+Both childs may still leave space for optimisation.
+Optimise child of rank 1 first but do not use result as coefficient.
+Push coefficient from the outside into the Mul of the other child.
+e.g. ((y.T*(A0+A1))*B)*y = ((y.T*A0+y.T*A1)*B)*y = (y.T*A0+y.T*A1)*(B*y)
+
+--------case 2) child 1 is matrix, child2 is matrix
+Examples:
+
+a) (A*B*C)*y
+–––––––––––––––––––––––––––––––––––––––––––––––––––––––
+        outmost_mul(A*B*C,y)   ---->    A*B*outmost_mul(C,y)   ---->    A*(B*outmost_mul(C,y))
+
+            outmost_mul1                     Mul2                                Mul3
+            /      |                      /     |                               /   |
+        Mul2       y   ---->           Mul3     outmost_mul1     ---->        A     Mul2
+        /  |                          /   |       /    |                           /   |
+    Mul3   C                         A    B      C     y                          B    outmost_mul
+    /  |                                                                              /         |
+    A   B                                                                             C          y
+
+b) y.T*TensorOp(op1, op2)
+–––––––––––––––––––––––––––––––––––––––––––––––––––––––
+        outmost_mul                               TensorOp
+        /      |                                 /       |
+    y.T       TensorOp        ---->    outmost_mul      op2
+                /    |                    /    |
+            op1      op2                y.T   op1
+
+        :arg expr: a Multiplication
+        :arg self: a MemoizerArg object.
+        :arg state: state carries a coefficient in .coeff,
+                    and information if multiply from front (0) or back (1) in .pick_op
+        :returns: an optimised Multiplication
+    """
+    if expr.rank == 1:
+        # Optimise the child first that must contain a coefficient
+        prio_child, = tuple(filter(lambda child: child.rank == 1, expr.children))
+        pick_op = expr.children.index(prio_child)
+    else:
+        # Optimise the first child first if multiplication happens from front,
+        # otw. we we walk into second child first.
+        prio_child = expr.children[state.pick_op]
+        pick_op = state.pick_op
+    other_child = expr.children[flip(pick_op)]
+    if state.coeff and expr.rank == 1:
+        assert "So far Slate cannot express linear algebra as in case 1b. If that changes, remove the assertion."
+        # Optimise child of rank 1 first but do not use result as coefficient.
+        coeff = self(prio_child, ActionBag(None, pick_op))
+        pushed_other_child = self(other_child, ActionBag(state.coeff, pick_op))
+        return Mul(pushed_other_child, prio_child) if pick_op else Mul(prio_child, pushed_other_child)
+    else:
+        # Optimise child of rank 1 first and use result as coefficient
+        coeff = self(prio_child, state)
+        return self(other_child, ActionBag(coeff, pick_op))
+
+
+@_push_mul.register(Factorization)
+def _push_mul_factorization(expr, self, state):
+    """Drop any factorisations. This is needed because whenever
+    a Solve node is created so is a Factorization node inside it.
+    The Factorization nodes are only needed for the Eigen Backend however."""
+    return self(*expr.children, state)

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -1122,7 +1122,7 @@ class Mul(BinaryOp):
 
     def __init__(self, A, B):
         """Constructor for the Mul class."""
-        if A.shape[1] != B.shape[0]:
+        if A.shape[-1] != B.shape[0]:
             raise ValueError("Illegal op on a %s-tensor with a %s-tensor."
                              % (A.shape, B.shape))
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -1237,7 +1237,8 @@ def space_equivalence(A, B):
 precedences = [
     [AssembledVector, Block, Factorization, Tensor],
     [Add],
-    [Mul, Solve],
+    [Mul],
+    [Solve],
     [UnaryOp],
 ]
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -39,7 +39,7 @@ from firedrake.formmanipulation import ExtractSubBlock
 
 __all__ = ['AssembledVector', 'Block', 'Factorization', 'Tensor',
            'Inverse', 'Transpose', 'Negative',
-           'Add', 'Mul', 'Solve']
+           'Add', 'Mul', 'Solve', 'BlockAssembledVector']
 
 
 class RemoveNegativeRestrictions(MultiFunction):
@@ -470,11 +470,12 @@ class AssembledVector(TensorBase):
 
 class BlockAssembledVector(AssembledVector):
     """This class is a symbolic representation of an assembled
-    vector of data contained in a set of :class:`firedrake.Function`s
+    vector of data contained in a set of :class:`firedrake.Function` s
     defined on pieces of a split mixed function space.
 
     :arg functions: A tuple of firedrake functions.
     """
+
     def __new__(cls, function, split_functions, indices):
         if isinstance(split_functions, tuple) \
            and all(isinstance(f, Coefficient) for f in split_functions):

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -312,6 +312,24 @@ def test_partially_optimised(TC_non_symm, TC_double_mass, TC):
 
 
 #######################################
+# Test transposition optimisation pass
+#######################################
+def test_drop_transposes(TC_non_symm):
+    """Test Optimisers's ability to drop double transposes."""
+    A, C = TC_non_symm
+
+    expressions = [A.T.T, A.T.T.inv, A.T.T+A.T.T]
+    opt_expressions = [A, A.inv, A+A]
+    compare_tensor_expressions(expressions)
+    compare_slate_tensors(expressions, opt_expressions)
+
+    expressions = [A.solve(A.T.T*C)]
+    opt_expressions = [A.solve(A*C)]
+    compare_vector_expressions(expressions)
+    compare_slate_tensors(expressions, opt_expressions)
+
+
+#######################################
 # Helper functions
 #######################################
 def compare_tensor_expressions(expressions):

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -236,12 +236,12 @@ def test_push_mul_nested(TC, TC_without_trace, TC_non_symm):
     opt = assemble((T3*T3.T.solve(C3.T)).T, form_compiler_parameters={"optimise": False}).dat.data
     ref = assemble(C3*(T3.inv*T3.T), form_compiler_parameters={"optimise": False}).dat.data
     for r, o in zip(ref, opt):
-        assert np.allclose(o, r, rtol=1e-14)
+        assert np.allclose(o, r, rtol=1e-12)
 
     opt = assemble((T3.T.solve(T3.T.solve(C3))).T*T3, form_compiler_parameters={"optimise": False}).dat.data
     ref = assemble((C3.T*T3.inv)*(T3.inv*T3), form_compiler_parameters={"optimise": False}).dat.data
     for r, o in zip(ref, opt):
-        assert np.allclose(o, r, rtol=1e-14)
+        assert np.allclose(o, r, rtol=1e-12)
 
 
 def test_push_mul_schurlike(TC, TC_without_trace):
@@ -260,7 +260,7 @@ def test_push_mul_non_symm(TC_non_symm):
     T, C = TC_non_symm
     ref = assemble(T, form_compiler_parameters={"optimise": False}).M.values
     opt = assemble(T.T, form_compiler_parameters={"optimise": False}).M.values
-    assert not np.allclose(opt, ref, rtol=1e-14)  # go sure problem is non-symmetric
+    assert not np.allclose(opt, ref, rtol=1e-12)  # go sure problem is non-symmetric
     expressions = [T*C, T.inv*C, T.T*C]
     compare_vector_expressions_mixed(expressions)  # only testing data is sufficient here
 
@@ -295,7 +295,7 @@ def test_partially_optimised(TC_non_symm, TC_double_mass, TC):
     opt = assemble((C*(A.solve(A.solve(A)))), form_compiler_parameters={"optimise": True}).dat.data
     ref = assemble((C*(A.inv*(A.inv*(A)))), form_compiler_parameters={"optimise": False}).dat.data
     for r, o in zip(ref, opt):
-        assert np.allclose(o, r, rtol=1e-14)
+        assert np.allclose(o, r, rtol=1e-12)
     compare_slate_tensors([(C*(A.solve(A.solve(A))))], [(A.T.solve(A.T.solve(C.T))).T*A])
 
     # Test some symmetric, mixed, nested expressions
@@ -336,14 +336,14 @@ def compare_tensor_expressions(expressions):
     for expr in expressions:
         ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).M.values
         opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).M.values
-        assert np.allclose(opt, ref, rtol=1e-14)
+        assert np.allclose(opt, ref, rtol=1e-12)
 
 
 def compare_vector_expressions(expressions):
     for expr in expressions:
         ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).dat.data
         opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).dat.data
-        assert np.allclose(opt, ref, rtol=1e-14)
+        assert np.allclose(opt, ref, rtol=1e-12)
 
 
 def compare_vector_expressions_mixed(expressions):
@@ -351,7 +351,7 @@ def compare_vector_expressions_mixed(expressions):
         ref = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": False}}).dat.data
         opt = assemble(expr, form_compiler_parameters={"slate_compiler": {"optimise": True}}).dat.data
         for r, o in zip(ref, opt):
-            assert np.allclose(o, r, rtol=1e-14)
+            assert np.allclose(o, r, rtol=1e-12)
 
 
 def compare_slate_tensors(expressions, opt_expressions):


### PR DESCRIPTION
This PR introduces a new optimisation pass for the Slate compiler.

In the new optimisation pass Slate expressions are resorted so that the corresponding generated code contains a minimal amount of matrix-shaped temporaries. This is useful for high order FEM where the local assembly tensors are big. By using less matrix-shaped temporaries we reduce the amount of data transfer, which is a bottleneck for high-order FEM. Note that the tradeoff is the execution of more FLOPS.

The resorting works by pushing the multiplication of a matrix with a vector as far inside an expression as possible. For example if we have an expressions `(A+B)*f`, where A,B are `Tensors` of rank 2 and f is an `AssembledVector`, then the new compiler pass resorts the expression to `A*f+B*f`. In the compiler pass we also replace all inverses with solves with help of `A.inv*f=A.solve(f)`.

While I want this compiler pass so that I can replace the multiplication in `A*f+B*f` by Actions later on, we should already benefit from this optimisation without that replacement. That is so because: 
1) E.g. `(A+B)*f` theoretically builds 3 matrix-shaped temporaries A, B and A+B, while `A*f+B*f` only builds A and B. BUT in the generated C code the expression is inlined (see C code below) and I don't exactly know what the C compiler is doing under the hood with that. I am afraid it is smart enough to optimise this expression, so that we maybe only really benefit from this optimisation step WITH the replacement of the multiplication by an Action. I have looked at the assembly code for this example, but I have no experience with it and don't understand it well enough to understand if what I say is true. I have timed the difference of the optimised and non-optimised expression for a FE discretisation that results in local tensors of size 400x400, but the timings are almost the same.
2) We certainly benefit of replacing inverse operations with solve operations. The assembly of the optimised expression on a warm cache takes a fraction of the non-optimised expression in this case.

An example of the generated C code is 
Not optimised expression `(A+B)*f`:
```
static void slate_loopy(double *__restrict__ output, double const *__restrict__ T0, double const *__restrict__ T1)
{
  for (int32_t i = 0; i <= 399; ++i)
    for (int32_t i_0 = 0; i_0 <= 399; ++i_0)
      output[i] = output[i] + (T0[400 * i + i_0] + T0[400 * i + i_0]) * T1[i_0];
}
```
Optimised expression `A*f+B*f`
```
static void slate_loopy(double *__restrict__ output, double const *__restrict__ T0, double const *__restrict__ T1)
{
  double t0;

  for (int32_t i = 0; i <= 399; ++i)
  {
    t0 = 0.0;
    for (int32_t i_0 = 0; i_0 <= 399; ++i_0)
      t0 = t0 + T0[400 * i + i_0] * T1[i_0];
    output[i] = output[i] + t0 + t0;
  }
}
```

In addition to the multiplication pass, I also introduce a transpose optimisation pass, which rewrites `A.T.T->A` wherever possible.
