### PR TITLE
Pin pytest version to 6.2.5

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,6 +1,6 @@
 sympy
 cachetools
-pytest
+pytest<=6.2.5
 pytest-xdist
 ipython
 matplotlib


### PR DESCRIPTION
Our parallel tests break with [new release](https://pypi.org/project/pytest/#history) 7.0.0. Obviously we should figure out a better fix but this should get our CI up and running again.

Turns out it wasn't my fault after all!