### PR TITLE
Increase CI timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           . ../build/bin/activate
           echo OMP_NUM_THREADS is $OMP_NUM_THREADS
           echo OPENBLAS_NUM_THREADS is $OPENBLAS_NUM_THREADS
-          python -m pytest --durations=200 -n 12 --cov firedrake --timeout=600 -v tests
+          python -m pytest --durations=200 -n 12 --cov firedrake --timeout=1800 -v tests
       - name: Test pyadjoint
         if: ${{ matrix.scalar-type == 'real' }}
         run: |


### PR DESCRIPTION
We've started hitting some occasional CI fails where tests have been timing out. I originally set the timeout to be 600s when the longest test seemed to take 400s. This appears to no longer be the case and failures due to timing out are happening quite often. We are only using `pytest-timeout` to catch tests that deadlock so I've bumped the timeout value to avoid this happening any more.