### PR TITLE
Set CI Python version to 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
       - name: Build Firedrake
         run: |
           cd ..

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -118,9 +118,8 @@ packages can be installed into an existing Firedrake installation using
 System requirements
 -------------------
 
-Firedrake requires Python 3.6.x to 3.8.x (many externally managed
-dependencies such as VTK have yet to create binary wheels for 3.9.x).
-The installation script is tested on Ubuntu and MacOS X. On Ubuntu 18.04
+Firedrake requires Python 3.7.x to 3.10.x.
+The installation script is tested on Ubuntu and MacOS X. On Ubuntu 20.04
 or later, the system installed Python 3 is supported and tested. On
 MacOS, the homebrew_ installed Python 3 is supported and tested::
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1539,7 +1539,7 @@ if mode == "install":
         log.debug("Removing get-pip.py")
         os.remove("get-pip.py")
     # Ensure pip, setuptools and wheel are at the latest version.
-    run_pip(["install", "-U", "setuptools==59.8"])  # Unpin this when numpy will build with latest setuptools
+    run_pip(["install", "-U", "setuptools<=59.8"])  # Unpin this when numpy will build with latest setuptools
     run_pip(["install", "-U", "pip"])
     run_pip(["install", "-U", "wheel"])
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -40,6 +40,10 @@ firedrake_apps = {
                 "git+ssh://github.com/FEMlium/FEMlium.git@main#egg=FEMlium"),
 }
 
+# The range of Python versions currently supported
+max_python_version = 3, 10
+min_python_version = 3, 7
+
 
 class InstallError(Exception):
     # Exception for generic install problems.
@@ -82,6 +86,16 @@ def deep_update(this, that):
     return this
 
 
+def pyver2str(version):
+    """Convert a Python version tuple into a dot-separated string.
+
+    Examples:
+        pyver2str((3, 8)) -> "3.8"
+        pyver2str((3, 9, 2)) -> "3.9.2"
+    """
+    return ".".join(map(str, version))
+
+
 if os.path.basename(__file__) == "firedrake-install":
     mode = "install"
     logfile_directory = os.path.abspath(os.getcwd())
@@ -121,15 +135,17 @@ log = logging.getLogger()
 
 log.info("Running %s" % " ".join(sys.argv))
 
-if sys.version_info >= (3, 11):
-    print("""\nCan not install Firedrake with Python 3.11 at the moment:
-Some wheels are not yet available for Python 3.11 for some required package(s).
-Please install with Python 3.10 (or an earlier version >= 3.6).""")
+if sys.version_info > max_python_version:
+    print("""\nCan not install Firedrake with Python {current_version} at the moment.
+Please install with Python {max_version} (or an earlier version >= {min_version}).
+""".format(current_version=pyver2str(sys.version_info[:2]),
+           max_version=pyver2str(max_python_version),
+           min_version=pyver2str(min_python_version)))
     sys.exit(1)
-elif sys.version_info < (3, 6):
+elif sys.version_info < min_python_version:
     if mode == "install":
-        print("""\nInstalling Firedrake requires Python 3, at least version 3.6.
-You should run firedrake-install with python3.""")
+        print("""\nInstalling Firedrake requires Python 3, at least version {}.
+You should run firedrake-install with python3.""".format(pyver2str(min_python_version)))
     if mode == "update":
         if hasattr(sys, "real_prefix"):
             # sys.real_prefix exists iff we are in an active virtualenv.


### PR DESCRIPTION
Currently our CI builds with Python 3.8 even though Firedrake is supposed to work with 3.7. I think it makes sense to run our CI with the oldest supported version to avoid compatibility issues like #2337.

In this PR I have:
- Modified our CI to run using Python 3.7.
- Updated the website to say that 3.7 is the minimum supported version.
- Tried to improve `firedrake-install` a little so making future changes to this should be easier.