### PR TITLE
Prettier printing of Functions and adjoint blocks.

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -293,6 +293,9 @@ class FunctionSplitBlock(Block, Backend):
     def recompute_component(self, inputs, block_variable, idx, prepared):
         return self.backend.Function.sub(inputs[0], self.idx)
 
+    def __str__(self):
+        return f"{self.get_dependencies()[0]}[{self.idx}]"
+
 
 class FunctionMergeBlock(Block, Backend):
     def __init__(self, func, idx, ad_block_tag=None):
@@ -330,6 +333,10 @@ class FunctionMergeBlock(Block, Backend):
         parent_out = self.get_outputs()[0].checkpoint
         parent_out.assign(parent_in)
         parent_out.sub(self.idx).assign(sub_func)
+
+    def __str__(self):
+        deps = self.get_dependencies()
+        return f"{deps[1]}[{self.idx}].assign({deps[0]})"
 
 
 class MeshOutputBlock(Block):
@@ -666,6 +673,10 @@ class InterpolateBlock(Block, Backend):
     def recompute_component(self, inputs, block_variable, idx, prepared):
         return self.backend.interpolate(prepared, self.V)
 
+    def __str__(self):
+        target_string = f"〈{str(self.V.ufl_element().shortstr())}〉"
+        return f"interpolate({self.expr},  {target_string})"
+
 
 class SupermeshProjectBlock(Block, Backend):
     r"""
@@ -770,3 +781,7 @@ class SupermeshProjectBlock(Block, Backend):
         if len(hessian_inputs) != 1:
             raise NotImplementedError("SupermeshProjectBlock must have a single output")
         return self.evaluate_adj_component(inputs, hessian_inputs, block_variable, idx).vector()
+
+    def __str__(self):
+        target_string = f"〈{str(self.target_space.ufl_element().shortstr())}〉"
+        return f"project({self.get_dependencies()[0]}, {target_string}))"

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sys
 import ufl
+from ufl.formatting.ufl2unicode import ufl2unicode
 import ctypes
 from collections import OrderedDict
 from ctypes import POINTER, c_int, c_double, c_void_p
@@ -206,7 +207,7 @@ class CoordinatelessFunction(ufl.Coefficient):
         if self._name is not None:
             return self._name
         else:
-            return super(Function, self).__str__()
+            return ufl2unicode(self)
 
 
 class Function(ufl.Coefficient, FunctionMixin):
@@ -660,6 +661,9 @@ class Function(ufl.Coefficient, FunctionMixin):
         if len(arg.shape) == 1:
             g_result = g_result[0]
         return g_result
+
+    def __str__(self):
+        return ufl2unicode(self)
 
 
 class PointNotInDomainError(Exception):


### PR DESCRIPTION
The `__str__` method is supposed to produce human-readable output. Currently `Function` outputs strings of the form `w_{20}` instead of `w₂₀`. This is a hangover from Python 2 where unicode wasn't unique. This PR changes this.

Several adjoint blocks never had `__str__` methods, which makes visualising the tape to debug challenging. This PR now adds `__str__` methods for the blocks we are responsible for. Another PR will to pyadjoint will address the ones we inherit from there. The impact of this (and that one) is that we can create easy to understand tape visualisations such as:

![image](https://user-images.githubusercontent.com/848103/170869939-504c5e65-7f6e-4fb8-be0b-7b0c33ce801c.png)
