### PR TITLE
HypreAMS/ADS: Fix parallel bugs when chopping the gradient and add support for quads and hexes

### DIFF
--- a/firedrake/preconditioners/hypre_ads.py
+++ b/firedrake/preconditioners/hypre_ads.py
@@ -4,6 +4,7 @@ from firedrake.functionspace import FunctionSpace, VectorFunctionSpace
 from firedrake.ufl_expr import TestFunction
 from firedrake.interpolation import Interpolator, interpolate
 from firedrake.dmhooks import get_function_space
+from firedrake.preconditioners.hypre_ams import chop
 from ufl import grad, curl, SpatialCoordinate
 
 __all__ = ("HypreADS",)
@@ -12,21 +13,33 @@ __all__ = ("HypreADS",)
 class HypreADS(PCBase):
     def initialize(self, obj):
         A, P = obj.getOperators()
+        appctx = self.get_appctx(obj)
         prefix = obj.getOptionsPrefix()
         V = get_function_space(obj.getDM())
         mesh = V.mesh()
 
         family = str(V.ufl_element().family())
+        formdegree = V.finat_element.formdegree
         degree = V.ufl_element().degree()
-        if family != 'Raviart-Thomas' or degree != 1:
+        try:
+            degree = max(degree)
+        except TypeError:
+            pass
+        if formdegree != 2 or degree != 1:
             raise ValueError("Hypre ADS requires lowest order RT elements! (not %s of degree %d)" % (family, degree))
 
         P1 = FunctionSpace(mesh, "Lagrange", 1)
-        NC1 = FunctionSpace(mesh, "N1curl", 1)
-        # DiscreteGradient
-        G = Interpolator(grad(TestFunction(P1)), NC1).callable().handle
-        # DiscreteCurl
-        C = Interpolator(curl(TestFunction(NC1)), V).callable().handle
+        NC1 = FunctionSpace(mesh, "N1curl" if mesh.ufl_cell().is_simplex() else "NCE", 1)
+        G_callback = appctx.get("get_gradient", None)
+        if G_callback is None:
+            G = chop(Interpolator(grad(TestFunction(P1)), NC1).callable().handle)
+        else:
+            G = G_callback(NC1, P1)
+        C_callback = appctx.get("get_curl", None)
+        if C_callback is None:
+            C = chop(Interpolator(curl(TestFunction(NC1)), V).callable().handle)
+        else:
+            C = C_callback(V, NC1)
 
         pc = PETSc.PC().create(comm=obj.comm)
         pc.incrementTabLevel(1, parent=obj)

--- a/firedrake/preconditioners/hypre_ams.py
+++ b/firedrake/preconditioners/hypre_ams.py
@@ -8,9 +8,23 @@ from firedrake.utils import complex_mode
 from firedrake_citations import Citations
 from firedrake import SpatialCoordinate
 from ufl import grad
-import numpy as np
 
 __all__ = ("HypreAMS",)
+
+
+def chop(A, tol=1E-10):
+    # remove (near) zeros from sparsity pattern
+    A.chop(tol)
+    B = PETSc.Mat().create(comm=A.comm)
+    B.setType(A.getType())
+    B.setSizes(A.getSizes())
+    B.setBlockSize(A.getBlockSize())
+    B.setUp()
+    B.setOption(PETSc.Mat.Option.IGNORE_ZERO_ENTRIES, True)
+    B.setPreallocationCSR(A.getValuesCSR())
+    B.assemble()
+    A.destroy()
+    return B
 
 
 class HypreAMS(PCBase):
@@ -20,27 +34,27 @@ class HypreAMS(PCBase):
 
         Citations().register("Kolev2009")
         A, P = obj.getOperators()
+        appctx = self.get_appctx(obj)
         prefix = obj.getOptionsPrefix()
         V = get_function_space(obj.getDM())
         mesh = V.mesh()
 
         family = str(V.ufl_element().family())
+        formdegree = V.finat_element.formdegree
         degree = V.ufl_element().degree()
-        if family != 'Nedelec 1st kind H(curl)' or degree != 1:
+        try:
+            degree = max(degree)
+        except TypeError:
+            pass
+        if formdegree != 1 or degree != 1:
             raise ValueError("Hypre AMS requires lowest order Nedelec elements! (not %s of degree %d)" % (family, degree))
 
         P1 = FunctionSpace(mesh, "Lagrange", 1)
-        G = Interpolator(grad(TestFunction(P1)), V).callable().handle
-
-        # remove (near) zeros from sparsity pattern
-        ai, aj, a = G.getValuesCSR()
-        a[np.abs(a) < 1e-10] = 0
-        G2 = PETSc.Mat().create()
-        G2.setType(PETSc.Mat.Type.AIJ)
-        G2.setSizes(G.sizes)
-        G2.setOption(PETSc.Mat.Option.IGNORE_ZERO_ENTRIES, True)
-        G2.setPreallocationCSR((ai, aj, a))
-        G2.assemble()
+        G_callback = appctx.get("get_gradient", None)
+        if G_callback is None:
+            G = chop(Interpolator(grad(TestFunction(P1)), V).callable().handle)
+        else:
+            G = G_callback(V, P1)
 
         pc = PETSc.PC().create(comm=obj.comm)
         pc.incrementTabLevel(1, parent=obj)
@@ -49,7 +63,7 @@ class HypreAMS(PCBase):
 
         pc.setType('hypre')
         pc.setHYPREType('ams')
-        pc.setHYPREDiscreteGradient(G2)
+        pc.setHYPREDiscreteGradient(G)
 
         zero_beta = PETSc.Options(prefix).getBool("pc_hypre_ams_zero_beta_poisson", default=False)
         if zero_beta:
@@ -58,7 +72,6 @@ class HypreAMS(PCBase):
         VectorP1 = VectorFunctionSpace(mesh, "Lagrange", 1)
         pc.setCoordinates(interpolate(SpatialCoordinate(mesh), VectorP1).dat.data_ro.copy())
         pc.setUp()
-
         self.pc = pc
 
     def apply(self, pc, x, y):


### PR DESCRIPTION
The gradient that we want to pass to hypre must be as sparse as possible. Previously we were chopping with numpy and didn't have a `comm`, nor were calling setUp on the new `Mat`. 

With this PR I also added support for quads and hexes, for which `Interpolator(grad(test), V)` fails because we don't have dual evaluation for `EnrichedElement`. Currently the user must supply their own sparse gradient, a feature that will be included in a future PR.