### PR TITLE
Use description and long_description according to distutils api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,10 @@ if 'CC' not in env:
 setup(name='firedrake',
       version=versioneer.get_version(),
       cmdclass=cmdclass,
-      description="""Firedrake is an automated system for the portable solution
-          of partial differential equations using the finite element method
-          (FEM)""",
+      description="An automated finite element system.",
+      long_description="""Firedrake is an automated system for the portable
+          solution of partial differential equations using the finite element
+          method (FEM)""",
       author="Imperial College London and others",
       author_email="firedrake@imperial.ac.uk",
       url="http://firedrakeproject.org",


### PR DESCRIPTION
It turns out that the `description` argument to `distutils.setup` should only have a single line. Distutils are now enforcing this: https://github.com/pypa/setuptools/pull/2870