### PR TITLE
Respect MACOSX_DEPLOYMENT_TARGET environment variable if set

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1157,7 +1157,8 @@ def build_and_install_petsc():
         # to workaround issues configuring PETSc on macos.
         #
         # Choosing 10.15 as the oldest MacOS version supported as at 2022-04-07
-        with environment(MACOSX_DEPLOYMENT_TARGET="10.15"):
+        macosx_deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "10.15")
+        with environment(MACOSX_DEPLOYMENT_TARGET=macosx_deployment_target):
             check_call([python, "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + petsc_options)
             check_call(["make", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch), "all"])
         if args.remove_build_files and not args.honour_petsc_dir:


### PR DESCRIPTION
With this change MacOS users can set an environment variable to fix their install, rather than needing to go and modify the pertinent line in `firedrake-install` which is the currently recommended solution.