### PR TITLE
Mac arm version check

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -209,8 +209,8 @@ If not, feel free to ask for more help in our
 .. graphviz:: install-debug.dot
 
 If you don't see the issue you're experiencing in this chart, please
-ask us on Slack or report a bug by creating a new `github issue
-<https://github.com/firedrakeproject/firedrake/issues>`__. To help us
+ask us on Slack or report a bug by creating a new `github discussion
+<https://github.com/firedrakeproject/firedrake/discussions>`__. To help us
 diagnose what's going wrong, **please include the following log files**:
 
 * ``firedrake-install.log`` from Firedrake, which you can find in the

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -118,11 +118,12 @@ packages can be installed into an existing Firedrake installation using
 System requirements
 -------------------
 
-Firedrake requires Python 3.6.x to 3.8.x (many externally managed
-dependencies such as VTK have yet to create binary wheels for 3.9.x).
-The installation script is tested on Ubuntu and MacOS X. On Ubuntu 18.04
-or later, the system installed Python 3 is supported and tested. On
-MacOS, the homebrew_ installed Python 3 is supported and tested::
+Firedrake requires Python 3.6.x to 3.10.x. On MacOS Arm (M1 or M2) Python 3.9.x
+or 3.10.x are required since these are the only versions for which VTK binary
+packages are currently available. The installation script is tested on Ubuntu
+and MacOS X. On Ubuntu 18.04 or later, the system installed Python 3 is
+supported and tested. On MacOS, the homebrew_ installed Python 3 is supported
+and tested::
 
   brew install python3
 
@@ -138,7 +139,7 @@ they have the system dependencies:
 * A Fortran compiler (for PETSc)
 * Blas and Lapack
 * Git, Mercurial
-* Python version 3.8.x-3.6.x
+* Python version 3.6.x-3.10.x (3.9.x-3.10.x on MacOS Arm)
 * The Python headers
 * autoconf, automake, libtool
 * CMake

--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -16,7 +16,7 @@ digraph triage {
 
     activate_venv [label="Activate the\nvenv first."];
     uninstall_anaconda [label="Deactivate\nAnaconda."];
-    update_python [label="Get Python 3.6-3.8"];
+    update_python [label="Get Python 3.6-3.10"];
     update_install_script [label="Fetch new\ninstall script"];
     get_homebrew [label="Use Homebrew."];
     brew_doctor [label="brew doctor"];

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -126,6 +126,10 @@ if sys.version_info >= (3, 11):
 Some wheels are not yet available for Python 3.11 for some required package(s).
 Please install with Python 3.10 (or an earlier version >= 3.6).""")
     sys.exit(1)
+elif sys.version_info < (3, 9) and osname == "Darwin" and arch == "arm64":
+    print("""
+Installing Firedrake on Mac Arm (M1 or M2) requires at least Python 3.9 since
+some required package(s) are not available for earlier Python versions.""")
 elif sys.version_info < (3, 6):
     if mode == "install":
         print("""\nInstalling Firedrake requires Python 3, at least version 3.6.


### PR DESCRIPTION
Firedrake won't install on M1 (presumably also M2) before 3.9 due to an absence of vtk wheels. This makes this a hard failure. It also corrects some out of date install documentation.