### PR TITLE
Allow alternative name for saving Functions

### DIFF
--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -711,8 +711,7 @@ class CheckpointFile(object):
         :arg name: optional alternative name to save the function under
         """
         if name:
-            g = Function(f.function_space(), name=name)
-            g.assign(f)
+            g = Function(f.function_space(), val=f.dat, name=name)
             return self.save_function(g, idx=idx)
 
         # -- Save function space --

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -699,7 +699,7 @@ class CheckpointFile(object):
                 topology_dm.setName(base_tmesh_name)
 
     @PETSc.Log.EventDecorator("SaveFunction")
-    def save_function(self, f, idx=None):
+    def save_function(self, f, idx=None, name=None):
         r"""Save a :class:`~.Function`.
 
         :arg f: the :class:`~.Function` to save.
@@ -708,7 +708,14 @@ class CheckpointFile(object):
             mode (non-timestepping); for each function of interest,
             this method must always be called with the idx parameter
             set or never be called with the idx parameter set.
+        :arg name: optional alternative name to save the function under
         """
+        if name:
+            g = Function(f.function_space(), name=name)
+            g.assign(f)
+            self.save_function(g, idx=None)
+            return
+
         # -- Save function space --
         V = f.function_space()
         self._save_function_space(V)

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -713,8 +713,7 @@ class CheckpointFile(object):
         if name:
             g = Function(f.function_space(), name=name)
             g.assign(f)
-            self.save_function(g, idx=None)
-            return
+            return self.save_function(g, idx=idx)
 
         # -- Save function space --
         V = f.function_space()


### PR DESCRIPTION
`DumbCheckpoint.store` had an optional `name` keyword argument so that a function could be saved with a name other than its actual name attribute. `CheckpointFile.save_function` doesn't have this option; this patch adds it. The mechanism is a little blunt but it works.