### PR TITLE
Fix demo links for manual

### DIFF
--- a/demos/DG_advection/DG_advection.py.rst
+++ b/demos/DG_advection/DG_advection.py.rst
@@ -307,7 +307,7 @@ The last step is to make the animation and save it to a file. ::
       print("Failed to write movie! Try installing `ffmpeg`.")
 
 This demo can be found as a script in
-`DG_advection.py <DG_advection.py>`__.
+:demo:`DG_advection.py <DG_advection.py>`.
 
 
 .. rubric:: References

--- a/demos/benney_luke/benney_luke.py.rst
+++ b/demos/benney_luke/benney_luke.py.rst
@@ -221,7 +221,7 @@ We are now ready to enter the main time iteration loop::
 
 The output can be visualised using `paraview <http://www.paraview.org/>`__.
 
-A python script version of this demo can be found `here <benney_luke.py>`__.
+A python script version of this demo can be found :demo:`here <benney_luke.py>`.
 
 The Benney-Luke system and weak formulations presented in this demo have also been used to model extreme waves that occur due to Mach reflection through the intersection of two obliquely incident solitary waves. More information can be found in :cite:`Gidel:2017`.
 

--- a/demos/burgers/burgers.py.rst
+++ b/demos/burgers/burgers.py.rst
@@ -113,4 +113,4 @@ which amount to applying a full LU decomposition as a preconditioner. ::
       t += timestep
       outfile.write(project(u, V_out, name="Velocity"))
     
-A python script version of this demo can be found `here <burgers.py>`__.
+A python script version of this demo can be found :demo:`here <burgers.py>`.

--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -247,7 +247,7 @@ Images of the solution at shown below.
 
    Solution at :math:`t = 5.3.`
 
-A python script version of this demo can be found `here <camassaholm.py>`__.
+A python script version of this demo can be found :demo:`here <camassaholm.py>`.
 
 .. rubric:: References
 

--- a/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
+++ b/demos/eigenvalues_QG_basinmodes/qgbasinmodes.py.rst
@@ -243,7 +243,7 @@ Below is a plot of the spatial structure of the imaginary part of one of the eig
 .. figure:: eigenmode_imag.png
    :align: center
 
-This demo can be found as a Python script in `qgbasinmodes.py <qgbasinmodes.py>`__.
+This demo can be found as a Python script in :demo:`qgbasinmodes.py <qgbasinmodes.py>`.
 
 .. rubric:: References
 

--- a/demos/extruded_continuity/extruded_continuity.py.rst
+++ b/demos/extruded_continuity/extruded_continuity.py.rst
@@ -147,4 +147,4 @@ We finally compare our solution to the expected solution: ::
   assert max(abs(out.dat.data - exact.dat.data)) < 1e-10
 
 This demo can be found as a script in
-`extruded_continuity.py <extruded_continuity.py>`__.
+:demo:`extruded_continuity.py <extruded_continuity.py>`.

--- a/demos/helmholtz/helmholtz.py.rst
+++ b/demos/helmholtz/helmholtz.py.rst
@@ -137,4 +137,4 @@ Alternatively, since we have an analytic solution, we can check the
   f.interpolate(cos(x*pi*2)*cos(y*pi*2))
   print(sqrt(assemble(dot(u - f, u - f) * dx)))
 
-A python script version of this demo can be found `here <helmholtz.py>`__.
+A python script version of this demo can be found :demo:`here <helmholtz.py>`.

--- a/demos/immersed_fem/immersed_fem.py.rst
+++ b/demos/immersed_fem/immersed_fem.py.rst
@@ -81,7 +81,7 @@ between parts of the mesh (see the concrete example at the end of this page).
   Physical Surface("Disc", 4) = {2};
 
 For simplicity, we have gathered all this commands in the file
-`immersed_domain.geo <immersed_domain.geo>`__. To generate a mesh using this file,
+:demo:`immersed_domain.geo <immersed_domain.geo>`. To generate a mesh using this file,
 you can type the following command in the terminal
 
 .. code-block:: none
@@ -160,4 +160,4 @@ using linear Lagrangian finite elements. ::
    # solve the variational problem
    solve(a == L, u, bcs=DirBC, solver_parameters={'ksp_type': 'cg'})
 
-A python script version of this demo can be found `here <immersed_fem.py>`__.
+A python script version of this demo can be found :demo:`here <immersed_fem.py>`.

--- a/demos/linear-wave-equation/linear_wave_equation.py.rst
+++ b/demos/linear-wave-equation/linear_wave_equation.py.rst
@@ -149,4 +149,4 @@ visualising the results Paraview will use it::
    An animation, produced in Paraview, illustrating the output of this simulation can be found `on youtube <https://www.youtube.com/watch?v=xhxvM1N8mDQ>`_.
   
 
-A python script version of this demo can be found `here <linear_wave_equation.py>`__. The gmsh input file is `here <wave_tank.geo>`__.
+A python script version of this demo can be found :demo:`here <linear_wave_equation.py>`. The gmsh input file is :demo:`here <wave_tank.geo>`.

--- a/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
+++ b/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
@@ -330,9 +330,9 @@ The result of the computation, visualised with `paraview <http://www.paraview.or
 The mesh is deflected for visualization only. As the model is linear, the actual mesh used for computation is fixed. Colours indicate values of the flow potential :math:`\phi`.
 
 
-A python script version of this demo can be found `here <linear_fluid_structure_interaction.py>`__.
+A python script version of this demo can be found :demo:`here <linear_fluid_structure_interaction.py>`.
 
-The mesh file is `here <L_domain.msh>`__. It can be generated with `gmsh <http://gmsh.info/>`__ from `this file <L_domain.geo>`__ with a command: gmsh -2 L_domain.geo.
+The mesh file is :demo:`here <L_domain.msh>`. It can be generated with `gmsh <http://gmsh.info/>`__ from :demo:`this file <L_domain.geo>` with a command: gmsh -2 L_domain.geo.
 
 An extended 3D version of this code is published `here <https://zenodo.org/record/1162196>`__.
 

--- a/demos/ma-demo/ma-demo.py.rst
+++ b/demos/ma-demo/ma-demo.py.rst
@@ -195,8 +195,8 @@ An image of the solution is shown below.
 .. figure:: ma.png
    :align: center
 
-A python script version of this demo can be found `here
-<ma-demo.py>`__.
+A python script version of this demo can be found :demo:`here
+<ma-demo.py>`.
 
 .. rubric:: References
 

--- a/demos/matrix_free/navier_stokes.py.rst
+++ b/demos/matrix_free/navier_stokes.py.rst
@@ -137,4 +137,4 @@ And finally we write the results to a file for visualisation. ::
   File("cavity.pvd").write(u, p)
 
 A runnable python script implementing this demo file is available
-`here <navier_stokes.py>`__.
+:demo:`here <navier_stokes.py>`.

--- a/demos/matrix_free/poisson.py.rst
+++ b/demos/matrix_free/poisson.py.rst
@@ -70,5 +70,5 @@ Finally, we set the preconditioner type for the assembled operator::
 
                                                 "assembled_pc_type": "ilu"})
 
-This demo is available as a runnable python file `here
-<poisson.py>`__.
+This demo is available as a runnable python file :demo:`here
+<poisson.py>`.

--- a/demos/matrix_free/rayleigh-benard.py.rst
+++ b/demos/matrix_free/rayleigh-benard.py.rst
@@ -244,4 +244,4 @@ Finally, we'll output the results for visualisation. ::
   File("benard.pvd").write(u, p, T)
 
 A runnable python script implementing this demo file is available
-`here <rayleigh-benard.py>`__.
+:demo:`here <rayleigh-benard.py>`.

--- a/demos/matrix_free/stokes.py.rst
+++ b/demos/matrix_free/stokes.py.rst
@@ -151,4 +151,4 @@ matrix using unpreconditioned conjugate gradients. ::
   solve(a == L, up, bcs=bcs, nullspace=nullspace, solver_parameters=parameters)
 
 A runnable python script implementing this demo file is available
-`here <stokes.py>`__.
+:demo:`here <stokes.py>`.

--- a/demos/multigrid/geometric_multigrid.py.rst
+++ b/demos/multigrid/geometric_multigrid.py.rst
@@ -261,5 +261,5 @@ Finally, we'll write the solution for visualisation with Paraview. ::
 
   File("stokes.pvd").write(u, p)
 
-A runnable python version of this demo can be found `here
-<geometric_multigrid.py>`__.
+A runnable python version of this demo can be found :demo:`here
+<geometric_multigrid.py>`.

--- a/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
+++ b/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
@@ -273,7 +273,7 @@ Below is a plot of the difference between the linear and nonlinear solutions to 
 .. figure:: fig_diff.png
    :align: center
 
-This demo can be found as a Python script in `qg_winddrivengyre.py <qg_winddrivengyre.py>`__.
+This demo can be found as a Python script in :demo:`qg_winddrivengyre.py <qg_winddrivengyre.py>`.
            
 .. rubric:: References
 

--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -171,4 +171,4 @@ Don't forget to show the image::
 
 This demo is based on the corresponding `DOLFIN mixed Poisson demo
 <http://fenicsproject.org/olddocs/dolfin/1.3.0/python/demo/documented/mixed-poisson/python/documentation.html>`__
-and can be found as a script in `poisson_mixed.py <poisson_mixed.py>`__.
+and can be found as a script in :demo:`poisson_mixed.py <poisson_mixed.py>`.

--- a/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
+++ b/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
@@ -245,7 +245,7 @@ execute the time loop. ::
           v.project(gradperp(psi0))
           output.write(q0, psi0, v, time=t)
 
-A python script version of this demo can be found `here <qg_1layer_wave.py>`__.
+A python script version of this demo can be found :demo:`here <qg_1layer_wave.py>`.
 
 .. rubric:: References
 

--- a/demos/saddle_point_pc/saddle_point_systems.py.rst
+++ b/demos/saddle_point_pc/saddle_point_systems.py.rst
@@ -612,8 +612,8 @@ geometric multigrid method with overlapping Schwarz smoothers (using
 preconditioners ``AMS`` and ``ADS``. See the separate manual page on
 :doc:`../preconditioning`.
 
-A runnable python script version of this demo is available `here
-<saddle_point_systems.py>`__.
+A runnable python script version of this demo is available :demo:`here
+<saddle_point_systems.py>`.
 
 .. rubric:: References
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.extlinks',
     'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
@@ -361,3 +362,8 @@ intersphinx_mapping = {
 bibtex_bibfiles = ['demos/demo_references.bib', '_static/bibliography.bib', '_static/firedrake-apps.bib', '_static/references.bib']
 
 numpydoc_show_class_members = False
+
+#  -- Options for sphinx.ext.extlinks ------------------------------------
+extlinks = {
+    'demo': ('https://firedrakeproject.org/demos/%s', None)
+}


### PR DESCRIPTION
The demos of the PDF version of the manual have links that point to the wrong places. This change makes them point to the website.