### PR TITLE
Throw away original residual form in AssembledPC

### DIFF
--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -5,7 +5,7 @@ from firedrake.functionspace import FunctionSpace, MixedFunctionSpace
 from firedrake.petsc import PETSc
 from firedrake.ufl_expr import TestFunction, TrialFunction
 import firedrake.dmhooks as dmhooks
-from firedrake.dmhooks import get_function_space, get_appctx
+from firedrake.dmhooks import get_function_space
 
 __all__ = ("AssembledPC", "AuxiliaryOperatorPC")
 
@@ -75,8 +75,6 @@ class AssembledPC(PCBase):
 
         # We set a DM and an appropriate SNESContext on the constructed PC so one
         # can do e.g. multigrid or patch solves.
-        from firedrake.variational_solver import NonlinearVariationalProblem
-        from firedrake.solving_utils import _SNESContext
         dm = opc.getDM()
         self._ctx_ref = self.new_snes_ctx(opc, a, bcs, mat_type,
                                           fcp=fcp, options_prefix=options_prefix)

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -78,10 +78,8 @@ class AssembledPC(PCBase):
         from firedrake.variational_solver import NonlinearVariationalProblem
         from firedrake.solving_utils import _SNESContext
         dm = opc.getDM()
-        octx = get_appctx(dm)
-        oproblem = octx._problem
-        nproblem = NonlinearVariationalProblem(oproblem.F, oproblem.u, bcs, J=a, form_compiler_parameters=fcp)
-        self._ctx_ref = _SNESContext(nproblem, mat_type, mat_type, octx.appctx, options_prefix=options_prefix)
+        self._ctx_ref = self.new_snes_ctx(opc, a, bcs, mat_type,
+                                          fcp=fcp, options_prefix=options_prefix)
 
         pc.setDM(dm)
         pc.setOptionsPrefix(options_prefix)


### PR DESCRIPTION
This fix is to prevent the coefficients in the original residual being injected when nesting `AssembledPC` and linear MG, as the latter (or more generally, any other nested PC) should be agnostic about the residual ufl form, and only deal with assembled residual vectors.