### PR TITLE
Adjoint disk checkpointing fixes

### DIFF
--- a/firedrake/adjoint/checkpointing.py
+++ b/firedrake/adjoint/checkpointing.py
@@ -278,7 +278,7 @@ class CheckpointFunction:
         with CheckpointFile(self.file.name, 'r') as infile:
             function = infile.load_function(self.mesh, self.stored_name)
         return type(function)(function.function_space(),
-                              function.dat, name=self.name, count=self.count)
+                              function.dat, name=self.name(), count=self.count)
 
 
 def maybe_disk_checkpoint(function):


### PR DESCRIPTION
Rather than writing every Function to the checkpoint file by name, the adjoint now writes a pseudo time sequence of Functions for each function space. This avoids exhausting the namespace for Functions in the HDF5 file.