### PR TITLE
Define MPI_Session in cython files for compatibility with current mpi4py main branch

### DIFF
--- a/firedrake/cython/mpi-compat.h
+++ b/firedrake/cython/mpi-compat.h
@@ -11,4 +11,9 @@ typedef void *PyMPI_MPI_Message;
 #define MPI_Message PyMPI_MPI_Message
 #endif
 
+#if (MPI_VERSION < 4) && !defined(PyMPI_HAVE_MPI_Session)
+typedef void *PyMPI_MPI_Session;
+#define MPI_Session PyMPI_MPI_Session
+#endif
+
 #endif/*MPI_COMPAT_H*/


### PR DESCRIPTION
As of 12 days ago, `mpi4py` has a new define `MPI_Session` which must be added to `firedrake/cython/mpi-compat.h` to prevent a `error: unknown type name ‘MPI_Session’` upon compiling (at least) `firedrake/cython/dmcommon.c`. 

Also see the blame
https://github.com/mpi4py/mpi4py/blame/80c53a02c2f85c721c8c26b202a4ab0ed4ac02fc/src/mpi4py/include/mpi4py/mpi4py.h

Requires https://github.com/Unidata/netcdf4-python/pull/1156
Tested in https://github.com/fem-on-colab/fem-on-colab/actions/runs/1937787901