### PR TITLE
Download Bison by default

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -584,6 +584,8 @@ def get_petsc_options(minimal=False):
                      "--download-superlu_dist",
                      # Parallel mesh partitioner
                      "--download-ptscotch",
+                     # Parser generator
+                     "--download-bison",
                      # For superlu_dist amongst others.
                      "--with-cxx-dialect=C++11"}
 


### PR DESCRIPTION
Firedrake depends on PTScotch since 2021-10-13. Apparently this needs Bison 3.0, which some users do not have and so have had install issues. Best to just download Bison by default.