### PR TITLE
Mesh defaults to using dmplex comm if dmplex given

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2043,12 +2043,11 @@ def Mesh(meshfile, **kwargs):
     import firedrake.function as function
 
     if isinstance(meshfile, PETSc.DMPlex):
-        default_comm = meshfile.comm.tompi4py()
+        user_comm = meshfile.comm.tompi4py()
     else:
-        default_comm = COMM_WORLD
+        user_comm = kwargs.get("comm", COMM_WORLD)
 
     name = kwargs.get("name", DEFAULT_MESH_NAME)
-    user_comm = kwargs.get("comm", default_comm)
     reorder = kwargs.get("reorder", None)
     if reorder is None:
         reorder = parameters["reorder_meshes"]
@@ -2079,9 +2078,6 @@ def Mesh(meshfile, **kwargs):
     geometric_dim = kwargs.get("dim", None)
     if isinstance(meshfile, PETSc.DMPlex):
         plex = meshfile
-        # Check that the plex is defined over the same comm as the user has specified
-        if MPI.Comm.Compare(user_comm, plex.comm.tompi4py()) not in {MPI.CONGRUENT, MPI.IDENT}:
-            raise ValueError("Communicator used to create `plex` must be at least congruent to the communicator used to create the mesh")
     else:
         basename, ext = os.path.splitext(meshfile)
         if ext.lower() in ['.e', '.exo']:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2042,8 +2042,13 @@ def Mesh(meshfile, **kwargs):
     """
     import firedrake.function as function
 
+    if isinstance(meshfile, PETSc.DMPlex):
+        default_comm = meshfile.comm.tompi4py()
+    else:
+        default_comm = COMM_WORLD
+
     name = kwargs.get("name", DEFAULT_MESH_NAME)
-    user_comm = kwargs.get("comm", COMM_WORLD)
+    user_comm = kwargs.get("comm", default_comm)
     reorder = kwargs.get("reorder", None)
     if reorder is None:
         reorder = parameters["reorder_meshes"]

--- a/tests/regression/test_ensembleparallelism.py
+++ b/tests/regression/test_ensembleparallelism.py
@@ -215,3 +215,11 @@ def test_nonblocking_send_recv():
         assert assemble((u - u_expect)**2*dx) < 1e-8
     else:
         assert norm(u) < 1e-8
+
+
+@pytest.mark.parallel(nprocs=4)
+def test_mg_mesh():
+    nspace = 2
+    ensemble = Ensemble(COMM_WORLD, nspace)
+    basemesh = UnitIntervalMesh(4, comm=ensemble.comm)
+    mh = MeshHierarchy(basemesh, 1)

--- a/tests/regression/test_ensembleparallelism.py
+++ b/tests/regression/test_ensembleparallelism.py
@@ -215,11 +215,3 @@ def test_nonblocking_send_recv():
         assert assemble((u - u_expect)**2*dx) < 1e-8
     else:
         assert norm(u) < 1e-8
-
-
-@pytest.mark.parallel(nprocs=4)
-def test_mg_mesh():
-    nspace = 2
-    ensemble = Ensemble(COMM_WORLD, nspace)
-    basemesh = UnitIntervalMesh(4, comm=ensemble.comm)
-    mh = MeshHierarchy(basemesh, 1)

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -462,13 +462,18 @@ def test_boxmesh_kind(kind, num_cells):
 
 
 @pytest.mark.parallel(nprocs=4)
-def test_split_comm_mg_mesh():
+def test_split_comm_dm_mesh():
     nspace = 2
     rank = COMM_WORLD.rank
 
     # split global comm into 2 comms of size 2
     comm = COMM_WORLD.Split(color=(rank // nspace), key=rank)
 
+    # check that dm comm is used, not COMM_WORLD
     mesh = UnitIntervalMesh(4, comm=comm)
     dm = mesh.topology_dm
-    mesh = Mesh(dm)  # noqa: F841
+    mesh0 = Mesh(dm)  # noqa: F841
+
+    # check that comm argument is ignored
+    bad_comm = COMM_WORLD.Split(color=(rank % nspace), key=rank)
+    mesh1 = Mesh(dm, comm=bad_comm)  # noqa: F841

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -459,3 +459,17 @@ def test_boxmesh_kind(kind, num_cells):
     m = BoxMesh(1, 1, 1, 1, 1, 1, diagonal=kind)
     m.init()
     assert m.num_cells() == num_cells
+
+
+@pytest.mark.parallel(nprocs=4)
+def test_split_comm_mg_mesh():
+    nspace = 2
+    rank = COMM_WORLD.rank
+
+    # split global comm into 2 comms of size 2
+    comm = COMM_WORLD.Split(color=(rank // nspace), key=rank)
+
+    basemesh = UnitIntervalMesh(4, comm=comm)
+
+    # MeshHierarchy will use the mesh dmplex to construct new meshes
+    mh = MeshHierarchy(basemesh, 1)

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -472,4 +472,4 @@ def test_split_comm_mg_mesh():
     basemesh = UnitIntervalMesh(4, comm=comm)
 
     # MeshHierarchy will use the mesh dmplex to construct new meshes
-    mh = MeshHierarchy(basemesh, 1)
+    mh = MeshHierarchy(basemesh, 1)  # noqa: F841

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -469,7 +469,6 @@ def test_split_comm_mg_mesh():
     # split global comm into 2 comms of size 2
     comm = COMM_WORLD.Split(color=(rank // nspace), key=rank)
 
-    basemesh = UnitIntervalMesh(4, comm=comm)
-
-    # MeshHierarchy will use the mesh dmplex to construct new meshes
-    mh = MeshHierarchy(basemesh, 1)  # noqa: F841
+    mesh = UnitIntervalMesh(4, comm=comm)
+    dm = mesh.topology_dm
+    mesh = Mesh(dm)  # noqa: F841


### PR DESCRIPTION
`Mesh` promises to use the DMPlex comm if a DMPlex is passed to construct the mesh from. [This commit](https://github.com/firedrakeproject/firedrake/commit/8296de82826d092eea6152f63362229ec4cbcfe9) changes this to use COMM_WORLD if the comm argument is None, regardless of whether a DMPlex is given as the mesh or not.
This breaks when a DMPlex is given whose comm is not COMM_WORLD.

This PR should fix this, and adds a test to check for this.