### PR TITLE
Yet more M1 fixes

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -539,106 +539,109 @@ If you really want to use your own Python packages, please run again with the
 --honour-pythonpath option.
 """)
 
-petsc_options = {"--with-fortran-bindings=0",
-                 "--with-debugging=0",
-                 "--with-shared-libraries=1",
-                 "--with-c2html=0",
-                 "--download-eigen=%s/src/eigen-3.3.3.tgz " % firedrake_env,
-                 # File format
-                 "--download-hdf5",
-                 # AMG
-                 "--download-hypre",
-                 # Sparse direct solver
-                 "--download-superlu_dist",
-                 # Parallel mesh partitioner
-                 "--download-ptscotch",
-                 # For superlu_dist amongst others.
-                 "--with-cxx-dialect=C++11"}
 
-if osname == "Darwin":
-    petsc_options.add("--with-x=0")
+def get_petsc_options():
+    petsc_options = {"--with-fortran-bindings=0",
+                     "--with-debugging=0",
+                     "--with-shared-libraries=1",
+                     "--with-c2html=0",
+                     "--download-eigen=%s/src/eigen-3.3.3.tgz " % firedrake_env,
+                     # File format
+                     "--download-hdf5",
+                     # AMG
+                     "--download-hypre",
+                     # Sparse direct solver
+                     "--download-superlu_dist",
+                     # Parallel mesh partitioner
+                     "--download-ptscotch",
+                     # For superlu_dist amongst others.
+                     "--with-cxx-dialect=C++11"}
 
-if not options["minimal_petsc"]:
-    petsc_options.add("--with-zlib")
-    # File formats
-    petsc_options.add("--download-netcdf")
-    petsc_options.add("--download-pnetcdf")
-    # Sparse direct solvers
-    petsc_options.add("--download-suitesparse")
-    petsc_options.add("--download-pastix")
-    # Required by pastix
-    petsc_options.add("--download-hwloc")
     if osname == "Darwin":
-        petsc_options.add("--download-hwloc-configure-arguments=--disable-opencl")
-    # Serial mesh partitioner
-    petsc_options.add("--download-metis")
-    if options.get("with_parmetis", None):
-        # Non-free license.
-        petsc_options.add("--download-parmetis")
+        petsc_options.add("--with-x=0")
 
-if options["petsc_int_type"] == "int32":
-    # Sparse direct solver
-    petsc_options.add("--download-scalapack")  # Needed for mumps
-    petsc_options.add("--download-mumps")
-    # Serial mesh partitioner
-    petsc_options.add("--download-chaco")
     if not options["minimal_petsc"]:
-        # AMG
-        petsc_options.add("--download-ml")
-else:
-    petsc_options.add("--with-64-bit-indices")
+        petsc_options.add("--with-zlib")
+        # File formats
+        petsc_options.add("--download-netcdf")
+        petsc_options.add("--download-pnetcdf")
+        # Sparse direct solvers
+        petsc_options.add("--download-suitesparse")
+        petsc_options.add("--download-pastix")
+        # Required by pastix
+        petsc_options.add("--download-hwloc")
+        if osname == "Darwin":
+            petsc_options.add("--download-hwloc-configure-arguments=--disable-opencl")
+        # Serial mesh partitioner
+        petsc_options.add("--download-metis")
+        if options.get("with_parmetis", None):
+            # Non-free license.
+            petsc_options.add("--download-parmetis")
 
-if options["complex"]:
-    petsc_options -= {'--download-hypre'}
-    petsc_options -= {'--download-ml'}
-    petsc_options.add('--with-scalar-type=complex')
-
-if options.get("mpiexec") is not None:
-    petsc_options.add("--with-mpiexec={}".format(options["mpiexec"]))
-    petsc_options.add("--with-cc={}".format(options["mpicc"]))
-    petsc_options.add("--with-cxx={}".format(options["mpicxx"]))
-    petsc_options.add("--with-fc={}".format(options["mpif90"]))
-else:
-    # Download mpich if the user does not tell us about an MPI.
-    petsc_options.add("--download-mpich")
-    if osname == "Darwin":
-        petsc_options.add("--download-mpich-configure-arguments=--disable-opencl")
-
-if options.get("with_blas") == "download":
-    # Download openblas if the user specifies.
-    petsc_options.add("--download-openblas")
-    petsc_options.add("--download-openblas-make-options='USE_THREAD=0 USE_LOCKING=1 USE_OPENMP=0'")
-    if osname == "Darwin":
-        petsc_options.add("--CFLAGS=-Wno-implicit-function-declaration")
-elif options.get("with_blas") is not None:
-    petsc_options.add("--with-blaslapack-dir={}".format(options["with_blas"]))
-    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib".format(options["with_blas"]))
-    if osname == "Darwin":
-        petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(options["with_blas"]))
+    if options["petsc_int_type"] == "int32":
+        # Sparse direct solver
+        petsc_options.add("--download-scalapack")  # Needed for mumps
+        petsc_options.add("--download-mumps")
+        # Serial mesh partitioner
+        petsc_options.add("--download-chaco")
+        if not options["minimal_petsc"]:
+            # AMG
+            petsc_options.add("--download-ml")
     else:
-        petsc_options.add("--CFLAGS=-I{}/include".format(options["with_blas"]))
-elif osname == "Darwin":
-    brew_gcc_prefix = check_output(["brew", "--prefix", "gcc"])[:-1]
-    brew_gcc_info = json.loads(check_output(["brew", "info", "--json", "gcc"])[:-1])
-    gcc_major_version = brew_gcc_info[0]["installed"][0]["version"].split(".")[0]
-    brew_gcc_libdir = brew_gcc_prefix + "/lib/gcc/" + gcc_major_version
-    brew_blas_prefix = check_output(["brew", "--prefix", "openblas"])[:-1]
-    petsc_options.add("--with-blaslapack-dir={}".format(brew_blas_prefix))
-    petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(brew_blas_prefix))
-    petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(brew_blas_prefix, brew_gcc_libdir))
+        petsc_options.add("--with-64-bit-indices")
 
-for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
-    if option.startswith("--with-hdf5-dir"):
-        petsc_options.discard("--download-hdf5")
-        os.environ["HDF5_DIR"] = option.replace("--with-hdf5-dir=", "")
-    petsc_options.add(option)
-if "HDF5_DIR" in os.environ and "--download-hdf5" in petsc_options:
-    del os.environ["HDF5_DIR"]
-    log.info("""\nWarning: HDF5_DIR environment variable set, but ignored;
-use PETSC_CONFIGURE_OPTIONS="--with-hdf5-dir=$HDF5_DIR"
-to have PETSc built against $HDF5_DIR.
-""")
-petsc_options = list(petsc_options)
+    if options["complex"]:
+        petsc_options -= {'--download-hypre'}
+        petsc_options -= {'--download-ml'}
+        petsc_options.add('--with-scalar-type=complex')
+
+    if options.get("mpiexec") is not None:
+        petsc_options.add("--with-mpiexec={}".format(options["mpiexec"]))
+        petsc_options.add("--with-cc={}".format(options["mpicc"]))
+        petsc_options.add("--with-cxx={}".format(options["mpicxx"]))
+        petsc_options.add("--with-fc={}".format(options["mpif90"]))
+    else:
+        # Download mpich if the user does not tell us about an MPI.
+        petsc_options.add("--download-mpich")
+        if osname == "Darwin":
+            petsc_options.add("--download-mpich-configure-arguments=--disable-opencl")
+
+    if options.get("with_blas") == "download":
+        # Download openblas if the user specifies.
+        petsc_options.add("--download-openblas")
+        petsc_options.add("--download-openblas-make-options='USE_THREAD=0 USE_LOCKING=1 USE_OPENMP=0'")
+        if osname == "Darwin":
+            petsc_options.add("--CFLAGS=-Wno-implicit-function-declaration")
+    elif options.get("with_blas") is not None:
+        petsc_options.add("--with-blaslapack-dir={}".format(options["with_blas"]))
+        petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib".format(options["with_blas"]))
+        if osname == "Darwin":
+            petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(options["with_blas"]))
+        else:
+            petsc_options.add("--CFLAGS=-I{}/include".format(options["with_blas"]))
+    elif osname == "Darwin":
+        brew_gcc_prefix = check_output(["brew", "--prefix", "gcc"])[:-1]
+        brew_gcc_info = json.loads(check_output(["brew", "info", "--json", "gcc"])[:-1])
+        gcc_major_version = brew_gcc_info[0]["installed"][0]["version"].split(".")[0]
+        brew_gcc_libdir = brew_gcc_prefix + "/lib/gcc/" + gcc_major_version
+        brew_blas_prefix = check_output(["brew", "--prefix", "openblas"])[:-1]
+        petsc_options.add("--with-blaslapack-dir={}".format(brew_blas_prefix))
+        petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(brew_blas_prefix))
+        petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(brew_blas_prefix, brew_gcc_libdir))
+
+    for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
+        if option.startswith("--with-hdf5-dir"):
+            petsc_options.discard("--download-hdf5")
+            os.environ["HDF5_DIR"] = option.replace("--with-hdf5-dir=", "")
+        petsc_options.add(option)
+    if "HDF5_DIR" in os.environ and "--download-hdf5" in petsc_options:
+        del os.environ["HDF5_DIR"]
+        log.info("""\nWarning: HDF5_DIR environment variable set, but ignored;
+    use PETSC_CONFIGURE_OPTIONS="--with-hdf5-dir=$HDF5_DIR"
+    to have PETSc built against $HDF5_DIR.
+    """)
+    return list(petsc_options)
+
 
 if mode == "update" and petsc_int_type_changed:
     log.warning("""Force rebuilding all packages because PETSc int type changed""")
@@ -992,7 +995,8 @@ def build_and_install_petsc():
     with directory("petsc"):
         petsc_dir, petsc_arch = get_petsc_dir()
         check_call(["rm", "-rf", os.path.join(petsc_dir, petsc_arch)])
-        check_call([python, "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + list(petsc_options))
+        petsc_options = get_petsc_options()
+        check_call([python, "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + petsc_options)
         check_call(["make", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch), "all"])
         if args.remove_build_files and not args.honour_petsc_dir:
             log.info("Cleaning up PETSc build artifacts")
@@ -1290,6 +1294,7 @@ if mode == "install" and args.show_petsc_configure_options:
     log.info("*********************************************")
     log.info("Would build PETSc with the following options:")
     log.info("*********************************************\n")
+    petsc_options = get_petsc_options()
     log.info("\n".join(petsc_options))
     log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
     sys.exit(0)
@@ -1436,7 +1441,8 @@ if mode == "install" or not args.update_script:
                     brew_install(package)
 
             if args.with_blas is None and mode == "install":
-                config["with_blas"] = brew_blas_prefix
+                config["with_blas"] = check_output(["brew", "--prefix", "openblas"])[:-1]
+
         else:
             log.info("Xcode and homebrew installation disabled. Proceeding on the rash assumption that packaged dependencies are in place.")
             log.info("Please use the --show-dependencies for more information.")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -636,10 +636,9 @@ def get_petsc_options():
         petsc_options.add(option)
     if "HDF5_DIR" in os.environ and "--download-hdf5" in petsc_options:
         del os.environ["HDF5_DIR"]
-        log.info("""\nWarning: HDF5_DIR environment variable set, but ignored;
-    use PETSC_CONFIGURE_OPTIONS="--with-hdf5-dir=$HDF5_DIR"
-    to have PETSc built against $HDF5_DIR.
-    """)
+        log.info("\nWarning: HDF5_DIR environment variable set, but ignored; "
+                 "use PETSC_CONFIGURE_OPTIONS=\"--with-hdf5-dir=$HDF5_DIR\" "
+                 "to have PETSc built against $HDF5_DIR.")
     return list(petsc_options)
 
 


### PR DESCRIPTION
Fixes #2243. Tested on my Mac by first running `brew uninstall --force $(brew list)` so that there's no GCC or OpenBLAS and then reinstalling Firedrake.

The problem that I introduced before was that the script assumes that Homebrew has installed GCC in order to make a list of PETSc configure options, when in fact Homebrew will only install GCC later in the install process than when the PETSc options are created. What I did here with suggestions from @dham was to factor out the PETSc options making into a function that gets called only when it's needed.