### PR TITLE
install: Fix determination of BLAS location on MacOS

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1438,14 +1438,17 @@ if mode == "install" or not args.update_script:
                 else:
                     log.info("Installing required package '{0}' via Homebrew.".format(package))
                     brew_install(package)
-
-            if args.with_blas is None and mode == "install":
-                config["with_blas"] = check_output(["brew", "--prefix", "openblas"])[:-1]
-
         else:
             log.info("Xcode and homebrew installation disabled. Proceeding on the rash assumption that packaged dependencies are in place.")
             log.info("Please use the --show-dependencies for more information.")
 
+        # Unconditionally require openblas ("brew" is required above)
+        if args.with_blas is None and mode == "install":
+            config["with_blas"] = check_output(["brew", "--prefix", "openblas"])[:-1]
+            blas_location = config["with_blas"]
+            if not os.path.exists(blas_location):
+                raise InstallError("Automatic determination of BLAS looked for openblas in %s but didn't find it\n"
+                                   "Please provide location of a BLAS library with --with-blas (or use --with-blas=download)" % blas_location)
     elif osname == "Linux":
         # Check for apt.
         try:
@@ -1461,6 +1464,7 @@ if mode == "install" or not args.update_script:
             log.info("apt-get not found or disabled. Proceeding on the rash assumption that your compiled dependencies are in place.")
             log.info("Please use the --show-dependencies for more information.")
 else:
+    # Only actually relevant on MacOS
     blas_location = config["options"].get("with_blas")
 
 if mode == "install":
@@ -1538,6 +1542,7 @@ if blas_location == "download":
 if blas_location is not None:
     blas["BLAS"] = blas_location
     blas["OPENBLAS"] = blas_location
+log.info("BLAS config is %s" % blas)
 
 # Configuration is now complete, and we have a venv so we dump the
 # config file in order to maximise the chance that firedrake-update


### PR DESCRIPTION
Previously we shoved the location in config["with_blas"] if we were
asking firedrake-install to install openblas. That didn't update the
blas_location variable that is inspected later to set up the BLAS
environment config, so we would never actually use the information we
determined. Log this information so that we can check things.

In addition, since the MacOS install unconditionally requires
homebrew (even with --no-package-manager), automatically determine the
BLAS location even when --no-package-manager is passed. Error early if
this does not resolve to an actual installed BLAS.