### PR TITLE
Update clean function in firedrake-install for PEP 518.

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -982,7 +982,11 @@ def clean(package):
     with directory(package):
         with environment(**blas):
             # loopy needs knowledge of the system BLAS just to run setup.py
-            check_call([python, "setup.py", "clean"])
+            if os.path.isfile("setup.py"):
+                check_call([python, "setup.py", "clean"])
+            else:  # PEP 518 build system
+                if os.path.exists("build") and os.path.isdir("build"):
+                    shutil.rmtree("build")
 
 
 def pip_uninstall(package):


### PR DESCRIPTION
I am updating `FEMlium` to use PEP 518 (installation via `setup.cfg` and `pyproject.toml`, complete removal of `requirements.txt` and `setup.py`). While testing my branch to make sure that it doesn't break the `firedrake-install` and `firedrake-update` scripts, I have realized that the `clean` function defined therein needs to be updated for the PEP 518 case for the `firedrake-update` script to run without errors. Indeed, it tries to run `python setup.py clean` which would clearly raise an error if `setup.py` is missing.

This PR takes this new case into account. There are currently two commits in this PR:
* https://github.com/firedrakeproject/firedrake/pull/2525/commits/c7a4e1fa6cfaac494db8e0ba1f4caa4c8ac920dd is the only relevant commit, which changes the implementation of the `clean` function;
* https://github.com/firedrakeproject/firedrake/pull/2525/commits/f631482323b82b4b51d938281da9ea8848fa226b is a *temporary* commit that enables docker build (but not push) on this branch as well. Indeed, we must test `firedrake-update` with apps. Such script, to my understanding, is only called at the `Build full Firedrake Docker container` stage, which is skipped on non-`master` branches.

To be extra safe, we will need four CI runs:
1. [x] the first run will happen before I merge my branch, to double check that this PR does not break the existing `firedrake-install` or `firedrake-update` scripts. In the first run, I expect to see in the CI output something like
```
[...]
Installing pip dependencies for FEMlium
Installing pip dependencies for [name of the next package]
[...]
```
2. [x] after a successful first run, I will merge my branch. I will *temporarily revert* https://github.com/firedrakeproject/firedrake/pull/2525/commits/c7a4e1fa6cfaac494db8e0ba1f4caa4c8ac920dd and I will then ask you to trigger again a CI run. I expect this run to fail while cleaning `FEMlium`, due to the fact that `setup.py` is missing.
3. [ ] after a failing second run, I will delete my temporary revert, getting back to the configuration at 1. I will then ask you to trigger again a CI run, which I expect to succeed. The output should show something like the following, because I do not have requirements.txt anymore. 
```
[...]
Installing pip dependencies for FEMlium
No dependencies found. Skipping.
Installing pip dependencies for [name of the next package]
[...]
```
4. [ ] after a successful third run, I will delete https://github.com/firedrakeproject/firedrake/pull/2525/commits/f631482323b82b4b51d938281da9ea8848fa226b, resulting in a PR with only https://github.com/firedrakeproject/firedrake/pull/2525/commits/c7a4e1fa6cfaac494db8e0ba1f4caa4c8ac920dd , which should be ready to merge at that point. 