### PR TITLE
Revert "Install: pin setuptools to 58.4 for now"

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1493,9 +1493,8 @@ if mode == "install":
         log.debug("bootstrapping pip succeeded")
         log.debug("Removing get-pip.py")
         os.remove("get-pip.py")
-    # Pin setuptools to a working version until latest version is fixed
-    run_pip(["install", "-U", "setuptools==58.4"])
     # Ensure pip, setuptools and wheel are at the latest version.
+    run_pip(["install", "-U", "setuptools"])
     run_pip(["install", "-U", "pip"])
     run_pip(["install", "-U", "wheel"])
 


### PR DESCRIPTION
This reverts commit 214f07a27265ac62d8c7217be2fea34448b107e3.  The issue in pypa/setuptools#2849 should be fixed, so we can remove pinning the setuptools version again.