### PR TITLE
Add pytest-timeout to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,19 +49,19 @@ jobs:
         run: |
           . ../build/bin/activate
           python $(which firedrake-clean)
-          python -m pip install pytest-cov pytest-xdist
+          python -m pip install pytest-cov pytest-timeout pytest-xdist
           python -m pip list
       - name: Test Firedrake
         run: |
           . ../build/bin/activate
           echo OMP_NUM_THREADS is $OMP_NUM_THREADS
           echo OPENBLAS_NUM_THREADS is $OPENBLAS_NUM_THREADS
-          python -m pytest --durations=200 -n 12 --cov firedrake -v tests
+          python -m pytest --durations=200 -n 12 --cov firedrake --timeout=600 -v tests
       - name: Test pyadjoint
         if: ${{ matrix.scalar-type == 'real' }}
         run: |
           . ../build/bin/activate
-          cd ../build/src/pyadjoint; python -m pytest --durations=200 -n 12 -v tests/firedrake_adjoint
+          cd ../build/src/pyadjoint; python -m pytest --durations=200 -n 12 --timeout=600 -v tests/firedrake_adjoint
       - name: Cleanup
         # Belt and braces: clean up before and after the run.
         if: ${{ always() }}


### PR DESCRIPTION
I've been trying to track down a test today that hangs and had difficulty because currently the CI continues to run until it is terminated after a number of hours. This means that I don't know which tests are the ones responsible for the hanging.

This change should timeout tests that are hanging so we can see which they are.

I chose 600s as the timeout limit because our longest test is currently around 400s so it should not be accidentally triggered.