### PR TITLE
Preserve the function_arg shape in homogenize

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -358,7 +358,7 @@ class DirichletBC(BCBase, DirichletBCMixin):
         Set the value to zero.
 
         '''
-        self.function_arg = 0
+        self.function_arg = ufl.zero(self.function_arg.ufl_shape)
 
     def restore(self):
         '''Restore the original value of this boundary condition.


### PR DESCRIPTION
Homogenize replaces the DirichletBC function_arg by zero. If the function space is vector/tensor valued, we should have a zero vector/tensor as appropriate.