### PR TITLE
Vertex only mesh tolerance

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2176,7 +2176,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
     if pdim != gdim:
         raise ValueError(f"Mesh geometric dimension {gdim} must match point list dimension {pdim}")
 
-    swarm = _pic_swarm_in_mesh(mesh, vertexcoords, tolerance)
+    swarm = _pic_swarm_in_mesh(mesh, vertexcoords, tolerance=tolerance)
 
     if missing_points_behaviour:
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2108,8 +2108,9 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
         ranks.
     :kwarg tolerance: the amount by which the local coordinates of a point are
         allowed to fall outside the cell while still having the point count as
-        in the cell. Increase the default (1.0e-14) somewhat if vertices are
-        being lost in the :class:`VertexOnlyMesh` construction process.
+        in the cell. Increase the default (1.0e-14) somewhat if vertices
+        interior to the domain are being lost in the :class:`VertexOnlyMesh`
+        construction process.
 
     .. note::
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2272,6 +2272,10 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None):
         RealType)]``. All fields must have the same number of points. For more
         information see `the DMSWARM API reference
         <https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/DMSWARM/DMSWARM.html>_.
+    :kwarg tolerance: the amount by which the local coordinates of a point are
+        allowed to fall outside the cell while still having the point count as
+        in the cell. Increase the default (1.0e-14) somewhat if vertices are
+        being lost in the :class:`VertexOnlyMesh` construction process.
     :return: the immersed DMSwarm
 
     .. note::

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2106,6 +2106,10 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
         that they have the same list of vertices (else the test is not
         possible): this operation scales with number of vertices and number of
         ranks.
+    :kwarg tolerance: the amount by which the local coordinates of a point are
+        allowed to fall outside the cell while still having the point count as
+        in the cell. Increase the default (1.0e-14) somewhat if vertices are
+        being lost in the :class:`VertexOnlyMesh` construction process.
 
     .. note::
 
@@ -2272,10 +2276,6 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None):
         RealType)]``. All fields must have the same number of points. For more
         information see `the DMSWARM API reference
         <https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/DMSWARM/DMSWARM.html>_.
-    :kwarg tolerance: the amount by which the local coordinates of a point are
-        allowed to fall outside the cell while still having the point count as
-        in the cell. Increase the default (1.0e-14) somewhat if vertices are
-        being lost in the :class:`VertexOnlyMesh` construction process.
     :return: the immersed DMSwarm
 
     .. note::

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -176,3 +176,21 @@ def test_extrude(parentmesh):
     inputcoords, inputcoordslocal = cell_midpoints(parentmesh)
     vm = VertexOnlyMesh(parentmesh, inputcoords)
     ExtrudedMesh(vm, 1)
+
+
+def test_point_tolerance():
+    """Test the tolerance parameter to VertexOnlyMesh.
+
+    This test works by checking a point outside the domain. Tolerance does not
+    in fact promise to fix the problem of points outside the domain in the
+    general case. It is instead there to cope with losing points on internal
+    cell boundaries due to roundoff. The latter case is difficult to test in a
+    manner which is robust to roundoff behaviour in different environments."""
+    m = UnitSquareMesh(1, 1)
+    # Make the mesh non-axis-aligned.
+    m.coordinates.dat.data[1, :] = [1.1, 1]
+    coords = [[1.0501, 0.5]]
+    vm = VertexOnlyMesh(m, coords, tolerance=0.1)
+    assert vm.cell_set.size == 1
+    vm = VertexOnlyMesh(m, coords, tolerance=None)
+    assert vm.cell_set.size == 0


### PR DESCRIPTION
How do we feel about letting users specify the cell inclusion tolerance when setting up a VertexOnlyMesh? This will allow users to work around particles getting lost due to roundoff?

This PR doesn't have docstrings yet. I am canvassing opinions about whether this is an OK thing to do.
