### PR TITLE
VertexOnlyMesh on ExtrudedMesh

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -602,11 +602,10 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     dofs_per_target_cell = cnm.arity
     base_cells = vmx.cell_parent_base_cell_list
     heights = vmx.cell_parent_extrusion_height_list
+    assert cnm.values.shape[1] == dofs_per_target_cell
+    assert len(cnm.offset) == dofs_per_target_cell
     target_cell_parent_node_list = [
-        [
-            cnm.values[base_cell, dof_idx] + height * cnm.offset[dof_idx]
-            for dof_idx in range(dofs_per_target_cell)
-        ]
+        cnm.values[base_cell, :] + height * cnm.offset[:]
         for base_cell, height in zip(base_cells, heights)
     ]
     return op2.Map(

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -474,9 +474,9 @@ def rebuild_te(element, expr, rt_var_name):
 
 def compose_map_and_cache(map1, map2):
     """
-    Retrieve a :class:`PyOP2.ComposedMap` map from the cache of map1
+    Retrieve a :class:`pyop2.ComposedMap` map from the cache of map1
     using map2 as the cache key. The composed map maps from the iterset
-    of map1 to the toset of map2. Makes :class:`PyOP2.ComposedMap` and
+    of map1 to the toset of map2. Makes :class:`pyop2.ComposedMap` and
     caches the result on map1 if the composed map is not found.
 
     :arg map1: The map with the desired iterset from which the result is
@@ -497,19 +497,19 @@ def compose_map_and_cache(map1, map2):
 
 def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     """Build a map from the cells of a vertex only mesh to the nodes of the
-    source mesh's cell node map where the source mesh is extruded.
+    nodes on the source mesh where the source mesh is extruded.
 
     Parameters
     ----------
     vertex_only_mesh : :class:`mesh.MeshGeometry`
         The ``mesh.VertexOnlyMesh`` whose cells we iterate over.
-    extruded_cell_node_map : :class:`PyOP2.Map`
+    extruded_cell_node_map : :class:`pyop2.Map`
         The cell node map of the function space on the extruded mesh within
         which the ``mesh.VertexOnlyMesh`` is immersed.
 
     Returns
     -------
-    :class:`PyOP2.Map`
+    :class:`pyop2.Map`
         The map from the cells of the vertex only mesh to the nodes of the
         source mesh's cell node map. The map iterset is the
         ``vertex_only_mesh.cell_set`` and the map toset is the
@@ -519,8 +519,8 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     -----
 
     For an extruded mesh the cell node map is a map from a
-    :class:`PyOP2.ExtrudedSet` (the cells of the extruded mesh) to a
-    :class:`PyOP2.Set` (the nodes of the extruded mesh).
+    :class:`pyop2.ExtrudedSet` (the cells of the extruded mesh) to a
+    :class:`pyop2.Set` (the nodes of the extruded mesh).
 
     Take for example
 
@@ -544,7 +544,7 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
         |                      |                      |
         | extrusion_height = 0 | extrusion_height = 0 |
         -------------------layer 1-------------------
-        base_cell_num = 0         base_cell_num = 1
+          base_cell_num = 0      base_cell_num = 1
 
 
     If we declare ``FunctionSpace(mx, "CG", 2)`` then the node numbering (i.e.
@@ -563,9 +563,9 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
         2 ---------9-----------16---------23---------30
         |                       |                     |
         1          8           15         22         29
-        | base_cell_num = 0     |  base_cell_num = 1  |
+        |                       |                     |
         0 ---------7-----------14---------21---------28
-
+          base_cell_num = 0       base_cell_num = 1
 
     Cell node map values for an extruded mesh are indexed by the base cell
     number (rows) and the degree of freedom (DoF) index (columns). So

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -195,7 +195,7 @@ def make_interpolator(expr, V, subset, access):
                 if source_mesh.extruded:
                     # ExtrudedSet cannot be a map target so we need to build
                     # this ourselves
-                    argfs_map = vom_cell_parent_node_map_extruded(target_mesh, argfs.cell_node_map())
+                    argfs_map = vom_cell_parent_node_map_extruded(target_mesh, argfs_map)
                 else:
                     argfs_map = compose_map_and_cache(target_mesh.cell_parent_cell_map, argfs_map)
         sparsity = op2.Sparsity((V.dof_dset, argfs.dof_dset),

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -499,13 +499,101 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     """Build a map from the cells of a vertex only mesh to the nodes of the
     source mesh's cell node map where the source mesh is extruded.
 
-    :arg vertex_only_mesh: The `mesh.VertexOnlyMesh` mesh whose cells we
-        iterate over.
-    :arg extruded_cell_node_map: The cell node map of the function space on the
-        extruded source mesh.
+    Parameters
+    ----------
+    vertex_only_mesh : :class:`mesh.MeshGeometry`
+        The ``mesh.VertexOnlyMesh`` whose cells we iterate over.
+    extruded_cell_node_map : :class:`PyOP2.Map`
+        The cell node map of the function space on the extruded mesh within
+        which the ``mesh.VertexOnlyMesh`` is immersed.
 
-    :returns: A :class:`PyOP2.Map` with iterset over the vertex only mesh cells
-        and toset over the source mesh nodes.
+    Returns
+    -------
+    :class:`PyOP2.Map`
+        The map from the cells of the vertex only mesh to the nodes of the
+        source mesh's cell node map. The map iterset is the
+        ``vertex_only_mesh.cell_set`` and the map toset is the
+        ``extruded_cell_node_map.toset``.
+
+    Notes
+    -----
+
+    For an extruded mesh the cell node map is a map from a
+    :class:`PyOP2.ExtrudedSet` (the cells of the extruded mesh) to a
+    :class:`PyOP2.Set` (the nodes of the extruded mesh).
+
+    Take for example
+
+    ``mx = ExtrudedMesh(UnitIntervalMesh(2), 3)`` with
+    ``mx.layers = 4``
+
+    which looks like
+
+    .. code-block:: text
+
+        -------------------layer 4-------------------
+        | parent_cell_num =  2 | parent_cell_num =  5 |
+        |                      |                      |
+        | extrusion_height = 2 | extrusion_height = 2 |
+        -------------------layer 3-------------------
+        | parent_cell_num =  1 | parent_cell_num =  4 |
+        |                      |                      |
+        | extrusion_height = 1 | extrusion_height = 1 |
+        -------------------layer 2-------------------
+        | parent_cell_num =  0 | parent_cell_num =  3 |
+        |                      |                      |
+        | extrusion_height = 0 | extrusion_height = 0 |
+        -------------------layer 1-------------------
+        base_cell_num = 0         base_cell_num = 1
+
+
+    If we declare ``FunctionSpace(mx, "CG", 2)`` then the node numbering (i.e.
+    Degree of Freedom/DoF numbering) is
+
+    .. code-block:: text
+
+        6 ---------13----------20---------27---------34
+        |                       |                     |
+        5          12          19         26         33
+        |                       |                     |
+        4 ---------11----------18---------25---------32
+        |                       |                     |
+        3          10          17         24         31
+        |                       |                     |
+        2 ---------9-----------16---------23---------30
+        |                       |                     |
+        1          8           15         22         29
+        | base_cell_num = 0     |  base_cell_num = 1  |
+        0 ---------7-----------14---------21---------28
+
+
+    Cell node map values for an extruded mesh are indexed by the base cell
+    number (rows) and the degree of freedom (DoF) index (columns). So
+    ``extruded_cell_node_map.values[0] = [14, 15, 16,  0,  1,  2,  7,  8,  9]``
+    are all the DoF/node numbers for the ``base_cell_num = 0``.
+    Similarly
+    ``extruded_cell_node_map.values[1] = [28, 29, 30, 21, 22, 23, 14, 15, 16]``
+    contain all 9 of the DoFs for ``base_cell_num = 1``.
+    To get the DoFs/nodes for the rest of the  cells we need to include the
+    ``extruded_cell_node_map.offset``, which tells us how far each cell's
+    DoFs/nodes are translated up from the first layer to the second, and
+    multiply these by the the given ``extrusion_height``. So in our example
+    ``extruded_cell_node_map.offset = [2, 2, 2, 2, 2, 2, 2, 2, 2]`` (we index
+    this with the DoF/node index - it's an array because each DoF/node in the
+    extruded mesh cell, in principal, can be offset upwards by a different
+    amount).
+    For ``base_cell_num = 0`` with ``extrusion_height = 1``
+    (``parent_cell_num = 1``) we add ``1*2 = 2`` to each of the DoFs/nodes in
+    ``extruded_cell_node_map.values[0]`` to get
+    ``extruded_cell_node_map.values[0] + 1 * extruded_cell_node_map.offset[0] =
+    [16, 17, 18,  2,  3,  4,  9, 10, 11]`` where ``0`` is the DoF/node index.
+
+    For each cell (vertex) of a vertex only mesh immersed in a parent
+    extruded mesh, we can can get the corresponding ``base_cell_num`` and
+    ``extrusion_height`` of the parent extruded mesh. Armed with this
+    information we use the above to work out the corresponding DoFs/nodes on
+    the parent extruded mesh.
+
     """
     if not isinstance(vertex_only_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology):
         raise TypeError("The input mesh must be a VertexOnlyMesh")
@@ -514,8 +602,16 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     dofs_per_target_cell = cnm.arity
     base_cells = vmx.cell_parent_base_cell_list
     heights = vmx.cell_parent_extrusion_height_list
-    target_cell_parent_node_list = [[cnm.values[base_cell, dof_idx] + height*cnm.offset[dof_idx] for dof_idx in range(dofs_per_target_cell)] for base_cell, height in zip(base_cells, heights)]
-    return op2.Map(vmx.cell_set, cnm.toset, dofs_per_target_cell, target_cell_parent_node_list)
+    target_cell_parent_node_list = [
+        [
+            cnm.values[base_cell, dof_idx] + height * cnm.offset[dof_idx]
+            for dof_idx in range(dofs_per_target_cell)
+        ]
+        for base_cell, height in zip(base_cells, heights)
+    ]
+    return op2.Map(
+        vmx.cell_set, cnm.toset, dofs_per_target_cell, target_cell_parent_node_list
+    )
 
 
 class GlobalWrapper(object):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -512,7 +512,8 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     cnm = extruded_cell_node_map
     vmx = vertex_only_mesh
     dofs_per_target_cell = cnm.arity
-    base_cells, heights = numpy.array([0, 1]), numpy.array([0, 2])  # Need to work this out for the general case
+    base_cells = vmx.cell_parent_base_cell_list
+    heights = vmx.cell_parent_extrusion_height_list
     target_cell_parent_node_list = [[cnm.values[base_cell, dof_idx] + height*cnm.offset[dof_idx] for dof_idx in range(dofs_per_target_cell)] for base_cell, height in zip(base_cells, heights)]
     return op2.Map(vmx.cell_set, cnm.toset, dofs_per_target_cell, target_cell_parent_node_list)
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2323,13 +2323,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
 
     .. note::
 
-        Extruded and immersed manifold meshes are not yet supported.
-
-    .. note::
-
-        Modifying the coordinates of the parent mesh is not currently
-        supported. Doing so will cause interpolation to Functions defined on
-        the VertexOnlyMesh to return the wrong values.
+        Manifold meshes are not yet supported.
 
     .. note::
         When running in parallel with ``redundant = False``, ``vertexcoords``

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2559,8 +2559,8 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         fields += [("parentcellbasenum", 1, IntType), ("parentcellextrusionheight", 1, IntType)]
         base_parent_cell_nums = parent_cell_nums // (parent_mesh.layers - 1)
         extrusion_heights = parent_cell_nums % (parent_mesh.layers - 1)
-        # Can't find plex numbering for extruded meshes so set all to -1
-        plex_parent_cell_nums = -np.ones_like(parent_cell_nums)
+        # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.
+        plex_parent_cell_nums = parent_mesh.topology.cell_closure[base_parent_cell_nums, -1]
     elif coords_dat_version > 0:
         # The parent mesh coordinates have been modified. The DMSwarm parent
         # mesh plex numbering is now not guaranteed to match up with DMPlex

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2662,9 +2662,11 @@ def _parent_mesh_embedding(vertex_coords, parent_mesh, tolerance):
 
     if parent_mesh.extruded:
         if parent_mesh.variable_layers:
-            # TODO: Don't know what the total local number of cells is in this
-            # case
-            raise NotImplementedError("Variable layers not supported")
+            # The below could work as a hack but for now raise notimplementederror
+            # import firedrake.functionspace as functionspace
+            # import firedrake.function as function
+            # pm_local_size_wo_halos = len(function.Function(functionspace.FunctionSpace(parent_mesh, "DG", 0)).dat.data_ro)
+            raise NotImplementedError("Not implemented for ExtrudedMesh with variable layers.")
         pm_local_size_wo_halos = parent_mesh.cell_set.size * (parent_mesh.layers - 1)
     else:
         pm_local_size_wo_halos = parent_mesh.cell_set.size

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2323,7 +2323,8 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
 
     .. note::
 
-        Manifold meshes are not yet supported.
+        Manifold meshes and extruded meshes with variable extrusion layers are
+        not yet supported.
 
     .. note::
         When running in parallel with ``redundant = False``, ``vertexcoords``
@@ -2554,9 +2555,10 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         fields += [("parentcellbasenum", 1, IntType), ("parentcellextrusionheight", 1, IntType)]
         base_parent_cell_nums = parent_cell_nums // (parent_mesh.layers - 1)
         extrusion_heights = parent_cell_nums % (parent_mesh.layers - 1)
-        # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.
-        plex_parent_cell_nums = parent_mesh.topology.cell_closure[base_parent_cell_nums, -1]
+        # Can't find plex numbering for extruded meshes so set all to -1
+        plex_parent_cell_nums = -np.ones_like(parent_cell_nums)
     else:
+        # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.
         plex_parent_cell_nums = parent_mesh.topology.cell_closure[parent_cell_nums, -1]
 
     _, coordsdim = coords.shape

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2538,8 +2538,6 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         # need to store the base parent cell number and the height to be able
         # to map point coordinates back to the parent mesh
         if parent_mesh.variable_layers:
-            # TODO: Don't know how variable layer cell numbering works - below
-            # assumes constant layers.
             raise NotImplementedError("Cannot create a DMSwarm in an ExtrudedMesh with variable layers.")
         # Extruded mesh parent_cell_nums goes from bottom to top. So for
         # mx = ExtrudedMesh(UnitIntervalMesh(2), 3) we have

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2521,10 +2521,16 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     tdim = parent_mesh.topological_dimension()
     gdim = parent_mesh.geometric_dimension()
 
+    # Need to save the coords dat version here because _parent_mesh_embedding
+    # will change it. This is due to a bug somewhere in the kernel generation
+    # of MeshGeometry.locate_cell_and_reference_coordinate - accessing the
+    # coordinates ought to be a read only operation but, for some reason,
+    # increments the dat version.
+    coords_dat_version = parent_mesh.coordinates.dat.dat_version
+
     if fields is None:
         fields = []
     fields += [("parentcellnum", 1, IntType), ("refcoord", tdim, RealType)]
-
     coords, reference_coords, parent_cell_nums = \
         _parent_mesh_embedding(coords, parent_mesh, tolerance)
 
@@ -2556,6 +2562,12 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         base_parent_cell_nums = parent_cell_nums // (parent_mesh.layers - 1)
         extrusion_heights = parent_cell_nums % (parent_mesh.layers - 1)
         # Can't find plex numbering for extruded meshes so set all to -1
+        plex_parent_cell_nums = -np.ones_like(parent_cell_nums)
+    elif coords_dat_version > 0:
+        # The parent mesh coordinates have been modified. The DMSwarm parent
+        # mesh plex numbering is now not guaranteed to match up with DMPlex
+        # numbering so are set to -1. DMSwarm functions which rely on the
+        # DMPlex numbering,such as DMSwarmMigrate() will not work as expected.
         plex_parent_cell_nums = -np.ones_like(parent_cell_nums)
     else:
         # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2535,16 +2535,17 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
 
     # Add point coordinates. This amounts to our own implementation of
     # DMSwarmSetPointCoordinates because Firedrake's mesh coordinate model
-    # doesn't always exactly coincide with that of DMPlex.
+    # doesn't always exactly coincide with that of DMPlex: in most cases the
+    # plex_parent_cell_nums (DMSwarm_cellid field) and parent_cell_nums
+    # (parentcellnum field), the latter being the numbering used by firedrake,
+    # refer fundamentally to the same cells. For extruded meshes the DMPlex
+    # dimension is based on the topological dimension of the base mesh.
 
     # NOTE ensure that swarm.restoreField is called for each field too!
     swarm_coords = swarm.getField("DMSwarmPIC_coor").reshape((num_vertices, gdim))
-    # Once we support extruded meshes, the plex cell ID won't coincide with the
-    # Firedrake cell ID so the following fields will differ.
     swarm_parent_cell_nums = swarm.getField("DMSwarm_cellid")
     field_parent_cell_nums = swarm.getField("parentcellnum")
     field_reference_coords = swarm.getField("refcoord").reshape((num_vertices, tdim))
-
     swarm_coords[...] = coords
     swarm_parent_cell_nums[...] = plex_parent_cell_nums
     field_parent_cell_nums[...] = parent_cell_nums

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2584,6 +2584,13 @@ def _parent_mesh_embedding(vertex_coords, parent_mesh, tolerance):
     reference_coords = np.empty((num_vertices, tdim), dtype=RealType)
     valid = np.full(num_vertices, False)
 
+    if parent_mesh.extruded:
+        if parent_mesh.variable_layers:
+            raise NotImplementedError("Variable layers not supported")
+        pm_local_size_wo_halos = parent_mesh.cell_set.size * (parent_mesh.layers - 1)
+    else:
+        pm_local_size_wo_halos = parent_mesh.cell_set.size
+
     # Create an out of mesh point to use in locate_cell when needed
     out_of_mesh_point = np.full((1, gdim), np.inf)
 
@@ -2591,9 +2598,8 @@ def _parent_mesh_embedding(vertex_coords, parent_mesh, tolerance):
         if i < num_vertices:
             parent_cell_num, reference_coord = \
                 parent_mesh.locate_cell_and_reference_coordinate(vertex_coords[i], tolerance)
-            # parent_cell_num >= parent_mesh.cell_set.size means the vertex is in the halo
-            # and is to be discarded.
-            if parent_cell_num is not None and parent_cell_num < parent_mesh.cell_set.size:
+            # At the moment we discard vertices in parent mesh halos
+            if parent_cell_num is not None and parent_cell_num < pm_local_size_wo_halos:
                 valid[i] = True
                 parent_cell_nums[i] = parent_cell_num
                 reference_coords[i] = reference_coord

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1448,7 +1448,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
             entity_dofs[0] = 1
             self._vertex_numbering = self.create_section(entity_dofs)
 
-    @utils.cached_property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_closure(self):
         """2D array of ordered cell closures
 
@@ -1484,11 +1484,11 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
             raise ValueError("Unknown facet type '%s'" % kind)
         raise AttributeError("Cells in a VertexOnlyMeshTopology have no facets.")
 
-    @utils.cached_property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def exterior_facets(self):
         return self._facets("exterior")
 
-    @utils.cached_property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def interior_facets(self):
         return self._facets("interior")
 
@@ -1520,12 +1520,12 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         else:
             return self.num_vertices()
 
-    @utils.cached_property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_set(self):
         size = list(self._entity_classes[self.cell_dimension(), :])
         return op2.Set(size, "Cells", comm=self.comm)
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_cell_list(self):
         """Return a list of parent mesh cells numbers in vertex only
         mesh cell order.
@@ -1534,7 +1534,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         self.topology_dm.restoreField("parentcellnum")
         return cell_parent_cell_list
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_cell_map(self):
         """Return the :class:`pyop2.Map` from vertex only mesh cells to
         parent mesh cells.
@@ -1542,7 +1542,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         return op2.Map(self.cell_set, self._parent_mesh.cell_set, 1,
                        self.cell_parent_cell_list, "cell_parent_cell")
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_base_cell_list(self):
         """Return a list of parent mesh base cells numbers in vertex only
         mesh cell order.
@@ -1553,7 +1553,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         self.topology_dm.restoreField("parentcellbasenum")
         return cell_parent_base_cell_list
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_base_cell_map(self):
         """Return the :class:`pyop2.Map` from vertex only mesh cells to
         parent mesh base cells.
@@ -1563,7 +1563,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         return op2.Map(self.cell_set, self._parent_mesh.cell_set, 1,
                        self.cell_parent_base_cell_list, "cell_parent_base_cell")
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_extrusion_height_list(self):
         """Return a list of parent mesh extrusion heights in vertex only
         mesh cell order.
@@ -1574,7 +1574,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         self.topology_dm.restoreField("parentcellextrusionheight")
         return cell_parent_extrusion_height_list
 
-    @property
+    @utils.cached_property  # TODO: Recalculate if mesh moves
     def cell_parent_extrusion_height_map(self):
         """Return the :class:`pyop2.Map` from vertex only mesh cells to
         parent mesh extrusion heights.

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -149,7 +149,7 @@ def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
     A_w.interpolate(v, output=w_v)
     assert np.allclose(w_v.dat.data_ro, np.sum(vertexcoords, axis=1))
     # use it again for a different Function in V
-    v = Function(V).assign(Constant(2))
+    v = Function(V).assign(Constant(2, domain=parentmesh))
     A_w.interpolate(v, output=w_v)
     assert np.allclose(w_v.dat.data_ro, 2)
 
@@ -288,9 +288,9 @@ def test_scalar_real_interpolation(parentmesh, vertexcoords):
     # Remove below when interpolating constant onto Real works for extruded
     if type(parentmesh.topology) is mesh.ExtrudedMeshTopology:
         with pytest.raises(ValueError):
-            interpolate(Constant(1.0), V)
+            interpolate(Constant(1.0, domain=parentmesh), V)
         return
-    v = interpolate(Constant(1.0), V)
+    v = interpolate(Constant(1.0, domain=parentmesh), V)
     w_v = interpolate(v, W)
     assert np.allclose(w_v.dat.data_ro, 1.)
 
@@ -303,9 +303,9 @@ def test_scalar_real_interpolator(parentmesh, vertexcoords):
     # Remove below when interpolating constant onto Real works for extruded
     if type(parentmesh.topology) is mesh.ExtrudedMeshTopology:
         with pytest.raises(ValueError):
-            interpolate(Constant(1.0), V)
+            interpolate(Constant(1.0, domain=parentmesh), V)
         return
-    v = interpolate(Constant(1.0), V)
+    v = interpolate(Constant(1.0, domain=parentmesh), V)
     A_w = Interpolator(TestFunction(V), W)
     w_v = Function(W)
     A_w.interpolate(v, output=w_v)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -285,6 +285,11 @@ def test_scalar_real_interpolation(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     W = FunctionSpace(vm, "DG", 0)
     V = FunctionSpace(parentmesh, "Real", 0)
+    # Remove below when interpolating constant onto Real works for extruded
+    if type(parentmesh.topology) is mesh.ExtrudedMeshTopology:
+        with pytest.raises(ValueError):
+            interpolate(Constant(1.0), V)
+        return
     v = interpolate(Constant(1.0), V)
     w_v = interpolate(v, W)
     assert np.allclose(w_v.dat.data_ro, 1.)
@@ -295,6 +300,11 @@ def test_scalar_real_interpolator(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords)
     W = FunctionSpace(vm, "DG", 0)
     V = FunctionSpace(parentmesh, "Real", 0)
+    # Remove below when interpolating constant onto Real works for extruded
+    if type(parentmesh.topology) is mesh.ExtrudedMeshTopology:
+        with pytest.raises(ValueError):
+            interpolate(Constant(1.0), V)
+        return
     v = interpolate(Constant(1.0), V)
     A_w = Interpolator(TestFunction(V), W)
     w_v = Function(W)

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -19,8 +19,7 @@ import subprocess
                                      marks=pytest.mark.xfail(raises=(subprocess.CalledProcessError, NotImplementedError),
                                                              reason="immersed parent meshes not supported")),
                         pytest.param("periodicrectangle"),
-                        pytest.param("shiftedmesh",
-                                     marks=pytest.mark.skip(reason="meshes with modified coordinate fields are not supported"))],
+                        "shiftedmesh"],
                 ids=lambda x: f"{x}-mesh")
 def parentmesh(request):
     if request.param == "interval":

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -18,7 +18,7 @@ import subprocess
                                      # CalledProcessError is so the parallel tests correctly xfail
                                      marks=pytest.mark.xfail(raises=(subprocess.CalledProcessError, NotImplementedError),
                                                              reason="immersed parent meshes not supported")),
-                        pytest.param("periodicrectangle"),
+                        "periodicrectangle",
                         "shiftedmesh"],
                 ids=lambda x: f"{x}-mesh")
 def parentmesh(request):

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -12,6 +12,7 @@ import subprocess
                         "square",
                         "squarequads",
                         "extruded",
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere",
@@ -30,6 +31,8 @@ def parentmesh(request):
         return UnitSquareMesh(2, 2, quadrilateral=True)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
+    elif request.param == "extrudedvariablelayers":
+        return ExtrudedMesh(UnitIntervalMesh(3), np.array([[0, 3], [0, 3], [0, 2]]), np.array([3, 3, 2]))
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -39,7 +39,7 @@ def parentmesh(request):
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":
-        m = UnitSquareMesh(1, 1)
+        m = UnitSquareMesh(10, 10)
         m.coordinates.dat.data[:] -= 0.5
         return m
 

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -29,7 +29,7 @@ def parentmesh(request):
     elif request.param == "squarequads":
         return UnitSquareMesh(2, 2, quadrilateral=True)
     elif request.param == "extruded":
-        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+        return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -11,7 +11,7 @@ import subprocess
 @pytest.fixture(params=["interval",
                         "square",
                         "squarequads",
-                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "extruded",
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere",

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -12,7 +12,7 @@ import subprocess
                         "square",
                         "squarequads",
                         "extruded",
-                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere",

--- a/tests/vertexonly/test_poisson_inverse_conductivity.py
+++ b/tests/vertexonly/test_poisson_inverse_conductivity.py
@@ -56,8 +56,8 @@ def test_poisson_inverse_conductivity(num_points):
     # Compute the true solution of the PDE.
     u_true = Function(V)
     v = TestFunction(V)
-    f = Constant(1.0)
-    k0 = Constant(0.5)
+    f = Constant(1.0, domain=m)
+    k0 = Constant(0.5, domain=m)
     bc = DirichletBC(V, 0, 'on_boundary')
     F = (k0 * exp(q_true) * inner(grad(u_true), grad(v)) - f * v) * dx
     solve(F == 0, u_true, bc)
@@ -75,7 +75,7 @@ def test_poisson_inverse_conductivity(num_points):
     signal_to_noise = 20
     U = u_true.dat.data_ro[:]
     u_range = U.max() - U.min()
-    σ = Constant(u_range / signal_to_noise)
+    σ = Constant(u_range / signal_to_noise, domain=point_cloud)
     ζ = generator.standard_normal(len(xs))
     u_obs_vals = np.array(u_true.at(xs)) + float(σ) * ζ
 
@@ -93,7 +93,7 @@ def test_poisson_inverse_conductivity(num_points):
 
     # Two terms in the functional
     misfit_expr = 0.5 * ((u_obs - interpolate(u, P0DG)) / σ)**2
-    α = Constant(0.5)
+    α = Constant(0.5, domain=m)
     regularisation_expr = 0.5 * α**2 * inner(grad(q), grad(q))
 
     # Form functional and reduced functional

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -41,7 +41,7 @@ def cell_midpoints(m):
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.skip(reason="immersed parent meshes not supported and will segfault PETSc when creating the DMSwarm")),
-                        pytest.param("periodicrectangle"),
+                        "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -42,7 +42,7 @@ def cell_midpoints(m):
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.skip(reason="immersed parent meshes not supported and will segfault PETSc when creating the DMSwarm")),
                         pytest.param("periodicrectangle"),
-                        pytest.param("shiftedmesh", marks=pytest.mark.skip(reason="meshes with modified coordinate fields are not supported"))])
+                        "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":
         return UnitIntervalMesh(1)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -160,10 +160,10 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     assert nptsglobal == len(inputpointcoords)
     assert nptsglobal == swarm.getSize()
     # Check the parent cell indexes match those in the parent mesh unless
-    # extruded, in which case they should all be -1
+    # parent mesh is shifted, in which case they should all be -1
     cell_indexes = parentmesh.cell_closure[:, -1]
     for index in localparentcellindices:
-        if parentmesh.extruded or coords_dat_version > 0:
+        if coords_dat_version > 0:
             assert index == -1
         else:
             assert np.any(index == cell_indexes)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -15,8 +15,6 @@ def cell_midpoints(m):
     `midpoints` are the midpoints for the entire mesh even if the mesh is
     distributed and `local_midpoints` are the midpoints of only the
     rank-local non-ghost cells."""
-    if isinstance(m.topology, mesh.ExtrudedMeshTopology):
-        raise NotImplementedError("Extruded meshes are not supported")
     m.init()
     V = VectorFunctionSpace(m, "DG", 0)
     f = Function(V).interpolate(SpatialCoordinate(m))
@@ -39,7 +37,7 @@ def cell_midpoints(m):
 
 @pytest.fixture(params=["interval",
                         "square",
-                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "extruded",
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.skip(reason="immersed parent meshes not supported and will segfault PETSc when creating the DMSwarm")),

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -59,7 +59,7 @@ def parentmesh(request):
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":
-        m = UnitSquareMesh(1, 1)
+        m = UnitSquareMesh(10, 10)
         m.coordinates.dat.data[:] -= 0.5
         return m
 

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -49,7 +49,7 @@ def parentmesh(request):
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
     elif request.param == "extruded":
-        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+        return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -38,7 +38,7 @@ def cell_midpoints(m):
 @pytest.fixture(params=["interval",
                         "square",
                         "extruded",
-                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.skip(reason="immersed parent meshes not supported and will segfault PETSc when creating the DMSwarm")),

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -91,7 +91,7 @@ def functionspace_tests(vm):
     # Assembly works as expected - global assembly (integration) of a
     # constant on a vertex only mesh is evaluation of that constant
     # num_vertices (globally) times
-    f.interpolate(Constant(2))
+    f.interpolate(Constant(2, domain=vm))
     assert np.isclose(assemble(f*dx), 2*num_cells_mpi_global)
 
 
@@ -128,7 +128,7 @@ def vectorfunctionspace_tests(vm):
     # num_vertices (globally) times. Note that we get a vertex cell for
     # each geometric dimension so we have to sum over geometric
     # dimension too.
-    f.interpolate(Constant([1] * gdim))
+    f.interpolate(Constant([1] * gdim, domain=vm))
     assert np.isclose(assemble(inner(f, f)*dx), num_cells_mpi_global*gdim)
 
 

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -8,7 +8,7 @@ from mpi4py import MPI
 
 @pytest.fixture(params=["interval",
                         "square",
-                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "extruded",
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -12,7 +12,7 @@ from mpi4py import MPI
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
-                        pytest.param("periodicrectangle"),
+                        "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 @pytest.fixture(params=["interval",
                         "square",
                         "extruded",
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
@@ -21,6 +22,8 @@ def parentmesh(request):
         return UnitSquareMesh(1, 1)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
+    elif request.param == "extrudedvariablelayers":
+        return ExtrudedMesh(UnitIntervalMesh(3), np.array([[0, 3], [0, 3], [0, 2]]), np.array([3, 3, 2]))
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -9,7 +9,7 @@ from mpi4py import MPI
 @pytest.fixture(params=["interval",
                         "square",
                         "extruded",
-                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -20,7 +20,7 @@ def parentmesh(request):
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
     elif request.param == "extruded":
-        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+        return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -30,7 +30,7 @@ def parentmesh(request):
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":
-        m = UnitSquareMesh(1, 1)
+        m = UnitSquareMesh(10, 10)
         m.coordinates.dat.data[:] -= 0.5
         return m
 

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -13,7 +13,7 @@ from mpi4py import MPI
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
                         pytest.param("periodicrectangle"),
-                        pytest.param("shiftedmesh", marks=pytest.mark.skip(reason="meshes with modified coordinate fields are not supported"))])
+                        "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":
         return UnitIntervalMesh(1)

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -15,8 +15,6 @@ def cell_midpoints(m):
     `midpoints` are the midpoints for the entire mesh even if the mesh is
     distributed and `local_midpoints` are the midpoints of only the
     rank-local non-ghost cells."""
-    if isinstance(m.topology, mesh.ExtrudedMeshTopology):
-        raise NotImplementedError("Extruded meshes are not supported")
     m.init()
     V = VectorFunctionSpace(m, "DG", 0)
     f = Function(V).interpolate(SpatialCoordinate(m))
@@ -39,7 +37,7 @@ def cell_midpoints(m):
 
 @pytest.fixture(params=["interval",
                         "square",
-                        pytest.param("extruded", marks=pytest.mark.xfail(reason="extruded meshes not supported")),
+                        "extruded",
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -41,7 +41,7 @@ def cell_midpoints(m):
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
-                        pytest.param("periodicrectangle"),
+                        "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -38,7 +38,7 @@ def cell_midpoints(m):
 @pytest.fixture(params=["interval",
                         "square",
                         "extruded",
-                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -22,7 +22,7 @@ def cell_midpoints(m):
     # may not be the same on all ranks (note we exclude ghost cells
     # hence using num_cells_local = m.cell_set.size). Below local means
     # MPI rank local.
-    num_cells_local = m.cell_set.size
+    num_cells_local = len(f.dat.data_ro)
     num_cells = MPI.COMM_WORLD.allreduce(num_cells_local, op=MPI.SUM)
     # reshape is for 1D case where f.dat.data_ro has shape (num_cells_local,)
     local_midpoints = f.dat.data_ro.reshape(num_cells_local, m.ufl_cell().geometric_dimension())

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -110,10 +110,11 @@ def verify_vertexonly_mesh(m, vm, inputvertexcoords):
     vm.init()
     # Find in-bounds and non-halo-region input coordinates
     in_bounds = []
-    _, owned, _ = m.cell_set.sizes
+    # this method of getting owned cells works for all mesh types
+    owned_cells = len(Function(FunctionSpace(m, "DG", 0)).dat.data_ro)
     for i in range(len(inputvertexcoords)):
         cell_num = m.locate_cell(inputvertexcoords[i])
-        if cell_num is not None and cell_num < owned:
+        if cell_num is not None and cell_num < owned_cells:
             in_bounds.append(i)
     # Correct coordinates (though not guaranteed to be in same order)
     np.allclose(np.sort(vm.coordinates.dat.data_ro), np.sort(inputvertexcoords[in_bounds]))

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -215,3 +215,19 @@ def test_point_tolerance():
     assert vm.cell_set.size == 1
     vm = VertexOnlyMesh(m, coords, tolerance=None)
     assert vm.cell_set.size == 0
+
+
+def test_missing_points_behaviour(parentmesh):
+    """
+    Generate points outside of the parentmesh and check we get the expected
+    error behaviour
+    """
+    inputcoord = np.full((1, parentmesh.geometric_dimension()), np.inf)
+    assert len(inputcoord) == 1
+    # No error by default
+    vm = VertexOnlyMesh(parentmesh, inputcoord)
+    assert vm.cell_set.size == 0
+    with pytest.raises(ValueError):
+        vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour='error')
+    with pytest.warns(UserWarning):
+        vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour='warn')

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -42,7 +42,7 @@ def cell_midpoints(m):
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
                         pytest.param("periodicrectangle"),
-                        pytest.param("shiftedmesh", marks=pytest.mark.skip(reason="meshes with modified coordinate fields are not supported"))])
+                        "shiftedmesh"])
 def parentmesh(request):
     if request.param == "interval":
         return UnitIntervalMesh(1)

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -59,7 +59,7 @@ def parentmesh(request):
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":
-        m = UnitSquareMesh(1, 1)
+        m = UnitSquareMesh(10, 10)
         m.coordinates.dat.data[:] -= 0.5
         return m
 

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -38,6 +38,7 @@ def cell_midpoints(m):
 @pytest.fixture(params=["interval",
                         "square",
                         "extruded",
+                        pytest.param("extrudedvariablelayers", marks=pytest.mark.xfail(reason="Extruded meshes with variable layers not supported")),
                         "cube",
                         "tetrahedron",
                         pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
@@ -50,6 +51,8 @@ def parentmesh(request):
         return UnitSquareMesh(1, 1)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
+    elif request.param == "extrudedvariablelayers":
+        return ExtrudedMesh(UnitIntervalMesh(3), np.array([[0, 3], [0, 3], [0, 2]]), np.array([3, 3, 2]))
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -49,7 +49,7 @@ def parentmesh(request):
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
     elif request.param == "extruded":
-        return ExtrudedMesh(UnitSquareMesh(1, 1), 1)
+        return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "cube":
         return UnitCubeMesh(1, 1, 1)
     elif request.param == "tetrahedron":


### PR DESCRIPTION
Add support for extruded meshes. Also update tests to demonstrate that meshes whose coordinate fields have been shifted are in fact supported. Furthermore, ensure all `Constant`s have a domain.