### PR TITLE
Make importing applications a non-strict xfail

### DIFF
--- a/tests/regression/test_import_applications.py
+++ b/tests/regression/test_import_applications.py
@@ -10,6 +10,7 @@ def app(request):
 
 
 @pytest.mark.skipif("FIREDRAKE_CI_TESTS" not in os.environ, reason="Not running in CI")
+@pytest.mark.xfail(strict=False)
 def test_import_app(app):
     # Have to run this in a subprocess in case the import pollutes the
     # test environment, e.g. by modifying firedrake parameters.


### PR DESCRIPTION
Resolves #2390. Importing external applications (Icepack, Thetis, Gusto, Irksome, Femlium) can fail without breaking the build.