### PR TITLE
Fix BOP

### DIFF
--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -45,7 +45,7 @@ import numpy as np
 import loopy
 import gem
 from gem import indices as make_indices
-from tsfc.kernel_args import OutputKernelArg
+from tsfc.kernel_args import OutputKernelArg, CoefficientKernelArg
 from tsfc.loopy import generate as generate_loopy
 import copy
 
@@ -191,6 +191,10 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
     orig_coeffs = orig_expr.coefficients()
     get_index = lambda n: orig_coeffs.index(new_coeffs[n]) if new_coeffs[n] in orig_coeffs else n
     coeff_map = tuple((get_index(n), split_map) for (n, split_map) in slate_expr.coeff_map)
+
+    coefficients = list(filter(lambda elm: isinstance(elm, CoefficientKernelArg), arguments))
+    assert len(list(chain(*(map[1] for map in coeff_map)))) == len(coefficients), "KernelInfo must be generated with a coefficient map that maps EXACTLY all cofficients there are in its arguments attribute."
+    assert len(loopy_merged.callables_table[name].subkernel.args) - int(builder.bag.needs_mesh_layers) == len(arguments), "Outer loopy kernel must have the same amount of args as there are in arguments"
 
     kinfo = KernelInfo(kernel=loopykernel,
                        integral_type="cell",  # slate can only do things as contributions to the cell integrals

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -187,11 +187,10 @@ def generate_loopy_kernel(slate_expr, compiler_parameters=None):
                                                        events=events+(slate_loopy_event,))
 
     # map the coefficients in the order that PyOP2 needs
-    new_coeffs = slate_expr.coefficients()
     orig_coeffs = orig_expr.coefficients()
-    get_index = lambda n: orig_coeffs.index(new_coeffs[n]) if new_coeffs[n] in orig_coeffs else n
-    coeff_map = tuple((get_index(n), split_map) for (n, split_map) in slate_expr.coeff_map)
-
+    new_coeffs = slate_expr.coefficients()
+    map_new_to_orig = [orig_coeffs.index(c) for c in new_coeffs]
+    coeff_map = tuple((map_new_to_orig[n], split_map) for (n, split_map) in slate_expr.coeff_map)
     coefficients = list(filter(lambda elm: isinstance(elm, CoefficientKernelArg), arguments))
     assert len(list(chain(*(map[1] for map in coeff_map)))) == len(coefficients), "KernelInfo must be generated with a coefficient map that maps EXACTLY all cofficients there are in its arguments attribute."
     assert len(loopy_merged.callables_table[name].subkernel.args) - int(builder.bag.needs_mesh_layers) == len(arguments), "Outer loopy kernel must have the same amount of args as there are in arguments"

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -78,7 +78,7 @@ def _push_block_transpose(expr, self, indices):
 @_push_block.register(Reciprocal)
 def _push_block_distributive(expr, self, indices):
     """Distributes Blocks for these nodes"""
-    return type(expr)(*map(self, expr.children, repeat(indices))) if indices else expr
+    return type(expr)(*map(self, expr.children, repeat(indices)))
 
 
 @_push_block.register(Factorization)
@@ -87,6 +87,7 @@ def _push_block_distributive(expr, self, indices):
 @_push_block.register(Mul)
 def _push_block_stop(expr, self, indices):
     """Blocks cannot be pushed further into this set of nodes."""
+    expr = type(expr)(*map(self, expr.children, repeat(tuple())))
     return Block(expr, indices) if indices else expr
 
 

--- a/firedrake/slate/slac/optimise.py
+++ b/firedrake/slate/slac/optimise.py
@@ -100,7 +100,7 @@ def _push_block_tensor(expr, self, indices):
 @_push_block.register(AssembledVector)
 def _push_block_assembled_vector(expr, self, indices):
     """Turns a Block on an AssembledVector into the  specialized node BlockAssembledVector."""
-    return BlockAssembledVector(expr._function, Block(expr, indices).form, indices) if indices else expr
+    return BlockAssembledVector(expr._function, expr, indices) if indices else expr
 
 
 @_push_block.register(Block)


### PR DESCRIPTION
### Problem number 1: Recursion
I realised that the block push optimisation pass is aborting too early, so that we are missing out on performance gains. We need to recurse into every child to check if there is a `Block`. Examples where this is the case were introduced in 8a36889cad10aa2646812f848c847eaac64e521b. This also seemed to be an issue for all tests involving the SCPC preconditioner `tests/slate/test_cg_poisson.py`.

**Fix**: 342639742c60b7c8bc56fb7d0d9a4e27155e898a

### Problem number 2: Shapes of BAVs
After fixing the recursion for the block push, the first issue I had was a shape mismatch error in the multiplicand for the very first test, because shapes for `BlockAssembledVectors` (BAV) were not determined correctly.

**Fix**
I am passing the whole block into the BAV here https://github.com/firedrakeproject/firedrake/blob/d7f30976e00aa294935c99b89e5b0673141662f4/firedrake/slate/slac/optimise.py#L103 rather than the form associated with the block, so that I could recycle its `arguments` and `argfunctionspaces` here https://github.com/firedrakeproject/firedrake/blob/d7f30976e00aa294935c99b89e5b0673141662f4/firedrake/slate/slate.py#L543 and here https://github.com/firedrakeproject/firedrake/blob/d7f30976e00aa294935c99b89e5b0673141662f4/firedrake/slate/slate.py#L532 Those are used to determine the shape.

### Problem number 3: Coefficient maps
After that I started to have issues with the coefficient maps. The general story behind this is that PyOP2 is passing the coefficients in the order that they appear in the original Slate expression. We then rewrite the Slate expression and the order might change. I had introduced a coefficient map which maps the original coefficient order and the optimised coefficient order.
The problem for blocks on AssembledVectors: If we push blocks inward, we might start from this expression here `AV_4[((1,),)]_3 + -(M_6[((1,), (0,))]_5 * (PartialPivLU(M_6[((0,), (0,))]_8)_7).inv * AV_4[((0,),)]_9)` and rewrite it to `BAV_10 + -(M_11 * PartialPivLU(M_13)_12 \ BAV_14)`. `AV_4` is an assembled vector on a mixed coefficient and we index two times into a part of it, this gets then turned into two `BlockAssembledVectors (BAV)` in the optimisation pass. PyOP2 passes splits of the mixed coefficients in order (first split, second split, etc), but the Slate compiler passes the coefficient arguments to the kernels in the order of how they appear in the optimised expression. `BAV_10` corresponds to the second part of the (original) mixed coefficient, but it’s the first argument in the Slate kernel. This means that the we don’t only need to order the coefficients but also their splits.

**Fix**
In order to sort the the split map we need to save more information when we ask for the coefficients of a BAV which is why querying BAVs for their coefficients will return `BlockFunctions` now, as introduced here https://github.com/firedrakeproject/firedrake/blob/d7f30976e00aa294935c99b89e5b0673141662f4/firedrake/slate/slate.py#L46 In the `BlockFunction`, in addition to the split functions corresponding to the BAV, we also keep track of indices of the block and also the original function, so that we can generate the correct split map here https://github.com/firedrakeproject/firedrake/blob/d7f30976e00aa294935c99b89e5b0673141662f4/firedrake/slate/slate.py#L217
We ask for the coefficients two more times. Once to generate a coefficient dict (which is used to generate the arguments to the Slate kernel e.g.) and once to fill the temporaries (corresponding to the Slate assembled vectors) with the data that are passed to the Slate kernels. We need to adapt there to the changes above and that is what is happening in the changes of the `KernelBuilder`