### PR TITLE
JDBetteridge/pin setuptools

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1522,7 +1522,7 @@ if mode == "install":
         log.debug("Removing get-pip.py")
         os.remove("get-pip.py")
     # Ensure pip, setuptools and wheel are at the latest version.
-    run_pip(["install", "-U", "setuptools"])
+    run_pip(["install", "-U", "setuptools==59.8"])  # Unpin this when numpy will build with latest setuptools
     run_pip(["install", "-U", "pip"])
     run_pip(["install", "-U", "wheel"])
 


### PR DESCRIPTION
Latest numpy triggers:
```
RuntimeError: Setuptools version is '60.6.0', version < '60.0.0' is required. See pyproject.toml 
```
Pin setuptools until this goes away