### PR TITLE
Refactor parallel test markers

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -5,3 +5,4 @@ git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc
 git+https://github.com/OP2/PyOP2.git#egg=pyop2
 git+https://github.com/dolfin-adjoint/pyadjoint.git#egg=pyadjoint
 git+https://github.com/firedrakeproject/petsc.git@firedrake#egg=petsc
+git+https://github.com/firedrakeproject/pytest-mpi.git@main#egg=pytest-mpi

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1716,8 +1716,9 @@ if mode == "install":
         log.debug("bootstrapping pip succeeded")
         log.debug("Removing get-pip.py")
         os.remove("get-pip.py")
-    # Ensure pip, setuptools and wheel are at the latest version.
+    # Ensure pip, setuptools, hatchling and wheel are at the latest version.
     run_pip(["install", "-U", "setuptools==59.2.0"])  # Unpin this when numpy will build with latest setuptools
+    run_pip(["install", "-U", "hatch"])
     run_pip(["install", "-U", "pip"])
     run_pip(["install", "-U", "wheel==0.37.0"])  # Unpin this when numpy will build with latest wheel
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,39 +2,9 @@
 
 import pytest
 
-from subprocess import check_call
-from pyadjoint.tape import get_working_tape
-from firedrake.utils import complex_mode
-
-
-def parallel(item):
-    """Run a test in parallel.
-
-    :arg item: The test item to run.
-    """
-    from mpi4py import MPI
-    if MPI.COMM_WORLD.size > 1:
-        raise RuntimeError("parallel test can't be run within parallel environment")
-    marker = item.get_closest_marker("parallel")
-    if marker is None:
-        raise RuntimeError("Parallel test doesn't have parallel marker")
-    nprocs = marker.kwargs.get("nprocs", 3)
-    if nprocs < 2:
-        raise RuntimeError("Need at least two processes to run parallel test")
-
-    # Only spew tracebacks on rank 0.
-    # Run xfailing tests to ensure that errors are reported to calling process
-    call = ["mpiexec", "-n", "1", "python", "-m", "pytest", "--runxfail", "-s", "-q", "%s::%s" % (item.fspath, item.name)]
-    call.extend([":", "-n", "%d" % (nprocs - 1), "python", "-m", "pytest", "--runxfail", "--tb=no", "-q",
-                 "%s::%s" % (item.fspath, item.name)])
-    check_call(call)
-
 
 def pytest_configure(config):
     """Register an additional marker."""
-    config.addinivalue_line(
-        "markers",
-        "parallel(nprocs): mark test to run in parallel on nprocs processors")
     config.addinivalue_line(
         "markers",
         "skipcomplex: mark as skipped in complex mode")
@@ -46,39 +16,9 @@ def pytest_configure(config):
         "skipcomplexnoslate: mark as skipped in complex mode due to lack of Slate")
 
 
-@pytest.fixture(autouse=True)
-def old_pytest_runtest_setup(request):
-    item = request.node
-    if item.get_closest_marker("parallel"):
-        from mpi4py import MPI
-        if MPI.COMM_WORLD.size > 1:
-            # Turn on source hash checking
-            from firedrake import parameters
-            from functools import partial
-
-            def _reset(check):
-                parameters["pyop2_options"]["check_src_hashes"] = check
-
-            # Reset to current value when test is cleaned up
-            item.addfinalizer(partial(_reset,
-                                      parameters["pyop2_options"]["check_src_hashes"]))
-
-            parameters["pyop2_options"]["check_src_hashes"] = True
-        else:
-            # Blow away function arg in "master" process, to ensure
-            # this test isn't run on only one process.
-            item.obj = lambda *args, **kwargs: None
-
-
-def pytest_runtest_call(item):
-    from mpi4py import MPI
-    if item.get_closest_marker("parallel") and MPI.COMM_WORLD.size == 1:
-        # Spawn parallel processes to run test
-        parallel(item)
-
-
 def pytest_collection_modifyitems(session, config, items):
-    from firedrake.utils import SLATE_SUPPORTS_COMPLEX
+    from firedrake.utils import complex_mode, SLATE_SUPPORTS_COMPLEX
+
     for item in items:
         if complex_mode:
             if item.get_closest_marker("skipcomplex") is not None:
@@ -93,6 +33,8 @@ def pytest_collection_modifyitems(session, config, items):
 @pytest.fixture(scope="module", autouse=True)
 def check_empty_tape(request):
     """Check that the tape is empty at the end of each module"""
+    from pyadjoint.tape import get_working_tape
+
     def fin():
         tape = get_working_tape()
         if tape is not None:


### PR DESCRIPTION
I need to implement parallel tests for pyop3 so I think it makes sense to have a [separate package](https://github.com/connorjward/pytest-mpi) (should be moved into firedrakeproject) containing the pytest plugin. That way other packages can use the functionality without needing to copy our `conftest.py`.