### PR TITLE
Rename .split() -> .subfunctions

### DIFF
--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -94,11 +94,11 @@ two variables. ::
   W = MixedFunctionSpace((V, V))
 
 We construct a :class:`~.Function` to store the two variables at time
-level ``n``, and :meth:`~.Function.split` it so that we can
+level ``n``, and :meth:`~.Function.subfunctions` it so that we can
 interpolate the initial condition into the two components. ::
 
   w0 = Function(W)
-  m0, u0 = w0.split()
+  m0, u0 = w0.subfunctions()
 
 Then we interpolate the initial condition,
 
@@ -161,12 +161,12 @@ rather than blocked system. ::
       'ksp_type': 'preonly',
       'pc_type': 'lu'})
 
-Next we use the other form of :meth:`~.Function.split`, ``w0.split()``,
+Next we use the other form of :meth:`~.Function.subfunctions`, ``w0.subfunctions()``,
 which is the way to split up a Function in order to access its data
 e.g. for output. ::
 
-  m0, u0 = w0.split()
-  m1, u1 = w1.split()
+  m0, u0 = w0.subfunctions()
+  m1, u1 = w1.subfunctions()
 
 We choose a final time, and initialise a :class:`~.File` object for
 storing ``u``. as well as an array for storing the function to be visualised::

--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -98,7 +98,7 @@ level ``n``, and :meth:`~.Function.subfunctions` it so that we can
 interpolate the initial condition into the two components. ::
 
   w0 = Function(W)
-  m0, u0 = w0.subfunctions()
+  m0, u0 = w0.subfunctions
 
 Then we interpolate the initial condition,
 
@@ -161,12 +161,12 @@ rather than blocked system. ::
       'ksp_type': 'preonly',
       'pc_type': 'lu'})
 
-Next we use the other form of :meth:`~.Function.subfunctions`, ``w0.subfunctions()``,
+Next we use the other form of :meth:`~.Function.subfunctions`, ``w0.subfunctions``,
 which is the way to split up a Function in order to access its data
 e.g. for output. ::
 
-  m0, u0 = w0.subfunctions()
-  m1, u1 = w1.subfunctions()
+  m0, u0 = w0.subfunctions
+  m1, u1 = w1.subfunctions
 
 We choose a final time, and initialise a :class:`~.File` object for
 storing ``u``. as well as an array for storing the function to be visualised::

--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -94,7 +94,7 @@ two variables. ::
   W = MixedFunctionSpace((V, V))
 
 We construct a :class:`~.Function` to store the two variables at time
-level ``n``, and :meth:`~.Function.subfunctions` it so that we can
+level ``n``, and :attr:`~.Function.subfunctions` it so that we can
 interpolate the initial condition into the two components. ::
 
   w0 = Function(W)
@@ -161,7 +161,7 @@ rather than blocked system. ::
       'ksp_type': 'preonly',
       'pc_type': 'lu'})
 
-Next we use the other form of :meth:`~.Function.subfunctions`, ``w0.subfunctions``,
+Next we use the other form of :attr:`~.Function.subfunctions`, ``w0.subfunctions``,
 which is the way to split up a Function in order to access its data
 e.g. for output. ::
 

--- a/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
+++ b/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
@@ -306,7 +306,7 @@ In the end, we proceed with the actual computation loop::
         # symplectic Euler scheme
         LVS_phi_f.solve()
         LVS_U_phi.solve()
-        tmp_f, tmp_s = result_mixed.split()
+        tmp_f, tmp_s = result_mixed.subfunctions
         phi.assign(tmp_f)
         U.assign(tmp_s)
         LVS_eta.solve()

--- a/demos/ma-demo/ma-demo.py.rst
+++ b/demos/ma-demo/ma-demo.py.rst
@@ -186,7 +186,7 @@ We then put all of these options into the iterative solver, ::
 
 and output the solution to a file. ::
 
-  u, sigma = w.split()
+  u, sigma = w.subfunctions
   u_solv.solve()
   File("u.pvd").write(u)
 

--- a/demos/matrix_free/navier_stokes.py.rst
+++ b/demos/matrix_free/navier_stokes.py.rst
@@ -130,7 +130,7 @@ find the Reynolds number. ::
 
 And finally we write the results to a file for visualisation. ::
 
-  u, p = up.split()
+  u, p = up.subfunctions
   u.rename("Velocity")
   p.rename("Pressure")
 

--- a/demos/matrix_free/rayleigh-benard.py.rst
+++ b/demos/matrix_free/rayleigh-benard.py.rst
@@ -236,7 +236,7 @@ them, although doing so would be quite easy.::
 
 Finally, we'll output the results for visualisation. ::
 
-  u, p, T = upT.split()
+  u, p, T = upT.subfunctions
   u.rename("Velocity")
   p.rename("Pressure")
   T.rename("Temperature")

--- a/demos/matrix_free/stokes.py.rst
+++ b/demos/matrix_free/stokes.py.rst
@@ -126,7 +126,7 @@ visualisation.  We split the function into its velocity and pressure
 parts and give them reasonable names, then write them to a paraview
 file.::
 
-  u, p = up.split()
+  u, p = up.subfunctions
   u.rename("Velocity")
   p.rename("Pressure")
 

--- a/demos/multigrid/geometric_multigrid.py.rst
+++ b/demos/multigrid/geometric_multigrid.py.rst
@@ -255,7 +255,7 @@ approximations.
 
 Finally, we'll write the solution for visualisation with Paraview. ::
 
-  u, p = u.split()
+  u, p = u.subfunctions
   u.rename("Velocity")
   p.rename("Pressure")
 

--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -138,7 +138,7 @@ solver parameters. Afterwards we extract the components ``sigma`` and ``u``
 on each of the subspaces with ``split``. ::
 
   solve(a == L, w, bcs=[bc0, bc1])
-  sigma, u = w.split()
+  sigma, u = w.subfunctions
 
 Lastly we write the component of the solution corresponding to the primal
 variable on the DG space to a file in VTK format for later inspection with a

--- a/docs/notebooks/05-mixed-poisson.ipynb
+++ b/docs/notebooks/05-mixed-poisson.ipynb
@@ -1755,7 +1755,7 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "sigmah, uh = wh.split()\n",
+    "sigmah, uh = wh.subfunctions\n",
     "fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True)\n",
     "\n",
     "quiver(sigmah, axes=axes[0])\n",

--- a/docs/notebooks/06-pde-constrained-optimisation.ipynb
+++ b/docs/notebooks/06-pde-constrained-optimisation.ipynb
@@ -2194,7 +2194,7 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "u_init, p_init = w.split()\n",
+    "u_init, p_init = w.subfunctions()\n",
     "\n",
     "fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u_init, resolution=1/3, seed=0, axes=axes[0])\n",
@@ -4330,7 +4330,7 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "u_opt, p_opt = w_opt.split()\n",
+    "u_opt, p_opt = w_opt.subfunctions()\n",
     "\n",
     "fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u_opt, resolution=1/3, seed=0, axes=axes[0])\n",

--- a/docs/notebooks/06-pde-constrained-optimisation.ipynb
+++ b/docs/notebooks/06-pde-constrained-optimisation.ipynb
@@ -2194,7 +2194,7 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "u_init, p_init = w.subfunctions()\n",
+    "u_init, p_init = w.subfunctions\n",
     "\n",
     "fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u_init, resolution=1/3, seed=0, axes=axes[0])\n",
@@ -4330,7 +4330,7 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "u_opt, p_opt = w_opt.subfunctions()\n",
+    "u_opt, p_opt = w_opt.subfunctions\n",
     "\n",
     "fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u_opt, resolution=1/3, seed=0, axes=axes[0])\n",

--- a/docs/notebooks/07-geometric-multigrid.ipynb
+++ b/docs/notebooks/07-geometric-multigrid.ipynb
@@ -1045,7 +1045,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "w = solver._problem.u\n",
-    "u, p = w.subfunctions()\n",
+    "u, p = w.subfunctions\n",
     "fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u, resolution=1/30, seed=4, axes=axes[0])\n",
     "axes[0].set_aspect(\"equal\")\n",

--- a/docs/notebooks/07-geometric-multigrid.ipynb
+++ b/docs/notebooks/07-geometric-multigrid.ipynb
@@ -1045,7 +1045,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "w = solver._problem.u\n",
-    "u, p = w.split()\n",
+    "u, p = w.subfunctions()\n",
     "fig, axes = plt.subplots(ncols=2, sharex=True, sharey=True)\n",
     "streamlines = streamplot(u, resolution=1/30, seed=4, axes=axes[0])\n",
     "axes[0].set_aspect(\"equal\")\n",

--- a/docs/notebooks/08-composable-solvers.ipynb
+++ b/docs/notebooks/08-composable-solvers.ipynb
@@ -1018,7 +1018,7 @@
    "source": [
     "%matplotlib notebook\n",
     "import matplotlib.pyplot as plt\n",
-    "u_h, p_h = w.split()\n",
+    "u_h, p_h = w.subfunctions()\n",
     "fig, axes = plt.subplots()\n",
     "streamlines = streamplot(u_h, resolution=1/30, seed=0, axes=axes)\n",
     "fig.colorbar(streamlines);"

--- a/docs/notebooks/08-composable-solvers.ipynb
+++ b/docs/notebooks/08-composable-solvers.ipynb
@@ -1018,7 +1018,7 @@
    "source": [
     "%matplotlib notebook\n",
     "import matplotlib.pyplot as plt\n",
-    "u_h, p_h = w.subfunctions()\n",
+    "u_h, p_h = w.subfunctions\n",
     "fig, axes = plt.subplots()\n",
     "streamlines = streamplot(u_h, resolution=1/30, seed=0, axes=axes)\n",
     "fig.colorbar(streamlines);"

--- a/firedrake/adjoint/blocks.py
+++ b/firedrake/adjoint/blocks.py
@@ -321,7 +321,7 @@ class FunctionMergeBlock(Block, Backend):
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx,
                                prepared=None):
         if idx == 0:
-            return adj_inputs[0].split()[self.idx].vector()
+            return adj_inputs[0].subfunctions[self.idx].vector()
         else:
             return adj_inputs[0]
 

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -1211,7 +1211,7 @@ class _FormHandler:
         """Yield the form coefficients referenced in ``kinfo``."""
         for idx, subidxs in kinfo.coefficient_map:
             for subidx in subidxs:
-                yield form.coefficients()[idx].split()[subidx]
+                yield form.coefficients()[idx].subfunctions[subidx]
 
     @staticmethod
     def index_function_spaces(form, indices):

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -215,7 +215,7 @@ class BCBase(object):
             if len(field) == 1:
                 W = V
             else:
-                W = V.split()[field_renumbering[index]] if use_split else V.sub(field_renumbering[index])
+                W = V.subfunctions()[field_renumbering[index]] if use_split else V.sub(field_renumbering[index])
             if cmpt is not None:
                 W = W.sub(cmpt)
             return W

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -218,7 +218,7 @@ class BCBase(object):
             if len(field) == 1:
                 W = V
             else:
-                W = V.subfunctions()[field_renumbering[index]] if use_split else V.sub(field_renumbering[index])
+                W = V.subfunctions[field_renumbering[index]] if use_split else V.sub(field_renumbering[index])
             if cmpt is not None:
                 W = W.sub(cmpt)
             return W

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -780,7 +780,7 @@ class CheckpointFile(object):
         if isinstance(V.topological, impl.MixedFunctionSpace):
             base_path = self._path_to_mixed_function(mesh.name, V_name, f.name())
             self.require_group(base_path)
-            for i, fsub in enumerate(f.split()):
+            for i, fsub in enumerate(f.subfunctions()):
                 path = os.path.join(base_path, str(i))
                 self.require_group(path)
                 self.set_attr(path, PREFIX + "_function", fsub.name())

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -780,7 +780,7 @@ class CheckpointFile(object):
         if isinstance(V.topological, impl.MixedFunctionSpace):
             base_path = self._path_to_mixed_function(mesh.name, V_name, f.name())
             self.require_group(base_path)
-            for i, fsub in enumerate(f.subfunctions()):
+            for i, fsub in enumerate(f.subfunctions):
                 path = os.path.join(base_path, str(i))
                 self.require_group(path)
                 self.set_attr(path, PREFIX + "_function", fsub.name())

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -111,13 +111,14 @@ class Constant(ufl.Coefficient, ConstantMixin):
         """Return a null function space."""
         return None
 
+    @utils.cached_property
     def subfunctions(self):
         return (self,)
-        
+
     def split(self):
         import warnings
-        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
-        return self.subfunctions()
+        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        return self.subfunctions
 
     def cell_node_map(self, bcs=None):
         """Return a null cell to node map."""

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -111,8 +111,13 @@ class Constant(ufl.Coefficient, ConstantMixin):
         """Return a null function space."""
         return None
 
-    def split(self):
+    def subfunctions(self):
         return (self,)
+        
+    def split(self):
+        import warnings
+        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
+        return self.subfunctions()
 
     def cell_node_map(self, bcs=None):
         """Return a null cell to node map."""

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -117,7 +117,7 @@ class Constant(ufl.Coefficient, ConstantMixin):
 
     def split(self):
         import warnings
-        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     def cell_node_map(self, bcs=None):

--- a/firedrake/ensemble.py
+++ b/firedrake/ensemble.py
@@ -100,7 +100,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to allreduce.
         :arg f_reduced: the result of the reduction.
         :arg op: MPI reduction operator. Defaults to MPI.SUM.
-        :returns: list of MPI.Request objects (one for each of f.split()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
         :raises ValueError: if function communicators mismatch each other or the ensemble
             spatial communicator, or if the functions are in different spaces
         """
@@ -141,7 +141,7 @@ class Ensemble(object):
         :arg f_reduced: the result of the reduction on rank root.
         :arg op: MPI reduction operator. Defaults to MPI.SUM.
         :arg root: rank to reduce to. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.split()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
         :raises ValueError: if function communicators mismatch each other or the ensemble
             spatial communicator, or is the functions are in different spaces
         """
@@ -172,7 +172,7 @@ class Ensemble(object):
 
         :arg f: The :class:`.Function` to broadcast.
         :arg root: rank to broadcast from. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.split()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -204,7 +204,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to receive into
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg tag: the tag of the message. Defaults to MPI.ANY_TAG.
-        :arg statuses: MPI.Status objects (one for each of f.split() or None).
+        :arg statuses: MPI.Status objects (one for each of f.subfunctions() or None).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -222,7 +222,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to send
         :arg dest: the rank to send to
         :arg tag: the tag of the message. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.split()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -238,7 +238,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to receive into
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg tag: the tag of the message. Defaults to MPI.ANY_TAG.
-        :returns: list of MPI.Request objects (one for each of f.split()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -280,7 +280,7 @@ class Ensemble(object):
         :arg frecv: The a :class:`.Function` to receive into.
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg recvtag: the tag of the received message. Defaults to MPI.ANY_TAG.
-        :returns: list of MPI.Request objects (one for each of fsend.split() and frecv.split()).
+        :returns: list of MPI.Request objects (one for each of fsend.subfunctions() and frecv.subfunctions()).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         # functions don't necessarily have to match

--- a/firedrake/ensemble.py
+++ b/firedrake/ensemble.py
@@ -100,7 +100,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to allreduce.
         :arg f_reduced: the result of the reduction.
         :arg op: MPI reduction operator. Defaults to MPI.SUM.
-        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions).
         :raises ValueError: if function communicators mismatch each other or the ensemble
             spatial communicator, or if the functions are in different spaces
         """
@@ -141,7 +141,7 @@ class Ensemble(object):
         :arg f_reduced: the result of the reduction on rank root.
         :arg op: MPI reduction operator. Defaults to MPI.SUM.
         :arg root: rank to reduce to. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions).
         :raises ValueError: if function communicators mismatch each other or the ensemble
             spatial communicator, or is the functions are in different spaces
         """
@@ -172,7 +172,7 @@ class Ensemble(object):
 
         :arg f: The :class:`.Function` to broadcast.
         :arg root: rank to broadcast from. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -204,7 +204,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to receive into
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg tag: the tag of the message. Defaults to MPI.ANY_TAG.
-        :arg statuses: MPI.Status objects (one for each of f.subfunctions() or None).
+        :arg statuses: MPI.Status objects (one for each of f.subfunctions or None).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -222,7 +222,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to send
         :arg dest: the rank to send to
         :arg tag: the tag of the message. Defaults to 0.
-        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -238,7 +238,7 @@ class Ensemble(object):
         :arg f: The a :class:`.Function` to receive into
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg tag: the tag of the message. Defaults to MPI.ANY_TAG.
-        :returns: list of MPI.Request objects (one for each of f.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of f.subfunctions).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         self._check_function(f)
@@ -280,7 +280,7 @@ class Ensemble(object):
         :arg frecv: The a :class:`.Function` to receive into.
         :arg source: the rank to receive from. Defaults to MPI.ANY_SOURCE.
         :arg recvtag: the tag of the received message. Defaults to MPI.ANY_TAG.
-        :returns: list of MPI.Request objects (one for each of fsend.subfunctions() and frecv.subfunctions()).
+        :returns: list of MPI.Request objects (one for each of fsend.subfunctions and frecv.subfunctions).
         :raises ValueError: if function communicator mismatches the ensemble spatial communicator.
         """
         # functions don't necessarily have to match

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -95,7 +95,7 @@ class ExtractSubBlock(MultiFunction):
         if o in self._arg_cache:
             return self._arg_cache[o]
 
-        V_is = V.split()
+        V_is = V.subfunctions
         indices = self.blocks[o.number()]
 
         try:

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -116,7 +116,7 @@ class CoordinatelessFunction(ufl.Coefficient):
     @PETSc.Log.EventDecorator()
     def split(self):
         import warnings
-        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     @utils.cached_property
@@ -314,7 +314,7 @@ class Function(ufl.Coefficient, FunctionMixin):
     @FunctionMixin._ad_annotate_split
     def split(self):
         import warnings
-        warnings.warn(".split() was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     @utils.cached_property

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -134,7 +134,7 @@ class CoordinatelessFunction(ufl.Coefficient):
 
         :arg i: the index to extract
 
-        See also :property:`subfunctions`.
+        See also :attr:`subfunctions`.
 
         If the :class:`Function` is defined on a
         rank-n :class:`~.FunctionSpace`, this returns a proxy object
@@ -331,7 +331,7 @@ class Function(ufl.Coefficient, FunctionMixin):
 
         :arg i: the index to extract
 
-        See also :property:`subfunctions`.
+        See also :attr:`subfunctions`.
 
         If the :class:`Function` is defined on a
         :class:`~.VectorFunctionSpace` or :class:`~.TensorFunctiionSpace` this returns a proxy object

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -100,9 +100,10 @@ class WithGeometry(ufl.FunctionSpace):
         self.cargo.topological = val
 
     @utils.cached_property
-    def _subfunctions(self):
+    def subfunctions(self):
+        r"""Split into a tuple of constituent spaces."""
         return tuple(WithGeometry.create(subspace, self.mesh())
-                     for subspace in self.topological.subfunctions())
+                     for subspace in self.topological.subfunctions)
 
     mesh = ufl.FunctionSpace.ufl_domain
 
@@ -119,15 +120,10 @@ class WithGeometry(ufl.FunctionSpace):
         return self.ufl_domain().ufl_cell()
 
     @PETSc.Log.EventDecorator()
-    def subfunctions(self):
-        r"""Split into a tuple of constituent spaces."""
-        return self._subfunctions
-        
-    @PETSc.Log.EventDecorator()
     def split(self):
         import warnings
-        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
-        return self._subfunctions
+        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        return self.subfunctions
 
     @utils.cached_property
     def _components(self):
@@ -135,7 +131,7 @@ class WithGeometry(ufl.FunctionSpace):
             return tuple(WithGeometry.create(self.topological.sub(i), self.mesh())
                          for i in range(self.value_size))
         else:
-            return self._subfunctions
+            return self.subfunctions
 
     @PETSc.Log.EventDecorator()
     def sub(self, i):
@@ -275,10 +271,10 @@ class WithGeometry(ufl.FunctionSpace):
         return "WithGeometry(%s, %s)" % (self.topological, self.mesh())
 
     def __iter__(self):
-        return iter(self._subfunctions)
+        return iter(self.subfunctions)
 
     def __getitem__(self, i):
-        return self._subfunctions[i]
+        return self.subfunctions[i]
 
     def __mul__(self, other):
         r"""Create a :class:`.MixedFunctionSpace` composed of this
@@ -502,14 +498,15 @@ class FunctionSpace(object):
                                                    self.ufl_element(),
                                                    self.name)
 
+    @utils.cached_property
     def subfunctions(self):
         r"""Split into a tuple of constituent spaces."""
         return (self, )
 
     def split(self):
         import warnings
-        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
-        return self.subfunctions()
+        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        return self.subfunctions
 
     def __getitem__(self, i):
         r"""Return the ith subspace."""
@@ -716,15 +713,16 @@ class MixedFunctionSpace(object):
     def __hash__(self):
         return hash(tuple(self))
 
+    @utils.cached_property
     def subfunctions(self):
         r"""The list of :class:`FunctionSpace`\s of which this
         :class:`MixedFunctionSpace` is composed."""
         return self._spaces
-        
+
     def split(self):
         import warnings
-        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
-        return self.subfunctions()
+        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        return self.subfunctions
 
     def sub(self, i):
         r"""Return the `i`th :class:`FunctionSpace` in this

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -100,9 +100,9 @@ class WithGeometry(ufl.FunctionSpace):
         self.cargo.topological = val
 
     @utils.cached_property
-    def _split(self):
+    def _subfunctions(self):
         return tuple(WithGeometry.create(subspace, self.mesh())
-                     for subspace in self.topological.split())
+                     for subspace in self.topological.subfunctions())
 
     mesh = ufl.FunctionSpace.ufl_domain
 
@@ -119,9 +119,15 @@ class WithGeometry(ufl.FunctionSpace):
         return self.ufl_domain().ufl_cell()
 
     @PETSc.Log.EventDecorator()
-    def split(self):
+    def subfunctions(self):
         r"""Split into a tuple of constituent spaces."""
-        return self._split
+        return self._subfunctions
+        
+    @PETSc.Log.EventDecorator()
+    def split(self):
+        import warnings
+        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
+        return self._subfunctions
 
     @utils.cached_property
     def _components(self):
@@ -129,7 +135,7 @@ class WithGeometry(ufl.FunctionSpace):
             return tuple(WithGeometry.create(self.topological.sub(i), self.mesh())
                          for i in range(self.value_size))
         else:
-            return self._split
+            return self._subfunctions
 
     @PETSc.Log.EventDecorator()
     def sub(self, i):
@@ -269,10 +275,10 @@ class WithGeometry(ufl.FunctionSpace):
         return "WithGeometry(%s, %s)" % (self.topological, self.mesh())
 
     def __iter__(self):
-        return iter(self._split)
+        return iter(self._subfunctions)
 
     def __getitem__(self, i):
-        return self._split[i]
+        return self._subfunctions[i]
 
     def __mul__(self, other):
         r"""Create a :class:`.MixedFunctionSpace` composed of this
@@ -496,9 +502,14 @@ class FunctionSpace(object):
                                                    self.ufl_element(),
                                                    self.name)
 
-    def split(self):
+    def subfunctions(self):
         r"""Split into a tuple of constituent spaces."""
         return (self, )
+
+    def split(self):
+        import warnings
+        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
+        return self.subfunctions()
 
     def __getitem__(self, i):
         r"""Return the ith subspace."""
@@ -705,10 +716,15 @@ class MixedFunctionSpace(object):
     def __hash__(self):
         return hash(tuple(self))
 
-    def split(self):
+    def subfunctions(self):
         r"""The list of :class:`FunctionSpace`\s of which this
         :class:`MixedFunctionSpace` is composed."""
         return self._spaces
+        
+    def split(self):
+        import warnings
+        warnings.warn(".split() was renamed as .subfunctions()", category=FutureWarning)
+        return self.subfunctions()
 
     def sub(self, i):
         r"""Return the `i`th :class:`FunctionSpace` in this

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -122,7 +122,7 @@ class WithGeometry(ufl.FunctionSpace):
     @PETSc.Log.EventDecorator()
     def split(self):
         import warnings
-        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     @utils.cached_property
@@ -505,7 +505,7 @@ class FunctionSpace(object):
 
     def split(self):
         import warnings
-        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     def __getitem__(self, i):
@@ -721,7 +721,7 @@ class MixedFunctionSpace(object):
 
     def split(self):
         import warnings
-        warnings.warn(".split() method was changed to .subfunctions property (without paranthesis)", category=FutureWarning)
+        warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
         return self.subfunctions
 
     def sub(self, i):

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -211,7 +211,7 @@ class TransferManager(object):
             return self._native_transfer(source_element, transfer_op)(source, target)
         if type(source_element) is ufl.MixedElement:
             assert type(target_element) is ufl.MixedElement
-            for source_, target_ in zip(source.subfunctions(), target.subfunctions()):
+            for source_, target_ in zip(source.subfunctions, target.subfunctions):
                 self.op(source_, target_, transfer_op=transfer_op)
             return target
         # Get some work vectors
@@ -273,7 +273,7 @@ class TransferManager(object):
             return self._native_transfer(source_element, Op.RESTRICT)(gf, gc)
         if type(source_element) is ufl.MixedElement:
             assert type(target_element) is ufl.MixedElement
-            for source_, target_ in zip(gf.subfunctions(), gc.subfunctions()):
+            for source_, target_ in zip(gf.subfunctions, gc.subfunctions):
                 self.restrict(source_, target_)
             return gc
         dgf = self.DG_work(Vf)

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -211,7 +211,7 @@ class TransferManager(object):
             return self._native_transfer(source_element, transfer_op)(source, target)
         if type(source_element) is ufl.MixedElement:
             assert type(target_element) is ufl.MixedElement
-            for source_, target_ in zip(source.split(), target.split()):
+            for source_, target_ in zip(source.subfunctions(), target.subfunctions()):
                 self.op(source_, target_, transfer_op=transfer_op)
             return target
         # Get some work vectors
@@ -273,7 +273,7 @@ class TransferManager(object):
             return self._native_transfer(source_element, Op.RESTRICT)(gf, gc)
         if type(source_element) is ufl.MixedElement:
             assert type(target_element) is ufl.MixedElement
-            for source_, target_ in zip(gf.split(), gc.split()):
+            for source_, target_ in zip(gf.subfunctions(), gc.subfunctions()):
                 self.restrict(source_, target_)
             return gc
         dgf = self.DG_work(Vf)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -32,7 +32,7 @@ def prolong(coarse, fine):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(coarse.subfunctions(), fine.subfunctions()):
+        for in_, out in zip(coarse.subfunctions, fine.subfunctions):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.prolong(in_, out)
         return fine
@@ -93,7 +93,7 @@ def restrict(fine_dual, coarse_dual):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(fine_dual.subfunctions(), coarse_dual.subfunctions()):
+        for in_, out in zip(fine_dual.subfunctions, coarse_dual.subfunctions):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.restrict(in_, out)
         return coarse_dual
@@ -155,7 +155,7 @@ def inject(fine, coarse):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(fine.subfunctions(), coarse.subfunctions()):
+        for in_, out in zip(fine.subfunctions, coarse.subfunctions):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.inject(in_, out)
         return

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -32,7 +32,7 @@ def prolong(coarse, fine):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(coarse.split(), fine.split()):
+        for in_, out in zip(coarse.subfunctions(), fine.subfunctions()):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.prolong(in_, out)
         return fine
@@ -93,7 +93,7 @@ def restrict(fine_dual, coarse_dual):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(fine_dual.split(), coarse_dual.split()):
+        for in_, out in zip(fine_dual.subfunctions(), coarse_dual.subfunctions()):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.restrict(in_, out)
         return coarse_dual
@@ -155,7 +155,7 @@ def inject(fine, coarse):
     if len(Vc) > 1:
         if len(Vc) != len(Vf):
             raise ValueError("Mixed spaces have different lengths")
-        for in_, out in zip(fine.split(), coarse.split()):
+        for in_, out in zip(fine.subfunctions(), coarse.subfunctions()):
             manager = firedrake.dmhooks.get_transfer_manager(in_.function_space().dm)
             manager.inject(in_, out)
         return

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -205,7 +205,7 @@ def matrix_funptr(form, state):
                 args.append(statearg)
                 continue
             for ind in indices:
-                c_ = c.split()[ind]
+                c_ = c.subfunctions[ind]
                 map_ = get_map(c_)
                 arg = c_.dat(op2.READ, map_)
                 args.append(arg)
@@ -295,7 +295,7 @@ def residual_funptr(form, state):
                 args.append(statearg)
                 continue
             for ind in indices:
-                c_ = c.split()[ind]
+                c_ = c.subfunctions[ind]
                 map_ = get_map(c_)
                 arg = c_.dat(op2.READ, map_)
                 args.append(arg)
@@ -516,7 +516,7 @@ def make_c_arguments(form, kernel, state, get_map, require_state=False,
                 raise ValueError(f"Active indices of state (dont_split) function must be (0, ), not {indices}")
             coeffs.append(c)
         else:
-            coeffs.extend([c.split()[ind] for ind in indices])
+            coeffs.extend([c.subfunctions[ind] for ind in indices])
     if require_state:
         assert state in coeffs, "Couldn't find state vector in form coefficients"
     data_args = []

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1153,7 +1153,7 @@ class MixedInterpolationMatrix(StandaloneInterpolationMatrix):
         self.uc = Vc if isinstance(Vc, firedrake.Function) else firedrake.Function(Vc)
 
         self.standalones = []
-        for (i, (uf_sub, uc_sub)) in enumerate(zip(self.uf.split(), self.uc.split())):
+        for (i, (uf_sub, uc_sub)) in enumerate(zip(self.uf.subfunctions, self.uc.subfunctions)):
             Vf_sub_bcs = [bc for bc in Vf_bcs if bc.function_space().index == i]
             Vc_sub_bcs = [bc for bc in Vc_bcs if bc.function_space().index == i]
             standalone = StandaloneInterpolationMatrix(uf_sub, uc_sub, Vf_sub_bcs, Vc_sub_bcs)

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -589,7 +589,7 @@ class LocalLoopyKernelBuilder(object):
         for i, (c, split_map) in enumerate(self.expression.coeff_map):
             coeff = coeffs[c]
             if type(coeff.ufl_element()) == MixedElement:
-                splits = coeff.split()
+                splits = coeff.subfunctions
                 coeff_dict[coeff] = OrderedDict({splits[j]: (f"w_{i}_{j}", self.extent(splits[j])) for j in split_map})
             else:
                 coeff_dict[coeff] = (f"w_{i}", self.extent(coeff))

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -334,7 +334,7 @@ class LocalKernelBuilder(object):
         for i, coefficient in enumerate(self.expression.coefficients()):
             if type(coefficient.ufl_element()) == MixedElement:
                 csym_info = []
-                for j, _ in enumerate(coefficient.split()):
+                for j, _ in enumerate(coefficient.subfunctions):
                     csym_info.append(ast.Symbol("w_%d_%d" % (i, j)))
             else:
                 csym_info = (ast.Symbol("w_%d" % i),)

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -662,7 +662,7 @@ class Block(TensorBase):
         nargs = []
         for i, arg in enumerate(tensor.arguments()):
             V = arg.function_space()
-            V_is = V.split()
+            V_is = V.subfunctions()
             idx = as_tuple(self._blocks[i])
             if len(idx) == 1:
                 fidx, = idx

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -230,7 +230,7 @@ class TensorBase(object, metaclass=ABCMeta):
                 coeff_map[m].update(c.indices[0])
             else:
                 m = self.coefficients().index(c)
-                split_map = tuple(range(len(c.split()))) if isinstance(c, Function) or isinstance(c, Constant) else tuple(range(1))
+                split_map = tuple(range(len(c.subfunctions))) if isinstance(c, Function) or isinstance(c, Constant) else tuple(range(1))
                 coeff_map[m].update(split_map)
         return tuple((k, tuple(sorted(v)))for k, v in coeff_map.items())
 
@@ -662,7 +662,7 @@ class Block(TensorBase):
         nargs = []
         for i, arg in enumerate(tensor.arguments()):
             V = arg.function_space()
-            V_is = V.subfunctions()
+            V_is = V.subfunctions
             idx = as_tuple(self._blocks[i])
             if len(idx) == 1:
                 fidx, = idx
@@ -696,7 +696,7 @@ class Block(TensorBase):
         else:
             # turns the Block on an AssembledVector into a set off coefficients
             # corresponding to the indices of the Block
-            return tuple(tensor._function.split()[i] for i in chain(*self._indices))
+            return tuple(tensor._function.subfunctions[i] for i in chain(*self._indices))
 
     @cached_property
     def assembled(self):

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -284,8 +284,8 @@ class HybridizationPC(SCBase):
         S = self.schur_builder.inner_S
 
         # Split functions and reconstruct each bit separately
-        split_residual = self.broken_residual.split()
-        split_sol = self.broken_solution.split()
+        split_residual = self.broken_residual.subfunctions
+        split_sol = self.broken_solution.subfunctions
         g = AssembledVector(split_residual[id0])
         f = AssembledVector(split_residual[id1])
         sigma = split_sol[id0]
@@ -334,8 +334,8 @@ class HybridizationPC(SCBase):
             # Transfer unbroken_rhs into broken_rhs
             # NOTE: Scalar space is already "broken" so no need for
             # any projections
-            unbroken_scalar_data = self.unbroken_residual.split()[self.pidx]
-            broken_scalar_data = self.broken_residual.split()[self.pidx]
+            unbroken_scalar_data = self.unbroken_residual.subfunctions[self.pidx]
+            broken_scalar_data = self.broken_residual.subfunctions[self.pidx]
             unbroken_scalar_data.dat.copy(broken_scalar_data.dat)
 
             # Assemble the new "broken" hdiv residual
@@ -344,8 +344,8 @@ class HybridizationPC(SCBase):
             # We do this by splitting the residual equally between
             # basis functions that add together to give unbroken
             # basis functions.
-            unbroken_res_hdiv = self.unbroken_residual.split()[self.vidx]
-            broken_res_hdiv = self.broken_residual.split()[self.vidx]
+            unbroken_res_hdiv = self.unbroken_residual.subfunctions[self.vidx]
+            broken_res_hdiv = self.broken_residual.subfunctions[self.vidx]
             broken_res_hdiv.assign(0)
             par_loop(self.average_kernel, ufl.dx,
                      {"w": (self.weight, READ),
@@ -393,13 +393,13 @@ class HybridizationPC(SCBase):
 
         with PETSc.Log.Event("HybridProject"):
             # Project the broken solution into non-broken spaces
-            broken_pressure = self.broken_solution.split()[self.pidx]
-            unbroken_pressure = self.unbroken_solution.split()[self.pidx]
+            broken_pressure = self.broken_solution.subfunctions[self.pidx]
+            unbroken_pressure = self.unbroken_solution.subfunctions[self.pidx]
             broken_pressure.dat.copy(unbroken_pressure.dat)
 
             # Compute the hdiv projection of the broken hdiv solution
-            broken_hdiv = self.broken_solution.split()[self.vidx]
-            unbroken_hdiv = self.unbroken_solution.split()[self.vidx]
+            broken_hdiv = self.broken_solution.subfunctions[self.vidx]
+            unbroken_hdiv = self.unbroken_solution.subfunctions[self.vidx]
             unbroken_hdiv.assign(0)
 
             par_loop(self.average_kernel, ufl.dx,

--- a/firedrake/slate/static_condensation/la_utils.py
+++ b/firedrake/slate/static_condensation/la_utils.py
@@ -119,8 +119,8 @@ def backward_solve(A, b, x, schur_builder, reconstruct_fields):
     nfields = len(all_fields)
     reconstruct_fields = as_tuple(reconstruct_fields)
 
-    _b = b.split()
-    _x = x.split()
+    _b = b.subfunctions
+    _x = x.subfunctions
 
     # Ordering matters
     systems = []

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -219,7 +219,7 @@ class SCPC(SCBase):
         from firedrake.assemble import OneFormAssembler
         from firedrake.slate.static_condensation.la_utils import backward_solve
 
-        fields = x.split()
+        fields = x.subfunctions
         systems = backward_solve(A, rhs, x, schur_builder, reconstruct_fields=elim_fields)
 
         local_solvers = []
@@ -260,7 +260,7 @@ class SCPC(SCBase):
             x.copy(v)
 
         # Disassemble the incoming right-hand side
-        with self.residual.split()[self.c_field].dat.vec as vc, self.weight.dat.vec_ro as wc:
+        with self.residual.subfunctions[self.c_field].dat.vec as vc, self.weight.dat.vec_ro as wc:
             vc.pointwiseMult(vc, wc)
 
         # Now assemble residual for the reduced problem
@@ -279,9 +279,9 @@ class SCPC(SCBase):
 
             with self.condensed_rhs.dat.vec_ro as rhs:
                 if self.condensed_ksp.getInitialGuessNonzero():
-                    acc = self.solution.split()[self.c_field].dat.vec
+                    acc = self.solution.subfunctions[self.c_field].dat.vec
                 else:
-                    acc = self.solution.split()[self.c_field].dat.vec_wo
+                    acc = self.solution.subfunctions[self.c_field].dat.vec_wo
                 with acc as sol:
                     self.condensed_ksp.solve(rhs, sol)
 

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -327,7 +327,7 @@ class _SNESContext(object):
         for field in fields:
             F = splitter.split(problem.F, argument_indices=(field, ))
             J = splitter.split(problem.J, argument_indices=(field, field))
-            us = problem.u.split()
+            us = problem.u.subfunctions
             V = F.arguments()[0].function_space()
             # Exposition:
             # We are going to make a new solution Function on the sub

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -315,7 +315,7 @@ def extract_numbered_coefficients(expr, numbers):
     coefficients = []
     for coeff in (orig_coefficients[i] for i in numbers):
         if type(coeff.ufl_element()) == ufl.MixedElement:
-            coefficients.extend(coeff.split())
+            coefficients.extend(coeff.subfunctions)
         else:
             coefficients.append(coeff)
     return coefficients

--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -135,7 +135,7 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
          provide the derivative of a coefficient function.
 
     :raises ValueError: If any of the coefficients in ``form`` were
-        obtained from ``u.subfunctions()``.  UFL doesn't notice that these
+        obtained from ``u.subfunctions``.  UFL doesn't notice that these
         are related to ``u`` and so therefore the derivative is
         wrong (instead one should have written ``split(u)``).
 
@@ -148,8 +148,8 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
     # TODO: What about Constant?
     u_is_x = isinstance(u, ufl.SpatialCoordinate)
     uc, = (u,) if u_is_x else extract_coefficients(u)
-    if not u_is_x and len(uc.subfunctions()) > 1 and set(extract_coefficients(form)) & set(uc.subfunctions()):
-        raise ValueError("Taking derivative of form wrt u, but form contains coefficients from u.subfunctions()."
+    if not u_is_x and len(uc.subfunctions) > 1 and set(extract_coefficients(form)) & set(uc.subfunctions):
+        raise ValueError("Taking derivative of form wrt u, but form contains coefficients from u.subfunctions."
                          "\nYou probably meant to write split(u) when defining your form.")
 
     mesh = form.ufl_domain()

--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -135,7 +135,7 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
          provide the derivative of a coefficient function.
 
     :raises ValueError: If any of the coefficients in ``form`` were
-        obtained from ``u.split()``.  UFL doesn't notice that these
+        obtained from ``u.subfunctions()``.  UFL doesn't notice that these
         are related to ``u`` and so therefore the derivative is
         wrong (instead one should have written ``split(u)``).
 
@@ -148,8 +148,8 @@ def derivative(form, u, du=None, coefficient_derivatives=None):
     # TODO: What about Constant?
     u_is_x = isinstance(u, ufl.SpatialCoordinate)
     uc, = (u,) if u_is_x else extract_coefficients(u)
-    if not u_is_x and len(uc.split()) > 1 and set(extract_coefficients(form)) & set(uc.split()):
-        raise ValueError("Taking derivative of form wrt u, but form contains coefficients from u.split()."
+    if not u_is_x and len(uc.subfunctions()) > 1 and set(extract_coefficients(form)) & set(uc.subfunctions()):
+        raise ValueError("Taking derivative of form wrt u, but form contains coefficients from u.subfunctions()."
                          "\nYou probably meant to write split(u) when defining your form.")
 
     mesh = form.ufl_domain()

--- a/tests/equation_bcs/test_bcs_reconstruct.py
+++ b/tests/equation_bcs/test_bcs_reconstruct.py
@@ -49,5 +49,5 @@ def test_bc_on_sub_sub_domain():
     f.interpolate(as_vector([cos(2 * pi * x) * cos(2 * pi * y),
                              cos(2 * pi * x) * cos(2 * pi * y)]))
 
-    assert sqrt(assemble(dot(uu.split()[0] - f, uu.split()[0] - f) * dx)) < 4.0e-03
-    assert sqrt(assemble(dot(uu.split()[1] - f, uu.split()[1] - f) * dx)) < 4.0e-03
+    assert sqrt(assemble(dot(uu.subfunctions[0] - f, uu.subfunctions[0] - f) * dx)) < 4.0e-03
+    assert sqrt(assemble(dot(uu.subfunctions[1] - f, uu.subfunctions[1] - f) * dx)) < 4.0e-03

--- a/tests/equation_bcs/test_equation_bcs.py
+++ b/tests/equation_bcs/test_equation_bcs.py
@@ -189,7 +189,7 @@ def linear_poisson_mixed(solver_parameters, mesh_num, porder):
 
     solve(a == L, w, bcs=[bc2, bc3, bc4], solver_parameters=solver_parameters)
 
-    sigma, u = w.split()
+    sigma, u = w.subfunctions
 
     f.interpolate(cos(2 * pi * x + pi / 3) * cos(2 * pi * y))
     g = Function(BDM).project(as_vector([-2 * pi * sin(2 * pi * x + pi / 3) * cos(2 * pi * y), -2 * pi * cos(2 * pi * x + pi / 3) * sin(2 * pi * y)]))

--- a/tests/extrusion/test_mixed_bcs.py
+++ b/tests/extrusion/test_mixed_bcs.py
@@ -41,7 +41,7 @@ def test_multiple_poisson_Pn(quadrilateral, degree):
 
     wexact = Function(W)
 
-    u, p = wexact.split()
+    u, p = wexact.subfunctions
 
     xs = SpatialCoordinate(mesh)
     u.interpolate(1 + 9*xs[2])
@@ -88,7 +88,7 @@ def test_multiple_poisson_strong_weak_Pn(quadrilateral, degree):
 
     wexact = Function(W)
 
-    u, p = wexact.split()
+    u, p = wexact.subfunctions
 
     xs = SpatialCoordinate(mesh)
     u.interpolate(11 - xs[2])
@@ -134,7 +134,7 @@ def test_stokes_taylor_hood(mat_type):
 
     w = Function(W)
 
-    u, p = w.split()
+    u, p = w.subfunctions
     solve(a == L, w, bcs=bcs,
           solver_parameters={'pc_type': 'fieldsplit',
                              'pc_fieldsplit_type': 'schur',

--- a/tests/extrusion/test_real_tensorproduct.py
+++ b/tests/extrusion/test_real_tensorproduct.py
@@ -167,7 +167,7 @@ def test_real_tensorproduct_mixed(V):
     Q = FunctionSpace(mesh, "P", 2)
 
     W = V*Q
-    for (s_, s) in zip(W.split(), (V, Q)):
+    for (s_, s) in zip(W.subfunctions, (V, Q)):
         assert s_.node_set is s.node_set
         assert s_.dof_dset is s.dof_dset
 

--- a/tests/multigrid/test_nested_split.py
+++ b/tests/multigrid/test_nested_split.py
@@ -85,7 +85,7 @@ def test_nested_split_multigrid(parameters):
     F += inner(s, r)*dx - inner(x, r)*dx
 
     expect = Function(W)
-    u_expect, p_expect, s_expect = expect.split()
+    u_expect, p_expect, s_expect = expect.subfunctions()
 
     u_expect.interpolate(x**2 + y**2)
     p_expect.interpolate(sin(pi*x)*tan(pi*x*0.25)*sin(pi*y))
@@ -98,7 +98,7 @@ def test_nested_split_multigrid(parameters):
     solver = NonlinearVariationalSolver(problem, options_prefix="",
                                         solver_parameters=parameters)
     solver.solve()
-    u, p, s = w.split()
+    u, p, s = w.subfunctions()
 
     assert norm(assemble(u_expect - u)) < 5e-5
     assert norm(assemble(p_expect - p)) < 1e-6

--- a/tests/multigrid/test_nested_split.py
+++ b/tests/multigrid/test_nested_split.py
@@ -85,7 +85,7 @@ def test_nested_split_multigrid(parameters):
     F += inner(s, r)*dx - inner(x, r)*dx
 
     expect = Function(W)
-    u_expect, p_expect, s_expect = expect.subfunctions()
+    u_expect, p_expect, s_expect = expect.subfunctions
 
     u_expect.interpolate(x**2 + y**2)
     p_expect.interpolate(sin(pi*x)*tan(pi*x*0.25)*sin(pi*y))
@@ -98,7 +98,7 @@ def test_nested_split_multigrid(parameters):
     solver = NonlinearVariationalSolver(problem, options_prefix="",
                                         solver_parameters=parameters)
     solver.solve()
-    u, p, s = w.subfunctions()
+    u, p, s = w.subfunctions
 
     assert norm(assemble(u_expect - u)) < 5e-5
     assert norm(assemble(p_expect - p)) < 1e-6

--- a/tests/multigrid/test_poisson_gtmg.py
+++ b/tests/multigrid/test_poisson_gtmg.py
@@ -59,7 +59,7 @@ def run_gtmg_mixed_poisson():
               'coarse_space_bcs': get_p1_prb_bcs()}
 
     solve(a == L, w, solver_parameters=params, appctx=appctx)
-    _, uh = w.subfunctions()
+    _, uh = w.subfunctions
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))
@@ -135,7 +135,7 @@ def run_gtmg_scpc_mixed_poisson():
     bcs = DirichletBC(W.sub(2), Constant(0.0), "on_boundary")
 
     solve(a == L, w, bcs=bcs, solver_parameters=params, appctx=appctx)
-    _, uh, _ = w.subfunctions()
+    _, uh, _ = w.subfunctions
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))

--- a/tests/multigrid/test_poisson_gtmg.py
+++ b/tests/multigrid/test_poisson_gtmg.py
@@ -59,7 +59,7 @@ def run_gtmg_mixed_poisson():
               'coarse_space_bcs': get_p1_prb_bcs()}
 
     solve(a == L, w, solver_parameters=params, appctx=appctx)
-    _, uh = w.split()
+    _, uh = w.subfunctions()
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))
@@ -135,7 +135,7 @@ def run_gtmg_scpc_mixed_poisson():
     bcs = DirichletBC(W.sub(2), Constant(0.0), "on_boundary")
 
     solve(a == L, w, bcs=bcs, solver_parameters=params, appctx=appctx)
-    _, uh, _ = w.split()
+    _, uh, _ = w.subfunctions()
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))

--- a/tests/multigrid/test_two_poisson_gmg.py
+++ b/tests/multigrid/test_two_poisson_gmg.py
@@ -80,7 +80,7 @@ def run_two_poisson(typ):
     # eigenmode.  This stresses the preconditioner much more.  e.g. 10
     # iterations of ilu fails to converge this problem sufficiently.
     x = SpatialCoordinate(W.mesh())
-    for h in f.split():
+    for h in f.subfunctions():
         h.interpolate(-0.5*pi*pi*(4*cos(pi*x[0]) - 5*cos(pi*x[0]*0.5) + 2)*sin(pi*x[1]))
 
     problem = NonlinearVariationalProblem(F, u, bcs=bcs)
@@ -94,7 +94,7 @@ def run_two_poisson(typ):
     for exact in [exact_P2, exact_P1]:
         exact.interpolate(sin(pi*x[0])*tan(pi*x[0]*0.25)*sin(pi*x[1]))
 
-    sol_P2, sol_P1 = u.split()
+    sol_P2, sol_P1 = u.subfunctions()
     return norm(assemble(exact_P2 - sol_P2)), norm(assemble(exact_P1 - sol_P1))
 
 

--- a/tests/multigrid/test_two_poisson_gmg.py
+++ b/tests/multigrid/test_two_poisson_gmg.py
@@ -80,7 +80,7 @@ def run_two_poisson(typ):
     # eigenmode.  This stresses the preconditioner much more.  e.g. 10
     # iterations of ilu fails to converge this problem sufficiently.
     x = SpatialCoordinate(W.mesh())
-    for h in f.subfunctions():
+    for h in f.subfunctions:
         h.interpolate(-0.5*pi*pi*(4*cos(pi*x[0]) - 5*cos(pi*x[0]*0.5) + 2)*sin(pi*x[1]))
 
     problem = NonlinearVariationalProblem(F, u, bcs=bcs)
@@ -94,7 +94,7 @@ def run_two_poisson(typ):
     for exact in [exact_P2, exact_P1]:
         exact.interpolate(sin(pi*x[0])*tan(pi*x[0]*0.25)*sin(pi*x[1]))
 
-    sol_P2, sol_P1 = u.subfunctions()
+    sol_P2, sol_P1 = u.subfunctions
     return norm(assemble(exact_P2 - sol_P2)), norm(assemble(exact_P1 - sol_P1))
 
 

--- a/tests/output/test_adjoint_disk_checkpointing.py
+++ b/tests/output/test_adjoint_disk_checkpointing.py
@@ -32,7 +32,7 @@ def adjoint_example(mesh):
     # InterpolateBlock
     m = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
 
-    u, v = w.split()
+    u, v = w.subfunctions()
     # FunctionAssignBlock, FunctionMergeBlock
     v.assign(m)
     # FunctionSplitBlock, GenericSolveBlock

--- a/tests/output/test_adjoint_disk_checkpointing.py
+++ b/tests/output/test_adjoint_disk_checkpointing.py
@@ -32,7 +32,7 @@ def adjoint_example(mesh):
     # InterpolateBlock
     m = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
 
-    u, v = w.subfunctions()
+    u, v = w.subfunctions
     # FunctionAssignBlock, FunctionMergeBlock
     v.assign(m)
     # FunctionSplitBlock, GenericSolveBlock

--- a/tests/output/test_io_function.py
+++ b/tests/output/test_io_function.py
@@ -263,7 +263,7 @@ def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
     VA = functools.reduce(lambda a, b: a * b, VA_list)
     method = "project"
     fA = Function(VA, name=func_name)
-    fA0, fA1 = fA.split()
+    fA0, fA1 = fA.subfunctions()
     _initialise_function(fA0, _get_expr(VA[0]), method)
     fA1.dat.data.itemset(3.14)
     with CheckpointFile(filename, 'w', comm=COMM_WORLD) as afile:
@@ -279,7 +279,7 @@ def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
                 fB = afile.load_function(meshB, func_name)
             VB = fB.function_space()
             fBe = Function(VB)
-            fBe0, fBe1 = fBe.split()
+            fBe0, fBe1 = fBe.subfunctions()
             _initialise_function(fBe0, _get_expr(VB[0]), method)
             fBe1.dat.data.itemset(3.14)
             assert assemble(inner(fB - fBe, fB - fBe) * dx) < 1.e-16

--- a/tests/output/test_io_function.py
+++ b/tests/output/test_io_function.py
@@ -263,7 +263,7 @@ def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
     VA = functools.reduce(lambda a, b: a * b, VA_list)
     method = "project"
     fA = Function(VA, name=func_name)
-    fA0, fA1 = fA.subfunctions()
+    fA0, fA1 = fA.subfunctions
     _initialise_function(fA0, _get_expr(VA[0]), method)
     fA1.dat.data.itemset(3.14)
     with CheckpointFile(filename, 'w', comm=COMM_WORLD) as afile:
@@ -279,7 +279,7 @@ def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
                 fB = afile.load_function(meshB, func_name)
             VB = fB.function_space()
             fBe = Function(VB)
-            fBe0, fBe1 = fBe.subfunctions()
+            fBe0, fBe1 = fBe.subfunctions
             _initialise_function(fBe0, _get_expr(VB[0]), method)
             fBe1.dat.data.itemset(3.14)
             assert assemble(inner(fB - fBe, fB - fBe) * dx) < 1.e-16

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -41,7 +41,7 @@ def fs(request, mesh):
 @pytest.fixture
 def f(fs):
     f = Function(fs, name="f")
-    f_split = f.split()
+    f_split = f.subfunctions()
     x = SpatialCoordinate(fs.mesh())[0]
 
     # NOTE: interpolation of UFL expressions into mixed
@@ -61,7 +61,7 @@ def f(fs):
 @pytest.fixture
 def one(fs):
     one = Function(fs, name="one")
-    ones = one.split()
+    ones = one.subfunctions()
 
     # NOTE: interpolation of UFL expressions into mixed
     # function spaces is not yet implemented
@@ -87,7 +87,7 @@ def M(fs):
 def test_one_form(M, f):
     one_form = assemble(action(M, f))
     assert isinstance(one_form, Function)
-    for f in one_form.split():
+    for f in one_form.subfunctions():
         if f.function_space().rank == 2:
             assert abs(f.dat.data.sum() - 0.5*sum(f.function_space().shape)) < 1.0e-12
         else:

--- a/tests/regression/test_assemble.py
+++ b/tests/regression/test_assemble.py
@@ -41,7 +41,7 @@ def fs(request, mesh):
 @pytest.fixture
 def f(fs):
     f = Function(fs, name="f")
-    f_split = f.subfunctions()
+    f_split = f.subfunctions
     x = SpatialCoordinate(fs.mesh())[0]
 
     # NOTE: interpolation of UFL expressions into mixed
@@ -61,7 +61,7 @@ def f(fs):
 @pytest.fixture
 def one(fs):
     one = Function(fs, name="one")
-    ones = one.subfunctions()
+    ones = one.subfunctions
 
     # NOTE: interpolation of UFL expressions into mixed
     # function spaces is not yet implemented
@@ -87,7 +87,7 @@ def M(fs):
 def test_one_form(M, f):
     one_form = assemble(action(M, f))
     assert isinstance(one_form, Function)
-    for f in one_form.subfunctions():
+    for f in one_form.subfunctions:
         if f.function_space().rank == 2:
             assert abs(f.dat.data.sum() - 0.5*sum(f.function_space().shape)) < 1.0e-12
         else:

--- a/tests/regression/test_auxiliary_dm.py
+++ b/tests/regression/test_auxiliary_dm.py
@@ -131,7 +131,7 @@ def test_auxiliary_dm():
     solver.solve()
 
     # Error in L2 norm
-    (u, v, alpha) = z.split()
+    (u, v, alpha) = z.subfunctions()
     u_exact = problem.analytical_solution(mesh)
     error_L2 = errornorm(u_exact, u, 'L2') / errornorm(u_exact, Function(FunctionSpace(mesh, 'CG', 1)), 'L2')
     assert error_L2 < 0.02

--- a/tests/regression/test_auxiliary_dm.py
+++ b/tests/regression/test_auxiliary_dm.py
@@ -131,7 +131,7 @@ def test_auxiliary_dm():
     solver.solve()
 
     # Error in L2 norm
-    (u, v, alpha) = z.subfunctions()
+    (u, v, alpha) = z.subfunctions
     u_exact = problem.analytical_solution(mesh)
     error_L2 = errornorm(u_exact, u, 'L2') / errornorm(u_exact, Function(FunctionSpace(mesh, 'CG', 1)), 'L2')
     assert error_L2 < 0.02

--- a/tests/regression/test_ensembleparallelism.py
+++ b/tests/regression/test_ensembleparallelism.py
@@ -32,7 +32,7 @@ def function_profile(x, y, rank, cpt):
 def unique_function(mesh, rank, W):
     u = Function(W)
     x, y = SpatialCoordinate(mesh)
-    for cpt, v in enumerate(u.subfunctions()):
+    for cpt, v in enumerate(u.subfunctions):
         v.interpolate(function_profile(x, y, rank, cpt))
     return u
 

--- a/tests/regression/test_ensembleparallelism.py
+++ b/tests/regression/test_ensembleparallelism.py
@@ -32,7 +32,7 @@ def function_profile(x, y, rank, cpt):
 def unique_function(mesh, rank, W):
     u = Function(W)
     x, y = SpatialCoordinate(mesh)
-    for cpt, v in enumerate(u.split()):
+    for cpt, v in enumerate(u.subfunctions()):
         v.interpolate(function_profile(x, y, rank, cpt))
     return u
 

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -374,7 +374,7 @@ def test_assign_from_mfs_sub(cg1, vcg1):
     u = Function(cg1)
     v = Function(vcg1)
 
-    w1, w2 = w.subfunctions()
+    w1, w2 = w.subfunctions
 
     w1.assign(4)
     w2.assign(10)
@@ -389,7 +389,7 @@ def test_assign_from_mfs_sub(cg1, vcg1):
     Q = vcg1*cg1
     q = Function(Q)
 
-    q1, q2 = q.subfunctions()
+    q1, q2 = q.subfunctions
 
     q1.assign(11)
     q2.assign(12)
@@ -453,7 +453,7 @@ def test_assign_mixed_multiple_shaped():
     z2.dat[3].data[:] = [[15, 16], [17, 18]]
 
     q = assemble(z1 - z2)
-    for q, p1, p2 in zip(q.subfunctions(), z1.subfunctions(), z2.subfunctions()):
+    for q, p1, p2 in zip(q.subfunctions, z1.subfunctions, z2.subfunctions):
         assert np.allclose(q.dat.data_ro, p1.dat.data_ro - p2.dat.data_ro)
 
 

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -374,7 +374,7 @@ def test_assign_from_mfs_sub(cg1, vcg1):
     u = Function(cg1)
     v = Function(vcg1)
 
-    w1, w2 = w.split()
+    w1, w2 = w.subfunctions()
 
     w1.assign(4)
     w2.assign(10)
@@ -389,7 +389,7 @@ def test_assign_from_mfs_sub(cg1, vcg1):
     Q = vcg1*cg1
     q = Function(Q)
 
-    q1, q2 = q.split()
+    q1, q2 = q.subfunctions()
 
     q1.assign(11)
     q2.assign(12)
@@ -453,7 +453,7 @@ def test_assign_mixed_multiple_shaped():
     z2.dat[3].data[:] = [[15, 16], [17, 18]]
 
     q = assemble(z1 - z2)
-    for q, p1, p2 in zip(q.split(), z1.split(), z2.split()):
+    for q, p1, p2 in zip(q.subfunctions(), z1.subfunctions(), z2.subfunctions()):
         assert np.allclose(q.dat.data_ro, p1.dat.data_ro - p2.dat.data_ro)
 
 

--- a/tests/regression/test_fieldsplit_breadcrumbs.py
+++ b/tests/regression/test_fieldsplit_breadcrumbs.py
@@ -34,6 +34,6 @@ def test_fieldsplit_breadcrumbs():
         u_source.assign(g*i)
         solver.solve()
 
-        u, eta = solution.subfunctions()
+        u, eta = solution.subfunctions
         assert numpy.allclose(u.dat.data_ro, u_source.dat.data_ro)
         assert numpy.allclose(eta.dat.data_ro, 0)

--- a/tests/regression/test_fieldsplit_breadcrumbs.py
+++ b/tests/regression/test_fieldsplit_breadcrumbs.py
@@ -34,6 +34,6 @@ def test_fieldsplit_breadcrumbs():
         u_source.assign(g*i)
         solver.solve()
 
-        u, eta = solution.split()
+        u, eta = solution.subfunctions()
         assert numpy.allclose(u.dat.data_ro, u_source.dat.data_ro)
         assert numpy.allclose(eta.dat.data_ro, 0)

--- a/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
+++ b/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
@@ -94,11 +94,11 @@ def test_fieldsplit_fieldsplit_aux_multigrid():
                            "snes_monitor": None}
     nsp_guess = MixedVectorSpaceBasis(G, [G.sub(0), VectorSpaceBasis(constant=True)])
     solve(F_guess == 0, g, bcs=Gbcs, nullspace=nsp_guess, solver_parameters=solver_params_guess)
-    (u_guess, p_guess) = g.split()
-    z.split()[0].interpolate(Constant(gamma))
-    z.split()[1].assign(u_guess)
-    z.split()[2].assign(p_guess)
-    z.split()[3].interpolate(Constant(10))
+    (u_guess, p_guess) = g.subfunctions()
+    z.subfunctions()[0].interpolate(Constant(gamma))
+    z.subfunctions()[1].assign(u_guess)
+    z.subfunctions()[2].assign(p_guess)
+    z.subfunctions()[3].interpolate(Constant(10))
 
     solver_params = {
         "snes_monitor": None,

--- a/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
+++ b/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
@@ -94,11 +94,11 @@ def test_fieldsplit_fieldsplit_aux_multigrid():
                            "snes_monitor": None}
     nsp_guess = MixedVectorSpaceBasis(G, [G.sub(0), VectorSpaceBasis(constant=True)])
     solve(F_guess == 0, g, bcs=Gbcs, nullspace=nsp_guess, solver_parameters=solver_params_guess)
-    (u_guess, p_guess) = g.subfunctions()
-    z.subfunctions()[0].interpolate(Constant(gamma))
-    z.subfunctions()[1].assign(u_guess)
-    z.subfunctions()[2].assign(p_guess)
-    z.subfunctions()[3].interpolate(Constant(10))
+    (u_guess, p_guess) = g.subfunctions
+    z.subfunctions[0].interpolate(Constant(gamma))
+    z.subfunctions[1].assign(u_guess)
+    z.subfunctions[2].assign(p_guess)
+    z.subfunctions[3].interpolate(Constant(10))
 
     solver_params = {
         "snes_monitor": None,

--- a/tests/regression/test_fieldsplit_split_reorder_bcs.py
+++ b/tests/regression/test_fieldsplit_split_reorder_bcs.py
@@ -118,7 +118,7 @@ def run(solver, solution, permute):
     solver.solve()
     sol = solver._problem.u
     errors = tuple(errornorm(expect, actual, 'L2') for
-                   expect, actual in zip(solution, permute(*sol.subfunctions())))
+                   expect, actual in zip(solution, permute(*sol.subfunctions)))
     diff = numpy.abs(errors - numpy.asarray([0.02551217479,
                                              0.01991075140,
                                              0.22550499155,

--- a/tests/regression/test_fieldsplit_split_reorder_bcs.py
+++ b/tests/regression/test_fieldsplit_split_reorder_bcs.py
@@ -118,7 +118,7 @@ def run(solver, solution, permute):
     solver.solve()
     sol = solver._problem.u
     errors = tuple(errornorm(expect, actual, 'L2') for
-                   expect, actual in zip(solution, permute(*sol.split())))
+                   expect, actual in zip(solution, permute(*sol.subfunctions())))
     diff = numpy.abs(errors - numpy.asarray([0.02551217479,
                                              0.01991075140,
                                              0.22550499155,

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -80,14 +80,14 @@ def test_function_space_vector_function_space_differ(mesh):
 def test_indexed_function_space_index(fs):
     assert [s.index for s in fs] == list(range(2))
     # Create another mixed space in reverse order
-    fs0, fs1 = fs.subfunctions()
+    fs0, fs1 = fs.subfunctions
     assert [s.index for s in (fs1 * fs0)] == list(range(2))
     # Verify the indices of the original IndexedFunctionSpaces haven't changed
     assert fs0.index == 0 and fs1.index == 1
 
 
 def test_mixed_function_space_split(fs):
-    assert fs.subfunctions() == tuple(fs)
+    assert fs.subfunctions == tuple(fs)
 
 
 def test_function_space_collapse(cg1):

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -80,14 +80,14 @@ def test_function_space_vector_function_space_differ(mesh):
 def test_indexed_function_space_index(fs):
     assert [s.index for s in fs] == list(range(2))
     # Create another mixed space in reverse order
-    fs0, fs1 = fs.split()
+    fs0, fs1 = fs.subfunctions()
     assert [s.index for s in (fs1 * fs0)] == list(range(2))
     # Verify the indices of the original IndexedFunctionSpaces haven't changed
     assert fs0.index == 0 and fs1.index == 1
 
 
 def test_mixed_function_space_split(fs):
-    assert fs.split() == tuple(fs)
+    assert fs.subfunctions() == tuple(fs)
 
 
 def test_function_space_collapse(cg1):

--- a/tests/regression/test_helmholtz_sphere.py
+++ b/tests/regression/test_helmholtz_sphere.py
@@ -54,7 +54,7 @@ def run_helmholtz_mixed_sphere(MeshClass, r, meshd, eltd):
                                            'fieldsplit_0_ksp_type': 'cg',
                                            'fieldsplit_1_ksp_type': 'cg'})
 
-    _, u = soln.split()
+    _, u = soln.subfunctions()
     f.interpolate(x[0]*x[1]*x[2]/13.0)
     return errornorm(f, u, degree_rise=0)
 

--- a/tests/regression/test_helmholtz_sphere.py
+++ b/tests/regression/test_helmholtz_sphere.py
@@ -54,7 +54,7 @@ def run_helmholtz_mixed_sphere(MeshClass, r, meshd, eltd):
                                            'fieldsplit_0_ksp_type': 'cg',
                                            'fieldsplit_1_ksp_type': 'cg'})
 
-    _, u = soln.subfunctions()
+    _, u = soln.subfunctions
     f.interpolate(x[0]*x[1]*x[2]/13.0)
     return errornorm(f, u, degree_rise=0)
 

--- a/tests/regression/test_l2pullbacks.py
+++ b/tests/regression/test_l2pullbacks.py
@@ -88,7 +88,7 @@ def helmholtz_mixed(r, meshtype, family, hdegree, vdegree=None, meshd=None, usea
         f.project(sin(x[0]*pi*2)*sin(x[1]*pi*2))
         return sqrt(assemble(dot(sol[2] - f, sol[2] - f) * dx))
     elif meshtype in ['spherical-quad', 'spherical-tri']:
-        _, u = sol.subfunctions()
+        _, u = sol.subfunctions
         f.project(x[0]*x[1]*x[2]/13.0)
         return errornorm(f, u, degree_rise=0)
 

--- a/tests/regression/test_l2pullbacks.py
+++ b/tests/regression/test_l2pullbacks.py
@@ -88,7 +88,7 @@ def helmholtz_mixed(r, meshtype, family, hdegree, vdegree=None, meshd=None, usea
         f.project(sin(x[0]*pi*2)*sin(x[1]*pi*2))
         return sqrt(assemble(dot(sol[2] - f, sol[2] - f) * dx))
     elif meshtype in ['spherical-quad', 'spherical-tri']:
-        _, u = sol.split()
+        _, u = sol.subfunctions()
         f.project(x[0]*x[1]*x[2]/13.0)
         return errornorm(f, u, degree_rise=0)
 

--- a/tests/regression/test_manifolds.py
+++ b/tests/regression/test_manifolds.py
@@ -43,7 +43,7 @@ def run_no_manifold():
     solve(a == L, up, bcs=bc, nullspace=nullspace, solver_parameters=params)
     exact = Function(V1).interpolate(x[0] - 0.5)
 
-    u, p = up.split()
+    u, p = up.subfunctions()
     assert errornorm(exact, p, degree_rise=0) < 1e-8
 
 
@@ -85,7 +85,7 @@ def run_manifold():
     solve(a == L, up, bcs=bc, nullspace=nullspace, solver_parameters=params)
     exact = Function(V1).interpolate(x_n[0] - 0.5)
 
-    u, p = up.split()
+    u, p = up.subfunctions()
     assert errornorm(exact, p, degree_rise=0) < 1e-8
 
 

--- a/tests/regression/test_manifolds.py
+++ b/tests/regression/test_manifolds.py
@@ -43,7 +43,7 @@ def run_no_manifold():
     solve(a == L, up, bcs=bc, nullspace=nullspace, solver_parameters=params)
     exact = Function(V1).interpolate(x[0] - 0.5)
 
-    u, p = up.subfunctions()
+    u, p = up.subfunctions
     assert errornorm(exact, p, degree_rise=0) < 1e-8
 
 
@@ -85,7 +85,7 @@ def run_manifold():
     solve(a == L, up, bcs=bc, nullspace=nullspace, solver_parameters=params)
     exact = Function(V1).interpolate(x_n[0] - 0.5)
 
-    u, p = up.subfunctions()
+    u, p = up.subfunctions
     assert errornorm(exact, p, degree_rise=0) < 1e-8
 
 

--- a/tests/regression/test_mixed_interior_facets.py
+++ b/tests/regression/test_mixed_interior_facets.py
@@ -35,7 +35,7 @@ def test_mfs(mesh2D):
     W = V3 * V1 * V2
 
     u = Function(W)
-    u0, u1, u2 = u.subfunctions()
+    u0, u1, u2 = u.subfunctions
     u0.interpolate(Constant(1))
     u1.project(Constant((-1.0, -1.0)))
     u2.interpolate(Constant(1))

--- a/tests/regression/test_mixed_interior_facets.py
+++ b/tests/regression/test_mixed_interior_facets.py
@@ -35,7 +35,7 @@ def test_mfs(mesh2D):
     W = V3 * V1 * V2
 
     u = Function(W)
-    u0, u1, u2 = u.split()
+    u0, u1, u2 = u.subfunctions()
     u0.interpolate(Constant(1))
     u1.project(Constant((-1.0, -1.0)))
     u2.interpolate(Constant(1))

--- a/tests/regression/test_mixed_tensor.py
+++ b/tests/regression/test_mixed_tensor.py
@@ -21,7 +21,7 @@ def test_mass_mixed_tensor(W):
 
     a = (inner(u, v) + inner(p, q) + inner(s, t))*dx
 
-    V, Q, T = W.split()
+    V, Q, T = W.subfunctions()
 
     u = TrialFunction(V)
     v = TestFunction(V)

--- a/tests/regression/test_mixed_tensor.py
+++ b/tests/regression/test_mixed_tensor.py
@@ -21,7 +21,7 @@ def test_mass_mixed_tensor(W):
 
     a = (inner(u, v) + inner(p, q) + inner(s, t))*dx
 
-    V, Q, T = W.subfunctions()
+    V, Q, T = W.subfunctions
 
     u = TrialFunction(V)
     v = TestFunction(V)

--- a/tests/regression/test_moore_spence.py
+++ b/tests/regression/test_moore_spence.py
@@ -58,9 +58,9 @@ def test_moore_spence():
 
     # Set initial guesses for state, parameter, null eigenmode
     z = Function(Z)
-    z.subfunctions()[0].assign(th)
-    z.subfunctions()[1].assign(lm)
-    z.subfunctions()[2].assign(eigenmode)
+    z.subfunctions[0].assign(th)
+    z.subfunctions[1].assign(lm)
+    z.subfunctions[2].assign(eigenmode)
 
     # Write Moore-Spence system of equations
     theta, lmbda, phi = split(z)

--- a/tests/regression/test_moore_spence.py
+++ b/tests/regression/test_moore_spence.py
@@ -58,9 +58,9 @@ def test_moore_spence():
 
     # Set initial guesses for state, parameter, null eigenmode
     z = Function(Z)
-    z.split()[0].assign(th)
-    z.split()[1].assign(lm)
-    z.split()[2].assign(eigenmode)
+    z.subfunctions()[0].assign(th)
+    z.subfunctions()[1].assign(lm)
+    z.subfunctions()[2].assign(eigenmode)
 
     # Write Moore-Spence system of equations
     theta, lmbda, phi = split(z)

--- a/tests/regression/test_mtw.py
+++ b/tests/regression/test_mtw.py
@@ -61,7 +61,7 @@ def test_mtw():
 
         solve(F == 0, up, solver_parameters=params)
 
-        u, p = up.split()
+        u, p = up.subfunctions()
         l2_u.append(errornorm(uex, u))
         l2_p.append(errornorm(pex, p))
 

--- a/tests/regression/test_mtw.py
+++ b/tests/regression/test_mtw.py
@@ -61,7 +61,7 @@ def test_mtw():
 
         solve(F == 0, up, solver_parameters=params)
 
-        u, p = up.subfunctions()
+        u, p = up.subfunctions
         l2_u.append(errornorm(uex, u))
         l2_p.append(errornorm(pex, p))
 

--- a/tests/regression/test_nonlinear_stokes_hdiv.py
+++ b/tests/regression/test_nonlinear_stokes_hdiv.py
@@ -92,7 +92,7 @@ def test_nonlinear_stokes_hdiv():
 
     solve(F == 0, w, bcs=bcs, solver_parameters=params)
 
-    u, p = w.subfunctions()
+    u, p = w.subfunctions
 
     # test for penetration on bottom
     assert sqrt(assemble(dot(u, n)**2*ds(3))) < 1e-14

--- a/tests/regression/test_nonlinear_stokes_hdiv.py
+++ b/tests/regression/test_nonlinear_stokes_hdiv.py
@@ -92,7 +92,7 @@ def test_nonlinear_stokes_hdiv():
 
     solve(F == 0, w, bcs=bcs, solver_parameters=params)
 
-    u, p = w.split()
+    u, p = w.subfunctions()
 
     # test for penetration on bottom
     assert sqrt(assemble(dot(u, n)**2*ds(3))) < 1e-14

--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -126,7 +126,7 @@ def test_nullspace_mixed():
     exact = Function(DG)
     exact.interpolate(x[1] - 0.5)
 
-    sigma, u = w.split()
+    sigma, u = w.subfunctions()
     assert sqrt(assemble(inner((u - exact), (u - exact))*dx)) < 1e-7
 
     # Now using a Schur complement
@@ -141,7 +141,7 @@ def test_nullspace_mixed():
                              'fieldsplit_1_ksp_type': 'cg',
                              'fieldsplit_1_pc_type': 'none'})
 
-    sigma, u = w.split()
+    sigma, u = w.subfunctions()
     assert sqrt(assemble(inner((u - exact), (u - exact))*dx)) < 5e-8
 
 
@@ -313,13 +313,13 @@ def test_near_nullspace_mixed():
     bcs = [DirichletBC(W[0].sub(0), 0, (1, 2)), DirichletBC(W[0].sub(1), 0, (3, 4))]
 
     rotW = Function(W)
-    rotV, _ = rotW.split()
+    rotV, _ = rotW.subfunctions()
     rotV.interpolate(as_vector((-y, x)))
 
     c0 = Function(W)
-    c0V, _ = c0.split()
+    c0V, _ = c0.subfunctions()
     c1 = Function(W)
-    c1V, _ = c1.split()
+    c1V, _ = c1.subfunctions()
     c0V.interpolate(Constant([1., 0.]))
     c1V.interpolate(Constant([0., 1.]))
 

--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -126,7 +126,7 @@ def test_nullspace_mixed():
     exact = Function(DG)
     exact.interpolate(x[1] - 0.5)
 
-    sigma, u = w.subfunctions()
+    sigma, u = w.subfunctions
     assert sqrt(assemble(inner((u - exact), (u - exact))*dx)) < 1e-7
 
     # Now using a Schur complement
@@ -141,7 +141,7 @@ def test_nullspace_mixed():
                              'fieldsplit_1_ksp_type': 'cg',
                              'fieldsplit_1_pc_type': 'none'})
 
-    sigma, u = w.subfunctions()
+    sigma, u = w.subfunctions
     assert sqrt(assemble(inner((u - exact), (u - exact))*dx)) < 5e-8
 
 
@@ -313,13 +313,13 @@ def test_near_nullspace_mixed():
     bcs = [DirichletBC(W[0].sub(0), 0, (1, 2)), DirichletBC(W[0].sub(1), 0, (3, 4))]
 
     rotW = Function(W)
-    rotV, _ = rotW.subfunctions()
+    rotV, _ = rotW.subfunctions
     rotV.interpolate(as_vector((-y, x)))
 
     c0 = Function(W)
-    c0V, _ = c0.subfunctions()
+    c0V, _ = c0.subfunctions
     c1 = Function(W)
-    c1V, _ = c1.subfunctions()
+    c1V, _ = c1.subfunctions
     c0V.interpolate(Constant([1., 0.]))
     c1V.interpolate(Constant([0., 1.]))
 

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -66,7 +66,7 @@ def test_mixed_direct_par_loop(f_mixed):
         """
         par_loop((domain, instructions), direct, {'c': (f_mixed, WRITE)},
                  is_loopy_kernel=True)
-        assert all(np.allclose(f.dat.data, 1.0) for f in f_mixed.subfunctions())
+        assert all(np.allclose(f.dat.data, 1.0) for f in f_mixed.subfunctions)
 
 
 @pytest.mark.parametrize('idx', [0, 1])
@@ -123,7 +123,7 @@ def test_indirect_par_loop_read_const_mixed(f_mixed, const):
         """
         par_loop((domain, instructions), dx, {'d': (f_mixed, WRITE), 'constant': (const, READ)},
                  is_loopy_kernel=True)
-        assert all(np.allclose(f.dat.data, const.dat.data) for f in f_mixed.subfunctions())
+        assert all(np.allclose(f.dat.data, const.dat.data) for f in f_mixed.subfunctions)
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -66,7 +66,7 @@ def test_mixed_direct_par_loop(f_mixed):
         """
         par_loop((domain, instructions), direct, {'c': (f_mixed, WRITE)},
                  is_loopy_kernel=True)
-        assert all(np.allclose(f.dat.data, 1.0) for f in f_mixed.split())
+        assert all(np.allclose(f.dat.data, 1.0) for f in f_mixed.subfunctions())
 
 
 @pytest.mark.parametrize('idx', [0, 1])
@@ -123,7 +123,7 @@ def test_indirect_par_loop_read_const_mixed(f_mixed, const):
         """
         par_loop((domain, instructions), dx, {'d': (f_mixed, WRITE), 'constant': (const, READ)},
                  is_loopy_kernel=True)
-        assert all(np.allclose(f.dat.data, const.dat.data) for f in f_mixed.split())
+        assert all(np.allclose(f.dat.data, const.dat.data) for f in f_mixed.subfunctions())
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -53,7 +53,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         a = (inner(f[i], f[i]) * inner(grad(u), grad(v)))*dx
         L = inner(Constant(rhs), v)*dx
         bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape()), "on_boundary")
-               for Q in V.subfunctions()]
+               for Q in V.subfunctions]
     else:
         a = inner(grad(u), grad(v))*dx
         L = inner(Constant(rhs), v)*dx

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -53,7 +53,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         a = (inner(f[i], f[i]) * inner(grad(u), grad(v)))*dx
         L = inner(Constant(rhs), v)*dx
         bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape()), "on_boundary")
-               for Q in V.split()]
+               for Q in V.subfunctions()]
     else:
         a = inner(grad(u), grad(v))*dx
         L = inner(Constant(rhs), v)*dx

--- a/tests/regression/test_piola_mixed_fn.py
+++ b/tests/regression/test_piola_mixed_fn.py
@@ -34,7 +34,7 @@ def test_sphere_project():
     W = U1*U2*U3
 
     f = Function(W)
-    f1, f2, f3 = f.subfunctions()
+    f1, f2, f3 = f.subfunctions
     f1.assign(1)
     f2.assign(2)
     f3.assign(3)

--- a/tests/regression/test_piola_mixed_fn.py
+++ b/tests/regression/test_piola_mixed_fn.py
@@ -34,7 +34,7 @@ def test_sphere_project():
     W = U1*U2*U3
 
     f = Function(W)
-    f1, f2, f3 = f.split()
+    f1, f2, f3 = f.subfunctions()
     f1.assign(1)
     f2.assign(2)
     f3.assign(3)

--- a/tests/regression/test_point_eval_api.py
+++ b/tests/regression/test_point_eval_api.py
@@ -118,7 +118,7 @@ def test_dont_raise_mixed():
     V2 = FunctionSpace(mesh, "RT", 2)
     V = V1 * V2
     f = Function(V)
-    f1, f2 = f.subfunctions()
+    f1, f2 = f.subfunctions
     x = SpatialCoordinate(mesh)
     f1.interpolate(x[0] + 1.2*x[1])
     f2.project(as_vector((x[1], 0.8 + x[0])))

--- a/tests/regression/test_point_eval_api.py
+++ b/tests/regression/test_point_eval_api.py
@@ -118,7 +118,7 @@ def test_dont_raise_mixed():
     V2 = FunctionSpace(mesh, "RT", 2)
     V = V1 * V2
     f = Function(V)
-    f1, f2 = f.split()
+    f1, f2 = f.subfunctions()
     x = SpatialCoordinate(mesh)
     f1.interpolate(x[0] + 1.2*x[1])
     f2.project(as_vector((x[1], 0.8 + x[0])))

--- a/tests/regression/test_point_eval_fs.py
+++ b/tests/regression/test_point_eval_fs.py
@@ -111,7 +111,7 @@ def test_triangle_mixed(mesh_triangle):
     V2 = FunctionSpace(mesh_triangle, "RT", 2)
     V = V1 * V2
     f = Function(V)
-    f1, f2 = f.split()
+    f1, f2 = f.subfunctions()
     x = SpatialCoordinate(mesh_triangle)
     f1.interpolate(x[0] + 1.2*x[1])
     f2.project(as_vector((x[1], 0.8 + x[0])))

--- a/tests/regression/test_point_eval_fs.py
+++ b/tests/regression/test_point_eval_fs.py
@@ -111,7 +111,7 @@ def test_triangle_mixed(mesh_triangle):
     V2 = FunctionSpace(mesh_triangle, "RT", 2)
     V = V1 * V2
     f = Function(V)
-    f1, f2 = f.subfunctions()
+    f1, f2 = f.subfunctions
     x = SpatialCoordinate(mesh_triangle)
     f1.interpolate(x[0] + 1.2*x[1])
     f2.project(as_vector((x[1], 0.8 + x[0])))

--- a/tests/regression/test_poisson_mixed_no_bcs.py
+++ b/tests/regression/test_poisson_mixed_no_bcs.py
@@ -55,7 +55,7 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
     # Compute solution
     w = Function(W)
     solve(a == L, w, solver_parameters=parameters)
-    sigma, u = w.split()
+    sigma, u = w.subfunctions()
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))

--- a/tests/regression/test_poisson_mixed_no_bcs.py
+++ b/tests/regression/test_poisson_mixed_no_bcs.py
@@ -55,7 +55,7 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
     # Compute solution
     w = Function(W)
     solve(a == L, w, solver_parameters=parameters)
-    sigma, u = w.subfunctions()
+    sigma, u = w.subfunctions
 
     # Analytical solution
     f.interpolate(x[0]*(1-x[0])*x[1]*(1-x[1]))

--- a/tests/regression/test_poisson_mixed_strong_bcs.py
+++ b/tests/regression/test_poisson_mixed_strong_bcs.py
@@ -55,7 +55,7 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
     # Compute solution
     w = Function(W)
     solve(a == L, w, bcs=bcs, solver_parameters=parameters)
-    sigma, u = w.subfunctions()
+    sigma, u = w.subfunctions
 
     # Analytical solution
     f.interpolate(42*x[1])

--- a/tests/regression/test_poisson_mixed_strong_bcs.py
+++ b/tests/regression/test_poisson_mixed_strong_bcs.py
@@ -55,7 +55,7 @@ def poisson_mixed(size, parameters={}, quadrilateral=False):
     # Compute solution
     w = Function(W)
     solve(a == L, w, bcs=bcs, solver_parameters=parameters)
-    sigma, u = w.split()
+    sigma, u = w.subfunctions()
 
     # Analytical solution
     f.interpolate(42*x[1])

--- a/tests/regression/test_poisson_sphere.py
+++ b/tests/regression/test_poisson_sphere.py
@@ -35,7 +35,7 @@ def run_hdiv_l2(MeshClass, refinement, hdiv_space, degree):
                                                              'pc_fieldsplit_schur_fact_type': 'FULL',
                                                              'fieldsplit_0_ksp_max_it': 100})
 
-    sigma, u = w.split()
+    sigma, u = w.subfunctions()
 
     L2_error_u = errornorm(u_exact, u, degree_rise=1)
 

--- a/tests/regression/test_poisson_sphere.py
+++ b/tests/regression/test_poisson_sphere.py
@@ -35,7 +35,7 @@ def run_hdiv_l2(MeshClass, refinement, hdiv_space, degree):
                                                              'pc_fieldsplit_schur_fact_type': 'FULL',
                                                              'fieldsplit_0_ksp_max_it': 100})
 
-    sigma, u = w.subfunctions()
+    sigma, u = w.subfunctions
 
     L2_error_u = errornorm(u_exact, u, degree_rise=1)
 

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -228,7 +228,7 @@ def test_mixed_projector(mat_type):
     xs = SpatialCoordinate(m)
 
     v = Function(Vc)
-    v0, v1 = v.split()  # sub_functions
+    v0, v1 = v.subfunctions
     v0.interpolate(xs[0]*xs[1] + cos(xs[0]+xs[1]))
     v1.interpolate(xs[0]*xs[1] + sin(xs[0]+xs[1]))
     mass1 = assemble(sum(split(v))*dx)

--- a/tests/regression/test_real_space.py
+++ b/tests/regression/test_real_space.py
@@ -161,7 +161,7 @@ def test_real_mixed_solve():
         f = Function(mfs)
         x = SpatialCoordinate(mesh)
 
-        f0, _ = f.subfunctions()
+        f0, _ = f.subfunctions
 
         f0.interpolate(cos(x[0]))
 
@@ -194,7 +194,7 @@ def test_real_mixed_solve_split_comms():
         f = Function(mfs)
         x = SpatialCoordinate(mesh)
 
-        f0, _ = f.subfunctions()
+        f0, _ = f.subfunctions
 
         f0.interpolate(cos(x[0]))
 
@@ -230,7 +230,7 @@ def test_real_space_mixed_assign():
 
     f = Function(W)
 
-    q, v = f.subfunctions()
+    q, v = f.subfunctions
 
     q.assign(2)
     g = Function(V)

--- a/tests/regression/test_real_space.py
+++ b/tests/regression/test_real_space.py
@@ -161,7 +161,7 @@ def test_real_mixed_solve():
         f = Function(mfs)
         x = SpatialCoordinate(mesh)
 
-        f0, _ = f.split()
+        f0, _ = f.subfunctions()
 
         f0.interpolate(cos(x[0]))
 
@@ -194,7 +194,7 @@ def test_real_mixed_solve_split_comms():
         f = Function(mfs)
         x = SpatialCoordinate(mesh)
 
-        f0, _ = f.split()
+        f0, _ = f.subfunctions()
 
         f0.interpolate(cos(x[0]))
 
@@ -230,7 +230,7 @@ def test_real_space_mixed_assign():
 
     f = Function(W)
 
-    q, v = f.split()
+    q, v = f.subfunctions()
 
     q.assign(2)
     g = Function(V)

--- a/tests/regression/test_split.py
+++ b/tests/regression/test_split.py
@@ -28,7 +28,7 @@ def test_function_split_raises():
 
     f = Function(W)
 
-    u, p = f.split()
+    u, p = f.subfunctions()
 
     phi = u*dx + p*dx
 
@@ -45,7 +45,7 @@ def test_split_function_derivative():
 
     f = Function(W)
 
-    u, p = f.split()
+    u, p = f.subfunctions()
 
     f.assign(1)
 

--- a/tests/regression/test_split.py
+++ b/tests/regression/test_split.py
@@ -28,7 +28,7 @@ def test_function_split_raises():
 
     f = Function(W)
 
-    u, p = f.subfunctions()
+    u, p = f.subfunctions
 
     phi = u*dx + p*dx
 
@@ -45,7 +45,7 @@ def test_split_function_derivative():
 
     f = Function(W)
 
-    u, p = f.subfunctions()
+    u, p = f.subfunctions
 
     f.assign(1)
 

--- a/tests/regression/test_stokes_hdiv_parallel.py
+++ b/tests/regression/test_stokes_hdiv_parallel.py
@@ -117,7 +117,7 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
         solve(a == L, UP, bcs=bcs, nullspace=nullspace, solver_parameters=parameters,
               appctx=appctx)
 
-        u, p = UP.subfunctions()
+        u, p = UP.subfunctions
         u_error = u - u_exact
         p_error = p - p_exact
         err_u.append(sqrt(abs(assemble(inner(u_error, u_error) * dx))))

--- a/tests/regression/test_stokes_hdiv_parallel.py
+++ b/tests/regression/test_stokes_hdiv_parallel.py
@@ -117,7 +117,7 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
         solve(a == L, UP, bcs=bcs, nullspace=nullspace, solver_parameters=parameters,
               appctx=appctx)
 
-        u, p = UP.split()
+        u, p = UP.subfunctions()
         u_error = u - u_exact
         p_error = p - p_exact
         err_u.append(sqrt(abs(assemble(inner(u_error, u_error) * dx))))

--- a/tests/regression/test_stokes_mini.py
+++ b/tests/regression/test_stokes_mini.py
@@ -40,7 +40,7 @@ def run_stokes_mini(mat_type, n):
 
     w = Function(W)
 
-    u, p = w.subfunctions()
+    u, p = w.subfunctions
 
     solve(a == L, w, bcs=bcs,
           solver_parameters={'pc_type': 'fieldsplit',

--- a/tests/regression/test_stokes_mini.py
+++ b/tests/regression/test_stokes_mini.py
@@ -40,7 +40,7 @@ def run_stokes_mini(mat_type, n):
 
     w = Function(W)
 
-    u, p = w.split()
+    u, p = w.subfunctions()
 
     solve(a == L, w, bcs=bcs,
           solver_parameters={'pc_type': 'fieldsplit',

--- a/tests/regression/test_vector_laplace_on_quadrilaterals.py
+++ b/tests/regression/test_vector_laplace_on_quadrilaterals.py
@@ -46,7 +46,7 @@ def vector_laplace(n, degree):
                              'fieldsplit_1_pc_type': 'lu',
                              'ksp_monitor': None})
 
-    out_s, out_u = out.subfunctions()
+    out_s, out_u = out.subfunctions
 
     return (sqrt(assemble(inner(out_u - exact_u, out_u - exact_u) * dx)),
             sqrt(assemble(inner(out_s - exact_s, out_s - exact_s) * dx)))

--- a/tests/regression/test_vector_laplace_on_quadrilaterals.py
+++ b/tests/regression/test_vector_laplace_on_quadrilaterals.py
@@ -46,7 +46,7 @@ def vector_laplace(n, degree):
                              'fieldsplit_1_pc_type': 'lu',
                              'ksp_monitor': None})
 
-    out_s, out_u = out.split()
+    out_s, out_u = out.subfunctions()
 
     return (sqrt(assemble(inner(out_u - exact_u, out_u - exact_u) * dx)),
             sqrt(assemble(inner(out_s - exact_s, out_s - exact_s) * dx)))

--- a/tests/regression/test_vfs_component_bcs.py
+++ b/tests/regression/test_vfs_component_bcs.py
@@ -129,7 +129,7 @@ def test_poisson_in_mixed_plus_vfs_components(V, mat_type, make_val):
 
     expected = Function(W)
 
-    u, p, r = expected.split()
+    u, p, r = expected.subfunctions()
 
     x = SpatialCoordinate(V.mesh())
     u.interpolate(as_vector((42*x[0], 5*x[1] + 10)))
@@ -189,7 +189,7 @@ def test_stokes_component_all():
     Ucmp = Function(W)
     solve(a == L, Ucmp, bcs=bcs_cmp, solver_parameters=params)
 
-    for a, b in zip(Uall.split(), Ucmp.split()):
+    for a, b in zip(Uall.subfunctions(), Ucmp.subfunctions()):
         assert np.allclose(a.dat.data_ro, b.dat.data_ro)
 
 

--- a/tests/regression/test_vfs_component_bcs.py
+++ b/tests/regression/test_vfs_component_bcs.py
@@ -129,7 +129,7 @@ def test_poisson_in_mixed_plus_vfs_components(V, mat_type, make_val):
 
     expected = Function(W)
 
-    u, p, r = expected.subfunctions()
+    u, p, r = expected.subfunctions
 
     x = SpatialCoordinate(V.mesh())
     u.interpolate(as_vector((42*x[0], 5*x[1] + 10)))
@@ -189,7 +189,7 @@ def test_stokes_component_all():
     Ucmp = Function(W)
     solve(a == L, Ucmp, bcs=bcs_cmp, solver_parameters=params)
 
-    for a, b in zip(Uall.subfunctions(), Ucmp.subfunctions()):
+    for a, b in zip(Uall.subfunctions, Ucmp.subfunctions):
         assert np.allclose(a.dat.data_ro, b.dat.data_ro)
 
 

--- a/tests/slate/test_assemble_tensors.py
+++ b/tests/slate/test_assemble_tensors.py
@@ -35,7 +35,7 @@ def function_space(request, mesh):
 def f(function_space):
     """Generate a Firedrake function given a particular function space."""
     f = Function(function_space)
-    f_split = f.split()
+    f_split = f.subfunctions
     x = SpatialCoordinate(function_space.mesh())
 
     # NOTE: interpolation of UFL expressions into mixed
@@ -56,7 +56,7 @@ def f(function_space):
 def g(function_space):
     """Generates a Firedrake function given a particular function space."""
     g = Function(function_space)
-    g_split = g.split()
+    g_split = g.subfunctions
     x = SpatialCoordinate(function_space.mesh())
 
     # NOTE: interpolation of UFL expressions into mixed
@@ -169,7 +169,7 @@ def test_mixed_coefficient_scalar(mesh):
     V = FunctionSpace(mesh, "DG", 0)
     W = V * V
     f = Function(W)
-    g, h = f.split()
+    g, h = f.subfunctions
     f.assign(1)
     assert np.allclose(assemble(Tensor((g + f[0] + h + f[1])*dx)), 4.0)
 

--- a/tests/slate/test_darcy_hybridized_mixed.py
+++ b/tests/slate/test_darcy_hybridized_mixed.py
@@ -43,7 +43,7 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
                      'hybridization': {'ksp_type': 'preonly',
                                        'pc_type': 'lu'}}
     solve(a == L, w, bcs=bcs, solver_parameters=hybrid_params)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     w2 = Function(W)
     sc_params = {'mat_type': 'aij',
@@ -51,7 +51,7 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
                  'pc_type': 'lu',
                  'pc_factor_mat_solver_type': 'mumps'}
     solve(a == L, w2, bcs=bcs, solver_parameters=sc_params)
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)

--- a/tests/slate/test_darcy_hybridized_mixed.py
+++ b/tests/slate/test_darcy_hybridized_mixed.py
@@ -43,7 +43,7 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
                      'hybridization': {'ksp_type': 'preonly',
                                        'pc_type': 'lu'}}
     solve(a == L, w, bcs=bcs, solver_parameters=hybrid_params)
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     w2 = Function(W)
     sc_params = {'mat_type': 'aij',
@@ -51,7 +51,7 @@ def test_darcy_flow_hybridization(degree, hdiv_family):
                  'pc_type': 'lu',
                  'pc_factor_mat_solver_type': 'mumps'}
     solve(a == L, w2, bcs=bcs, solver_parameters=sc_params)
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)

--- a/tests/slate/test_hdg_poisson.py
+++ b/tests/slate/test_hdg_poisson.py
@@ -85,7 +85,7 @@ def run_LDG_H_problem(r, degree, quads=False):
     solver.solve()
 
     # Computed flux, scalar, and trace
-    q_h, u_h, uhat_h = s.split()
+    q_h, u_h, uhat_h = s.subfunctions()
 
     scalar_error = errornorm(a_scalar, u_h, norm_type="L2")
     flux_error = errornorm(a_flux, q_h, norm_type="L2")

--- a/tests/slate/test_hdg_poisson.py
+++ b/tests/slate/test_hdg_poisson.py
@@ -85,7 +85,7 @@ def run_LDG_H_problem(r, degree, quads=False):
     solver.solve()
 
     # Computed flux, scalar, and trace
-    q_h, u_h, uhat_h = s.subfunctions()
+    q_h, u_h, uhat_h = s.subfunctions
 
     scalar_error = errornorm(a_scalar, u_h, norm_type="L2")
     flux_error = errornorm(a_flux, q_h, norm_type="L2")

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -41,7 +41,7 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
 
     appctx = {'trace_nullspace': nullspace_basis}
     solve(a == L, w, solver_parameters=params, appctx=appctx)
-    u_h, _ = w.subfunctions()
+    u_h, _ = w.subfunctions
     error = errornorm(u_exact, u_h)
     return error
 

--- a/tests/slate/test_hybrid_poisson_sphere.py
+++ b/tests/slate/test_hybrid_poisson_sphere.py
@@ -41,7 +41,7 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
 
     appctx = {'trace_nullspace': nullspace_basis}
     solve(a == L, w, solver_parameters=params, appctx=appctx)
-    u_h, _ = w.split()
+    u_h, _ = w.subfunctions()
     error = errornorm(u_exact, u_h)
     return error
 

--- a/tests/slate/test_matrix_free_hybridization.py
+++ b/tests/slate/test_matrix_free_hybridization.py
@@ -35,7 +35,7 @@ def test_matrix_free_hybridization():
                                         'ksp_rtol': 1e-8,
                                         'mat_type': 'matfree'}}
     solve(a == L, w, bcs=bcs, solver_parameters=matfree_params)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     w2 = Function(W)
     aij_params = {'mat_type': 'matfree',
@@ -47,7 +47,7 @@ def test_matrix_free_hybridization():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'aij'}}
     solve(a == L, w2, bcs=bcs, solver_parameters=aij_params)
-    _sigma, _u = w2.split()
+    _sigma, _u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)

--- a/tests/slate/test_matrix_free_hybridization.py
+++ b/tests/slate/test_matrix_free_hybridization.py
@@ -35,7 +35,7 @@ def test_matrix_free_hybridization():
                                         'ksp_rtol': 1e-8,
                                         'mat_type': 'matfree'}}
     solve(a == L, w, bcs=bcs, solver_parameters=matfree_params)
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     w2 = Function(W)
     aij_params = {'mat_type': 'matfree',
@@ -47,7 +47,7 @@ def test_matrix_free_hybridization():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'aij'}}
     solve(a == L, w2, bcs=bcs, solver_parameters=aij_params)
-    _sigma, _u = w2.subfunctions()
+    _sigma, _u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -63,7 +63,7 @@ def setup_poisson_3D():
     W = V * U
     sigma, u = TrialFunctions(W)
     tau, v = TestFunctions(W)
-    V, U = W.split()
+    V, U = W.subfunctions()
     f = Function(U)
     x, y, z = SpatialCoordinate(mesh)
     expr = (1+12*pi*pi)*cos(100*pi*x)*cos(100*pi*y)*cos(100*pi*z)
@@ -109,7 +109,7 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
               'hybridization': {'ksp_type': 'preonly',
                                 'pc_type': 'lu'}}
     solve(a == L, w, solver_parameters=params)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # (Non-hybrid) Need to slam it with preconditioning due to the
     # system's indefiniteness
@@ -122,7 +122,7 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
                              'pc_fieldsplit_schur_fact_type': 'FULL',
                              'fieldsplit_0_ksp_type': 'cg',
                              'fieldsplit_1_ksp_type': 'cg'})
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -186,7 +186,7 @@ def test_slate_hybridization_nested_schur():
                 'preonly_Shat': False, 'jacobi_Shat': False}
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     w2 = Function(W)
     solve(a == L, w2, solver_parameters={'ksp_type': 'preonly',
@@ -195,7 +195,7 @@ def test_slate_hybridization_nested_schur():
                                          'pc_python_type': 'firedrake.HybridizationPC',
                                          'hybridization': {'ksp_type': 'preonly',
                                                            'pc_type': 'lu'}})
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -289,7 +289,7 @@ def test_mixed_poisson_approximated_schur():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # setup second solver
     w2 = Function(W)
@@ -302,7 +302,7 @@ def test_mixed_poisson_approximated_schur():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'matfree'}}
     solve(a == L, w2, solver_parameters=aij_params)
-    _sigma, _u = w2.split()
+    _sigma, _u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)
@@ -354,7 +354,7 @@ def test_slate_hybridization_jacobi_prec_A00():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # setup second solver
     w2 = Function(W)
@@ -367,7 +367,7 @@ def test_slate_hybridization_jacobi_prec_A00():
                                                'pc_type': 'none',
                                                'ksp_rtol': 1e-8,
                                                'mat_type': 'matfree'}})
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -418,7 +418,7 @@ def test_slate_hybridization_jacobi_prec_schur():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # setup second solver
     w2 = Function(W)
@@ -431,7 +431,7 @@ def test_slate_hybridization_jacobi_prec_schur():
                                                'pc_type': 'none',
                                                'ksp_rtol': 1e-8,
                                                'mat_type': 'matfree'}})
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -484,7 +484,7 @@ def test_mixed_poisson_approximated_schur_jacobi_prec():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # setup second solver
     w2 = Function(W)
@@ -497,7 +497,7 @@ def test_mixed_poisson_approximated_schur_jacobi_prec():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'matfree'}}
     solve(a == L, w2, solver_parameters=aij_params)
-    _sigma, _u = w2.split()
+    _sigma, _u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)

--- a/tests/slate/test_slate_hybridization.py
+++ b/tests/slate/test_slate_hybridization.py
@@ -63,7 +63,7 @@ def setup_poisson_3D():
     W = V * U
     sigma, u = TrialFunctions(W)
     tau, v = TestFunctions(W)
-    V, U = W.subfunctions()
+    V, U = W.subfunctions
     f = Function(U)
     x, y, z = SpatialCoordinate(mesh)
     expr = (1+12*pi*pi)*cos(100*pi*x)*cos(100*pi*y)*cos(100*pi*z)
@@ -109,7 +109,7 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
               'hybridization': {'ksp_type': 'preonly',
                                 'pc_type': 'lu'}}
     solve(a == L, w, solver_parameters=params)
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # (Non-hybrid) Need to slam it with preconditioning due to the
     # system's indefiniteness
@@ -122,7 +122,7 @@ def test_slate_hybridization(degree, hdiv_family, quadrilateral):
                              'pc_fieldsplit_schur_fact_type': 'FULL',
                              'fieldsplit_0_ksp_type': 'cg',
                              'fieldsplit_1_ksp_type': 'cg'})
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -186,7 +186,7 @@ def test_slate_hybridization_nested_schur():
                 'preonly_Shat': False, 'jacobi_Shat': False}
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     w2 = Function(W)
     solve(a == L, w2, solver_parameters={'ksp_type': 'preonly',
@@ -195,7 +195,7 @@ def test_slate_hybridization_nested_schur():
                                          'pc_python_type': 'firedrake.HybridizationPC',
                                          'hybridization': {'ksp_type': 'preonly',
                                                            'pc_type': 'lu'}})
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -289,7 +289,7 @@ def test_mixed_poisson_approximated_schur():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # setup second solver
     w2 = Function(W)
@@ -302,7 +302,7 @@ def test_mixed_poisson_approximated_schur():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'matfree'}}
     solve(a == L, w2, solver_parameters=aij_params)
-    _sigma, _u = w2.subfunctions()
+    _sigma, _u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)
@@ -354,7 +354,7 @@ def test_slate_hybridization_jacobi_prec_A00():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # setup second solver
     w2 = Function(W)
@@ -367,7 +367,7 @@ def test_slate_hybridization_jacobi_prec_A00():
                                                'pc_type': 'none',
                                                'ksp_rtol': 1e-8,
                                                'mat_type': 'matfree'}})
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -418,7 +418,7 @@ def test_slate_hybridization_jacobi_prec_schur():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # setup second solver
     w2 = Function(W)
@@ -431,7 +431,7 @@ def test_slate_hybridization_jacobi_prec_schur():
                                                'pc_type': 'none',
                                                'ksp_rtol': 1e-8,
                                                'mat_type': 'matfree'}})
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -484,7 +484,7 @@ def test_mixed_poisson_approximated_schur_jacobi_prec():
     builder = solver.snes.ksp.pc.getPythonContext().getSchurComplementBuilder()
     assert options_check(builder, expected), "Some solver options have not ended up in the PC as wanted."
 
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # setup second solver
     w2 = Function(W)
@@ -497,7 +497,7 @@ def test_mixed_poisson_approximated_schur_jacobi_prec():
                                     'ksp_rtol': 1e-8,
                                     'mat_type': 'matfree'}}
     solve(a == L, w2, solver_parameters=aij_params)
-    _sigma, _u = w2.subfunctions()
+    _sigma, _u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, _sigma)

--- a/tests/slate/test_slate_hybridization_extr.py
+++ b/tests/slate/test_slate_hybridization_extr.py
@@ -47,7 +47,7 @@ def test_hybrid_extr_helmholtz(quad):
                                 'pc_type': 'lu',
                                 'pc_factor_mat_solver_type': 'mumps'}}
     solve(a == L, w, solver_parameters=params)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions
 
     w2 = Function(W)
     params2 = {'pc_type': 'fieldsplit',
@@ -58,7 +58,7 @@ def test_hybrid_extr_helmholtz(quad):
                'fieldsplit_0': {'ksp_type': 'cg'},
                'fieldsplit_1': {'ksp_type': 'cg'}}
     solve(a == L, w2, solver_parameters=params2)
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions
 
     sigma_err = errornorm(sigma_h, nh_sigma)
     u_err = errornorm(u_h, nh_u)

--- a/tests/slate/test_slate_hybridized_mixed_bcs.py
+++ b/tests/slate/test_slate_hybridized_mixed_bcs.py
@@ -35,7 +35,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
     bcs = [DirichletBC(W[0], zero(), "on_boundary")]
 
     solve(a == L, w, solver_parameters=params, bcs=bcs)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # (Non-hybrid)
     w2 = Function(W)
@@ -43,7 +43,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
           solver_parameters={'pc_type': 'lu',
                              'mat_type': 'aij',
                              'ksp_type': 'preonly'}, bcs=bcs)
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -87,7 +87,7 @@ def test_slate_hybridized_extruded_bcs(degree, hdiv_family):
     bcs = [DirichletBC(W[0], zero(), "top"),
            DirichletBC(W[0], zero(), "bottom")]
     solve(a == L, w, solver_parameters=params, bcs=bcs)
-    sigma_h, u_h = w.split()
+    sigma_h, u_h = w.subfunctions()
 
     # (Non-hybrid)
     w2 = Function(W)
@@ -95,7 +95,7 @@ def test_slate_hybridized_extruded_bcs(degree, hdiv_family):
           solver_parameters={'pc_type': 'lu',
                              'mat_type': 'aij',
                              'ksp_type': 'preonly'}, bcs=bcs)
-    nh_sigma, nh_u = w2.split()
+    nh_sigma, nh_u = w2.subfunctions()
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)

--- a/tests/slate/test_slate_hybridized_mixed_bcs.py
+++ b/tests/slate/test_slate_hybridized_mixed_bcs.py
@@ -35,7 +35,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
     bcs = [DirichletBC(W[0], zero(), "on_boundary")]
 
     solve(a == L, w, solver_parameters=params, bcs=bcs)
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # (Non-hybrid)
     w2 = Function(W)
@@ -43,7 +43,7 @@ def test_slate_hybridized_on_boundary(degree, hdiv_family, quadrilateral):
           solver_parameters={'pc_type': 'lu',
                              'mat_type': 'aij',
                              'ksp_type': 'preonly'}, bcs=bcs)
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)
@@ -87,7 +87,7 @@ def test_slate_hybridized_extruded_bcs(degree, hdiv_family):
     bcs = [DirichletBC(W[0], zero(), "top"),
            DirichletBC(W[0], zero(), "bottom")]
     solve(a == L, w, solver_parameters=params, bcs=bcs)
-    sigma_h, u_h = w.subfunctions()
+    sigma_h, u_h = w.subfunctions
 
     # (Non-hybrid)
     w2 = Function(W)
@@ -95,7 +95,7 @@ def test_slate_hybridized_extruded_bcs(degree, hdiv_family):
           solver_parameters={'pc_type': 'lu',
                              'mat_type': 'aij',
                              'ksp_type': 'preonly'}, bcs=bcs)
-    nh_sigma, nh_u = w2.subfunctions()
+    nh_sigma, nh_u = w2.subfunctions
 
     # Return the L2 error
     sigma_err = errornorm(sigma_h, nh_sigma)

--- a/tests/slate/test_slate_mixed_direct.py
+++ b/tests/slate/test_slate_mixed_direct.py
@@ -60,7 +60,7 @@ def test_slate_mixed_vector(Wd):
 
     expect = assemble(action(a, f))
 
-    for c, e in zip(C.split(), expect.split()):
+    for c, e in zip(C.subfunctions, expect.subfunctions):
         assert numpy.allclose(c.dat.data_ro, e.dat.data_ro)
 
 

--- a/tests/slate/test_variational_prb.py
+++ b/tests/slate/test_variational_prb.py
@@ -61,7 +61,7 @@ def test_lvp_equiv_hdg(degree, nested, elimination):
     ref_solver = LinearVariationalSolver(ref_problem, solver_parameters=params)
     ref_solver.solve()
 
-    _, __, uhat_ref = s.split()
+    _, __, uhat_ref = s.subfunctions()
 
     # Now using Slate expressions only
     _O = Tensor(a)

--- a/tests/slate/test_variational_prb.py
+++ b/tests/slate/test_variational_prb.py
@@ -61,7 +61,7 @@ def test_lvp_equiv_hdg(degree, nested, elimination):
     ref_solver = LinearVariationalSolver(ref_problem, solver_parameters=params)
     ref_solver.solve()
 
-    _, __, uhat_ref = s.subfunctions()
+    _, __, uhat_ref = s.subfunctions
 
     # Now using Slate expressions only
     _O = Tensor(a)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -252,7 +252,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     W = W1 * W2
     x = SpatialCoordinate(parentmesh)
     v = Function(V)
-    v1, v2 = v.subfunctions()
+    v1, v2 = v.subfunctions
     # Get Function in V1
     # use outer product to check Regge works
     expr1 = outer(x, x)
@@ -268,7 +268,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     # Interpolate Function in V into W
     w_v = interpolate(v, W)
     # Split result and check
-    w_v1, w_v2 = w_v.subfunctions()
+    w_v1, w_v2 = w_v.subfunctions
     assert np.allclose(w_v1.dat.data_ro, result1)
     assert np.allclose(w_v2.dat.data_ro, result2)
     # try and make reusable Interpolator from V to W
@@ -276,7 +276,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     w_v = Function(W)
     A_w.interpolate(v, output=w_v)
     # Split result and check
-    w_v1, w_v2 = w_v.subfunctions()
+    w_v1, w_v2 = w_v.subfunctions
     assert np.allclose(w_v1.dat.data_ro, result1)
     assert np.allclose(w_v2.dat.data_ro, result2)
     # Enough tests - don't both using it again for a different Function in V

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -252,7 +252,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     W = W1 * W2
     x = SpatialCoordinate(parentmesh)
     v = Function(V)
-    v1, v2 = v.split()
+    v1, v2 = v.subfunctions()
     # Get Function in V1
     # use outer product to check Regge works
     expr1 = outer(x, x)
@@ -268,7 +268,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     # Interpolate Function in V into W
     w_v = interpolate(v, W)
     # Split result and check
-    w_v1, w_v2 = w_v.split()
+    w_v1, w_v2 = w_v.subfunctions()
     assert np.allclose(w_v1.dat.data_ro, result1)
     assert np.allclose(w_v2.dat.data_ro, result2)
     # try and make reusable Interpolator from V to W
@@ -276,7 +276,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     w_v = Function(W)
     A_w.interpolate(v, output=w_v)
     # Split result and check
-    w_v1, w_v2 = w_v.split()
+    w_v1, w_v2 = w_v.subfunctions()
     assert np.allclose(w_v1.dat.data_ro, result1)
     assert np.allclose(w_v2.dat.data_ro, result2)
     # Enough tests - don't both using it again for a different Function in V


### PR DESCRIPTION
# Closes issue #2623 

## *Update* 
- On my virtual box, it passed the lint tests and then the tests appeared with warning and error in my first commit without any warning from my side. 
 
## Changes
- `.split()` method was renamed as `.subfunctions`
- `@utils.cached_property` decorator was added for `subfunctions(self)` property
- [FutureWarning](https://docs.python.org/3/library/exceptions.html#FutureWarning) added for `.split()` method as it concerns the end user. I want to address the warning as simple as possible. 
- `pytest` codes and `docs` were edited.
- In documentation `:meth:` was changed to `:attr:` which complies with [Sphinx documentation. ](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#role-py-attr)

## Why?

- Firedrake's `split()` function and `.split()` method do conceptually the same thing, but they return different types of objects and are thus used in different contexts, which has been confusing users for years, so it was decided to rename `.split()` method as `.subfunctions` property.

## Testing

```python
from firedrake import *

mesh = UnitSquareMesh(1, 1)
V = FunctionSpace(mesh, "DG", 0)
W = V*V

f = Function(W)
u, p = f.subfunctions
x, y = f.split()

print(u == x)
print(p == y)
```

**Result:**

```
/home/firedrake/firedrake/src/firedrake/firedrake/function.py:325
FutureWarning: The .split() method is deprecated, please use the .subfunctions property instead
warnings.warn("The .split() method is deprecated, please use the .subfunctions property instead", category=FutureWarning)
True
True
```

Fingers crossed. 🤞 
