### PR TITLE
Projector: matfree solver params

### DIFF
--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -100,7 +100,11 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         solver_parameters.setdefault("ksp_type", "cg")
         solver_parameters.setdefault("ksp_rtol", 1e-8)
         mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
-        if mat_type == "matfree":
+        if mat_type == "nest":
+            solver_parameters.setdefault("pc_type", "fieldsplit")
+            solver_parameters.setdefault("fieldsplit_pc_type", "bjacobi")
+            solver_parameters.setdefault("fieldsplit_sub_pc_type", "icc")
+        elif mat_type == "matfree":
             solver_parameters.setdefault("pc_type", "jacobi")
         else:
             solver_parameters.setdefault("pc_type", "bjacobi")

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -97,10 +97,14 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
             solver_parameters = {}
         else:
             solver_parameters = solver_parameters.copy()
+        mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
         solver_parameters.setdefault("ksp_type", "cg")
         solver_parameters.setdefault("ksp_rtol", 1e-8)
-        solver_parameters.setdefault("pc_type", "bjacobi")
-        solver_parameters.setdefault("sub_pc_type", "icc")
+        if mat_type.endswith("aij"):
+            solver_parameters.setdefault("pc_type", "bjacobi")
+            solver_parameters.setdefault("sub_pc_type", "icc")
+        else:
+            solver_parameters.setdefault("pc_type", "jacobi")
         self.source = source
         self.target = target
         self.solver_parameters = solver_parameters

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -97,14 +97,16 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
             solver_parameters = {}
         else:
             solver_parameters = solver_parameters.copy()
-        mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
         solver_parameters.setdefault("ksp_type", "cg")
         solver_parameters.setdefault("ksp_rtol", 1e-8)
-        if mat_type.endswith("aij"):
+        mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
+        if mat_type == "nest":
+            mat_type = solver_parameters.get("sub_mat_type", firedrake.parameters["default_sub_matrix_type"])
+        if mat_type == "matfree":
+            solver_parameters.setdefault("pc_type", "jacobi")
+        else:
             solver_parameters.setdefault("pc_type", "bjacobi")
             solver_parameters.setdefault("sub_pc_type", "icc")
-        else:
-            solver_parameters.setdefault("pc_type", "jacobi")
         self.source = source
         self.target = target
         self.solver_parameters = solver_parameters

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -100,8 +100,6 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         solver_parameters.setdefault("ksp_type", "cg")
         solver_parameters.setdefault("ksp_rtol", 1e-8)
         mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
-        if mat_type == "nest":
-            mat_type = solver_parameters.get("sub_mat_type", firedrake.parameters["default_sub_matrix_type"])
         if mat_type == "matfree":
             solver_parameters.setdefault("pc_type", "jacobi")
         else:

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -205,7 +205,7 @@ def test_projector(mat_type):
     Vd = FunctionSpace(m, "DG", 1)
     vo = Function(Vd)
 
-    P = Projector(v, vo, solver_parameters={"mat_type": mat_type,})
+    P = Projector(v, vo, solver_parameters={"mat_type": mat_type})
     P.project()
 
     mass2 = assemble(vo*dx)

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -219,7 +219,8 @@ def test_projector(mat_type):
     assert np.abs(mass1-mass2) < 1.0e-10
 
 
-def test_nest_projector():
+@pytest.mark.parametrize('mat_type', ['aij', 'nest', 'matfree'])
+def test_mixed_projector(mat_type):
     m = UnitSquareMesh(2, 2)
     Vc1 = FunctionSpace(m, "CG", 1)
     Vc2 = FunctionSpace(m, "CG", 2)
@@ -237,7 +238,7 @@ def test_nest_projector():
     Vd = Vd1 * Vd2
     vo = Function(Vd)
 
-    P = Projector(v, vo, solver_parameters={"mat_type": "nest"})
+    P = Projector(v, vo, solver_parameters={"mat_type": mat_type})
     P.project()
 
     mass2 = assemble(sum(split(vo))*dx)

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -193,7 +193,7 @@ def test_repeatable():
         assert (fd == ud).all()
 
 
-@pytest.mark.parametrize('mat_type', ['aij', 'nest', 'matfree'])
+@pytest.mark.parametrize('mat_type', ['aij', 'matfree'])
 def test_projector(mat_type):
     m = UnitSquareMesh(2, 2)
     Vc = FunctionSpace(m, "CG", 2)
@@ -282,7 +282,9 @@ def test_projector_bcs(tensor, same_fspace):
 
     ret = Function(V_ho)
     projector = Projector(v, ret, bcs=bcs, solver_parameters={"ksp_type": "preonly",
-                                                              "pc_type": "lu"})
+                                                              "pc_type": "lu",
+                                                              "mat_type": "nest",
+                                                              "sub_mat_type": "matfree"})
     projector.project()
 
     # Manually solve a Galerkin projection problem to get a reference

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -193,7 +193,8 @@ def test_repeatable():
         assert (fd == ud).all()
 
 
-def test_projector():
+@pytest.mark.parametrize('mat_type', ['aij', 'matfree'])
+def test_projector(mat_type):
     m = UnitSquareMesh(2, 2)
     Vc = FunctionSpace(m, "CG", 2)
     xs = SpatialCoordinate(m)
@@ -204,7 +205,7 @@ def test_projector():
     Vd = FunctionSpace(m, "DG", 1)
     vo = Function(Vd)
 
-    P = Projector(v, vo)
+    P = Projector(v, vo, solver_parameters={"mat_type": mat_type,})
     P.project()
 
     mass2 = assemble(vo*dx)

--- a/tests/regression/test_projection.py
+++ b/tests/regression/test_projection.py
@@ -193,7 +193,7 @@ def test_repeatable():
         assert (fd == ud).all()
 
 
-@pytest.mark.parametrize('mat_type', ['aij', 'matfree'])
+@pytest.mark.parametrize('mat_type', ['aij', 'nest', 'matfree'])
 def test_projector(mat_type):
     m = UnitSquareMesh(2, 2)
     Vc = FunctionSpace(m, "CG", 2)


### PR DESCRIPTION
Projection will fail to use the default solver (incomplete Cholesky) when `mat_type != "aij"`. This PR addresses this by setting Jacobi as the default matrix-free preconditioner for projection.