### PR TITLE
Firedrake changes for updating PETSc

### DIFF
--- a/demos/ma-demo/ma-demo.py.rst
+++ b/demos/ma-demo/ma-demo.py.rst
@@ -168,6 +168,7 @@ and use GAMG to approximate the inverse of the Schur complement matrix. ::
   #
      "fieldsplit_1_ksp_type": "preonly",
      "fieldsplit_1_pc_type": "gamg",
+     "fieldsplit_1_mg_levels_pc_type": "sor",
 
 Finally, we'd like to see some output to check things are working, and
 to limit the KSP solver to 20 iterations. ::

--- a/docs/notebooks/03-elasticity.ipynb
+++ b/docs/notebooks/03-elasticity.ipynb
@@ -1117,6 +1117,7 @@
     "uh = solve_elasticity(200, 200, options={\"ksp_type\": \"cg\", \n",
     "                                         \"ksp_max_it\": 100, \n",
     "                                         \"pc_type\": \"gamg\",\n",
+    "                                         \"mg_levels_pc_type\": \"sor\",\n",
     "                                         \"mat_type\": \"aij\",\n",
     "                                         \"ksp_converged_reason\": None})"
    ]

--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -341,6 +341,7 @@ def test_near_nullspace_mixed():
             'pc_type': 'python',
             'pc_python_type': 'firedrake.AssembledPC',
             'assembled_pc_type': 'gamg',
+            'assembled_mg_levels_pc_type': 'sor',
             'ksp_rtol': 1e-7,
             'ksp_converged_reason': None,
         },


### PR DESCRIPTION
Merge PETSc upstream.

The following commit in the upstream caused Firedrake tests that use gamg to fail with `DIVERGED_LINEAR_SOLVE` or similar:

"switch default GAMG smoothing to PCJACOBI" (`5f7df010c372f2aba7032437adc22ab0932ed26e`)

So we need to add options to recover old behaviour.