### PR TITLE
Introducing a few local preconditioners

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -693,8 +693,6 @@ def _make_parloops(expr, tensor, bcs, diagonal, fc_params, assembly_rank):
     domains = expr.ufl_domains()
 
     if isinstance(expr, slate.TensorBase):
-        if diagonal:
-            raise NotImplementedError("Diagonal + slate not supported")
         kernels = slac.compile_expression(expr, compiler_parameters=form_compiler_parameters)
     else:
         kernels = tsfc_interface.compile_form(expr, "form", parameters=form_compiler_parameters, diagonal=diagonal)

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -167,7 +167,7 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
 
     # Create a loopy builder for the Slate expression,
     # e.g. contains the loopy kernels coming from TSFC
-    gem_expr, var2terminal = slate_to_gem(slate_expr)
+    gem_expr, var2terminal = slate_to_gem(slate_expr, compiler_parameters["slate_compiler"])
 
     scalar_type = compiler_parameters["form_compiler"]["scalar_type"]
     slate_loopy, output_arg = gem_to_loopy(gem_expr, var2terminal, scalar_type)

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -71,6 +71,7 @@ def _push_block_transpose(expr, self, indices):
 @_push_block.register(Add)
 @_push_block.register(Negative)
 @_push_block.register(DiagonalTensor)
+@_push_block.register(Reciprocal)
 def _push_block_distributive(expr, self, indices):
     """Distributes Blocks for these nodes"""
     return type(expr)(*map(self, expr.children, repeat(indices))) if indices else expr
@@ -181,6 +182,7 @@ def _drop_double_transpose_transpose(expr, self):
 @_drop_double_transpose.register(Solve)
 @_drop_double_transpose.register(Inverse)
 @_drop_double_transpose.register(DiagonalTensor)
+@_drop_double_transpose.register(Reciprocal)
 def _drop_double_transpose_distributive(expr, self):
     """Distribute into the children of the expression. """
     return type(expr)(*map(self, expr.children))
@@ -205,6 +207,7 @@ def _push_mul_tensor(expr, self, state):
 
 @_push_mul.register(AssembledVector)
 @_push_mul.register(DiagonalTensor)
+@_push_mul.register(Reciprocal)
 def _push_mul_vector(expr, self, state):
     """Do not push into AssembledVectors."""
     return expr

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -223,8 +223,12 @@ def _push_mul_inverse(expr, self, state):
     with a coefficient into a Solve via A.inv*b = A.solve(b)
     or b*A^{-1}= (A.T.inv*b.T).T = A.T.solve(b.T).T ."""
     child, = expr.children
-    return (Solve(child, state.coeff) if state.pick_op
-            else Transpose(Solve(Transpose(child), Transpose(state.coeff))))
+    if expr.diagonal:
+        # Don't optimise further so that the translation to gem at a later can just spill ]1/a_ii[
+        return expr * state.coeff if state.pick_op else state.coeff * expr
+    else:
+        return (Solve(child, state.coeff) if state.pick_op
+                else Transpose(Solve(Transpose(child), Transpose(state.coeff))))
 
 
 @_push_mul.register(Transpose)

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -70,6 +70,7 @@ def _push_block_transpose(expr, self, indices):
 
 @_push_block.register(Add)
 @_push_block.register(Negative)
+@_push_block.register(DiagonalTensor)
 def _push_block_distributive(expr, self, indices):
     """Distributes Blocks for these nodes"""
     return type(expr)(*map(self, expr.children, repeat(indices))) if indices else expr
@@ -179,6 +180,7 @@ def _drop_double_transpose_transpose(expr, self):
 @_drop_double_transpose.register(Mul)
 @_drop_double_transpose.register(Solve)
 @_drop_double_transpose.register(Inverse)
+@_drop_double_transpose.register(DiagonalTensor)
 def _drop_double_transpose_distributive(expr, self):
     """Distribute into the children of the expression. """
     return type(expr)(*map(self, expr.children))
@@ -202,6 +204,7 @@ def _push_mul_tensor(expr, self, state):
 
 
 @_push_mul.register(AssembledVector)
+@_push_mul.register(DiagonalTensor)
 def _push_mul_vector(expr, self, state):
     """Do not push into AssembledVectors."""
     return expr

--- a/firedrake/slate/slac/tsfc_driver.py
+++ b/firedrake/slate/slac/tsfc_driver.py
@@ -60,7 +60,8 @@ def compile_terminal_form(tensor, prefix, *, tsfc_parameters=None, coffee=True):
         kernels = tsfc_compile(form,
                                subkernel_prefix,
                                parameters=tsfc_parameters,
-                               coffee=coffee, split=False)
+                               coffee=coffee, split=False, diagonal=tensor.diagonal)
+
         if kernels:
             cxt_k = ContextKernel(tensor=tensor,
                                   coefficients=form.coefficients(),

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -212,6 +212,13 @@ def _slate2gem_inverse(expr, self):
         return Inverse(self(tensor))
 
 
+@_slate2gem.register(sl.Reciprocal)
+def _slate2gem_reciprocal(expr, self):
+    child, = map(self, expr.children)
+    indices = tuple(make_indices(len(child.shape)))
+    return ComponentTensor(Division(Literal(1.), Indexed(child, indices)), indices)
+
+
 @_slate2gem.register(sl.Solve)
 def _slate2gem_solve(expr, self):
     return Solve(*map(self, expr.children))

--- a/firedrake/slate/slac/utils.py
+++ b/firedrake/slate/slac/utils.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from ufl.algorithms.multifunction import MultiFunction
 
 from gem import (Literal, Sum, Product, Indexed, ComponentTensor, IndexSum,
-                 Solve, Inverse, Variable, view)
+                 Solve, Inverse, Variable, view, Delta, Index)
 from gem import indices as make_indices
 from gem.node import Memoizer
 from gem.node import pre_traversal as traverse_dags
@@ -148,7 +148,7 @@ class Transformer(Visitor):
         return SymbolWithFuncallIndexing(o.symbol, o.rank, o.offset)
 
 
-def slate_to_gem(expression):
+def slate_to_gem(expression, options):
     """Convert a slate expression to gem.
 
     :arg expression: A slate expression.
@@ -156,7 +156,7 @@ def slate_to_gem(expression):
         gem variables to UFL "terminal" forms.
     """
 
-    mapper, var2terminal = slate2gem(expression)
+    mapper, var2terminal = slate2gem(expression, options)
     return mapper, var2terminal
 
 
@@ -184,6 +184,18 @@ def _slate2gem_block(expr, self):
     offsets = tuple(sum(shape[:idx]) for shape, (idx, *_)
                     in zip(child_shapes.values(), expr._indices))
     return view(child, *(slice(idx, idx+extent) for idx, extent in zip(offsets, expr.shape)))
+
+
+@_slate2gem.register(sl.DiagonalTensor)
+def _slate2gem_diagonal(expr, self):
+    if not self.matfree:
+        A, = map(self, expr.children)
+        assert A.shape[0] == A.shape[1]
+        i, j = (Index(extent=s) for s in A.shape)
+        return ComponentTensor(Product(Indexed(A, (i, i)), Delta(i, j)), (i, j))
+    else:
+        raise NotImplementedError("Diagonals on Slate expressions are \
+                                   not implemented in a matrix-free manner yet.")
 
 
 @_slate2gem.register(sl.Inverse)
@@ -237,9 +249,10 @@ def _slate2gem_factorization(expr, self):
     return A
 
 
-def slate2gem(expression):
+def slate2gem(expression, options):
     mapper = Memoizer(_slate2gem)
     mapper.var2terminal = OrderedDict()
+    mapper.matfree = options["replace_mul"]
     return mapper(expression), mapper.var2terminal
 
 

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -39,7 +39,7 @@ from firedrake.formmanipulation import ExtractSubBlock
 
 __all__ = ['AssembledVector', 'Block', 'Factorization', 'Tensor',
            'Inverse', 'Transpose', 'Negative',
-           'Add', 'Mul', 'Solve', 'BlockAssembledVector']
+           'Add', 'Mul', 'Solve', 'BlockAssembledVector', 'DiagonalTensor']
 
 
 class RemoveNegativeRestrictions(MultiFunction):
@@ -955,8 +955,9 @@ class Inverse(UnaryOp):
         assert A.shape[0] == A.shape[1], (
             "The inverse can only be computed on square tensors."
         )
+        self.diagonal = A.diagonal
 
-        if A.shape > (4, 4) and not isinstance(A, Factorization):
+        if A.shape > (4, 4) and not isinstance(A, Factorization) and not self.diagonal:
             A = Factorization(A, decomposition="PartialPivLU")
 
         super(Inverse, self).__init__(A)
@@ -1199,7 +1200,7 @@ class Solve(BinaryOp):
         decomposition = decomposition or "PartialPivLU"
 
         # Create a matrix factorization
-        A_factored = Factorization(A, decomposition=decomposition)
+        A_factored = Factorization(A, decomposition=decomposition) if not A.diagonal else A
 
         super(Solve, self).__init__(A_factored, B)
 
@@ -1220,6 +1221,43 @@ class Solve(BinaryOp):
         return self._args
 
 
+class DiagonalTensor(UnaryOp):
+    """An abstract Slate class representing the diagonal of a tensor.
+
+    .. warning::
+
+       This class will raise an error if the tensor is not square.
+    """
+    diagonal = True
+
+    def __init__(self, A):
+        """Constructor for the Diagonal class."""
+        assert A.rank == 2, "The tensor must be rank 2."
+        assert A.shape[0] == A.shape[1], (
+            "The diagonal can only be computed on square tensors."
+        )
+
+        super(DiagonalTensor, self).__init__(A)
+
+    @cached_property
+    def arg_function_spaces(self):
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
+        """
+        tensor, = self.operands
+        return tuple(arg.function_space() for arg in tensor.arguments())
+
+    def arguments(self):
+        """Returns a tuple of arguments associated with the tensor."""
+        tensor, = self.operands
+        return tensor.arguments()
+
+    def _output_string(self, prec=None):
+        """Creates a string representation of the diagonal of a tensor."""
+        tensor, = self.operands
+        return "(%s).diag" % tensor
+
+
 def space_equivalence(A, B):
     """Checks that two function spaces are equivalent.
 
@@ -1235,7 +1273,7 @@ def space_equivalence(A, B):
 
 # Establishes levels of precedence for Slate tensors
 precedences = [
-    [AssembledVector, Block, Factorization, Tensor],
+    [AssembledVector, Block, Factorization, Tensor, DiagonalTensor],
     [Add],
     [Mul],
     [Solve],

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -39,7 +39,8 @@ from firedrake.formmanipulation import ExtractSubBlock
 
 __all__ = ['AssembledVector', 'Block', 'Factorization', 'Tensor',
            'Inverse', 'Transpose', 'Negative',
-           'Add', 'Mul', 'Solve', 'BlockAssembledVector', 'DiagonalTensor']
+           'Add', 'Mul', 'Solve', 'BlockAssembledVector', 'DiagonalTensor',
+           'Reciprocal']
 
 
 class RemoveNegativeRestrictions(MultiFunction):
@@ -947,6 +948,37 @@ class UnaryOp(TensorOp):
         return "%s(%r)" % (type(self).__name__, tensor)
 
 
+class Reciprocal(UnaryOp):
+    """An abstract Slate class representing the reciprocal of a vector.
+    """
+
+    def __init__(self, A):
+        """Constructor for the Inverse class."""
+        assert A.rank == 1, "The tensor must be rank 1."
+
+        super(Reciprocal, self).__init__(A)
+
+    @cached_property
+    def arg_function_spaces(self):
+        """Returns a tuple of function spaces that the tensor
+        is defined on.
+        """
+        tensor, = self.operands
+        return tensor.arg_function_spaces
+
+    def arguments(self):
+        """Returns the expected arguments of the resulting tensor of
+        performing a specific unary operation on a tensor.
+        """
+        tensor, = self.operands
+        return tensor.arguments()
+
+    def _output_string(self, prec=None):
+        """Creates a string representation of the inverse of a tensor."""
+        tensor, = self.operands
+        return "(%s).reciprocal" % tensor
+
+
 class Inverse(UnaryOp):
     """An abstract Slate class representing the inverse of a tensor.
 
@@ -1279,7 +1311,7 @@ def space_equivalence(A, B):
 
 # Establishes levels of precedence for Slate tensors
 precedences = [
-    [AssembledVector, Block, Factorization, Tensor, DiagonalTensor],
+    [AssembledVector, Block, Factorization, Tensor, DiagonalTensor, Reciprocal],
     [Add],
     [Mul],
     [Solve],

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -331,3 +331,11 @@ def test_reciprocal(function_space):
     ref = assemble(mass, diagonal=True).dat.data
     for r, d in zip([1./d for d in ref], res):
         assert np.allclose(r, d, rtol=1e-14)
+
+    # test inverse of matrix built from diagonal
+    # for a Slate expression on a mass matrix
+    A = Tensor(mass)
+    res = assemble(DiagonalTensor(A+A).inv).M.values
+    ref = [1./d for d in assemble(mass + mass, diagonal=True).dat.data]
+    for r, d in zip(res, np.diag(ref)):
+        assert np.allclose(r, d, rtol=1e-14)

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -318,3 +318,16 @@ def test_diagonal(mass, matrix_mixed_facet):
     ref3 = np.concatenate(assemble(matrix_mixed_facet+matrix_mixed_facet, diagonal=True).dat.data)
     for r, d in zip(res3, np.diag(ref3)):
         assert np.allclose(r, d, rtol=1e-14)
+
+
+@pytest.mark.parametrize("function_space", ["dg0"], indirect=True)
+def test_reciprocal(function_space):
+    # test reciprocal of vector built from diagonal
+    # note: reciprocal does not commute with addition so one can only test DG
+    u = TrialFunction(function_space)
+    v = TestFunction(function_space)
+    mass = inner(u, v) * dx
+    res = assemble(Reciprocal(Tensor(mass, diagonal=True))).dat.data
+    ref = assemble(mass, diagonal=True).dat.data
+    for r, d in zip([1./d for d in ref], res):
+        assert np.allclose(r, d, rtol=1e-14)

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -82,6 +82,22 @@ def mass(function_space):
 
 
 @pytest.fixture
+def matrix_mixed_facet():
+    mesh = UnitSquareMesh(2, 2)
+    U = FunctionSpace(mesh, "RT", 1)
+    V = FunctionSpace(mesh, "DG", 0)
+    T = FunctionSpace(mesh, "HDiv Trace", 0)
+    n = FacetNormal(mesh)
+    W = U * V * T
+    u, p, lambdar = TrialFunctions(W)
+    w, q, gammar = TestFunctions(W)
+
+    return (inner(u, w)*dx + p*q*dx - div(w)*p*dx + q*div(u)*dx
+            + lambdar('+')*jump(w, n=n)*dS + gammar('+')*jump(u, n=n)*dS
+            + lambdar*gammar*ds)
+
+
+@pytest.fixture
 def rank_one_tensor(mass, f):
     return Tensor(action(mass, f))
 
@@ -270,3 +286,35 @@ def test_matrix_subblocks(mesh):
     for tensor, form in items:
         ref = assemble(form).M.values
         assert np.allclose(assemble(tensor).M.values, ref, rtol=1e-14)
+
+
+def test_diagonal(mass, matrix_mixed_facet):
+    n, _ = Tensor(mass).shape
+
+    # test vector built from diagonal
+    res = assemble(Tensor(mass, diagonal=True)).dat.data
+    ref = assemble(mass, diagonal=True).dat.data
+    for r, d in zip(ref, res):
+        assert np.allclose(r, d, rtol=1e-14)
+
+    # test matrix built from diagonal
+    res = assemble(DiagonalTensor(Tensor(mass))).M.values
+    ref = assemble(mass, diagonal=True).dat.data
+    ref = np.concatenate(ref) if len(np.shape(ref)) > 1 else ref  # vectorspace
+    ref = np.concatenate(ref) if len(np.shape(ref)) > 1 else ref  # tensorspace
+    for r, d in zip(ref, np.diag(res)):
+        assert np.allclose(r, d, rtol=1e-14)
+
+    # test matrix built from diagonal for non mass matrix
+    res2 = assemble(DiagonalTensor(Tensor(matrix_mixed_facet))).M.values
+    ref2 = np.concatenate(assemble(matrix_mixed_facet, diagonal=True).dat.data)
+    for r, d in zip(res2, np.diag(ref2)):
+        assert np.allclose(r, d, rtol=1e-14)
+
+    # test matrix built from diagonal
+    # for a Slate expression on a non mass matrix
+    A = Tensor(matrix_mixed_facet)
+    res3 = assemble(DiagonalTensor(A+A)).M.values
+    ref3 = np.concatenate(assemble(matrix_mixed_facet+matrix_mixed_facet, diagonal=True).dat.data)
+    for r, d in zip(res3, np.diag(ref3)):
+        assert np.allclose(r, d, rtol=1e-14)

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -330,6 +330,28 @@ def test_drop_transposes(TC_non_symm):
 
 
 #######################################
+# Test diagonal optimisation pass
+#######################################
+def test_push_diagonal(TC_non_symm):
+    """Test Optimisers's ability to push DiagonalTensors inside expressions."""
+    A, C = TC_non_symm
+
+    expressions = [DiagonalTensor(A), DiagonalTensor(A+A),
+                   DiagonalTensor(-A), DiagonalTensor(A*A),
+                   DiagonalTensor(A).inv]
+    opt_expressions = [DiagonalTensor(A), DiagonalTensor(A)+DiagonalTensor(A),
+                       -DiagonalTensor(A), DiagonalTensor(A*A),
+                       DiagonalTensor(A).inv]
+    compare_tensor_expressions(expressions)
+    compare_slate_tensors(expressions, opt_expressions)
+
+    expressions = [DiagonalTensor(A+A).solve(C)]
+    opt_expressions = [(DiagonalTensor(A)+DiagonalTensor(A)).solve(C)]
+    compare_vector_expressions(expressions)
+    compare_slate_tensors(expressions, opt_expressions)
+
+
+#######################################
 # Helper functions
 #######################################
 def compare_tensor_expressions(expressions):

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -111,7 +111,9 @@ def test_slate_hybridization_nested_schur():
               'pc_python_type': 'firedrake.HybridizationPC',
               'hybridization': {'ksp_type': 'preonly',
                                 'pc_type': 'lu',
-                                'nested_schur': 'true'}}
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'schur'}}}
     solve(a == L, w, solver_parameters=params)
     sigma_h, u_h = w.split()
 

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -27,7 +27,8 @@ from firedrake import *
 
 
 def setup_poisson():
-    mesh = UnitSquareMesh(1, 1)
+    n = 2
+    mesh = UnitSquareMesh(n, n)
     U = FunctionSpace(mesh, "RT", 4)
     V = FunctionSpace(mesh, "DG", 3)
     W = U * V
@@ -44,6 +45,36 @@ def setup_poisson():
     a = (inner(sigma, tau) + inner(u, div(tau)) + inner(div(sigma), v)) * dx
     L = -inner(f, v) * dx
     return a, L, W
+
+
+def setup_poisson_3D():
+    p = 3
+    n = 2
+    mesh = SquareMesh(n, n, 1, quadrilateral=True)
+    mesh = ExtrudedMesh(mesh, n)
+    RT = FiniteElement("RTCF", quadrilateral, p+1)
+    DG_v = FiniteElement("DG", interval, p)
+    DG_h = FiniteElement("DQ", quadrilateral, p)
+    CG = FiniteElement("CG", interval, p+1)
+    HDiv_ele = EnrichedElement(HDiv(TensorProductElement(RT, DG_v)),
+                               HDiv(TensorProductElement(DG_h, CG)))
+    V = FunctionSpace(mesh, HDiv_ele)
+    U = FunctionSpace(mesh, "DQ", p)
+    W = V * U
+    sigma, u = TrialFunctions(W)
+    tau, v = TestFunctions(W)
+    V, U = W.split()
+    f = Function(U)
+    x, y, z = SpatialCoordinate(mesh)
+    expr = (1+12*pi*pi)*cos(100*pi*x)*cos(100*pi*y)*cos(100*pi*z)
+    f.interpolate(expr)
+    a = (dot(sigma, tau) + div(tau)*u + div(sigma)*v)*dx(degree=8)
+    L = -f*v*dx(degree=8)
+    return a, L, W
+
+
+def options_check(builder, expected):
+    return all(bool(getattr(builder, k)) == v for k, v in expected.items())
 
 
 @pytest.mark.parametrize(("degree", "hdiv_family", "quadrilateral"),
@@ -101,6 +132,36 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
     assert u_err < 1e-11
 
 
+def test_slate_hybridization_wrong_option():
+    a, L, W = setup_poisson()
+
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'preonly',
+                                'pc_type': 'lu',
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'frog'}}}
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    with pytest.raises(ValueError):
+        # HybridizationPC isn't called directly from the Python interpreter,
+        # it's a callback that PETSc calls. This means that the call stack from pytest
+        # down to HybridizationPC goes via PETSc C code, which interferes with the exception
+        # before it is observed outside. Hence removing PETSc's error handler
+        # makes the problem go away, because PETSc stops interfering.
+        # We need to repush the error handler because popErrorHandler globally changes
+        # the system state for all future tests.
+        from firedrake.petsc import PETSc
+        PETSc.Sys.pushErrorHandler("ignore")
+        solver.solve()
+        PETSc.Sys.popErrorHandler("ignore")
+
+
 def test_slate_hybridization_nested_schur():
     a, L, W = setup_poisson()
 
@@ -114,7 +175,17 @@ def test_slate_hybridization_nested_schur():
                                 'localsolve': {'ksp_type': 'preonly',
                                                'pc_type': 'fieldsplit',
                                                'pc_fieldsplit_type': 'schur'}}}
-    solve(a == L, w, solver_parameters=params)
+
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+    expected = {'nested': True,
+                'preonly_A00': False, 'jacobi_A00': False,
+                'schur_approx': False,
+                'preonly_Shat': False, 'jacobi_Shat': False}
+    builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
+    assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
     sigma_h, u_h = w.split()
 
     w2 = Function(W)
@@ -132,3 +203,305 @@ def test_slate_hybridization_nested_schur():
 
     assert sigma_err < 1e-11
     assert u_err < 1e-11
+
+
+class DGLaplacian(AuxiliaryOperatorPC):
+    def form(self, pc, u, v):
+        W = u.function_space()
+        n = FacetNormal(W.mesh())
+        alpha = Constant(3**3)
+        gamma = Constant(4**3)
+        h = CellSize(W.mesh())
+        h_avg = (h('+') + h('-'))/2
+        a_dg = -(inner(grad(u), grad(v))*dx
+                 - inner(jump(u, n), avg(grad(v)))*dS
+                 - inner(avg(grad(u)), jump(v, n), )*dS
+                 + alpha/h_avg * inner(jump(u, n), jump(v, n))*dS
+                 - inner(u*n, grad(v))*ds
+                 - inner(grad(u), v*n)*ds
+                 + (gamma/h)*inner(u, v)*ds)
+        bcs = None
+        return (a_dg, bcs)
+
+
+class DGLaplacian3D(AuxiliaryOperatorPC):
+    def form(self, pc, u, v):
+        W = u.function_space()
+        n = FacetNormal(W.mesh())
+        gamma = Constant(4.**3)
+        h = CellVolume(W.mesh())/FacetArea(W.mesh())
+
+        a_dg = -(dot(grad(v), grad(u))*dx(degree=8)
+                 - dot(grad(v), (u)*n)*ds_v(degree=8)
+                 - dot(v*n, grad(u))*ds_v(degree=8)
+                 + gamma/h*dot(v, u)*ds_v(degree=8)
+                 - dot(grad(v), (u)*n)*ds_t(degree=8)
+                 - dot(v*n, grad(u))*ds_t(degree=8)
+                 + gamma/h*dot(v, u)*ds_t(degree=8)
+                 - dot(grad(v), (u)*n)*ds_b(degree=8)
+                 - dot(v*n, grad(u))*ds_b(degree=8)
+                 + gamma/h*dot(v, u)*ds_b(degree=8))
+
+        bcs = []
+        return (a_dg, bcs)
+
+
+def test_mixed_poisson_approximated_schur():
+    """A test, which compares a solution to a 2D mixed Poisson problem solved
+    globally matrixfree with a HybridizationPC and CG on the trace system to
+    a solution with uses a user supplied operator as preconditioner to the
+    Schur solver.
+
+    NOTE: With the setup in this test, using the approximated schur complemement
+    defined as DGLaplacian as a preconditioner to the schur complement,
+    reduces the condition number of the local solve from 16.77 to 6.06.
+    """
+    # setup FEM
+    a, L, W = setup_poisson()
+
+    # setup first solver
+    w = Function(W)
+    params = {'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'mat_type': 'matfree',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'cg',
+                                'pc_type': 'none',
+                                'ksp_rtol': 1e-8,
+                                'mat_type': 'matfree',
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'schur',
+                                               'fieldsplit_1': {'ksp_type': 'default',
+                                                                'pc_type': 'python',
+                                                                'pc_python_type': __name__ + '.DGLaplacian'}}}}
+
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+
+    # double-check options are set as expected
+    expected = {'nested': True,
+                'preonly_A00': False, 'jacobi_A00': False,
+                'schur_approx': True,
+                'preonly_Shat': False, 'jacobi_Shat': False}
+    builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
+    assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
+
+    sigma_h, u_h = w.split()
+
+    # setup second solver
+    w2 = Function(W)
+    aij_params = {'ksp_type': 'preonly',
+                  'pc_type': 'python',
+                  'mat_type': 'matfree',
+                  'pc_python_type': 'firedrake.HybridizationPC',
+                  'hybridization': {'ksp_type': 'cg',
+                                    'pc_type': 'none',
+                                    'ksp_rtol': 1e-8,
+                                    'mat_type': 'matfree'}}
+    solve(a == L, w2, solver_parameters=aij_params)
+    _sigma, _u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, _sigma)
+    u_err = errornorm(u_h, _u)
+
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8
+
+
+def test_slate_hybridization_jacobi_prec_A00():
+    """A test, which compares a solution to a 3D mixed Poisson problem solved
+    globally matrixfree with a HybridizationPC and CG on the trace system to
+    a solution with the same solver but which has a nested schur complement
+    in the trace solve operator and a jacobi preconditioner on the A00 block.
+
+    NOTE: With the setup in this test, using jacobi as a preconditioner to the
+    schur complement matrix, the condition number of the matrix of the local solve
+    P.inv * A.solve(...) is reduced from 36.59 to 3.06.
+    """
+    # setup FEM
+    a, L, W = setup_poisson_3D()
+
+    # setup first solver
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'cg',
+                                'pc_type': 'none',
+                                'ksp_rtol': 1e-12,
+                                'mat_type': 'matfree',
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'schur',
+                                               'fieldsplit_0': {'ksp_type': 'default',
+                                                                'pc_type': 'jacobi'}}}}
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+
+    # double-check options are set as expected
+    expected = {'nested': True,
+                'preonly_A00': False, 'jacobi_A00': True,
+                'schur_approx': False,
+                'preonly_Shat': False, 'jacobi_Shat': False,
+                'preonly_S': False, 'jacobi_S': False}
+    builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
+    assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
+
+    sigma_h, u_h = w.split()
+
+    # setup second solver
+    w2 = Function(W)
+    solve(a == L, w2,
+          solver_parameters={'mat_type': 'matfree',
+                             'ksp_type': 'preonly',
+                             'pc_type': 'python',
+                             'pc_python_type': 'firedrake.HybridizationPC',
+                             'hybridization': {'ksp_type': 'cg',
+                                               'pc_type': 'none',
+                                               'ksp_rtol': 1e-8,
+                                               'mat_type': 'matfree'}})
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8
+
+
+def test_slate_hybridization_jacobi_prec_schur():
+    """A test, which compares a solution to a 3D mixed Poisson problem solved
+    globally matrixfree with a HybridizationPC and CG on the trace system to
+    a solution with the same solver but which has a nested schur complement
+    in the trace solve operator and a jacobi preconditioner on the schur
+    complement.
+
+    NOTE With the setup in this test, using jacobi as apreconditioner to the
+    schur complement matrix the condition number of the matrix of the local solve
+    P.inv * A.solve(...) is reduced from 17.13 to 16.71
+    """
+    # setup FEM
+    a, L, W = setup_poisson_3D()
+
+    # setup first solver
+    w = Function(W)
+    params = {'mat_type': 'matfree',
+              'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'cg',
+                                'pc_type': 'none',
+                                'ksp_rtol': 1e-12,
+                                'mat_type': 'matfree',
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'schur',
+                                               'fieldsplit_1': {'ksp_type': 'default',
+                                                                'pc_type': 'jacobi'}}}}
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+
+    # double-check options are set as expected
+    expected = {'nested': True,
+                'preonly_A00': False, 'jacobi_A00': False,
+                'schur_approx': False,
+                'preonly_S': False, 'jacobi_S': True}
+    builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
+    assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
+
+    sigma_h, u_h = w.split()
+
+    # setup second solver
+    w2 = Function(W)
+    solve(a == L, w2,
+          solver_parameters={'mat_type': 'matfree',
+                             'ksp_type': 'preonly',
+                             'pc_type': 'python',
+                             'pc_python_type': 'firedrake.HybridizationPC',
+                             'hybridization': {'ksp_type': 'cg',
+                                               'pc_type': 'none',
+                                               'ksp_rtol': 1e-8,
+                                               'mat_type': 'matfree'}})
+    nh_sigma, nh_u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, nh_sigma)
+    u_err = errornorm(u_h, nh_u)
+
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8
+
+
+def test_mixed_poisson_approximated_schur_jacobi_prec():
+    """A test, which compares a solution to a 2D mixed Poisson problem solved
+    globally matrixfree with a HybridizationPC and CG on the trace system where
+    the a user supplied operator is used as preconditioner to the
+    Schur solver to a solution where the user supplied operator is replaced
+    with the jacobi preconditioning operator.
+    """
+    # setup FEM
+    a, L, W = setup_poisson()
+
+    # setup first solver
+    w = Function(W)
+    params = {'ksp_type': 'preonly',
+              'pc_type': 'python',
+              'mat_type': 'matfree',
+              'pc_python_type': 'firedrake.HybridizationPC',
+              'hybridization': {'ksp_type': 'cg',
+                                'pc_type': 'none',
+                                'ksp_rtol': 1e-8,
+                                'mat_type': 'matfree',
+                                'localsolve': {'ksp_type': 'preonly',
+                                               'pc_type': 'fieldsplit',
+                                               'pc_fieldsplit_type': 'schur',
+                                               'fieldsplit_1': {'ksp_type': 'default',
+                                                                'pc_type': 'python',
+                                                                'pc_python_type': __name__ + '.DGLaplacian',
+                                                                'aux_ksp_type': 'preonly',
+                                                                'aux_pc_type': 'jacobi'}}}}
+
+    eq = a == L
+    problem = LinearVariationalProblem(eq.lhs, eq.rhs, w)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
+
+    # double-check options are set as expected
+    expected = {'nested': True,
+                'preonly_A00': False, 'jacobi_A00': False,
+                'schur_approx': True,
+                'preonly_S': False, 'jacobi_S': False,
+                'preonly_Shat': True, 'jacobi_Shat': True}
+    builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
+    assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
+
+    sigma_h, u_h = w.split()
+
+    # setup second solver
+    w2 = Function(W)
+    aij_params = {'ksp_type': 'preonly',
+                  'pc_type': 'python',
+                  'mat_type': 'matfree',
+                  'pc_python_type': 'firedrake.HybridizationPC',
+                  'hybridization': {'ksp_type': 'cg',
+                                    'pc_type': 'none',
+                                    'ksp_rtol': 1e-8,
+                                    'mat_type': 'matfree'}}
+    solve(a == L, w2, solver_parameters=aij_params)
+    _sigma, _u = w2.split()
+
+    # Return the L2 error
+    sigma_err = errornorm(sigma_h, _sigma)
+    u_err = errornorm(u_h, _u)
+
+    assert sigma_err < 1e-8
+    assert u_err < 1e-8


### PR DESCRIPTION
This PR enables us to do specify some (local) preconditioners to the (local) operators in the local solves, used in the `HybridizationPC`.

All local preconditioners are controlled with PETSc options. The corresponding prefix is `_lmi_` which stands for local mixed inverse. There are options to control which preconditioner to use and if it is replacing the original operator (`preonly`) or not. All of this is **locally matrix-explicit** only, the locally matrix-free PR will be coming in later.

The two options of local preconditioners are
a) a Jacobi preconditioner and
b) a user-supplied operator. Note that b) was originally in a separate PR, see #2240.

The first commit d8a3e15 is only refactoring and also renaming some existing options to look more PETSc like. Then there follow some infrastructural additions to Slate and its translations into lower levels, which I needed for the local diagonal preconditioners.

The last commit 10bdca7 is a big one. It includes adding more infrastructure into the `SchurComplementBuilder` class to deal with the new preconditioners, including the handling of possible options which are explained in detail in the `SchurComplementBuilder` class description. Testing is part of this commit too (I test both getting the right solutions and handling the options correctly in one go)

