### PR TITLE
Let ufl_expr.CellSize call ufl.CellDiameter() instead of ufl.Circumradius

### DIFF
--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -259,7 +259,7 @@ def CellSize(mesh):
     :arg mesh: the mesh for which to calculate the cell size.
     """
     mesh.init()
-    return 2.0 * ufl.Circumradius(mesh)
+    return ufl.CellDiameter(mesh)
 
 
 @PETSc.Log.EventDecorator()


### PR DESCRIPTION
The `firderake.ufl_expr.CellSize` description reads:

> A symbolic representation of the cell size of a mesh.

In most books about finite element theory, the cell size _h_ used for convergence studies is (the minimum of) the cell diameters. For this reason, I suggest to call `ufl.CellDiameter()` instead of `ufl.Circumradius()`.