### PR TITLE
Use SubMatrices to compute eigvals in demo qgbasinmodes

### DIFF
--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -167,7 +167,7 @@ submatrices that omit these rows and the correspoing columns. ::
 
    bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntType)
    ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
-   (s, e), _ = petsc_a.getSizes()
+   s, e = petsc_a.getOwnershipRange()#(s, e), _ = petsc_a.getSizes()
    ISin = ISbd.complement(s, e)
    A = petsc_a.createSubMatrix(ISin, ISin)
    M = petsc_m.createSubMatrix(ISin, ISin)
@@ -219,7 +219,7 @@ converge any eigenvalues at all. ::
 If we did, we go ahead and extract them from the SLEPc eigenvalue
 solver::
 
-   vr, vi = petsc_a.getVecs()
+   vr, vi = A.getVecs()
 
    lam = es.getEigenpair(0, vr, vi)
 

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -109,6 +109,7 @@ Firedrake. We import the Firedrake, PETSc, and SLEPc libraries. ::
 
    from firedrake import *
    from firedrake.petsc import PETSc
+   import pyop2
    try:
        from slepc4py import SLEPc
    except ImportError:

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -165,7 +165,7 @@ submatrices that omit these rows and the correspoing columns. ::
    petsc_a = assemble(a).M.handle
    petsc_m = assemble(m, bcs=bc).M.handle
 
-   bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntTpye)
+   bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntType)
    ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
    (s, e), _ = petsc_a.getSizes()
    ISin= ISbd.complement(s, e)

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -155,9 +155,9 @@ To build the weak formulation of our equation we need to build two PETSc
 matrices in the form of a generalized eigenvalue problem,
 :math:`A\psi = \lambda M\psi`. We impose the boundary conditions on the
 mass matrix :math:`M`, since that is where we used integration by parts.
-For a more stable computation of the eigenvalues, we also create
-submatrices by removing rows and columns associated with the boundary
-conditions. ::
+To avoid spurious eigenvalues associated with the rows of :math:`M`
+that are modified by the Dirichlet boundary conditions, we create
+submatrices that omit these rows and the correspoing columns. ::
 
    a =  beta*phi*psi.dx(0)*dx
    m = -inner(grad(psi), grad(phi))*dx - F*psi*phi*dx

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -164,8 +164,8 @@ submatrices that omit these rows and the correspoing columns. ::
    petsc_a = assemble(a).M.handle
    petsc_m = assemble(m, bcs=bc).M.handle
 
-   bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(np.int32)
-   ISbd = PETSc.IS().createGeneral(bcnodes, comm=PETSc.COMM_SELF)
+   bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntTpye)
+   ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
    ISin= ISbd.complement(0, Vcg.dim())
    A = petsc_a.createSubMatrix(ISin, ISin)
    M = petsc_m.createSubMatrix(ISin, ISin)

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -167,7 +167,7 @@ submatrices that omit these rows and the correspoing columns. ::
 
    bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntType)
    ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
-   s, e = petsc_a.getOwnershipRange()#(s, e), _ = petsc_a.getSizes()
+   s, e = petsc_a.getOwnershipRange()
    ISin = ISbd.complement(s, e)
    A = petsc_a.createSubMatrix(ISin, ISin)
    M = petsc_m.createSubMatrix(ISin, ISin)

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -168,7 +168,7 @@ submatrices that omit these rows and the correspoing columns. ::
    bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntType)
    ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
    (s, e), _ = petsc_a.getSizes()
-   ISin= ISbd.complement(s, e)
+   ISin = ISbd.complement(s, e)
    A = petsc_a.createSubMatrix(ISin, ISin)
    M = petsc_m.createSubMatrix(ISin, ISin)
 

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -166,7 +166,8 @@ submatrices that omit these rows and the correspoing columns. ::
 
    bcnodes = Vcg.dof_dset.lgmap.apply(bc.nodes).astype(pyop2.datatypes.IntTpye)
    ISbd = PETSc.IS().createGeneral(bcnodes, comm=petsc_a.comm)
-   ISin= ISbd.complement(0, Vcg.dim())
+   (s, e), _ = petsc_a.getSizes()
+   ISin= ISbd.complement(s, e)
    A = petsc_a.createSubMatrix(ISin, ISin)
    M = petsc_m.createSubMatrix(ISin, ISin)
 


### PR DESCRIPTION
To compute the eigenvalues more robustly, create submatrices by removing rows and columns associated with degrees of freedom. This trick was suggested (on a different example) by @jandrej , @wence- , @francesco-ballarin and Matt Knepley, among others.

**Disclaimer** I haven't run the demo to check that it runs because I don't know how to convert an `*.py.rst` into a `*.py` I can run.