### PR TITLE
Ksagiyam/mixed real bc

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -440,6 +440,9 @@ def _assemble_expr(expr, tensor, bcs, opts, assembly_rank):
     :arg opts: :class:`_AssemblyOpts` containing the assembly options.
     :arg assembly_rank: The appropriate :class:`_AssemblyRank`.
     """
+    eq_bcs = tuple(bc for bc in bcs if isinstance(bc, EquationBCSplit))
+    if eq_bcs and opts.diagonal:
+        raise NotImplementedError("Diagonal assembly and EquationBC not supported")
     # We cache the parloops on the form but since parloops (currently) hold
     # references to large data structures (e.g. the output tensor) we only
     # cache a single set of parloops at any one time to prevent memory leaks.
@@ -448,23 +451,13 @@ def _assemble_expr(expr, tensor, bcs, opts, assembly_rank):
     parloop_init_args = (expr, tensor, bcs, opts.diagonal, opts.fc_params, assembly_rank)
     cached_init_args, cached_parloops = expr._cache.get("parloops", (None, None))
     parloops = cached_parloops if cached_init_args == parloop_init_args else None
-
     if not parloops:
         parloops = _make_parloops(*parloop_init_args)
         expr._cache["parloops"] = (parloop_init_args, parloops)
-
     for parloop in parloops:
         parloop.compute()
-
-    dir_bcs = tuple(bc for bc in bcs if isinstance(bc, DirichletBC))
-    _apply_dirichlet_bcs(tensor, dir_bcs, opts, assembly_rank)
-
-    eq_bcs = tuple(bc for bc in bcs if isinstance(bc, EquationBCSplit))
-    if eq_bcs and opts.diagonal:
-        raise NotImplementedError("Diagonal assembly and EquationBC not supported")
+    _apply_bcs(tensor, bcs, opts, assembly_rank)
     for bc in eq_bcs:
-        if assembly_rank == _AssemblyRank.VECTOR:
-            bc.zero(tensor)
         _assemble_expr(bc.f, tensor, bc.bcs, opts, assembly_rank)
 
 
@@ -584,44 +577,35 @@ def _matrix_arg(access, get_map, row, col, *,
                                   unroll_map=unroll)
 
 
-def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
+def _apply_bcs(tensor, bcs, opts, assembly_rank):
     """Apply Dirichlet boundary conditions to a tensor.
 
     :arg tensor: The tensor.
-    :arg bcs: Iterable of :class:`DirichletBC` objects.
+    :arg bcs: Iterable of :class:`DirichletBC` and/or :class:`EquationBCSplit` objects.
     :arg opts: :class:`_AssemblyOpts` containing the assembly options.
     :arg assembly_rank: are we doing a scalar, vector, or matrix.
     """
     if assembly_rank == _AssemblyRank.MATRIX:
         op2tensor = tensor.M
-        shape = tuple(len(a.function_space()) for a in tensor.a.arguments())
+        spaces = tuple(a.function_space() for a in tensor.a.arguments())
         for bc in bcs:
             V = bc.function_space()
-            nodes = bc.nodes
-            for i, j in numpy.ndindex(shape):
+            component = V.component
+            if component is not None:
+                V = V.parent
+            index = 0 if V.index is None else V.index
+            space = V if V.parent is None else V.parent
+            if isinstance(bc, DirichletBC):
+                if space != spaces[0]:
+                    raise TypeError("bc space does not match the test function space")
+                elif space != spaces[1]:
+                    raise TypeError("bc space does not match the trial function space")
                 # Set diagonal entries on bc nodes to 1 if the current
                 # block is on the matrix diagonal and its index matches the
                 # index of the function space the bc is defined on.
-                if i != j:
-                    continue
-                if V.component is None and V.index is not None:
-                    # Mixed, index (no ComponentFunctionSpace)
-                    if V.index == i:
-                        op2tensor[i, j].set_local_diagonal_entries(nodes)
-                elif V.component is not None:
-                    # ComponentFunctionSpace, check parent index
-                    if V.parent.index is not None:
-                        # Mixed, index doesn't match
-                        if V.parent.index != i:
-                            continue
-                        # Index matches
-                    op2tensor[i, j].set_local_diagonal_entries(nodes, idx=V.component)
-                elif V.index is None:
-                    op2tensor[i, j].set_local_diagonal_entries(nodes)
-                else:
-                    raise RuntimeError("Unhandled BC case")
+                op2tensor[index, index].set_local_diagonal_entries(bc.nodes, idx=component)
     elif assembly_rank == _AssemblyRank.VECTOR:
-        for bc in bcs:
+        for bc in [b for b in bcs if isinstance(b, DirichletBC)]:
             if opts.assembly_type == _AssemblyType.SOLUTION:
                 if opts.diagonal:
                     bc.set(tensor, 1)
@@ -631,6 +615,8 @@ def _apply_dirichlet_bcs(tensor, bcs, opts, assembly_rank):
                 bc.zero(tensor)
             else:
                 raise AssertionError
+        for bc in [b for b in bcs if isinstance(b, EquationBCSplit)]:
+            bc.zero(tensor)
     elif assembly_rank == _AssemblyRank.SCALAR:
         pass
     else:


### PR DESCRIPTION
To apply BCs correctly for mixed function spaces with real function space.

The following code currently produces a wrong result:
```
mesh = UnitSquareMesh(1, 1, quadrilateral=True)
V0 = FunctionSpace(mesh, "CG", 1)
V1 = FunctionSpace(mesh, "R", 0)
V = V0 * V1
v0, v1 = TestFunctions(V)
u0, u1 = TrialFunctions(V)
bc = DirichletBC(V.sub(0), 0.0, 1)
a = inner(u1, v0) * dx
A = assemble(a, bcs=[bc, ])
print(A.M[0][1].values)
```
Current output:
```
[[0.25]
 [0.25]
 [0.25]
 [0.25]]
```
Output after this PR:
```
[[0.  ]
 [0.  ]
 [0.25]
 [0.25]]
```