### PR TITLE
Only include components of mixed functions that are actually used

### DIFF
--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -55,8 +55,10 @@ def compile_element(expression, coordinates, parameters=None):
     # Initialise kernel builder
     builder = firedrake_interface.KernelBuilderBase(utils.ScalarType_c)
     builder.domain_coordinate[domain] = coordinates
-    x_arg = builder._coefficient(coordinates, "x")
-    f_arg = builder._coefficient(coefficient, "f")
+    builder._coefficient(coordinates, "x")
+    x_arg = builder.generate_arg_from_expression(builder.coefficient_map[coordinates])
+    builder._coefficient(coefficient, "f")
+    f_arg = builder.generate_arg_from_expression(builder.coefficient_map[coefficient])
 
     # TODO: restore this for expression evaluation!
     # expression = ufl_utils.split_coefficients(expression, builder.coefficient_split)

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -255,3 +255,14 @@ def test_assemble_only_valid_with_floats(mesh):
     a = dot(f*u, v) * dx
     with pytest.raises(ValueError):
         assemble(a)
+
+
+def test_assemble_mixed_function_sparse():
+    mesh = UnitSquareMesh(1, 1)
+    V0 = FunctionSpace(mesh, "CG", 1)
+    V = V0 * V0 * V0 * V0 * V0 * V0 * V0 * V0
+    f = Function(V)
+    f.sub(1).interpolate(Constant(2.0))
+    f.sub(4).interpolate(Constant(3.0))
+    v = assemble((inner(f[1], f[1]) + inner(f[4], f[4])) * dx)
+    assert np.allclose(v, 13.0)

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -44,14 +44,19 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
     u = TrialFunction(V)
     v = TestFunction(V)
 
-    a = inner(grad(u), grad(v))*dx
-
-    L = inner(Constant(rhs), v)*dx
-
     if problem_type == "mixed":
+        # We also test patch pc with kernel argument compression.
+        i = 1  # only active index
+        f = Function(V)
+        fval = numpy.full(V.sub(i).ufl_element().value_shape(), 1.0, dtype=float)
+        f.sub(i).interpolate(Constant(fval))
+        a = (inner(f[i], f[i]) * inner(grad(u), grad(v)))*dx
+        L = inner(Constant(rhs), v)*dx
         bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape()), "on_boundary")
                for Q in V.split()]
     else:
+        a = inner(grad(u), grad(v))*dx
+        L = inner(Constant(rhs), v)*dx
         bcs = DirichletBC(V, zero(V.ufl_element().value_shape()), "on_boundary")
 
     uh = Function(V)

--- a/tests/test_tsfc_interface.py
+++ b/tests/test_tsfc_interface.py
@@ -50,7 +50,7 @@ def rhs2(fs):
 
 @pytest.fixture
 def cache_key(mass):
-    return tsfc_interface.TSFCKernel(mass, 'mass', parameters["form_compiler"], {}, None).cache_key
+    return tsfc_interface.TSFCKernel(mass, 'mass', parameters["form_compiler"], (), None).cache_key
 
 
 class TestTSFCCache:
@@ -64,7 +64,7 @@ mesh = UnitSquareMesh(1, 1)
 V = FunctionSpace(mesh, "CG", 1)
 u = TrialFunction(V)
 v = TestFunction(V)
-key = tsfc_interface.TSFCKernel(inner(u,v)*dx, "mass", parameters["form_compiler"], {{}}, None).cache_key
+key = tsfc_interface.TSFCKernel(inner(u,v)*dx, "mass", parameters["form_compiler"], (), None).cache_key
 with open("{file}", "w") as f:
     f.write(key)
         """


### PR DESCRIPTION
Depends on https://github.com/firedrakeproject/tsfc/pull/271

Currently, kernel arguments include all components of a mixed function even if some of them are not actually used. This PR attempts to fix this, so that only those actually used appear in the kernel arg.

```
from firedrake import *
import time


mesh = UnitSquareMesh(1, 1)
V0 = FunctionSpace(mesh, "CG", 1)
V = V0 * V0 * V0 * V0 * V0 * V0
f = Function(V)
s = time.time()
assemble(inner(f[1], f[1]) * dx)
e = time.time()
print("time: ", e - s)
```

`master`:
```
time:  0.9075462818145752
```
This PR:
```
time:  0.6303689479827881
```