### PR TITLE
Pretty print constants to match Functions

### DIFF
--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -5,6 +5,8 @@ from pyop2 import op2
 from pyop2.exceptions import DataTypeError, DataValueError
 from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType
+from ufl.formatting.ufl2unicode import ufl2unicode
+
 
 import firedrake.utils as utils
 from firedrake.adjoint.constant import ConstantMixin
@@ -143,3 +145,6 @@ class Constant(ufl.Coefficient, ConstantMixin):
 
     def __idiv__(self, o):
         raise NotImplementedError("Augmented assignment to Constant not implemented")
+
+    def __str__(self):
+        return ufl2unicode(self)


### PR DESCRIPTION
Some time ago we switched the `__str__` method on `Function` to use `ufl2unicode` and hence produce e.g. `w₂₄` instead of `w_{24}`. This change simply does the same for `Constant`