### PR TITLE
Fix syntax for MKL_Set_Num_Threads

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -131,7 +131,7 @@ try:
     if "openblas" in _blas_lib_path:
         _method_name = "openblas_set_num_threads"
     elif "libmkl" in _blas_lib_path:
-        _method_name = "mkl_set_num_threads"
+        _method_name = "MKL_Set_Num_Threads"
 
     if _method_name:
         try:


### PR DESCRIPTION
Per [this link](https://stackoverflow.com/questions/28283112/using-mkl-set-num-threads-with-numpy), mkl_set_num_threads is a Fortran-style (pass by reference) routine, while MKL_Set_Num_Threads is the C-style (pass by value) routine that we're expecting to call.

Before this fix, I couldn't run `import firedrake` when using MKL.