### PR TITLE
Fix hashing for Assign rvalues

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -397,7 +397,7 @@ def _compile_expression_key(comm, expr, to_element, ufl_element, domain, paramet
     # Since the caching is collective, this function must return a 2-tuple of
     # the form (comm, key) where comm is the communicator the cache is collective over.
     # FIXME FInAT elements are not safely hashable so we ignore them here
-    key = _hash_expr(expr), hash(ufl_element), utils.tuplify(parameters), log
+    key = hash_expr(expr), hash(ufl_element), utils.tuplify(parameters), log
     return comm, key
 
 
@@ -517,7 +517,7 @@ class GlobalWrapper(object):
         self.ufl_domain = lambda: None
 
 
-def _hash_expr(expr):
+def hash_expr(expr):
     """Return a numbering-invariant hash of a UFL expression.
 
     :arg expr: A UFL expression.

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -499,6 +499,26 @@ def test_expression_cache():
     assert len(u._expression_cache) == 5
 
 
+def test_global_expression_cache():
+    from firedrake.assemble_expressions import _pointwise_expression_cache
+
+    mesh = UnitSquareMesh(1, 1)
+    V = VectorFunctionSpace(mesh, "CG", 1)
+    u = Function(V)
+
+    _pointwise_expression_cache.clear()
+    assert len(_pointwise_expression_cache) == 0
+
+    u.assign(Constant(1))
+    assert len(_pointwise_expression_cache) == 1
+
+    u.assign(Constant(2))
+    assert len(_pointwise_expression_cache) == 1
+
+    u.assign(1)
+    assert len(_pointwise_expression_cache) == 2
+
+
 def test_augmented_assignment_broadcast():
     mesh = UnitSquareMesh(1, 1)
     V = FunctionSpace(mesh, "BDM", 1)


### PR DESCRIPTION
When I first implemented disk caching for `Assign` I used `Assign.slow_key` to determine whether we had a cache hit or not. However, it appears as though `slow_key` was the wrong choice as trivial code such as

```py
u.assign(Constant(1))
u.assign(Constant(1))
```

would result in a cache miss, and hence a write to disk. The only way I found to avoid it was to write:

```py
rhs = Constant(1)
u.assign(rhs)
u.assign(rhs)
```

I'm now using the same hashing function as I do for interpolation and it seems to have resolved the problem. I am also now only caching in memory rather than to disk since the codegen going on here is not very expensive (but still worth caching).

Many thanks to @dorugeber for flagging this.