### PR TITLE
remove deprecated numpy.long

### DIFF
--- a/firedrake/cython/supermeshimpl.pyx
+++ b/firedrake/cython/supermeshimpl.pyx
@@ -140,8 +140,8 @@ def intersection_finder(mesh_A, mesh_B):
 
     vertices_A = numpy.ndarray.astype(mesh_A.coordinates.dat.data_ro_with_halos.real, dtype=RealType)
     vertices_B = numpy.ndarray.astype(mesh_B.coordinates.dat.data_ro_with_halos.real, dtype=RealType)
-    vertex_map_A = mesh_A.coordinates.cell_node_map().values_with_halo.astype(numpy.long)
-    vertex_map_B = mesh_B.coordinates.cell_node_map().values_with_halo.astype(numpy.long)
+    vertex_map_A = mesh_A.coordinates.cell_node_map().values_with_halo.astype(int)
+    vertex_map_B = mesh_B.coordinates.cell_node_map().values_with_halo.astype(int)
     nnodes_A = mesh_A.coordinates.dof_dset.total_size
     nnodes_B = mesh_B.coordinates.dof_dset.total_size
     dim_A = mesh_A.geometric_dimension()
@@ -160,8 +160,8 @@ def intersection_finder(mesh_A, mesh_B):
 
     libsupermesh_tree_intersection_finder_query_output(&nindices)
 
-    indices = numpy.empty((nindices,), dtype=numpy.long)
-    indptr  = numpy.empty((mesh_A.num_cells() + 1,), dtype=numpy.long)
+    indices = numpy.empty((nindices,), dtype=int)
+    indptr  = numpy.empty((mesh_A.num_cells() + 1,), dtype=int)
 
     libsupermesh_tree_intersection_finder_get_output(&ncells_A, &nindices, <long*>indices.data, <long*>indptr.data)
 


### PR DESCRIPTION
Numpy have deprecated  `numpy.long` in favour of the built-in `int`. This causes warnings when users use supermeshing. This PR fixes this. See:
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated