### PR TITLE
Unify tolerance as a parameter of a MeshTopology

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -490,7 +490,10 @@ class Function(ufl.Coefficient, FunctionMixin):
         :arg arg: The point to locate.
         :arg args: Additional points.
         :kwarg dont_raise: Do not raise an error if a point is not found.
-        :kwarg tolerance: Tolerance to use when checking for points in cell.
+        :kwarg tolerance: Tolerence to use when checking if a point is in a
+            cell. Default is the :attr:`MeshTopology.tolerance` of the mesh the
+            function is defined on. Changing this from default will cause the
+            spatial index to be rebuilt which can take some time.
         """
         # Need to ensure data is up-to-date for reading
         self.dat.global_to_local_begin(op2.READ)
@@ -508,6 +511,11 @@ class Function(ufl.Coefficient, FunctionMixin):
         dont_raise = kwargs.get('dont_raise', False)
 
         tolerance = kwargs.get('tolerance', None)
+        if tolerance is None:
+            tolerance = self.ufl_domain().tolerance
+        else:
+            self.ufl_domain().tolerance = tolerance
+
         # Handle f.at(0.3)
         if not arg.shape:
             arg = arg.reshape(-1)

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -33,8 +33,6 @@ def make_wrapper(function, **kwargs):
 
 
 def src_locate_cell(mesh, tolerance=None):
-    if tolerance is None:
-        tolerance = 1e-14
     src = ['#include <evaluate.h>']
     src.append(compile_coordinate_element(mesh.ufl_coordinate_element(), tolerance))
     src.append(make_wrapper(mesh.coordinates,

--- a/tests/regression/test_point_eval_api.py
+++ b/tests/regression/test_point_eval_api.py
@@ -141,3 +141,21 @@ def test_nascent_parallel_support():
     assert np.allclose(0.0576, f.at([0.12, 0.18]))
     assert np.allclose(1.0266, f.at([0.98, 0.87]))
     assert np.allclose([0.2176, 0.2822], f.at([0.12, 0.68], [0.63, 0.34]))
+
+
+def test_tolerance():
+    mesh = UnitSquareMesh(1, 1)
+    old_tol = mesh.tolerance
+    f = Function(VectorFunctionSpace(mesh, "CG", 1)).interpolate(SpatialCoordinate(mesh))
+    assert np.allclose([0.2, 0.4], f.at(0.2, 0.4))
+    # tolerance of mesh is not changed
+    assert mesh.tolerance == old_tol
+    # Outside mesh, but within tolerance
+    assert np.allclose([-0.1, 0.4], f.at((-0.1, 0.4), tolerance=0.2))
+    # tolerance of mesh is changed
+    assert mesh.tolerance == 0.2
+    # works if mesh tolerance is changed
+    mesh.tolerance = 1e-11
+    with pytest.raises(PointNotInDomainError):
+        f.at((-0.1, 0.4))
+    assert np.allclose([-1e-12, 0.4], f.at((-1e-12, 0.4)))

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -179,20 +179,29 @@ def test_extrude(parentmesh):
 
 
 def test_point_tolerance():
-    """Test the tolerance parameter to VertexOnlyMesh.
-
-    This test works by checking a point outside the domain. Tolerance does not
-    in fact promise to fix the problem of points outside the domain in the
-    general case. It is instead there to cope with losing points on internal
-    cell boundaries due to roundoff. The latter case is difficult to test in a
-    manner which is robust to roundoff behaviour in different environments."""
+    """Test the tolerance parameter of VertexOnlyMesh."""
     m = UnitSquareMesh(1, 1)
+    assert m.tolerance == 1e-14
+    assert m.tolerance == m.topology.tolerance
     # Make the mesh non-axis-aligned.
     m.coordinates.dat.data[1, :] = [1.1, 1]
     coords = [[1.0501, 0.5]]
     vm = VertexOnlyMesh(m, coords, tolerance=0.1)
     assert vm.cell_set.size == 1
-    vm = VertexOnlyMesh(m, coords, tolerance=None)
+    # check that the tolerance is passed through to the parent mesh
+    assert m.tolerance == 0.1
+    assert m.topology.tolerance == 0.1
+    vm = VertexOnlyMesh(m, coords, tolerance=0.0)
+    assert vm.cell_set.size == 0
+    assert m.tolerance == 0.0
+    assert m.topology.tolerance == 0.0
+    # See if changing the tolerance on the parent mesh changes the tolerance
+    # on the VertexOnlyMesh
+    m.tolerance = 0.1
+    vm = VertexOnlyMesh(m, coords)
+    assert vm.cell_set.size == 1
+    m.tolerance = 0.0
+    vm = VertexOnlyMesh(m, coords)
     assert vm.cell_set.size == 0
 
 


### PR DESCRIPTION
Now setting the tolerance elsewhere updates this (and causes rebuilding of the spatial index if necessary).