### PR TITLE
Add `__new__` to Constant

### DIFF
--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -48,6 +48,12 @@ class Constant(ufl.Coefficient, ConstantMixin):
        :func:`~.Mesh` as the domain argument.
     """
 
+    def __new__(cls, *args, **kwargs):
+        # Hack to avoid hitting `ufl.Coefficient.__new__` which may perform operations
+        # meant for coefficients and not constants (e.g. check if the function space is dual or not)
+        # This is a consequence of firedrake.Constant inheriting from ufl.Constant instead of ufl.Coefficient.
+        return object.__new__(cls)
+
     @ConstantMixin._ad_annotate_init
     def __init__(self, value, domain=None):
         # Init also called in mesh constructor, but constant can be built without mesh


### PR DESCRIPTION
This tiny PR overwrites `__new__` for `Constant` which currently inherits from `ufl.Coefficient`. This change comes from #2294 and address the issue in #2305.