### PR TITLE
Use safe CFLAGS for libsupermesh

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1085,7 +1085,8 @@ def build_and_install_libsupermesh():
                             "-DMPI_C_COMPILER=" + cc,
                             "-DMPI_CXX_COMPILER=" + cxx,
                             "-DMPI_Fortran_COMPILER=" + f90,
-                            "-DCMAKE_Fortran_COMPILER=" + f90])
+                            "-DCMAKE_Fortran_COMPILER=" + f90,
+                            "-DLIBSUPERMESH_AUTO_COMPILER_FLAGS=OFF"])
                 check_call(["make"])
                 check_call(["make", "install"])
     else:


### PR DESCRIPTION
By default libsupermesh uses `-march=native` during compilation. This can
cause install failures on some systems (e.g. Intel Tiger Lake + GCC
9.3). Here we now tell cmake to use the standard CFLAGS during compilation.

The offending line in libsupermesh's `CMakeLists.txt` is [here](https://bitbucket.org/libsupermesh/libsupermesh/src/69012e50dc6ba10721ed536871db8a84f6e68691/CMakeLists.txt#lines-100).

Related to #2275 and #2214.