### PR TITLE
sphinx: pin at sphinx==6.1.1

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1414,7 +1414,8 @@ def install_documentation_dependencies():
     """Just install the required dependencies. There are no provenance
     issues here so no need to record this in the configuration dict."""
     log.info("Installing documentation dependencies")
-    run_pip(["install", "-U", "sphinx"])
+    log.info("We use 6.1.1 until the issue with 6.1.2 (https://github.com/sphinx-doc/sphinx/issues/11115) is resolved.\n")
+    run_pip(["install", "-U", "sphinx==6.1.1"])
     run_pip(["install", "-U", "sphinx-autobuild"])
     run_pip(["install", "-U", "sphinxcontrib-bibtex"])
     run_pip(["install", "-U", "bibtexparser"])


### PR DESCRIPTION
sphinx issue https://github.com/sphinx-doc/sphinx/issues/11115 causes doc build to fail with:
```
Exception occurred:
  File "/home/firedrake/firedrake/lib/python3.10/site-packages/sphinx/util/console.py", line 86, in colorize
    return escseq(name) + text + escseq('reset')
TypeError: can only concatenate str (not "PosixPath") to str
```
(See, e.g., https://github.com/firedrakeproject/firedrake/actions/runs/3881939929/jobs/6621505751)

Pin at `6.1.1` for now.