### PR TITLE
install: work around build failure caused by pybind11==2.10.0

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1698,7 +1698,9 @@ if mode == "install":
 
     # Force Cython to install first to work around pip dependency issues.
     run_pip_install(["Cython>=0.22"])
-    run_pip_install(["pybind11"])
+    # See build failure caused by pybind11==2.10.0 at https://github.com/firedrakeproject/firedrake/runs/7370283417?check_suite_focus=true.
+    log.info("We use pybind11==2.9.2 until the issue with pybind11==2.10.0 is resolved.\n")
+    run_pip_install(["pybind11==2.9.2"])
 
     # Pre-install requested packages
     if args.pip_packages is not None:
@@ -1930,7 +1932,7 @@ Please consider updating your PETSc manually.
                 install(p+"/")
 
         # Ensure pytest is at the latest version
-        print('We use pytest==6.2.5 until the issue with pytest==7.0.0 is resolved.')
+        log.info("We use pytest==6.2.5 until the issue with pytest==7.0.0 is resolved.\n")
         run_pip(["install", "-U", "pytest==6.2.5"])
 
 with environment(**compiler_env):


### PR DESCRIPTION
Fix build failure caused by `pybind11==2.10.0`; see https://github.com/firedrakeproject/firedrake/runs/7370283417?check_suite_focus=true.