### PR TITLE
Prominently display petsc features at install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -673,9 +673,19 @@ def get_petsc_packages():
     with open(os.path.join(petsc_dir, petsc_arch, "include", "petscconf.h")) as fh:
         for line in fh.readlines():
             if line.startswith("#define PETSC_HAVE_PACKAGES"):
-                packages = set(line.split()[2].strip().strip('"').split(':'))
+                packages = set(line.split()[2].strip().strip(':"').split(':'))
                 break
     return packages
+
+
+def get_petsc_config():
+    petsc_dir, petsc_arch = get_petsc_dir()
+    with open(os.path.join(petsc_dir, petsc_arch, "include", "petscconfiginfo.h")) as fh:
+        for line in fh.readlines():
+            if line.startswith("static const char *petscconfigureoptions"):
+                info = line.split("=", maxsplit=1)[1].strip(' ";\n').split('--')[1:]
+                break
+    return ["--" + arg for arg in info]
 
 
 if mode == "update" and petsc_int_type_changed:
@@ -1341,48 +1351,6 @@ def create_compiler_env(cc, cxx, f90):
 
     return env
 
-
-if mode == "install" and args.show_petsc_configure_options:
-    if args.honour_petsc_dir:
-        log.info("******************************************************")
-        log.info("Specified PETSc was built with the following packages:")
-        log.info("******************************************************\n")
-        petsc_packages = get_petsc_packages()
-        log.info("\n".join(petsc_packages))
-        minimal = set(["blaslapack", "eigen3", "hdf5", "mpi", "ptscotch", "superlu_dist"])
-        reqd_packages = minimal
-        if not args.minimal_petsc:
-            full = set(["hwloc", "metis", "netcdf", "pastix", "pnetcdf", "suitesparse", "zlib"])
-            reqd_packages.update(full)
-        if args.with_parmetis:
-            reqd_packages.add("parmetis")
-        if args.petsc_int_type == "int32":
-            int32_m = set(["chaco", "mumps", "scalapack"])
-            reqd_packages.update(int32_m)
-        if not args.complex:
-            reqd_packages.add("hypre")
-        if (not args.complex) and (args.petsc_int_type == "int32") and (not args.minimal_petsc):
-            reqd_packages.add("ml")
-        print()
-        print("REQUIRED:")
-        print(*reqd_packages)
-
-        if reqd_packages < petsc_packages:
-            log.info("PETSc installed at {},{} is suitable".format(*get_petsc_dir()))
-        else:
-            log.info("PETSc installed at {},{} is unsuitable".format(*get_petsc_dir()))
-            log.info("Packages missing are:")
-            log.info("\n".join(reqd_packages - petsc_packages))
-    else:
-        log.info("*********************************************")
-        log.info("Would build PETSc with the following options:")
-        log.info("*********************************************\n")
-        petsc_options = get_petsc_options()
-        log.info("\n".join(petsc_options))
-        log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
-    sys.exit(0)
-
-
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
 If you really want to use your own PETSc build, please run again with the
@@ -1408,6 +1376,33 @@ if platform.uname()[0] == "Darwin" and args.opencascade:
     quit("""Sorry, automatically installing opencascade on OSX hasn't been
 implemented yet. (It's not a supported package in brew.)
 Please contact us to get this working.""")
+
+if mode == "install" and (args.show_petsc_configure_options or args.honour_petsc_dir):
+    if args.show_petsc_configure_options:
+        log.info("*********************************************")
+        log.info("Would build PETSc with the following options:")
+        log.info("*********************************************\n")
+    else:
+        log.info("*********************************************************************")
+        log.info("You must ensure that PETSc has been built with the following options:")
+        log.info("*********************************************************************\n")
+    petsc_options = get_petsc_options()
+    log.info("\n".join(sorted(petsc_options)))
+    if args.show_petsc_configure_options:
+        log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
+        sys.exit(0)
+    else:
+        log.info("\n")
+        log.info("*****************************************************")
+        log.info("Specified PETSc was built with the following options:")
+        log.info("PETSC_DIR={}  PETSC_ARCH={}".format(*get_petsc_dir()))
+        log.info("*****************************************************\n")
+        petsc_config = get_petsc_config()
+        log.info("\n".join(sorted(petsc_config)))
+        log.info("\nThe following external packages were detected and are used by PETSc:")
+        petsc_packages = get_petsc_packages()
+        log.info(", ".join(sorted(petsc_packages)))
+        log.info("\n")
 
 log.debug("Installer running with: %s" % sys.executable)
 log.debug("Python version: %s" % sys.version)

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -668,6 +668,16 @@ def get_petsc_options():
     return list(petsc_options)
 
 
+def get_petsc_packages():
+    petsc_dir, petsc_arch = get_petsc_dir()
+    with open(os.path.join(petsc_dir, petsc_arch, "include", "petscconf.h")) as fh:
+        for line in fh.readlines():
+            if line.startswith("#define PETSC_HAVE_PACKAGES"):
+                packages = set(line.split()[2].strip().strip('"').split(':'))
+                break
+    return packages
+
+
 if mode == "update" and petsc_int_type_changed:
     log.warning("""Force rebuilding all packages because PETSc int type changed""")
 
@@ -1333,12 +1343,43 @@ def create_compiler_env(cc, cxx, f90):
 
 
 if mode == "install" and args.show_petsc_configure_options:
-    log.info("*********************************************")
-    log.info("Would build PETSc with the following options:")
-    log.info("*********************************************\n")
-    petsc_options = get_petsc_options()
-    log.info("\n".join(petsc_options))
-    log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
+    if args.honour_petsc_dir:
+        log.info("******************************************************")
+        log.info("Specified PETSc was built with the following packages:")
+        log.info("******************************************************\n")
+        petsc_packages = get_petsc_packages()
+        log.info("\n".join(petsc_packages))
+        minimal = set(["blaslapack", "eigen3", "hdf5", "mpi", "ptscotch", "superlu_dist"])
+        reqd_packages = minimal
+        if not args.minimal_petsc:
+            full = set(["hwloc", "metis", "netcdf", "pastix", "pnetcdf", "suitesparse", "zlib"])
+            reqd_packages.update(full)
+        if args.with_parmetis:
+            reqd_packages.add("parmetis")
+        if args.petsc_int_type == "int32":
+            int32_m = set(["chaco", "mumps", "scalapack"])
+            reqd_packages.update(int32_m)
+        if not args.complex:
+            reqd_packages.add("hypre")
+        if (not args.complex) and (args.petsc_int_type == "int32") and (not args.minimal_petsc):
+            reqd_packages.add("ml")
+        print()
+        print("REQUIRED:")
+        print(*reqd_packages)
+
+        if reqd_packages < petsc_packages:
+            log.info("PETSc installed at {},{} is suitable".format(*get_petsc_dir()))
+        else:
+            log.info("PETSc installed at {},{} is unsuitable".format(*get_petsc_dir()))
+            log.info("Packages missing are:")
+            log.info("\n".join(reqd_packages - petsc_packages))
+    else:
+        log.info("*********************************************")
+        log.info("Would build PETSc with the following options:")
+        log.info("*********************************************\n")
+        petsc_options = get_petsc_options()
+        log.info("\n".join(petsc_options))
+        log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
     sys.exit(0)
 
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1404,18 +1404,6 @@ log.debug("\n\n")
 if mode == "install" and args.honour_petsc_dir:
     minimal_packages = get_petsc_packages(minimal=True)
     current_packages = get_petsc_packages()
-    if not minimal_packages < current_packages:
-        log.warning("*********************************************************************")
-        log.warning("Specified PETSc is missing the following packages:")
-        log.warning(", ".join(sorted(minimal_packages - current_packages)) + '\n')
-        log.warning("You must ensure that PETSc has been built with these minimal options:")
-        log.warning("*********************************************************************\n")
-        log.warning("\n".join(sorted(get_petsc_options(minimal=True))))
-        log.warning('')
-        log.warning("Eigen can be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz\n")
-        log.warning('Use --show-petsc-configure-options as an argument to the firedrake-install script if additional functionality is required.\n ')
-        log.warning("Install will proceed, but Firedrake may be missing key functionality and may not work at all!")
-
     log.debug("*****************************************************")
     log.debug("Specified PETSc was built with the following options:")
     log.debug("*****************************************************\n")
@@ -1424,6 +1412,18 @@ if mode == "install" and args.honour_petsc_dir:
     log.debug("The following external packages were detected and are used by PETSc:")
     log.debug(", ".join(sorted(current_packages)))
     log.debug("\n")
+    if not minimal_packages < current_packages:
+        log.error("*********************************************************************")
+        log.error("Specified PETSc is missing the following packages:")
+        log.error(", ".join(sorted(minimal_packages - current_packages)) + '\n')
+        log.error("You must ensure that PETSc has been built with these minimal options:")
+        log.error("*********************************************************************\n")
+        log.error("\n".join(sorted(get_petsc_options(minimal=True))))
+        log.error("")
+        log.error("Eigen can be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz\n")
+        log.error('Use --show-petsc-configure-options as an argument to the firedrake-install script to display options if additional functionality is required.\n ')
+        log.error("FATAL: Unable to install with specified PETSc")
+        exit(1)
 
 if mode == "install" or not args.update_script:
     # Check operating system.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1352,6 +1352,15 @@ def create_compiler_env(cc, cxx, f90):
     return env
 
 
+if mode == "install" and args.show_petsc_configure_options:
+    log.info("*********************************************")
+    log.info("Would build PETSc with the following options:")
+    log.info("*********************************************\n")
+    petsc_options = get_petsc_options()
+    log.info("\n".join(petsc_options))
+    log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
+    sys.exit(0)
+
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
 If you really want to use your own PETSc build, please run again with the
@@ -1378,39 +1387,27 @@ if platform.uname()[0] == "Darwin" and args.opencascade:
 implemented yet. (It's not a supported package in brew.)
 Please contact us to get this working.""")
 
-if mode == "install" and (args.show_petsc_configure_options or args.honour_petsc_dir):
-    if args.show_petsc_configure_options:
-        log.info("*********************************************")
-        log.info("Would build PETSc with the following options:")
-        log.info("*********************************************\n")
-    else:
-        log.info("*********************************************************************")
-        log.info("You must ensure that PETSc has been built with the following options:")
-        log.info("*********************************************************************\n")
-    petsc_options = get_petsc_options()
-    log.info("\n".join(sorted(petsc_options)))
-    if args.show_petsc_configure_options:
-        log.info("\nEigen will be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz")
-        sys.exit(0)
-    else:
-        log.info("\n")
-        log.info("*****************************************************")
-        log.info("Specified PETSc was built with the following options:")
-        log.info("PETSC_DIR={}  PETSC_ARCH={}".format(*get_petsc_dir()))
-        log.info("*****************************************************\n")
-        petsc_config = get_petsc_config()
-        log.info("\n".join(sorted(petsc_config)))
-        log.info("\nThe following external packages were detected and are used by PETSc:")
-        petsc_packages = get_petsc_packages()
-        log.info(", ".join(sorted(petsc_packages)))
-        log.info("\n")
-
 log.debug("Installer running with: %s" % sys.executable)
 log.debug("Python version: %s" % sys.version)
 
 log.debug("*** Current environment (output of 'env') ***")
 log.debug(check_output(["env"]))
 log.debug("\n\n")
+
+if mode == "install" and args.honour_petsc_dir:
+    log.info("*********************************************************************")
+    log.info("You must ensure that PETSc has been built with the following options:")
+    log.info("*********************************************************************\n")
+    log.info("\n".join(sorted(get_petsc_options())))
+    log.info("\n")
+    log.info("*****************************************************")
+    log.info("Specified PETSc was built with the following options:")
+    log.info("PETSC_DIR={}  PETSC_ARCH={}".format(*get_petsc_dir()))
+    log.info("*****************************************************\n")
+    log.info("\n".join(sorted(get_petsc_config())))
+    log.info("\nThe following external packages were detected and are used by PETSc:")
+    log.info(", ".join(sorted(get_petsc_packages())))
+    log.info("\n")
 
 if mode == "install" or not args.update_script:
     # Check operating system.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -563,7 +563,7 @@ If you really want to use your own Python packages, please run again with the
 """)
 
 
-def get_petsc_options():
+def get_petsc_options(minimal=False):
     petsc_options = {"--with-fortran-bindings=0",
                      "--with-debugging=0",
                      "--with-shared-libraries=1",
@@ -586,7 +586,7 @@ def get_petsc_options():
         # PETSc requires cmake version 3.18.1 or higher.
         petsc_options.add("--download-cmake")
 
-    if not options["minimal_petsc"]:
+    if (not options["minimal_petsc"]) and (not minimal):
         petsc_options.add("--with-zlib")
         # File formats
         petsc_options.add("--download-netcdf")
@@ -655,11 +655,12 @@ def get_petsc_options():
         petsc_options.add("--CFLAGS=-I{}/include -Wno-implicit-function-declaration".format(brew_blas_prefix))
         petsc_options.add("--LDFLAGS=-Wl,-rpath,{0}/lib -L{0}/lib -L{1}".format(brew_blas_prefix, brew_gcc_libdir))
 
-    for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
-        if option.startswith("--with-hdf5-dir"):
-            petsc_options.discard("--download-hdf5")
-            os.environ["HDF5_DIR"] = option.replace("--with-hdf5-dir=", "")
-        petsc_options.add(option)
+    if not minimal:
+        for option in shlex.split(os.environ.get("PETSC_CONFIGURE_OPTIONS", "")):
+            if option.startswith("--with-hdf5-dir"):
+                petsc_options.discard("--download-hdf5")
+                os.environ["HDF5_DIR"] = option.replace("--with-hdf5-dir=", "")
+            petsc_options.add(option)
     if "HDF5_DIR" in os.environ and "--download-hdf5" in petsc_options:
         del os.environ["HDF5_DIR"]
         log.info("\nWarning: HDF5_DIR environment variable set, but ignored; "
@@ -668,13 +669,19 @@ def get_petsc_options():
     return list(petsc_options)
 
 
-def get_petsc_packages():
-    petsc_dir, petsc_arch = get_petsc_dir()
-    with open(os.path.join(petsc_dir, petsc_arch, "include", "petscconf.h")) as fh:
-        for line in fh.readlines():
-            if line.startswith("#define PETSC_HAVE_PACKAGES"):
-                packages = set(line.split()[2].strip().strip(':"').split(':'))
-                break
+def get_petsc_packages(minimal=False):
+    if minimal:
+        packages = set([
+            "blaslapack", "chaco", "eigen3", "hdf5", "hypre", "mathlib",
+            "mpi", "mumps", "ptscotch", "scalapack", "superlu_dist"
+        ])
+    else:
+        petsc_dir, petsc_arch = get_petsc_dir()
+        with open(os.path.join(petsc_dir, petsc_arch, "include", "petscconf.h")) as fh:
+            for line in fh.readlines():
+                if line.startswith("#define PETSC_HAVE_PACKAGES"):
+                    packages = set(line.split()[2].strip().strip(':"').split(':'))
+                    break
     return packages
 
 
@@ -1395,19 +1402,28 @@ log.debug(check_output(["env"]))
 log.debug("\n\n")
 
 if mode == "install" and args.honour_petsc_dir:
-    log.info("*********************************************************************")
-    log.info("You must ensure that PETSc has been built with the following options:")
-    log.info("*********************************************************************\n")
-    log.info("\n".join(sorted(get_petsc_options())))
-    log.info("\n")
-    log.info("*****************************************************")
-    log.info("Specified PETSc was built with the following options:")
-    log.info("PETSC_DIR={}  PETSC_ARCH={}".format(*get_petsc_dir()))
-    log.info("*****************************************************\n")
-    log.info("\n".join(sorted(get_petsc_config())))
-    log.info("\nThe following external packages were detected and are used by PETSc:")
-    log.info(", ".join(sorted(get_petsc_packages())))
-    log.info("\n")
+    minimal_packages = get_petsc_packages(minimal=True)
+    current_packages = get_petsc_packages()
+    if not minimal_packages < current_packages:
+        log.warning("*********************************************************************")
+        log.warning("Specified PETSc is missing the following packages:")
+        log.warning(", ".join(sorted(minimal_packages - current_packages)) + '\n')
+        log.warning("You must ensure that PETSc has been built with these minimal options:")
+        log.warning("*********************************************************************\n")
+        log.warning("\n".join(sorted(get_petsc_options(minimal=True))))
+        log.warning('')
+        log.warning("Eigen can be downloaded from https://github.com/eigenteam/eigen-git-mirror/archive/3.3.3.tar.gz\n")
+        log.warning('Use --show-petsc-configure-options as an argument to the firedrake-install script if additional functionality is required.\n ')
+        log.warning("Install will proceed, but Firedrake may be missing key functionality and may not work at all!")
+
+    log.debug("*****************************************************")
+    log.debug("Specified PETSc was built with the following options:")
+    log.debug("*****************************************************\n")
+    log.debug("PETSC_DIR={}  PETSC_ARCH={}".format(*get_petsc_dir()))
+    log.debug("\n".join(sorted(get_petsc_config())) + '\n')
+    log.debug("The following external packages were detected and are used by PETSc:")
+    log.debug(", ".join(sorted(current_packages)))
+    log.debug("\n")
 
 if mode == "install" or not args.update_script:
     # Check operating system.

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1351,6 +1351,7 @@ def create_compiler_env(cc, cxx, f90):
 
     return env
 
+
 if "PETSC_DIR" in os.environ and not args.honour_petsc_dir:
     quit("""The PETSC_DIR environment variable is set. This is probably an error.
 If you really want to use your own PETSc build, please run again with the


### PR DESCRIPTION
When installing firedrake with `--honour-petsc-dir` list the configure options that we expect PETSc to have been built with.

Immediately after display the ones that were used to build the PETSc specified by `PETSC_DIR` and `PETSC_ARCH`.

Finally, print the external packages PETSc has detected during its own configure.