### PR TITLE
Use numpy for generalized eigendecomposition in fdm.py and remove the warning if scipy is not present

### DIFF
--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -16,9 +16,9 @@ from firedrake.preconditioners.patch import bcdofs
 from firedrake.preconditioners.pmg import get_permuted_map, tensor_product_space_query
 from firedrake.utils import IntType_c
 from firedrake.dmhooks import get_function_space, get_appctx
-from firedrake.logging import warning
 import firedrake
 import numpy
+import numpy.linalg
 from firedrake_citations import Citations
 
 Citations().add("Brubeck2021", """
@@ -32,22 +32,17 @@ Citations().add("Brubeck2021", """
 
 __all__ = ("FDMPC",)
 
-try:
-    from scipy.linalg import eigh
 
-    def sym_eig(A, B):
-        return eigh(A, B)
-except ImportError:
-    warning("scipy not available, using numpy for generalized eigendecomposition.")
-    import numpy.linalg as npla
-
-    def sym_eig(A, B):
-        L = npla.cholesky(B)
-        Linv = npla.inv(L)
-        C = numpy.dot(Linv, numpy.dot(A, Linv.T))
-        Z, W = npla.eigh(C)
-        V = numpy.dot(Linv.T, W)
-        return Z, V
+def sym_eig(A, B):
+    """
+    numpy version of `scipy.linalg.eigh`
+    """
+    L = numpy.linalg.cholesky(B)
+    Linv = numpy.linalg.inv(L)
+    C = numpy.dot(Linv, numpy.dot(A, Linv.T))
+    Z, W = numpy.linalg.eigh(C)
+    V = numpy.dot(Linv.T, W)
+    return Z, V
 
 
 class FDMPC(PCBase):


### PR DESCRIPTION
Users without scipy installed are getting the `"scipy not available, using numpy for generalized eigendecomposition."` warning every time they import firedrake, even if they don't need `FDMPC`. As a fix, we will always use the numpy alternative to compute the generalized eigendecomposition. 

Here is a benchmark proving that efficiency is not harmed:
```
degree   3 scipy 1.7977e-04 numpy 6.4373e-05
degree   5 scipy 7.0095e-05 numpy 5.9128e-05
degree   7 scipy 6.8665e-05 numpy 6.4373e-05
degree   9 scipy 7.6294e-05 numpy 7.2956e-05
degree  11 scipy 7.5579e-05 numpy 7.4148e-05
degree  13 scipy 1.4472e-04 numpy 1.6761e-04
degree  15 scipy 9.3222e-05 numpy 9.0599e-05
degree  17 scipy 1.0657e-04 numpy 1.8954e-04
degree  19 scipy 1.4901e-04 numpy 1.1611e-04
degree  21 scipy 1.6737e-04 numpy 1.6665e-04
degree  23 scipy 1.4615e-04 numpy 1.4400e-04
degree  25 scipy 1.6546e-04 numpy 1.5879e-04
degree  27 scipy 2.5177e-04 numpy 2.3675e-04
degree  29 scipy 2.0885e-04 numpy 2.1625e-04
degree  31 scipy 2.0218e-04 numpy 2.0289e-04
```