### PR TITLE
Assembly fixes

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -65,6 +65,9 @@ def assemble(expr, *args, **kwargs):
     :kwarg appctx: Additional information to hang on the assembled
         matrix if an implicit matrix is requested (mat_type ``"matfree"``).
     :kwarg options_prefix: PETSc options prefix to apply to matrices.
+    :kwarg zero_bc_nodes: If ``True``, set the boundary condition nodes in the
+        output tensor to zero rather than to the values prescribed by the
+        boundary condition. Default is ``False``.
 
     :returns: See below.
 
@@ -226,7 +229,8 @@ def _assemble_form(form, tensor=None, bcs=None, *,
                    sub_mat_type=None,
                    appctx=None,
                    options_prefix=None,
-                   form_compiler_parameters=None):
+                   form_compiler_parameters=None,
+                   zero_bc_nodes=False):
     """Assemble a form.
 
     See :func:`assemble` for a description of the arguments to this function.
@@ -258,7 +262,7 @@ def _assemble_form(form, tensor=None, bcs=None, *,
     is_cacheable = len(form.arguments()) == 1
     if is_cacheable:
         try:
-            key = tuple(bcs), diagonal, tuplify(form_compiler_parameters)
+            key = tuple(bcs), diagonal, tuplify(form_compiler_parameters), zero_bc_nodes
             assembler = form._cache[_FORM_CACHE_KEY][key]
             assembler.replace_tensor(tensor)
             return assembler.assemble()
@@ -271,7 +275,7 @@ def _assemble_form(form, tensor=None, bcs=None, *,
     elif rank == 1 or (rank == 2 and diagonal):
         assembler = OneFormAssembler(form, tensor, bcs, diagonal=diagonal,
                                      form_compiler_parameters=form_compiler_parameters,
-                                     needs_zeroing=False)
+                                     needs_zeroing=False, zero_bc_nodes=zero_bc_nodes)
     elif rank == 2:
         assembler = TwoFormAssembler(form, tensor, bcs, form_compiler_parameters,
                                      needs_zeroing=False)

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -270,9 +270,11 @@ def _assemble_form(form, tensor=None, bcs=None, *,
         assembler = ZeroFormAssembler(form, tensor, form_compiler_parameters)
     elif rank == 1 or (rank == 2 and diagonal):
         assembler = OneFormAssembler(form, tensor, bcs, diagonal=diagonal,
-                                     form_compiler_parameters=form_compiler_parameters)
+                                     form_compiler_parameters=form_compiler_parameters,
+                                     needs_zeroing=False)
     elif rank == 2:
-        assembler = TwoFormAssembler(form, tensor, bcs, form_compiler_parameters)
+        assembler = TwoFormAssembler(form, tensor, bcs, form_compiler_parameters,
+                                     needs_zeroing=False)
     else:
         raise AssertionError
 

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -146,6 +146,21 @@ def test_assemble_diagonal_bcs(mesh):
     assert np.allclose(M.petscmat.getDiagonal().array_r, Mdiag.dat.data_ro)
 
 
+def test_zero_bc_nodes(mesh):
+    V = FunctionSpace(mesh, "P", 3)
+    x, y = SpatialCoordinate(mesh)
+    f = Function(V).interpolate(sin(x + y))
+    v = TestFunction(V)
+    bcs = [DirichletBC(V, 1.0, 1), DirichletBC(V, 2.0, 3)]
+    a = inner(grad(f), grad(v))*dx
+
+    b1 = assemble(a)
+    for bc in bcs:
+        bc.zero(b1)
+    b2 = assemble(a, bcs=bcs, zero_bc_nodes=True)
+    assert np.allclose(b1.dat.data, b2.dat.data)
+
+
 @pytest.mark.xfail(reason="Assembler caching not currently supported for zero forms")
 def test_zero_form_assembler_cache(mesh):
     from firedrake.assemble import _FORM_CACHE_KEY
@@ -190,6 +205,10 @@ def test_one_form_assembler_cache(mesh):
     # changing form_compiler_parameters should increase the cache size
     assemble(L, form_compiler_parameters={"quadrature_degree": 2})
     assert len(L._cache[_FORM_CACHE_KEY]) == 3
+
+    # changing zero_bc_nodes should increase the cache size
+    assemble(L, zero_bc_nodes=True)
+    assert len(L._cache[_FORM_CACHE_KEY]) == 4
 
 
 @pytest.mark.xfail(reason="Assembler caching not currently supported for two forms")


### PR DESCRIPTION
This PR addresses two recent issues found in `assemble`:
1. https://github.com/firedrakeproject/firedrake/commit/1e2b585e5be07808318531f7c9f83b026baad030 fixes a zeroing bug noticed by @wence-.
2. https://github.com/firedrakeproject/firedrake/commit/209a81f62dd7b98c5bdc85912935155cd4bac921 adds `zero_bc_nodes` as a kwarg to `assemble` (requested by @colinjcotter and @pbrubeck).