### PR TITLE
user comm must match dm comm for Mesh construction

### DIFF
--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -139,7 +139,7 @@ def MeshHierarchy(mesh, refinement_levels,
 
     meshes = [mesh] + [mesh_builder(dm, dim=mesh.ufl_cell().geometric_dimension(),
                                     distribution_parameters=distribution_parameters,
-                                    reorder=reorder)
+                                    reorder=reorder, comm=mesh.comm)
                        for dm in dms]
 
     lgmaps = []

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -1725,6 +1725,7 @@ def PeriodicBoxMesh(
         name=name,
         distribution_name=distribution_name,
         permutation_name=permutation_name,
+        comm=comm,
     )
 
     old_coordinates = m.coordinates

--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -469,11 +469,17 @@ def test_split_comm_dm_mesh():
     # split global comm into 2 comms of size 2
     comm = COMM_WORLD.Split(color=(rank // nspace), key=rank)
 
-    # check that dm comm is used, not COMM_WORLD
     mesh = UnitIntervalMesh(4, comm=comm)
     dm = mesh.topology_dm
-    mesh0 = Mesh(dm)  # noqa: F841
 
-    # check that comm argument is ignored
+    # dm.comm is same as user comm
+    mesh0 = Mesh(dm, comm=comm)  # noqa: F841
+
+    # no user comm given (defaults to comm world)
+    with pytest.raises(ValueError):
+        mesh1 = Mesh(dm)  # noqa: F841
+
+    # wrong user comm given
     bad_comm = COMM_WORLD.Split(color=(rank % nspace), key=rank)
-    mesh1 = Mesh(dm, comm=bad_comm)  # noqa: F841
+    with pytest.raises(ValueError):
+        mesh2 = Mesh(dm, comm=bad_comm)  # noqa: F841


### PR DESCRIPTION
When creating a Mesh from a DMPlex, the comm given must match the comm on the DMPlex.
This reverses the changes in #2663 where the comm was ignored and the DMPlex comm was used in place of the user comm.