### PR TITLE
Check datatypes of forms

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -312,6 +312,10 @@ def _check_inputs(form, tensor, bcs, diagonal):
     else:
         raise AssertionError
 
+    if any(c.dat.dtype != ScalarType for c in form.coefficients()):
+        raise ValueError("Cannot assemble a form containing coefficients where the "
+                         "dtype is not the PETSc scalar type.")
+
 
 def _zero_tensor(tensor, form, diagonal):
     rank = len(form.arguments())

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -226,3 +226,13 @@ def test_two_form_assembler_cache(mesh):
     # changing form_compiler_parameters should increase the cache size
     assemble(a, form_compiler_parameters={"quadrature_degree": 2})
     assert len(a._cache[_FORM_CACHE_KEY]) == 4
+
+
+def test_assemble_only_valid_with_floats(mesh):
+    V = FunctionSpace(mesh, "CG", 1)
+    f = Function(V, dtype=np.int32)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = dot(f*u, v) * dx
+    with pytest.raises(ValueError):
+        assemble(a)


### PR DESCRIPTION
This PR adds a test to make sure that we throw an error if we try to assemble a form that contains the wrong datatypes. It also tests some PyOP2 changes (that throw the error).

Related:
- https://github.com/firedrakeproject/firedrake/discussions/2391
- https://github.com/OP2/PyOP2/pull/659