### PR TITLE
Fixing low-order mesh logic in PlaneSmoother

### DIFF
--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -618,7 +618,7 @@ class PlaneSmoother(object):
         ndof = 0
         for p_ in closure_of_p:
             (dof, offset) = (coordinatesSection.getDof(p_), coordinatesSection.getOffset(p_))
-            bary += data[offset : offset + dof].reshape(dof, gdim).sum(axis=0)
+            bary += data[offset:offset + dof].reshape(dof, gdim).sum(axis=0)
             ndof += dof
         bary /= ndof
         return bary

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -615,10 +615,12 @@ class PlaneSmoother(object):
 
         gdim = data.shape[1]
         bary = numpy.zeros(gdim)
+        ndof = 0
         for p_ in closure_of_p:
             (dof, offset) = (coordinatesSection.getDof(p_), coordinatesSection.getOffset(p_))
-            bary += data[offset:offset+dof].reshape(gdim)
-        bary /= len(closure_of_p)
+            bary += data[offset : offset + dof].reshape(dof, gdim).sum(axis=0)
+            ndof += dof
+        bary /= ndof
         return bary
 
     def sort_entities(self, dm, axis, dir, ndiv=None, divisions=None):


### PR DESCRIPTION
The `coords` function [here](https://github.com/firedrakeproject/firedrake/blob/660d46b5f380ed23ec3074efdf9301033fc1e3fa/firedrake/preconditioners/patch.py#L608) breaks with the following MFE when called for mesh of order greater than 2.
```
from firedrake import *

order = 3
LO_mesh = UnitSquareMesh(2,2)
HO_coords = Function(VectorFunctionSpace(LO_mesh,"CG",order)).interpolate(LO_mesh.coordinates)
HO_mesh = Mesh(HO_coords)

V = FunctionSpace(HO_mesh,"CG",1)
u = TrialFunction(V)
v = TestFunction(V)
a = inner(u,v)*dx
L = Constant(1)*v*dx
u = Function(V)
problem = LinearVariationalProblem(a,L,u)

sp = {'ksp_type': 'fgmres',
      'ksp_monitor': None,
      'pc_type': 'python',
      'pc_python_type': 'firedrake.PatchPC',
      'patch_pc_patch_construct_type': 'python',
      'patch_pc_patch_construct_python_type': 'firedrake.PlaneSmoother',
      'patch_pc_patch_construct_ps_sweeps': "0+3:1+3",
      }

solver = LinearVariationalSolver(problem, solver_parameters = sp)
try:
    solver.solve()
except:
    print("Solver didn't work")
```
This is a proposed fix from @wence- , which properly reshapes the coordinates data and averages over however many DoFs are returned from the section.  I've confirmed that it does fix the MFE above