### PR TITLE
pin pytest version at 6.2.5

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,6 +1,6 @@
 sympy
 cachetools
-pytest
+pytest==6.2.5
 pytest-xdist
 ipython
 matplotlib

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1835,7 +1835,8 @@ Please consider updating your PETSc manually.
                 install(p+"/")
 
         # Ensure pytest is at the latest version
-        run_pip(["install", "-U", "pytest"])
+        print('We use pytest==6.2.5 until the issue with pytest==7.0.0 is resolved.')
+        run_pip(["install", "-U", "pytest==6.2.5"])
 
 with environment(**compiler_env):
     with pipargs("--no-deps"):


### PR DESCRIPTION
`pytest==7.0.0` makes (probably) all parallel tests fail.