### PR TITLE
Add tests for FInAT HDiv and HCurl wrappers

### DIFF
--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -124,6 +124,28 @@ def test_compound_expression():
     assert np.allclose(g.dat.data, h.dat.data)
 
 
+def test_hdiv_extruded_interval():
+    mesh = ExtrudedMesh(UnitIntervalMesh(10), 10, 0.1)
+    x = SpatialCoordinate(mesh)
+    U = FunctionSpace(mesh, HDiv(TensorProductElement(FiniteElement("P", interval, 1), FiniteElement("DP", interval, 0))))
+    expr = as_vector([x[0], x[1]])
+    u = interpolate(expr, U)
+    u_proj = project(expr, U)
+
+    assert np.allclose(u.dat.data, u_proj.dat.data)
+
+
+def test_hcurl_extruded_interval():
+    mesh = ExtrudedMesh(UnitIntervalMesh(10), 10, 0.1)
+    x = SpatialCoordinate(mesh)
+    U = FunctionSpace(mesh, HCurl(TensorProductElement(FiniteElement("P", interval, 1), FiniteElement("DP", interval, 0))))
+    expr = as_vector([x[0], x[1]])
+    u = interpolate(expr, U)
+    u_proj = project(expr, U)
+
+    assert np.allclose(u.dat.data, u_proj.dat.data)
+
+
 # Requires the relevant FInAT or FIAT duals to be defined
 @pytest.mark.xfail(raises=NotImplementedError, reason="Requires the relevant FInAT or FIAT duals to be defined")
 def test_hdiv_2d():


### PR DESCRIPTION
Note that we cannot use test_hdiv_2d and test_hcurl_2d since these require EnrichedElement to have a dual (which it does not yet)

~Requires https://github.com/FInAT/FInAT/pull/98~ Merged