### PR TITLE
Add CITATION.md

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -11,3 +11,7 @@ from firedrake import *
 Citations.print_at_exit()
 ```
 Alternatively, you can pass a command-line option `-citations` to obtain the same result.
+
+## Archiving your code with Zenodo
+
+In order to make your simulation results traceable and reproducible, we can provide you with a citeable archive of the exact version of Firedrake and its key dependencies that you used in your simulations. For information on how to do this see https://firedrakeproject.org/zenodo.html.

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,13 @@
+# Citing Firedrake
+
+If you publish results using Firedrake, we would be grateful if you would cite the relevant papers.
+
+Please visit https://www.firedrakeproject.org/citing.html for the instructions.
+
+The simplest way to determine the relevant papers is by asking Firedrake itself. You can ask that a list of citations relevant to your computation be printed when exiting by calling `Citations.print_at_exit` after importing Firedrake:
+```python
+from firedrake import *
+
+Citations.print_at_exit()
+```
+Alternatively, you can pass a command-line option `-citations` to obtain the same result.


### PR DESCRIPTION
The previous attempt was https://github.com/firedrakeproject/firedrake/pull/2190.

With the `CITATION.md` file in the repository, GitHub adds the "Cite this repository" button.
Clicking "View citation file" opens the [`CITATION.md` file](https://github.com/IvanYashchuk/firedrake/blob/03681353a5140fc3e1ca519253c323df9b030245/CITATION.md).

![image](https://user-images.githubusercontent.com/19621411/140804715-d4e53497-f3a2-4d53-a09a-1eb10bb32d06.png)


This is the same approach that was chosen, for example, for the p4pdes repo (https://github.com/firedrakeproject/firedrake/pull/2190#issuecomment-902892655).

It also addresses David's concern about the previous attempt that was providing a single BibTeX entry when clicking  "Cite this repository" (https://github.com/firedrakeproject/firedrake/pull/2190#pullrequestreview-750523431).
