### PR TITLE
Append .real to coordinates in OCMH, just in case we're in complex mode

### DIFF
--- a/firedrake/mg/opencascade_mh.py
+++ b/firedrake/mg/opencascade_mh.py
@@ -151,7 +151,7 @@ def project_mesh_to_cad_3d(mesh, cad):
         surf = BRepAdaptor_Surface(face)
 
         for node in owned_nodes:
-            pt = gp_Pnt(*coorddata[node, :])
+            pt = gp_Pnt(*coorddata[node, :].real)
 
             proj = GeomAPI_ProjectPointOnSurf(pt, surf.Surface().Surface())
             if proj.NbPoints() > 0:
@@ -186,7 +186,7 @@ def project_mesh_to_cad_3d(mesh, cad):
                 continue
 
             for node in intersecting_nodes:
-                pt = gp_Pnt(*coorddata[node, :])
+                pt = gp_Pnt(*coorddata[node, :].real)
 
                 projections = []
                 for edge in intersecting_edges:
@@ -226,7 +226,7 @@ def project_mesh_to_cad_2d(mesh, cad):
         curve = BRepAdaptor_Curve(edge)
 
         for node in owned_nodes:
-            pt = gp_Pnt(*coorddata[node, :], 0)
+            pt = gp_Pnt(*coorddata[node, :].real, 0)
             proj = GeomAPI_ProjectPointOnCurve(pt, curve.Curve().Curve())
             if proj.NbPoints() > 0:
                 projpt = proj.NearestPoint()


### PR DESCRIPTION
`OCMH` breaks if you try to use it in complex mode because we store coordinates as complex numbers with 0 real parts and the geometry libraries are expecting proper real numbers.  

This addresses (at least part of) Issue #2619 .  That issue arises on a machine with an old OC library, so there may be two problems in the issue.  This fixes the obvious and easy part of it. 

One test fails locally for me (computing a volume) by a small tolerance, but the same fails in real mode on my machine.  We'll see what CI says here.

