### PR TITLE
Slate: Transpose(Tensor(form)) -> Tensor(adjoint(form))

### DIFF
--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -3,6 +3,7 @@ from functools import singledispatch
 from itertools import repeat
 from firedrake.slate.slate import *
 from collections import namedtuple
+from firedrake.ufl_expr import adjoint
 
 """ ActionBag class
 :arg coeff:     what we contract with.
@@ -235,6 +236,8 @@ def _drop_double_transpose_transpose(expr, self):
     if isinstance(child, Transpose):
         grandchild, = child.children
         return self(grandchild)
+    elif child.terminal and child.rank > 1:
+        return Tensor(adjoint(child.form))
     else:
         return type(expr)(*map(self, expr.children))
 

--- a/tests/slate/test_optimise.py
+++ b/tests/slate/test_optimise.py
@@ -328,6 +328,13 @@ def test_drop_transposes(TC_non_symm):
     compare_vector_expressions(expressions)
     compare_slate_tensors(expressions, opt_expressions)
 
+    assert A != A.T
+    from firedrake.slate.slac.optimise import optimise
+    T_opt = optimise(A.T, {"optimise": True})
+    assert isinstance(T_opt, Tensor)
+    assert np.allclose(assemble(T_opt.T).M.values,
+                       assemble(adjoint(T_opt.form)).M.values)
+
 
 #######################################
 # Test diagonal optimisation pass


### PR DESCRIPTION
This PR addresses https://github.com/firedrakeproject/firedrake/issues/2262. It's a small codegen improvement which inlines transposes into the local assembly kernels generated by TSFC. I have done this on the highest level (in Slate) via `def __new__`.