### PR TITLE
Update Docker Ubuntu and Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,6 @@ jobs:
         run: |
           cd ..
           rm -rf build
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Build Firedrake
         run: |
           cd ..

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -1,6 +1,6 @@
 # DockerFile for an environment into which firedrake can be installed.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # This DockerFile is looked after by
 MAINTAINER David Ham <david.ham@imperial.ac.uk>


### PR DESCRIPTION
Move the docker containers to the current Ubuntu LTS. Also remove the rather old Python 3.8 pin from the docker containers.

Due to the nature of changing the docker containers, the tests here are not reliable. #2482 provides the actual testing of this functionality.