### PR TITLE
tiger lake (or newer) processor and gcc/g++/gfortran 9.3 and older

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -10,3 +10,4 @@ pkgconfig
 cached_property
 requests
 nbval
+packaging

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -158,7 +158,7 @@ if platform.system() == "Linux":
         gfortranversionstring = os.popen('gfortran -dumpfullversion').read()
 
         # Check if the combination is a problem
-        if pversion.parse(gccversionstring) <= pversion.parse("9.3") or pversion.parse(gppversionstring) <= pversion.parse("9.3") or pversion.parse(gfortranversionstring) <= pversion.parse("9.3"):
+        if pversion.parse(gccversionstring) < pversion.parse("9.4") or pversion.parse(gppversionstring) < pversion.parse("9.4") or pversion.parse(gfortranversionstring) < pversion.parse("9.4"):
             print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible. Please install at least the gcc, g++ and gfortran in version 9.4.0.""")
             sys.exit(1)
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -16,6 +16,7 @@ from glob import iglob
 from itertools import chain
 import re
 import importlib
+import packaging
 
 osname = platform.uname().system
 arch = platform.uname().machine
@@ -151,17 +152,14 @@ if platform.system() == "Linux":
     if cpuinfostring.find('i3-11') != -1 or cpuinfostring.find('i5-11') != -1 or cpuinfostring.find('i7-11') != -1 or cpuinfostring.find('i9-11') != -1:
         # Get the compiler versions
         gccversionstring = os.popen('gcc --version').read()
-        gccversionstring = gccversionstring[gccversionstring.find(')')+2:gccversionstring.find('\n')]
 
         gppversionstring = os.popen('g++ --version').read()
-        gppversionstring = gppversionstring[g++versionstring.find(')')+2:gppversionstring.find('\n')]
 
         gfortranversionstring = os.popen('gfortran --version').read()
-        gfortranversionstring = gfortranversionstring[gfortranversionstring.find(')')+2:gfortranversionstring.find('\n')]
 
         # Check if the combination is a problem
-        if float(gccversionstring[0:gccversionstring.find('.') + 2]) <= 9.3 or float(gppversionstring[0:gppversionstring.find('.') + 2]) <= 9.3 or float(gfortranversionstring[0:gfortranversionstring.find('.') + 2]) <= 9.3:
-            print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible.""")
+        if packaging.version.parse(gccversionstring) <= packaging.version.parse("9.3") or packaging.version.parse(gppversionstring) <= packaging.version.parse("9.3") or packaging.version.parse(gfortranversionstring) <= packaging.version.parse("9.3"):
+            print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible. Please install at least the gcc, g++ and gfortran in version 9.4.0.""")
             sys.exit(1)
 
 branches = {}

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -160,7 +160,7 @@ if platform.system() == "Linux":
         gfortranversionstring = gfortranversionstring[gfortranversionstring.find(')')+2:gfortranversionstring.find('\n')]
 
         # Check if the combination is a problem
-        if float(gccversionstring[0:gccversionstring.find('.') + 2]) <= 9.3 or float(g++versionstring[0:g++versionstring.find('.') + 2]) <= 9.3 or float(gfortranversionstring[0:gfortranversionstring.find('.') + 2]) <= 9.3:
+        if float(gccversionstring[0:gccversionstring.find('.') + 2]) <= 9.3 or float(gppversionstring[0:gppversionstring.find('.') + 2]) <= 9.3 or float(gfortranversionstring[0:gfortranversionstring.find('.') + 2]) <= 9.3:
             print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible.""")
             sys.exit(1)
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -142,6 +142,27 @@ Please follow the instructions at http://www.firedrakeproject.org/download.html 
             print("""\nfiredrake-update must be run with Python 3, did you accidentally use Python 2?""")
     sys.exit(1)
 
+# Temporary catch for tigerlake processors with gcc/g++/gfortran 9.3
+# But only for Linux
+if platform.system() == "Linux":
+    # Get the cpu information
+    cpuinfostring = os.popen('lscpu').read()
+    # Check if it is a tigerlake processor
+    if cpuinfostring.find('i3-11') != -1 or cpuinfostring.find('i5-11') != -1 or cpuinfostring.find('i7-11') != -1 or cpuinfostring.find('i9-11') != -1:
+        # Get the compiler versions
+        gccversionstring = os.popen('gcc --version').read()
+        gccversionstring = gccversionstring[gccversionstring.find(')')+2:gccversionstring.find('\n')]
+
+        gppversionstring = os.popen('g++ --version').read()
+        gppversionstring = gppversionstring[g++versionstring.find(')')+2:gppversionstring.find('\n')]
+
+        gfortranversionstring = os.popen('gfortran --version').read()
+        gfortranversionstring = gfortranversionstring[gfortranversionstring.find(')')+2:gfortranversionstring.find('\n')]
+
+        # Check if the combination is a problem
+        if float(gccversionstring[0:gccversionstring.find('.') + 2]) <= 9.3 or float(g++versionstring[0:g++versionstring.find('.') + 2]) <= 9.3 or float(gfortranversionstring[0:gfortranversionstring.find('.') + 2]) <= 9.3:
+            print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible.""")
+            sys.exit(1)
 
 branches = {}
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -16,7 +16,7 @@ from glob import iglob
 from itertools import chain
 import re
 import importlib
-import packaging
+from packaging import version as pversion
 
 osname = platform.uname().system
 arch = platform.uname().machine
@@ -151,14 +151,14 @@ if platform.system() == "Linux":
     # Check if it is a tigerlake processor
     if cpuinfostring.find('i3-11') != -1 or cpuinfostring.find('i5-11') != -1 or cpuinfostring.find('i7-11') != -1 or cpuinfostring.find('i9-11') != -1:
         # Get the compiler versions
-        gccversionstring = os.popen('gcc --version').read()
+        gccversionstring = os.popen('gcc -dumpfullversion').read()
 
-        gppversionstring = os.popen('g++ --version').read()
+        gppversionstring = os.popen('g++ -dumpfullversion').read()
 
-        gfortranversionstring = os.popen('gfortran --version').read()
+        gfortranversionstring = os.popen('gfortran -dumpfullversion').read()
 
         # Check if the combination is a problem
-        if packaging.version.parse(gccversionstring) <= packaging.version.parse("9.3") or packaging.version.parse(gppversionstring) <= packaging.version.parse("9.3") or packaging.version.parse(gfortranversionstring) <= packaging.version.parse("9.3"):
+        if pversion.parse(gccversionstring) <= pversion.parse("9.3") or pversion.parse(gppversionstring) <= pversion.parse("9.3") or pversion.parse(gfortranversionstring) <= pversion.parse("9.3"):
             print("""\nThe combination of a Tiger Lake (or newer) with gcc g++ and gfortran in the version 9.3 is not possible. Please install at least the gcc, g++ and gfortran in version 9.4.0.""")
             sys.exit(1)
 


### PR DESCRIPTION
This should catch the problems from #2214 on linux systems and stop the installer in the first seconds.In this moment I have no acces to a windows/mac so that I restricted the catch to linux systems.