### PR TITLE
Support numpydoc docstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
           python -m pip install sphinx
           python -m pip install sphinxcontrib-bibtex
           python -m pip install bibtexparser
+          python -m pip install numpydoc
           python -m pip install git+https://github.com/sphinx-contrib/youtube.git
       - name: Check bibtex
         run: |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.graphviz',
               'sphinxcontrib.youtube',
-              'sphinxcontrib.bibtex']
+              'sphinxcontrib.bibtex',
+              'numpydoc']
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
@@ -259,8 +260,11 @@ intersphinx_mapping = {
     'ufl': ('https://fenics.readthedocs.io/projects/ufl/en/latest/', None),
     'h5py': ('http://docs.h5py.org/en/latest/', None),
     'matplotlib': ('https://matplotlib.org/', None),
-    'python':('https://docs.python.org/3/', None),
+    'python': ('https://docs.python.org/3/', None),
+    'pyadjoint': ('https://www.dolfin-adjoint.org/en/latest/', None),
 }
 
 #  -- Options for sphinxcontrib.bibtex ------------------------------------
 bibtex_bibfiles = ['demos/demo_references.bib', '_static/bibliography.bib', '_static/firedrake-apps.bib', '_static/references.bib']
+
+numpydoc_show_class_members = False

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1318,6 +1318,7 @@ def install_documentation_dependencies():
     run_pip(["install", "-U", "sphinxcontrib-bibtex"])
     run_pip(["install", "-U", "bibtexparser"])
     run_pip(["install", "-U", "sphinxcontrib-youtube"])
+    run_pip(["install", "-U", "numpydoc"])
 
 
 def clean_obsolete_packages():


### PR DESCRIPTION
Numpydoc is the docstring convention and supporting Python package used by Numpy. It allows for docstrings with less rst markup which are more human readable than the default Sphinx approach. We have discussed and, I believe, agreed to move towards using numpydoc.

This PR switches on the tooling for numpydoc in our Sphinx configuration and hence allows for new docstrings to use numpydoc conventions while producing web output which matches the rest of our API documentation. This is the first step in a gradual shift to numpydoc across our code base.

Numpydoc is documented at: https://numpydoc.readthedocs.io/en/latest/format.html