### PR TITLE
Fix adjoint with consecutive nonlinear solves

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -157,7 +157,9 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         dJdu = dJdu.copy()
 
         # Replace the form coefficients with checkpointed values.
-        dFdu_form = self._replace_form(dFdu_form)
+        replace_map = self._replace_map(dFdu_form)
+        replace_map[self.func] = self.get_outputs()[0].saved_output
+        dFdu_form = replace(dFdu_form, replace_map)
 
         compute_bdy = self._should_compute_boundary_adjoint(relevant_dependencies)
         adj_sol, adj_sol_bdy = self._assemble_and_solve_adj_eq(dFdu_form, dJdu, compute_bdy)


### PR DESCRIPTION
Similar to fix in dF/dm term, also in dF/du the u that we are solving
for should be replaced by the checkpoint of the _solution_ (i.e. the
output) in the forward model not by the checkpoint of the initial guess.
This only becomes relevant when F is actually nonlinear in u.

Bug introduced in #2201 , which has broken Thetis adjoint

Added regression test that tests a sequence of actual nonlinear solves
which fails without the fix.