### PR TITLE
Disk checkpointing

### DIFF
--- a/docs/source/checkpointing.rst
+++ b/docs/source/checkpointing.rst
@@ -199,6 +199,26 @@ with `idx` parameter always unset, and the same :class:`~.Function` can only be
 loaded using the same mode.
 
 
+Using disk checkpointing in adjoint simulations
+===============================================
+
+When adjoint annotation is active, the result of every Firedrake operation is
+stored in memory. For some simulations, this can result in a very large memory
+footprint. As an alternative, it is possible to specify that those intermediate
+results in forward evaluations of the tape which have type
+:class:`~firedrake.function.Function` be written to disk. This is usually the
+bulk of the data stored on the tape so this largely alleviates the memory
+problem, at the cost of the time taken to read to and write from disk.
+
+Having imported `firedrake_adjoint`, there are two steps required to enable
+disk checkpointing of the forward tape state.
+
+1. Call :func:`~firedrake.adjoint.checkpointing.enable_disk_checkpointing`.
+2. Wrap all mesh constructors in :func:`~firedrake.adjoint.checkpointing.checkpointable_mesh`.
+
+See the documentation of those functions for more detail.
+
+
 Checkpointing with DumbCheckpoint
 =================================
 

--- a/firedrake/adjoint/__init__.py
+++ b/firedrake/adjoint/__init__.py
@@ -5,6 +5,7 @@ from firedrake.adjoint.variational_solver import *     # noqa: F401
 from firedrake.adjoint.solving import *                # noqa: F401
 from firedrake.adjoint.mesh import *                   # noqa: F401
 from firedrake.adjoint.interpolate import *            # noqa: F401
+from firedrake.adjoint.checkpointing import *          # noqa: F401
 from pyadjoint.tape import Tape, set_working_tape
 
 set_working_tape(Tape())

--- a/firedrake/adjoint/checkpointing.py
+++ b/firedrake/adjoint/checkpointing.py
@@ -1,0 +1,286 @@
+"""A module providing support for disk checkpointing of the adjoint tape."""
+from pyadjoint import get_working_tape
+from pyadjoint.tape import TapePackageData
+from pyop2.mpi import COMM_WORLD
+import tempfile
+import os
+import shutil
+import atexit
+_stop_disk_checkpointing = 1
+_checkpoint_init_data = False
+
+__all__ = ["enable_disk_checkpointing", "disk_checkpointing",
+           "pause_disk_checkpointing", "continue_disk_checkpointing",
+           "stop_disk_checkpointing", "checkpointable_mesh"]
+
+
+def current_checkpoint_file(init=None):
+    """Return the current checkpoint file, if any.
+
+    Parameters
+    ----------
+    init : bool
+        If True, return the current checkpoint file for input data. If False,
+        return the current checkpoint file for block outputs.
+    """
+
+    checkpointer = get_working_tape()._package_data.get("firedrake")
+    if checkpointer:
+        if init or _checkpoint_init_data:
+            return checkpointer.init_checkpoint_file
+        else:
+            return checkpointer.current_checkpoint_file
+
+
+class checkpoint_init_data:
+    """Inside this context manager, checkpoint to the init file."""
+
+    def __enter__(self):
+        global _checkpoint_init_data
+        self._init = _checkpoint_init_data
+        _checkpoint_init_data = True
+
+    def __exit__(self, *args):
+        global _checkpoint_init_data
+        _checkpoint_init_data = self._init
+
+
+def enable_disk_checkpointing(dirname=None, comm=COMM_WORLD, cleanup=True):
+    """Add a DiskCheckpointer to the current tape and switch on
+    disk checkpointing.
+
+    Parameters
+    ----------
+    dirname : str
+        The directory in which the disk checkpoints should be stored. If not
+        specified then the current working directory is used. Checkpoints are
+        stored in a temporary subdirectory of this directory.
+    comm : mpi4py.MPI.Intracomm
+        The MPI communicator over which the computation to be disk checkpointed
+        is defined. This will usually match the communicator on which the
+        mesh(es) are defined.
+    cleanup : bool
+        If set to False, checkpoint files will not be deleted when no longer
+        required. This is usually only useful for debugging.
+    """
+    tape = get_working_tape()
+    if "firedrake" not in tape._package_data:
+        tape._package_data["firedrake"] = DiskCheckpointer(dirname, comm, cleanup)
+    if not disk_checkpointing():
+        continue_disk_checkpointing()
+
+
+def disk_checkpointing():
+    """Return true if disk checkpointing of the adjoint tape is active."""
+    return _stop_disk_checkpointing <= 0
+
+
+def pause_disk_checkpointing():
+    """Pause disk checkpointing and instead checkpoint to memory."""
+    global _stop_disk_checkpointing
+    _stop_disk_checkpointing += 1
+
+
+def continue_disk_checkpointing():
+    """Resume disk checkpointing."""
+    global _stop_disk_checkpointing
+    _stop_disk_checkpointing -= 1
+    return _stop_disk_checkpointing <= 0
+
+
+class stop_disk_checkpointing(object):
+    """A context manager inside which disk checkpointing is paused."""
+    def __enter__(self):
+        pause_disk_checkpointing()
+
+    def __exit__(self, *args):
+        continue_disk_checkpointing()
+
+
+class CheckPointFileReference:
+    """A filename which deletes the associated file when it is destroyed."""
+    def __init__(self, name, comm, cleanup=False):
+        self.name = name
+        self.comm = comm
+        self.cleanup = cleanup
+
+    def __del__(self):
+        if self.cleanup and self.comm.rank == 0 and os.path.exists(self.name):
+            os.remove(self.name)
+
+
+class DiskCheckpointer(TapePackageData):
+    """Manger for the disk checkpointing process.
+
+    Parameters
+    ----------
+    dirname : str
+        The directory in which the disk checkpoints should be stored. If not
+        specified then the current working directory is used. Checkpoints are
+        stored in a temporary subdirectory of this directory.
+    comm : mpi4py.MPI.Intracomm
+        The MPI communicator over which the computation to be disk checkpointed
+        is defined. This will usually match the communicator on which the
+        mesh(es) are defined.
+    cleanup : bool
+        If set to False, checkpoint files will not be deleted when no longer
+        required. This is usually only useful for debugging.
+    """
+
+    def __init__(self, dirname=None, comm=COMM_WORLD, cleanup=True):
+
+        if comm.rank == 0:
+            self.dirname = comm.bcast(tempfile.mkdtemp(
+                prefix="firedrake_adjoint_checkpoint_", dir=dirname or os.getcwd()
+            ))
+        else:
+            self.dirname = comm.bcast("")
+        self.comm = comm
+        self.cleanup = cleanup
+        if self.cleanup and comm.rank == 0:
+            # Delete the checkpoint folder on process exit.
+            atexit.register(shutil.rmtree, self.dirname)
+        # # A checkpoint file holding the state of block variables set outside
+        # the tape.
+        self.init_checkpoint_file = self.new_checkpoint_file()
+        self.current_checkpoint_file = self.new_checkpoint_file()
+
+    def new_checkpoint_file(self):
+        """Set up a disk checkpointing file."""
+        from firedrake.checkpointing import CheckpointFile
+        if self.comm.rank == 0:
+            _, checkpoint_file = tempfile.mkstemp(
+                dir=self.dirname, suffix=".h5"
+            )
+            checkpoint_file = self.comm.bcast(checkpoint_file)
+        else:
+            checkpoint_file = self.comm.bcast("")
+        # Let h5py create a file at this location just to be sure.
+        with CheckpointFile(checkpoint_file, 'w'):
+            pass
+        return CheckPointFileReference(checkpoint_file, self.comm,
+                                       self.cleanup)
+
+    def clear(self, init=True):
+        """Reset the DiskCheckPointer.
+
+        Set up new ones ready to continue checkpointing. In combination with
+        clearing all the block variable checkpoints from the tape, this will
+        delete the disk checkpoints.
+
+        Parameters
+        ----------
+        init : bool
+            Whether the checkpoint file containing the initial values of tape
+            dependencies should also be cleared.
+        """
+        if not self.cleanup:
+            return
+        if init:
+            self.init_checkpoint_file = self.new_checkpoint_file()
+        self.current_checkpoint_file = self.new_checkpoint_file()
+
+    def reset(self):
+        self.clear(init=False)
+
+    def copy(self):
+        # It's unclear in which circumstances a tape copy occurs, and hence
+        # what we should do about it.
+        raise NotImplementedError()
+
+    def checkpoint(self):
+        return {
+            "init": self.init_checkpoint_file,
+            "current": self.current_checkpoint_file
+        }
+
+    def restore_from_checkpoint(self, state):
+        self.init_checkpoint_file = state["init"]
+        self.current_checkpoint_file = state["current"]
+
+
+def checkpointable_mesh(mesh):
+    """Write a mesh to disk and read it back.
+
+    Since a mesh will be repartitioned by being written to disk and reread,
+    only meshes read from a checkpoint file are safe to use with disk
+    checkpointing.
+
+    The workflow for disk checkpointing is therefore to create the mesh(es)
+    required, and then call this function on them. Only the mesh(es) returned
+    by this function can be used in disk checkpointing.
+
+    Parameters
+    ----------
+    mesh : firedrake.Mesh
+        The mesh to be checkpointed.
+
+    Returns
+    -------
+    firedrake.Mesh
+        The checkpointed mesh to be used in the rest of the computation.
+    """
+    from firedrake.checkpointing import CheckpointFile
+    checkpoint_file = current_checkpoint_file(init=True)
+    if not checkpoint_file:
+        raise ValueError(
+            "No current checkpoint file. Call enable_disk_checkpointing()."
+        )
+
+    with CheckpointFile(checkpoint_file.name, 'a') as outfile:
+        outfile.save_mesh(mesh)
+    with CheckpointFile(checkpoint_file.name, 'r') as outfile:
+        return outfile.load_mesh(mesh.name)
+
+
+class CheckpointFunction:
+    """Metadata for a Function checkpointed to disk.
+
+    An object of this class replaces the :class:`~firedrake.Function` stored as
+    the checkpoint value in a `pyadjoint.BlockVariable`.
+
+    Upon instantiation the Function will be saved to the current checkpoint
+    file.
+
+    Parameters
+    ----------
+    function : firedrake.Function
+        The Function to be stored.
+    stored_name : str
+        The name under which the Function is stored in the file.
+    """
+    _checkpoint_index = 0
+
+    def __init__(self, function, stored_name=None):
+        from firedrake.checkpointing import CheckpointFile
+        self.name = function.name
+        self.mesh = function.function_space().mesh()
+        self.file = current_checkpoint_file()
+        self.count = function.count()
+        if stored_name:
+            self.stored_name = stored_name
+        else:
+            CheckpointFunction._checkpoint_index += 1
+            self.stored_name = self.name() \
+                + "_" + str(self._checkpoint_index)
+
+        if not self.file:
+            raise ValueError(
+                "No current checkpoint file. Call enable_disk_checkpointing()."
+            )
+
+        with CheckpointFile(self.file.name, 'a') as outfile:
+            outfile.save_function(function, name=self.stored_name)
+
+    def restore(self):
+        """Read and return this Function from the checkpoint."""
+        from firedrake.checkpointing import CheckpointFile
+        with CheckpointFile(self.file.name, 'r') as infile:
+            function = infile.load_function(self.mesh, self.stored_name)
+        return type(function)(function.function_space(),
+                              function.dat, name=self.name, count=self.count)
+
+
+def maybe_disk_checkpoint(function):
+    """Checkpoint a Function to disk if disk checkpointing is active."""
+    return CheckpointFunction(function) if disk_checkpointing() else function

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -4,6 +4,7 @@ from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape, no_annotations
 from firedrake.adjoint.blocks import FunctionAssignBlock, ProjectBlock, FunctionSplitBlock, FunctionMergeBlock, SupermeshProjectBlock
 import firedrake
+from .checkpointing import disk_checkpointing, CheckpointFunction, checkpoint_init_data
 
 
 class FunctionMixin(FloatingType):
@@ -195,7 +196,10 @@ class FunctionMixin(FloatingType):
         return wrapper
 
     def _ad_create_checkpoint(self):
-        return self.copy(deepcopy=True)
+        if disk_checkpointing():
+            return CheckpointFunction(self)
+        else:
+            return self.copy(deepcopy=True)
 
     @no_annotations
     def _ad_convert_type(self, value, options=None):
@@ -232,7 +236,17 @@ class FunctionMixin(FloatingType):
                 "Unknown Riesz representation %s" % riesz_representation)
 
     def _ad_restore_at_checkpoint(self, checkpoint):
-        return checkpoint
+        if isinstance(checkpoint, CheckpointFunction):
+            return checkpoint.restore()
+        else:
+            return checkpoint
+
+    def _ad_will_add_as_dependency(self):
+        """Method called when the object is added as a Block dependency.
+
+        """
+        with checkpoint_init_data():
+            super()._ad_will_add_as_dependency()
 
     @no_annotations
     def _ad_mul(self, other):

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -777,7 +777,10 @@ class CheckpointFile(object):
             dm = self._get_dm_for_checkpointing(tV)
             path = self._path_to_vec(tmesh.name, dm.name, tf.name())
             if path in self.h5pyfile:
-                timestepping = self.get_attr(os.path.join(path, tf.name()), "timestepping")
+                try:
+                    timestepping = self.get_attr(os.path.join(path, tf.name()), "timestepping")
+                except KeyError:
+                    timestepping = False
                 if timestepping:
                     assert idx is not None, "In timestepping mode: idx parameter must be set"
                 else:

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -230,7 +230,8 @@ class Function(ufl.Coefficient, FunctionMixin):
 
     @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_init
-    def __init__(self, function_space, val=None, name=None, dtype=ScalarType):
+    def __init__(self, function_space, val=None, name=None, dtype=ScalarType,
+                 count=None):
         r"""
         :param function_space: the :class:`.FunctionSpace`,
             or :class:`.MixedFunctionSpace` on which to build this :class:`Function`.
@@ -242,6 +243,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         :param name: user-defined name for this :class:`Function` (optional).
         :param dtype: optional data type for this :class:`Function`
                (defaults to ``ScalarType``).
+        :param count: The :class:`ufl.Coefficient` count which creates the
+            symbolic identity of this :class:`Function`.
         """
 
         V = function_space
@@ -261,7 +264,9 @@ class Function(ufl.Coefficient, FunctionMixin):
                                                 val=val, name=name, dtype=dtype)
 
         self._function_space = V
-        ufl.Coefficient.__init__(self, self.function_space().ufl_function_space())
+        ufl.Coefficient.__init__(
+            self, self.function_space().ufl_function_space(), count=count
+        )
 
         if cachetools:
             # LRU cache for expressions assembled onto this function

--- a/tests/output/test_adjoint_disk_checkpointing.py
+++ b/tests/output/test_adjoint_disk_checkpointing.py
@@ -1,0 +1,82 @@
+from firedrake import *
+from pyadjoint import (ReducedFunctional, get_working_tape, stop_annotating,
+                       annotate_tape, pause_annotation, Control)
+import numpy as np
+import os
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def handle_exit_annotation():
+    yield
+    # Since importing firedrake_adjoint modifies a global variable, we need to
+    # pause annotations at the end of the module
+    annotate = annotate_tape()
+    if annotate:
+        pause_annotation()
+
+
+def adjoint_example(mesh):
+    # This example is designed to exercise all the block types for which
+    # the disk checkpointer does something.
+    dg_space = FunctionSpace(mesh, "DG", 1)
+    cg_space = FunctionSpace(mesh, "CG", 2)
+    W = dg_space * cg_space
+
+    w = Function(W)
+
+    x, y = SpatialCoordinate(mesh)
+    # InterpolateBlock
+    m = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
+
+    u, v = w.split()
+    # FunctionAssignBlock, FunctionMergeBlock
+    v.assign(m)
+    # FunctionSplitBlock, GenericSolveBlock
+    u.project(v)
+
+    # AssembleBlock
+    J = assemble((u - v)**2 * dx)
+
+    Jhat = ReducedFunctional(J, Control(m))
+
+    with stop_annotating():
+        m_new = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
+    checkpointer = get_working_tape()._checkpoint_metadata
+    init_file_timestamp = os.stat(checkpointer.init_checkpoint_file).st_mtime
+    current_file_timestamp = os.stat(checkpointer.current_checkpoint_file).st_mtime
+    Jnew = Jhat(m_new)
+    # Check that any new disk checkpoints are written to the correct file.
+    assert init_file_timestamp == os.stat(checkpointer.init_checkpoint_file).st_mtime
+    assert current_file_timestamp < os.stat(checkpointer.current_checkpoint_file).st_mtime
+
+    assert np.allclose(J, Jnew)
+
+    grad_Jnew = Jhat.derivative()
+
+    return Jnew, grad_Jnew
+
+
+# A serial version of this test is included in the pyadjoint tests.
+@pytest.mark.parallel(nprocs=3)
+def test_disk_checkpointing():
+    from firedrake_adjoint import enable_disk_checkpointing, \
+        checkpointable_mesh, pause_disk_checkpointing
+    tape = get_working_tape()
+    tape.clear_tape()
+    enable_disk_checkpointing()
+
+    mesh = checkpointable_mesh(UnitSquareMesh(10, 10, name="mesh"))
+    J_disk, grad_J_disk = adjoint_example(mesh)
+    tape.clear_tape()
+    pause_disk_checkpointing()
+
+    J_mem, grad_J_mem = adjoint_example(mesh)
+
+    assert np.allclose(J_disk, J_mem)
+    assert np.allclose(assemble((grad_J_disk - grad_J_mem)**2*dx), 0.0)
+    tape.clear_tape()
+
+
+if __name__ == "__main__":
+    test_disk_checkpointing()

--- a/tests/output/test_adjoint_disk_checkpointing.py
+++ b/tests/output/test_adjoint_disk_checkpointing.py
@@ -1,13 +1,16 @@
 from firedrake import *
 from pyadjoint import (ReducedFunctional, get_working_tape, stop_annotating,
-                       annotate_tape, pause_annotation, Control)
+                       pause_annotation, Control)
 import numpy as np
 import os
 import pytest
 
 
 @pytest.fixture(autouse=True, scope="module")
-def handle_exit_annotation():
+def handle_annotation():
+    from firedrake_adjoint import annotate_tape, continue_annotation
+    if not annotate_tape():
+        continue_annotation()
     yield
     # Since importing firedrake_adjoint modifies a global variable, we need to
     # pause annotations at the end of the module

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.random import rand
 from firedrake import *
-from pyadjoint.tape import get_working_tape, pause_annotation, annotate_tape, stop_annotating
+from pyadjoint.tape import get_working_tape, pause_annotation, stop_annotating
 
 
 @pytest.fixture(autouse=True)
@@ -13,7 +13,10 @@ def handle_taping():
 
 
 @pytest.fixture(autouse=True, scope="module")
-def handle_exit_annotation():
+def handle_annotation():
+    from firedrake_adjoint import annotate_tape, continue_annotation
+    if not annotate_tape():
+        continue_annotation()
     yield
     # Since importing firedrake_adjoint modifies a global variable, we need to
     # pause annotations at the end of the module

--- a/tests/vertexonly/test_poisson_inverse_conductivity.py
+++ b/tests/vertexonly/test_poisson_inverse_conductivity.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from firedrake import *
-from pyadjoint.tape import get_working_tape, pause_annotation, continue_annotation, annotate_tape, set_working_tape
+from pyadjoint.tape import get_working_tape, pause_annotation, continue_annotation, set_working_tape
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +12,10 @@ def handle_taping():
 
 
 @pytest.fixture(autouse=True, scope="module")
-def handle_exit_annotation():
+def handle_annotation():
+    from firedrake_adjoint import annotate_tape, continue_annotation
+    if not annotate_tape():
+        continue_annotation()
     yield
     # Since importing firedrake_adjoint modifies a global variable, we need to
     # pause annotations at the end of the module


### PR DESCRIPTION
Enable disk checkpointing of the forward state in adjoint calculations. There are a few aspects to the design of this PR.

The API follows the API for annotation with calls to pause and continue disk checkpointing in the same way as pausing and continuing annotation. This is of limited utility now, since users will typically just switch on disk checkpointing and leave it. However, once revolve-style recomputation is implemented, it will be necessary.

The lifetime of the checkpoint files is attached to the lifetime of the checkpointed Functions on the tape. Each checkpoint file will be deleted once all the Functions it contains are no longer required.

The scope of the checkpointing files is the tape, and if the working tape is changed then these files change too. This is facilitated by changes in https://github.com/dolfin-adjoint/pyadjoint/pull/86 .

As well as docstrings, there is a short manual section. A demo or notebook will follow once revolve-style checkpointing follows in a further PR.