### PR TITLE
Do not use requirements.txt for icepack install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -900,8 +900,8 @@ def pip_requirements(package, parallel_compiler_env):
                         log.debug("Skipping failing install of optional pyadjoint dependency tensorflow")
                     else:
                         raise e
-        elif package == "loopy":
-            # loopy dependencies are installed in setup.py
+        elif package in {"loopy", "icepack"}:
+            # dependencies are installed in setup.py
             return
         else:
             reqs = get_requirements("%s/requirements.txt" % package)


### PR DESCRIPTION
Our CI is currently failing to build because of the `roltrilinos` dependency for icepack [here](https://github.com/icepack/icepack/blob/master/requirements.txt). This is only a problem because our way of handling dependencies is to parse the `requirements.txt` file and pip install the packages, ignoring the fact that this package is optional in icepack.

The tiny change I've made here is to use icepack's `setup.py` file instead of `requirements.txt`. Then the dependencies are resolved using pip and work as expected.