### PR TITLE
Disable very slow test

### DIFF
--- a/tests/regression/test_interpolation_nodes.py
+++ b/tests/regression/test_interpolation_nodes.py
@@ -43,6 +43,10 @@ def test_div_curl_preserving(V):
     dim = mesh.geometric_dimension()
     if dim == 3 and V.ufl_element().degree() == 3 and "Nedelec" not in V.ufl_element().family():
         pytest.skip("N2div interpolation kernel with exact quadrature creates tensors which risk stack overflow")
+    if dim == 3 and V.ufl_element().degree() == 2 and "Nedelec" not in V.ufl_element().family():
+        # This issue is probably down to gcc attempting to constant-propagate
+        # every entry in the array.
+        pytest.skip("N2div interpolation kernel with exact quadrature takes 40 minutes!")
     if dim == 2:
         x, y = SpatialCoordinate(mesh)
     elif dim == 3:


### PR DESCRIPTION
One of the interpolation tests suffers particularly from the large local tensors problem. This isn't going to get fixed rapidly so we'll just switch off the test so as not to inconvenience other developers.