### PR TITLE
Only pass lgmaps to assembly parloops if there are boundary conditions

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -591,6 +591,9 @@ class ExplicitMatrixAssembler(FormAssembler):
         return False
 
     def collect_lgmaps(self, knl, bcs):
+        if not bcs:
+            return None
+
         lgmaps = []
         for i, j in self.get_indicess(knl):
             row_bcs, col_bcs = self._filter_bcs(bcs, i, j)


### PR DESCRIPTION
This bug came up in #2485.

My understanding of BCs is a bit ropey but I think this is a safe change to introduce. Previously what would happen is inside the parloop we would always replace the lgmaps for the matrices even if there were no boundary conditions, in which case the old and new lgmaps would be the same.