### PR TITLE
Freeze tensor halo exchanges in assemble

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -395,8 +395,7 @@ class FormAssembler(abc.ABC):
         if self._needs_zeroing:
             self._as_pyop2_type(self._tensor).zero()
 
-        for parloop in self.parloops:
-            parloop()
+        self.execute_parloops()
 
         for bc in self._bcs:
             if isinstance(bc, EquationBC):  # can this be lifted?
@@ -414,6 +413,10 @@ class FormAssembler(abc.ABC):
             data = _FormHandler.index_tensor(tensor, self._form, lknl.indices, self.diagonal)
             parloop.arguments[0].data = data
         self._tensor = tensor
+
+    def execute_parloops(self):
+        for parloop in self.parloops:
+            parloop()
 
     @cached_property
     def local_kernels(self):
@@ -525,6 +528,13 @@ class OneFormAssembler(FormAssembler):
     @property
     def result(self):
         return self._tensor
+
+    def execute_parloops(self):
+        # We are repeatedly incrementing into the same Dat so intermediate halo exchanges
+        # can be skipped.
+        with self._tensor.dat.frozen_halo(op2.INC):
+            for parloop in self.parloops:
+                parloop()
 
     def _apply_bc(self, bc):
         # TODO Maybe this could be a singledispatchmethod?


### PR DESCRIPTION
If we're doing things like DG we can have more than one parloop inside `assemble`. Since we are just incrementing into the same `Dat` for each one, we can avoid excess communication by disabling ('freezing') intermediate halo exchanges for the output tensor.

In the DG advection demo (on 2 processes) I found that this reduced the number of messages sent from 1.83e4 to 1.11e4.

Credit to @tkarna for coming up with the idea.

This requires https://github.com/OP2/PyOP2/pull/680.