### PR TITLE
Pin setuptools and wheel to match numpy build requirements

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1609,9 +1609,9 @@ if mode == "install":
         log.debug("Removing get-pip.py")
         os.remove("get-pip.py")
     # Ensure pip, setuptools and wheel are at the latest version.
-    run_pip(["install", "-U", "setuptools==59.8"])  # Unpin this when numpy will build with latest setuptools
+    run_pip(["install", "-U", "setuptools==59.2.0"])  # Unpin this when numpy will build with latest setuptools
     run_pip(["install", "-U", "pip"])
-    run_pip(["install", "-U", "wheel"])
+    run_pip(["install", "-U", "wheel==0.37.0"])  # Unpin this when numpy will build with latest wheel
 
     # We haven't activated the venv so we need to manually set the environment.
     os.environ["VIRTUAL_ENV"] = firedrake_env


### PR DESCRIPTION
Build failures have been observed with mismatched setuptools and wheel versions.

(https://github.com/firedrakeproject/firedrake/runs/6402346437?check_suite_focus=true)

It appears numpy have pinned these to specific versions.