### PR TITLE
Copy only the linear algebra solver options for the adjoint solver

### DIFF
--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -55,7 +55,19 @@ def solve_init_params(self, args, kwargs, varform):
         self.adj_args = self.forward_args
 
     if len(self.adj_kwargs) <= 0:
-        self.adj_kwargs = self.forward_kwargs.copy()
+        la_kwargs = [
+            "bcs",
+            "solver_parameters",
+            "nullspace",
+            "transpose_nullspace",
+            "near_nullspace",
+            "options_prefix",
+        ]
+        self.adj_kwargs = dict(
+            (key, value)
+            for key, value in self.forward_kwargs.items()
+            if key in la_kwargs
+        )
 
         if varform:
             if "J" in self.forward_kwargs:


### PR DESCRIPTION
If I want to add options such as `post_jacobian_callback` to the `NonlinearVariationalSolver` as in:
```
import firedrake as fd
import firedrake_adjoint as fda
from firedrake import grad, inner, dx

mesh = fd.UnitSquareMesh(10, 10)
V = fd.FunctionSpace(mesh, "Lagrange", 1)

f = fd.Constant(1.0)

u = fd.Function(V)
v = fd.TestFunction(V)
bc = fd.DirichletBC(V, fd.Constant(1), "on_boundary")

F = f * inner(grad(u), grad(v)) * dx + u**2 * v * dx - f * v * dx
problem = fd.NonlinearVariationalProblem(F, u, bcs=bc)


def callback(X, J):
    return


solver = fd.NonlinearVariationalSolver(problem, post_jacobian_callback=callback)
solver.solve()
J = fd.assemble(u**2 * dx)
c = fda.Control(f)
Jhat = fda.ReducedFunctional(J, c)
print(Jhat.derivative().dat.data)
```
the adjoint solver crashes with
```
RuntimeError: Illegal keyword argument 'post_jacobian_callback'; valid keywords are 'bcs', 'solver_parameters', 'nullspace', 'transpose_nullspace', 'near_nullspace', 'options_prefix'
```
This PR fixes that.