### PR TITLE
Test Slate tensors: don't assemble diagonal of tensor with interior facets.

### DIFF
--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -82,19 +82,16 @@ def mass(function_space):
 
 
 @pytest.fixture
-def matrix_mixed_facet():
+def matrix_mixed_nofacet():
     mesh = UnitSquareMesh(2, 2)
     U = FunctionSpace(mesh, "RT", 1)
     V = FunctionSpace(mesh, "DG", 0)
     T = FunctionSpace(mesh, "HDiv Trace", 0)
-    n = FacetNormal(mesh)
     W = U * V * T
     u, p, lambdar = TrialFunctions(W)
     w, q, gammar = TestFunctions(W)
 
-    return (inner(u, w)*dx + p*q*dx - div(w)*p*dx + q*div(u)*dx
-            + lambdar('+')*jump(w, n=n)*dS + gammar('+')*jump(u, n=n)*dS
-            + lambdar*gammar*ds)
+    return (inner(u, w)*dx + p*q*dx - div(w)*p*dx + q*div(u)*dx)
 
 
 @pytest.fixture
@@ -288,7 +285,7 @@ def test_matrix_subblocks(mesh):
         assert np.allclose(assemble(tensor).M.values, ref, rtol=1e-14)
 
 
-def test_diagonal(mass, matrix_mixed_facet):
+def test_diagonal(mass, matrix_mixed_nofacet):
     n, _ = Tensor(mass).shape
 
     # test vector built from diagonal
@@ -306,16 +303,16 @@ def test_diagonal(mass, matrix_mixed_facet):
         assert np.allclose(r, d, rtol=1e-14)
 
     # test matrix built from diagonal for non mass matrix
-    res2 = assemble(DiagonalTensor(Tensor(matrix_mixed_facet))).M.values
-    ref2 = np.concatenate(assemble(matrix_mixed_facet, diagonal=True).dat.data)
+    res2 = assemble(DiagonalTensor(Tensor(matrix_mixed_nofacet))).M.values
+    ref2 = np.concatenate(assemble(matrix_mixed_nofacet, diagonal=True).dat.data)
     for r, d in zip(res2, np.diag(ref2)):
         assert np.allclose(r, d, rtol=1e-14)
 
     # test matrix built from diagonal
     # for a Slate expression on a non mass matrix
-    A = Tensor(matrix_mixed_facet)
+    A = Tensor(matrix_mixed_nofacet)
     res3 = assemble(DiagonalTensor(A+A)).M.values
-    ref3 = np.concatenate(assemble(matrix_mixed_facet+matrix_mixed_facet, diagonal=True).dat.data)
+    ref3 = np.concatenate(assemble(matrix_mixed_nofacet+matrix_mixed_nofacet, diagonal=True).dat.data)
     for r, d in zip(res3, np.diag(ref3)):
         assert np.allclose(r, d, rtol=1e-14)
 


### PR DESCRIPTION
I merged this PR earlier https://github.com/firedrakeproject/tsfc/pull/269 which caused some of the Slate tests fail. This is a fix.