### PR TITLE
Fix interpolation test for Nedelec, BDM and RT elements for variant=integral

### DIFF
--- a/tests/regression/test_interpolation_nodes.py
+++ b/tests/regression/test_interpolation_nodes.py
@@ -34,7 +34,7 @@ def degree(request):
                 ids=lambda x: "%s" % x)
 def V(request, mesh, degree):
     space = request.param
-    V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant="integral")
+    V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant=f"integral({5*degree})")
     return FunctionSpace(mesh, V_el)
 
 


### PR DESCRIPTION
We changed the default quadrature degree of the Nedelec, BDM and RT elements for variant=integral from 5k to k in fiat. Hence, if you want to still want to still be div/curl preserving in your interpolation, the quadrature degree should be set to something high, for this test we choose 5k.