### PR TITLE
Dolci/assign checkpoint

### DIFF
--- a/firedrake/adjoint/checkpointing.py
+++ b/firedrake/adjoint/checkpointing.py
@@ -6,6 +6,7 @@ import tempfile
 import os
 import shutil
 import atexit
+from abc import ABC, abstractmethod
 _stop_disk_checkpointing = 1
 _checkpoint_init_data = False
 
@@ -233,7 +234,19 @@ def checkpointable_mesh(mesh):
         return outfile.load_mesh(mesh.name)
 
 
-class CheckpointFunction:
+class CheckpointBase(ABC):
+    """A base class for indirect pyadjoint checkpoints.
+
+    The class constructor should somehow store the object to be
+    checkpointed."""
+
+    @abstractmethod
+    def restore(self):
+        """Recover and return the checkpointed object."""
+        pass
+
+
+class CheckpointFunction(CheckpointBase):
     """Metadata for a Function checkpointed to disk.
 
     An object of this class replaces the :class:`~firedrake.Function` stored as

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -21,7 +21,7 @@ class DelegatedFunctionCheckpoint:
         self.other = other
 
     def restore(self):
-        return other.saved_output()
+        return self.other.saved_output
 
 
 class FunctionMixin(FloatingType):
@@ -135,9 +135,10 @@ class FunctionMixin(FloatingType):
 
             if annotate:
                 block_var = self.create_block_variable()
+                block.add_output(block_var)
+                
                 if isinstance(other, type(self)):
                     block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
-                block.add_output(block_var)
 
             return ret
 

--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -4,16 +4,17 @@ from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape, no_annotations
 from firedrake.adjoint.blocks import FunctionAssignBlock, ProjectBlock, FunctionSplitBlock, FunctionMergeBlock, SupermeshProjectBlock
 import firedrake
-from .checkpointing import disk_checkpointing, CheckpointFunction, checkpoint_init_data
+from .checkpointing import disk_checkpointing, CheckpointFunction, \
+    CheckpointBase, checkpoint_init_data
 
 
-class DelegatedFunctionCheckpoint:
+class DelegatedFunctionCheckpoint(CheckpointBase):
     """A wrapper which delegates the checkpoint of this Function to another Function.
-    
+
     This enables us to avoid checkpointing a Function twice when it is copied.
-    
-    
-    Args:
+
+    Parameters
+    ----------
     other: BlockVariable
         The block variable to which we delegate checkpointing.
     """
@@ -136,7 +137,7 @@ class FunctionMixin(FloatingType):
             if annotate:
                 block_var = self.create_block_variable()
                 block.add_output(block_var)
-                
+
                 if isinstance(other, type(self)):
                     block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
 
@@ -257,7 +258,7 @@ class FunctionMixin(FloatingType):
                 "Unknown Riesz representation %s" % riesz_representation)
 
     def _ad_restore_at_checkpoint(self, checkpoint):
-        if isinstance(checkpoint, (CheckpointFunction, DelegatedFunctionCheckpoint)):
+        if isinstance(checkpoint, CheckpointBase):
             return checkpoint.restore()
         else:
             return checkpoint


### PR DESCRIPTION
A wrapper that delegates the checkpoint of a Function to another Function.  It makes enables us to avoid checkpointing a Function twice when it is copied.