### PR TITLE
mesh: add mark_entities() method and RelabeledMesh() function

### DIFF
--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -1853,36 +1853,6 @@ def get_facet_ordering(PETSc.DM plex, PETSc.Section facet_numbering):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_facet_markers(PETSc.DM dm, np.ndarray[PetscInt, ndim=1, mode="c"] facets):
-    """Get an array of facet labels in the mesh.
-
-    :arg dm: The DM that contains labels.
-    :arg facets: The array of facet points.
-    :returns: a numpy array of facet ids (or None if all facets had
-        the default marker).
-    """
-    cdef:
-        PetscInt nfacet, f, val
-        np.ndarray[PetscInt, ndim=1, mode="c"] ids
-        DMLabel label = NULL
-        PetscBool all_default = PETSC_TRUE
-
-    ids = np.empty_like(facets)
-    nfacet = facets.shape[0]
-    CHKERR(DMGetLabel(dm.dm, FACE_SETS_LABEL.encode(), &label))
-    for f in range(nfacet):
-        CHKERR(DMLabelGetValue(label, facets[f], &val))
-        if val != -1:
-            all_default = PETSC_FALSE
-        ids[f] = val
-    if all_default:
-        return None
-    else:
-        return ids
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
 def get_facets_by_class(PETSc.DM plex, label,
                         np.ndarray[PetscInt, ndim=1, mode="c"] ordering):
     """Builds a list of all facets ordered according to PyOP2 entity

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -18,7 +18,7 @@ from firedrake.adjoint import FunctionMixin
 from firedrake.petsc import PETSc
 
 
-__all__ = ['Function', 'PointNotInDomainError']
+__all__ = ['Function', 'PointNotInDomainError', 'CoordinatelessFunction']
 
 
 class _CFunction(ctypes.Structure):
@@ -146,13 +146,13 @@ class CoordinatelessFunction(ufl.Coefficient):
 
     @property
     def cell_set(self):
-        r"""The :class:`pyop2.Set` of cells for the mesh on which this
+        r"""The :class:`pyop2.types.set.Set` of cells for the mesh on which this
         :class:`Function` is defined."""
         return self.function_space()._mesh.cell_set
 
     @property
     def node_set(self):
-        r"""A :class:`pyop2.Set` containing the nodes of this
+        r"""A :class:`pyop2.types.set.Set` containing the nodes of this
         :class:`Function`. One or (for rank-1 and 2
         :class:`.FunctionSpace`\s) more degrees of freedom are stored
         at each node.
@@ -161,7 +161,7 @@ class CoordinatelessFunction(ufl.Coefficient):
 
     @property
     def dof_dset(self):
-        r"""A :class:`pyop2.DataSet` containing the degrees of freedom of
+        r"""A :class:`pyop2.types.dataset.DataSet` containing the degrees of freedom of
         this :class:`Function`."""
         return self.function_space().dof_dset
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -31,7 +31,7 @@ from firedrake.adjoint import MeshGeometryMixin
 
 
 __all__ = ['Mesh', 'ExtrudedMesh', 'VertexOnlyMesh', 'RelabeledMesh', 'SubDomainData', 'unmarked',
-           'DistributedMeshOverlapType', 'DEFAULT_MESH_NAME']
+           'DistributedMeshOverlapType', 'DEFAULT_MESH_NAME', 'MeshGeometry', 'MeshTopology']
 
 
 _cells = {

--- a/tests/regression/test_mark_entities.py
+++ b/tests/regression/test_mark_entities.py
@@ -1,0 +1,92 @@
+import pytest
+from firedrake import *
+
+
+@pytest.mark.parallel(nprocs=8)
+def test_mark_entities_mark_points_with_function_array():
+    # Mark cells in f0.
+    # +---+---+            +---+
+    # | \ | \ |  mark      |   |
+    # +---+---+ ----->     +---+
+    # | \ | \ |
+    # +---+---+
+    # Mark facets in f1.
+    # +---+---+
+    # | \ | \ |  mark        \
+    # +---+---+ -----> +---+
+    # | \ | \ |
+    # +---+---+
+    my_cell_label = 999
+    my_facet_label = 4
+
+    mesh = UnitSquareMesh(2, 2)
+    x, y = SpatialCoordinate(mesh)
+    V0 = FunctionSpace(mesh, "DP", 0)
+    f0 = Function(V0).interpolate(conditional(And(And(x > .6, x < .9),
+                                                  And(y > .6, y < .9)), 1., 0.))
+    V1 = FunctionSpace(mesh, "HDiv Trace", 0)
+    f1 = Function(V1).interpolate(conditional(Or(And(x < .4,
+                                                     And(y > .4, y < .6)),
+                                                 And(And(x > .6, x < .9),
+                                                     And(y > .6, y < .9))), 1., 0.))
+    mesh = RelabeledMesh(mesh,
+                         [f0, f1],
+                         [my_cell_label, my_facet_label])
+    # Check integrals.
+    v = assemble(Constant(1, domain=mesh) * dx)
+    assert abs(v - 1.0) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * dx(my_cell_label))
+    assert abs(v - .25) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * dS)
+    assert abs(v - (4 * .5 + 4 * .5 * sqrt(2))) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * dS(my_facet_label))
+    assert abs(v - (1 * .5 + 1 * .5 * sqrt(2))) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * dS(unmarked))
+    assert abs(v - (3 * .5 + 3 * .5 * sqrt(2))) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * dS((my_facet_label, unmarked)))
+    assert abs(v - (4 * .5 + 4 * .5 * sqrt(2))) < 1.e-10
+
+
+@pytest.mark.parallel(nprocs=7)
+def test_mark_entities_overlapping_facet_subdomains():
+    my_facet_label = 777
+    removed_label = 1
+
+    mesh = UnitSquareMesh(2, 2)
+    x, y = SpatialCoordinate(mesh)
+    V1 = FunctionSpace(mesh, "HDiv Trace", 0)
+    f1 = Function(V1).interpolate(conditional(And(x > .5, y > .9), 1., 0.))
+    mesh = RelabeledMesh(mesh,
+                         [f1, Function(V1)],
+                         [my_facet_label, removed_label])
+    # Check integrals.
+    v = assemble(Constant(1, domain=mesh) * ds(my_facet_label))
+    assert abs(v - 0.5) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * ds((my_facet_label, 4)))
+    assert abs(v - 1.5) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * ds(removed_label))
+    assert abs(v - 0.0) < 1.e-10
+    v = assemble(Constant(1, domain=mesh) * ds(unmarked))
+    assert abs(v - 1.0) < 1.e-10
+
+
+def test_mark_entities_mesh_mark_entities():
+    # +---+---+
+    # | \ | \ |  mark        \
+    # +---+---+ -----> +---+
+    # | \ | \ |
+    # +---+---+
+    label_name = "test_label"
+    label_value = 999
+    mesh = UnitSquareMesh(2, 2)
+    x, y = SpatialCoordinate(mesh)
+    V = FunctionSpace(mesh, "HDiv Trace", 0)
+    f = Function(V).interpolate(conditional(Or(And(x < .4,
+                                                   And(y > .4, y < .6)),
+                                               And(And(x > .6, x < .9),
+                                                   And(y > .6, y < .9))), 1., 0.))
+    mesh.mark_entities(f, label_name, label_value)
+    plex = mesh.topology.topology_dm
+    label = plex.getLabel(label_name)
+    assert label.getStratumIS(label_value).getSize() == 2
+    assert all(label.getStratumIS(label_value).getIndices() == [20, 30])


### PR DESCRIPTION
Allow for marking entities using indicator functions. This will be useful when:

- creating a mesh with modified labels
- making submeshes in the future

~TODO: make high-level interface: `RelabeledMesh()`.~ Done.