### PR TITLE
Reference element transfers in PMGPC

### DIFF
--- a/firedrake/preconditioners/low_order.py
+++ b/firedrake/preconditioners/low_order.py
@@ -1,4 +1,5 @@
 from firedrake.preconditioners.pmg import PMGPC, PMGSNES
+import ufl
 
 __all__ = ("P1PC", "P1SNES")
 
@@ -7,11 +8,54 @@ class P1PC(PMGPC):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        return super().reconstruct_degree(ele, self.coarse_degree)
+        cele = remove_empty_nodes(super().reconstruct_degree(ele, self.coarse_degree))
+        if cele is None:
+            raise ValueError
+        return cele
 
 
 class P1SNES(PMGSNES):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        return super().reconstruct_degree(ele, self.coarse_degree)
+        cele = remove_empty_nodes(super().reconstruct_degree(ele, self.coarse_degree))
+        if cele is None:
+            raise ValueError
+        return cele
+
+
+def remove_empty_nodes(ele):
+    if isinstance(ele, ufl.VectorElement):
+        wrapee = remove_empty_nodes(ele._sub_element)
+        return type(ele)(wrapee, dim=ele.num_sub_elements()) if wrapee else None
+    elif isinstance(ele, ufl.TensorElement):
+        wrapee = remove_empty_nodes(ele._sub_element)
+        return type(ele)(wrapee, shape=ele._shape, symmetry=ele.symmetry()) if wrapee else None
+    elif isinstance(ele, ufl.MixedElement):
+        return type(ele)(*list(map(remove_empty_nodes, ele.sub_elements())))
+    elif isinstance(ele, ufl.EnrichedElement):
+        elements = [e for e in list(map(remove_empty_nodes, ele._elements)) if e]
+        return type(ele)(*elements) if any(elements) else None
+    elif isinstance(ele, ufl.TensorProductElement):
+        factors = list(map(remove_empty_nodes, ele.sub_elements()))
+        return type(ele)(*factors, cell=ele.cell()) if all(factors) else None
+    elif isinstance(ele, ufl.WithMapping):
+        wrapee = remove_empty_nodes(ele.wrapee)
+        return type(ele)(wrapee, ele.mapping()) if wrapee else None
+    elif isinstance(ele, (ufl.HDivElement, ufl.HCurlElement, ufl.BrokenElement)):
+        wrapee = remove_empty_nodes(ele._element)
+        return type(ele)(wrapee) if wrapee else None
+    elif isinstance(ele, ufl.RestrictedElement):
+        wrapee = remove_empty_nodes(ele._element)
+        if wrapee is None:
+            return None
+        degree = wrapee.degree()
+        try:
+            degree = max(degree)
+        except TypeError:
+            pass
+        if degree == 1:
+            return None if ele._restriction_domain == "interior" else wrapee
+        return type(ele)(wrapee, restriction_domain=ele._restriction_domain)
+    else:
+        return ele

--- a/firedrake/preconditioners/low_order.py
+++ b/firedrake/preconditioners/low_order.py
@@ -8,7 +8,7 @@ class P1PC(PMGPC):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        cele = remove_empty_nodes(super().reconstruct_degree(ele, self.coarse_degree))
+        cele = super().reconstruct_degree(ele, self.coarse_degree)
         if cele is None:
             raise ValueError
         return cele
@@ -18,44 +18,7 @@ class P1SNES(PMGSNES):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        cele = remove_empty_nodes(super().reconstruct_degree(ele, self.coarse_degree))
+        cele = super().reconstruct_degree(ele, self.coarse_degree)
         if cele is None:
             raise ValueError
         return cele
-
-
-def remove_empty_nodes(ele):
-    if isinstance(ele, ufl.VectorElement):
-        wrapee = remove_empty_nodes(ele._sub_element)
-        return type(ele)(wrapee, dim=ele.num_sub_elements()) if wrapee else None
-    elif isinstance(ele, ufl.TensorElement):
-        wrapee = remove_empty_nodes(ele._sub_element)
-        return type(ele)(wrapee, shape=ele._shape, symmetry=ele.symmetry()) if wrapee else None
-    elif isinstance(ele, ufl.MixedElement):
-        return type(ele)(*list(map(remove_empty_nodes, ele.sub_elements())))
-    elif isinstance(ele, ufl.EnrichedElement):
-        elements = [e for e in list(map(remove_empty_nodes, ele._elements)) if e]
-        return type(ele)(*elements) if any(elements) else None
-    elif isinstance(ele, ufl.TensorProductElement):
-        factors = list(map(remove_empty_nodes, ele.sub_elements()))
-        return type(ele)(*factors, cell=ele.cell()) if all(factors) else None
-    elif isinstance(ele, ufl.WithMapping):
-        wrapee = remove_empty_nodes(ele.wrapee)
-        return type(ele)(wrapee, ele.mapping()) if wrapee else None
-    elif isinstance(ele, (ufl.HDivElement, ufl.HCurlElement, ufl.BrokenElement)):
-        wrapee = remove_empty_nodes(ele._element)
-        return type(ele)(wrapee) if wrapee else None
-    elif isinstance(ele, ufl.RestrictedElement):
-        wrapee = remove_empty_nodes(ele._element)
-        if wrapee is None:
-            return None
-        degree = wrapee.degree()
-        try:
-            degree = max(degree)
-        except TypeError:
-            pass
-        if degree == 1:
-            return None if ele._restriction_domain == "interior" else wrapee
-        return type(ele)(wrapee, restriction_domain=ele._restriction_domain)
-    else:
-        return ele

--- a/firedrake/preconditioners/low_order.py
+++ b/firedrake/preconditioners/low_order.py
@@ -1,5 +1,4 @@
 from firedrake.preconditioners.pmg import PMGPC, PMGSNES
-import ufl
 
 __all__ = ("P1PC", "P1SNES")
 

--- a/firedrake/preconditioners/low_order.py
+++ b/firedrake/preconditioners/low_order.py
@@ -7,17 +7,11 @@ class P1PC(PMGPC):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        cele = super().reconstruct_degree(ele, self.coarse_degree)
-        if cele is None:
-            raise ValueError
-        return cele
+        return super().reconstruct_degree(ele, self.coarse_degree)
 
 
 class P1SNES(PMGSNES):
     def coarsen_element(self, ele):
         if super().max_degree(ele) <= self.coarse_degree:
             raise ValueError
-        cele = super().reconstruct_degree(ele, self.coarse_degree)
-        if cele is None:
-            raise ValueError
-        return cele
+        return super().reconstruct_degree(ele, self.coarse_degree)

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1048,7 +1048,7 @@ def make_kron_code(Vf, Vc, t_in, t_out, mat_name, scratch):
             kronmxv_inplace(1, {cargs}, {fargs}, {nscal}, {Jargs}, &{t_out}, &{t_in});
                 """)
             elif shifts == fshifts:
-                if len(prolong_code) and psize > 1:
+                if has_code and psize > 1:
                     raise ValueError("Single tensor product to many tensor products not implemented for vectors")
                 # Single tensor product to many
                 prolong_code.append(f"""

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -945,6 +945,8 @@ def make_kron_code(Vf, Vc, t_in, t_out, mat_name, scratch):
     restrict_code = []
     felems, fshifts = get_line_elements(Vf)
     celems, cshifts = get_line_elements(Vc)
+    if len(felems) > 3 or len(celems) > 3:
+        raise ValueError("The expansion is too complicated")
 
     shifts = fshifts
     in_place = False

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1441,7 +1441,6 @@ class StandaloneInterpolationMatrix(object):
             return;
         }}
         """
-        print(kernel_code)
         from firedrake.slate.slac.compiler import BLASLAPACK_LIB, BLASLAPACK_INCLUDE
         prolong_kernel = op2.Kernel(kernel_code, "prolongation", include_dirs=BLASLAPACK_INCLUDE.split(),
                                     ldargs=BLASLAPACK_LIB.split(), requires_zeroed_output_arguments=True)

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1008,6 +1008,7 @@ def make_kron_code(Vf, Vc, t_in, t_out, mat_name, scratch):
     Jmats = []
     fshapes = []
     cshapes = []
+    has_code = False
     for felem, celem, shift in zip(felems, celems, shifts):
         if len(felem) != len(celem):
             raise ValueError("Fine and coarse elements do not have the same number of factors")
@@ -1058,7 +1059,7 @@ def make_kron_code(Vf, Vc, t_in, t_out, mat_name, scratch):
                 """)
             else:
                 # Many tensor products to single tensor product
-                if len(prolong_code):
+                if has_code:
                     raise ValueError("Many tensor products to single tensor product not implemented")
                 fskip = 0
                 prolong_code.append(f"""
@@ -1067,6 +1068,7 @@ def make_kron_code(Vf, Vc, t_in, t_out, mat_name, scratch):
                 restrict_code.append(f"""
             kronmxv(1, {cargs}, {fargs}, {nscal}, {Jargs}, {t_out}+{fskip}, {t_in}+{cskip}, {t_out}+{fskip}, {t_in}+{cskip});
                 """)
+            has_code = True
         fskip += nscal*numpy.prod(fshape)
         cskip += nscal*numpy.prod(cshape)
 


### PR DESCRIPTION
Here I have custom matrix-free transfer kernels between more general elements, which exploits structure on enriched elements of tensor-product elements (targeting cases such as `NCE_1 -> FacetElement(NCE_k)` ).

Ideally, the custom transfer kernels should be automatically generated through `Interpolator()`, but one problem is that we cannot get the matrix-free transpose from this required by multigrid restriction. The second reason why custom kernels are required is that `Interpolator() ` does not support EnrichedElements, as dual evaluation has not been impelemented yet.