### PR TITLE
Voting algorithm for VertexOnlyMesh

### DIFF
--- a/firedrake/evaluate.h
+++ b/firedrake/evaluate.h
@@ -51,7 +51,8 @@ extern int locate_cell(struct Function *f,
 		       ref_cell_l1_dist try_candidate,
 		       ref_cell_l1_dist_xtr try_candidate_xtr,
 		       void *temp_ref_coords,
-		       void *found_ref_coords);
+		       void *found_ref_coords,
+		       double *found_ref_cell_dist_l1);
 
 extern int evaluate(struct Function *f,
 		    double *x,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2762,13 +2762,6 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     tdim = parent_mesh.topological_dimension()
     gdim = parent_mesh.geometric_dimension()
 
-    # Need to save the coords dat version here because _parent_mesh_embedding
-    # will change it. This is due to a bug somewhere in the kernel generation
-    # of MeshGeometry.locate_cell_and_reference_coordinate - accessing the
-    # coordinates ought to be a read only operation but, for some reason,
-    # increments the dat version.
-    coords_dat_version = parent_mesh.coordinates.dat.dat_version
-
     if fields is None:
         fields = []
     fields += [("parentcellnum", 1, IntType), ("refcoord", tdim, RealType)]
@@ -2802,7 +2795,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         extrusion_heights = parent_cell_nums % (parent_mesh.layers - 1)
         # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.
         plex_parent_cell_nums = parent_mesh.topology.cell_closure[base_parent_cell_nums, -1]
-    elif coords_dat_version > 0:
+    elif parent_mesh.coordinates.dat.dat_version > 0:
         # The parent mesh coordinates have been modified. The DMSwarm parent
         # mesh plex numbering is now not guaranteed to match up with DMPlex
         # numbering so are set to -1. DMSwarm functions which rely on the

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -475,7 +475,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         :arg name: name of the mesh
         :kwarg tolerance: The relative tolerance (i.e. as defined on the
             reference cell) for the distance a point can be from a cell and
-            still be considered to be in the cell. Defaults to 1.0. Note that
+            still be considered to be in the cell. Note that
             this tolerance uses an L1 distance (aka 'manhatten', 'taxicab' or
             rectilinear distance) so will scale with the dimension of the mesh.
         """
@@ -864,7 +864,7 @@ class MeshTopology(AbstractMeshTopology):
         :kwarg comm: MPI communicator
         :kwarg tolerance: The relative tolerance (i.e. as defined on the
             reference cell) for the distance a point can be from a cell and
-            still be considered to be in the cell. Default is 1.0. Note that
+            still be considered to be in the cell. Note that
             this tolerance uses an L1 distance (aka 'manhatten', 'taxicab' or
             rectilinear distance) so will scale with the dimension of the mesh.
         """
@@ -1293,7 +1293,7 @@ class ExtrudedMeshTopology(MeshTopology):
         :kwarg tolerance:    The relative tolerance (i.e. as defined on the
                              reference cell) for the distance a point can be
                              from a cell and still be considered to be in the
-                             cell. Default is 1.0. Note that this tolerance
+                             cell. Note that this tolerance
                              uses an L1 distance (aka 'manhatten', 'taxicab' or
                              rectilinear distance) so will scale with the
                              dimension of the mesh.
@@ -1516,7 +1516,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         :arg reorder: whether to reorder the mesh (bool)
         :tolerance: The relative tolerance (i.e. as defined on the
             reference cell) for the distance a point can be from a cell and
-            still be considered to be in the cell. Defaults to 1.0.
+            still be considered to be in the cell.
         """
 
         super().__init__(name, tolerance=tolerance)
@@ -1702,6 +1702,13 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
 
     def mark_entities(self, tf, label_name, label_value):
         raise NotImplementedError("Currently not implemented for VertexOnlyMesh")
+
+    @utils.cached_property  # TODO: Recalculate if mesh moves
+    def cell_global_index(self):
+        """Return a list of unique cell IDs in vertex only mesh cell order."""
+        cell_global_index = np.copy(self.topology_dm.getField("globalindex"))
+        self.topology_dm.restoreField("globalindex")
+        return cell_global_index
 
 
 class MeshGeometryCargo:
@@ -2050,11 +2057,13 @@ values from f.)"""
 
         :arg x: point coordinates
         :kwarg tolerance: Tolerance for checking if a point is in a cell.
-            Default is this mesh's :attr:` property. Changing
+            Default is this mesh's :attr:`tolerance` property. Changing
             this from default will cause the spatial index to be rebuilt which
             can take some time.
-        :returns: tuple either (cell number, reference coordinates)
-            (int, numpy array), or (None, None) (point is not in the domain)
+        :returns: tuple either
+            (cell number, reference coordinates, ref_cell_dist_l1) of type
+            (int, numpy array, float), or, when point is not in the domain,
+            (None, None, None).
         """
         if self.variable_layers:
             raise NotImplementedError("Cell location not implemented for variable layers")
@@ -2067,13 +2076,15 @@ values from f.)"""
         if x.size != self.geometric_dimension():
             raise ValueError("Point coordinate dimension does not match mesh geometric dimension")
         X = np.empty_like(x)
+        ref_cell_dist_l1 = np.empty(1, dtype=utils.ScalarType)
         cell = self._c_locator(tolerance=tolerance)(self.coordinates._ctypes,
                                                     x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
+                                                    X.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                                    ref_cell_dist_l1.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         if cell == -1:
-            return (None, None)
+            return (None, None, None)
         else:
-            return cell, X
+            return cell, X, ref_cell_dist_l1[0]
 
     def _c_locator(self, tolerance=None):
         from pyop2 import compilation
@@ -2087,12 +2098,12 @@ values from f.)"""
         except KeyError:
             src = pq_utils.src_locate_cell(self, tolerance=tolerance)
             src += """
-    int locator(struct Function *f, double *x, double *X)
+    int locator(struct Function *f, double *x, double *X, double *ref_cell_dist_l1)
     {
         /* The type definitions and arguments used here are defined as
            statics in pointquery_utils.py */
         struct ReferenceCoords temp_reference_coords, found_reference_coords;
-        int cell = locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &temp_reference_coords, &found_reference_coords);
+        int cell = locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &temp_reference_coords, &found_reference_coords, ref_cell_dist_l1);
         for(int i=0; i<%(geometric_dimension)d; i++) {
             X[i] = found_reference_coords.X[i];
         }
@@ -2109,6 +2120,7 @@ values from f.)"""
                                                "-Wl,-rpath,%s/lib" % sys.prefix])
 
             locator.argtypes = [ctypes.POINTER(function._CFunction),
+                                ctypes.POINTER(ctypes.c_double),
                                 ctypes.POINTER(ctypes.c_double),
                                 ctypes.POINTER(ctypes.c_double)]
             locator.restype = ctypes.c_int
@@ -2392,7 +2404,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
     :kwarg tolerance:    The relative tolerance (i.e. as defined on the
                          reference cell) for the distance a point can be from a
                          cell and still be considered to be in the cell.
-                         Default is 1.0. Note that this tolerance uses an L1
+                         Note that this tolerance uses an L1
                          distance (aka 'manhatten', 'taxicab' or rectilinear
                          distance) so will scale with the dimension of the
                          mesh.
@@ -2523,10 +2535,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
     :kwarg missing_points_behaviour: optional string argument for what to do
         when vertices which are outside of the mesh are discarded. If
         ``'warn'``, will print a warning. If ``'error'`` will raise a
-        ValueError. Note that setting this will cause all MPI ranks to check
-        that they have the same list of vertices (else the test is not
-        possible): this operation scales with number of vertices and number of
-        ranks.
+        ValueError.
     :kwarg tolerance: The relative tolerance (i.e. as defined on the reference
         cell) for the distance a point can be from a mesh cell and still be
         considered to be in the cell. Note that this tolerance uses an L1
@@ -2552,21 +2561,15 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
 
     .. note::
         When running in parallel with ``redundant = False``, ``vertexcoords``
-        are strictly confined to the local ``mesh`` cells of that rank. This
+        will redistribute to the mesh partition where they are located. This
         means that if rank A has ``vertexcoords`` {X} that are not found in the
-        mesh cells  owned by rank A but are found in the mesh cells owned by
-        ank B, **and rank B has not been supplied with those**
-        ``vertexcoords``, then the ``vertexcoords`` {X} will be lost.
+        mesh cells owned by rank A but are found in the mesh cells owned by
+        rank B, **and rank B has not been supplied with those**, then they will
+        be moved to rank B.
 
-        This can be avoided by either
-
-        #. making sure that rank 0 has all vertex coordinates and setting
-           ``redundant = True`` or by
-        #. ensuring that ``vertexcoords`` are already found in cells owned by
-           the ``mesh`` partition of the given rank.
-
-        For more see `this github issue
-        <https://github.com/firedrakeproject/firedrake/issues/2178>`_.
+    .. note::
+        If the same coordinates are supplied more than once, they are always
+        assumed to be a new vertex.
 
     """
 
@@ -2610,36 +2613,13 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
     if pdim != gdim:
         raise ValueError(f"Mesh geometric dimension {gdim} must match point list dimension {pdim}")
 
-    swarm = _pic_swarm_in_mesh(mesh, vertexcoords, tolerance=tolerance, redundant=redundant)
+    swarm, n_missing_points = _pic_swarm_in_mesh(
+        mesh, vertexcoords, tolerance=tolerance, redundant=redundant
+    )
 
     if missing_points_behaviour:
-
-        def compare_arrays(x, y, datatype):
-            x, eqx = x
-            y, eqy = y
-            if not (eqx and eqy):
-                return (None, False)
-            elif x.shape != y.shape:
-                return (None, False)
-            else:
-                return (x, np.allclose(x, y))
-
-        op = MPI.Op.Create(compare_arrays, commute=True)
-
-        # check all ranks have the same vertexcoords so that check is valid
-        # NOTE this operation scales with number of vertices and ranks
-        _, allequal = mesh._comm.allreduce((vertexcoords, True), op=op)
-        op.Free()
-        if not allequal:
-            raise ValueError("Cannot check for missing points if different vertices on each MPI rank!")
-
-        # Check for missing points
-        nlocal = len(swarm.getField("parentcellnum"))
-        swarm.restoreField("parentcellnum")
-        nglobal = mesh._comm.allreduce(nlocal, op=MPI.SUM)
-        ninput = len(vertexcoords)
-        if nglobal < ninput:
-            msg = f"{ninput - nglobal} vertices are outside the mesh and have been removed from the VertexOnlyMesh"
+        if n_missing_points:
+            msg = f"{n_missing_points} vertices are outside the mesh and have been removed from the VertexOnlyMesh"
             if missing_points_behaviour == 'error':
                 raise ValueError(msg)
             elif missing_points_behaviour == 'warn':
@@ -2715,7 +2695,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         cause the parent mesh's spatial index to be rebuilt which can take some
         time.
     :kwarg redundant: If True, the DMSwarm will be created using only the
-        points specified on MPI rank 0. The default is True.
+        points specified on MPI rank 0.
     :return: the immersed DMSwarm
 
     .. note::
@@ -2729,22 +2709,39 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         usually with zeroed imaginary parts).
 
     .. note::
-        When running in parallel, ``coords`` are strictly confined to
-        the local DMPlex cells of that rank. This means that if rank A
-        has ``coords`` {X} that are not found in the DMPlex cells of rank
-        A but are found in the DMPlex cells of rank B, **and rank B has
-        not been supplied with those** ``coords`` then the ``coords`` {X}
-        will be lost.
+        When running in parallel with ``redundant = False``, ``coords``
+        will redistribute to the mesh partition where they are located. This
+        means that if rank A has ``coords`` {X} that are not found in the
+        mesh cells owned by rank A but are found in the mesh cells owned by
+        rank B, **and rank B has not been supplied with those**, then they will
+        be moved to rank B.
 
-        This can be avoided by either
+    .. note::
+        If the same coordinates are supplied more than once, they are always
+        assumed to be a new vertex.
 
-        #. making sure that all ranks are supplied with the same list of
-          ``coords`` or by
-        #. ensuring that ``coords`` are already localised for to the DMPlex
-           cells of the given rank.
+    .. note::
+        Three DMSwarm fields are created automatically here:
 
-        For more see `this github issue
-        <https://github.com/firedrakeproject/firedrake/issues/2178>`_.
+        #. ``parentcellnum`` which contains the firedrake cell number of the
+           immersed vertex and
+        #. ``refcoord`` which contains the reference coordinate of the immersed
+           vertex in the parent mesh cell.
+        #. ``globalindex`` which contains a unique ID for each DMSwarm point -
+           here this is the index into the ``coords`` array if ``redundant`` is
+           ``True``, otherwise it's an index in rank order, so if rank 0 has 10
+           points, rank 1 has 20 points, and rank 3 has 5 points, then rank 0's
+           points will be numbered 0-9, rank 1's points will be numbered 10-29,
+           and rank 3's points will be numbered 30-34. Note that this ought to
+           be ``DMSwarmField_pid`` but a bug in petsc4py means that this field
+           cannot be set.
+
+        Another three are required for proper functioning of the DMSwarm:
+
+        #. ``DMSwarmPIC_coor`` which contains the coordinates of the point.
+        #. ``DMSwarm_cellid`` the DMPlex cell within which the DMSwarm point is
+           located.
+        #. ``DMSwarm_rank``: the MPI rank which owns the DMSwarm point.
     """
 
     if tolerance is None:
@@ -2755,18 +2752,24 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     # Check coords
     coords = np.asarray(coords, dtype=RealType)
 
-    if redundant:
-        coords = parent_mesh._comm.bcast(coords, root=0)
-
     plex = parent_mesh.topology.topology_dm
     tdim = parent_mesh.topological_dimension()
     gdim = parent_mesh.geometric_dimension()
 
     if fields is None:
         fields = []
-    fields += [("parentcellnum", 1, IntType), ("refcoord", tdim, RealType)]
-    coords, reference_coords, parent_cell_nums = \
-        _parent_mesh_embedding(coords, parent_mesh, tolerance)
+    fields += [("parentcellnum", 1, IntType), ("refcoord", tdim, RealType), ("globalindex", 1, IntType)]
+
+    (
+        coords,
+        coords_idxs,
+        reference_coords,
+        parent_cell_nums,
+        ranks,
+        missing_coords_idxs,
+    ) = _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_halos=True)
+
+    n_missing_points = len(missing_coords_idxs)
 
     if parent_mesh.extruded:
         # need to store the base parent cell number and the height to be able
@@ -2858,12 +2861,19 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     swarm_parent_cell_nums = swarm.getField("DMSwarm_cellid")
     field_parent_cell_nums = swarm.getField("parentcellnum")
     field_reference_coords = swarm.getField("refcoord").reshape((num_vertices, tdim))
+    field_global_index = swarm.getField("globalindex")
+    field_rank = swarm.getField("DMSwarm_rank")
+
     swarm_coords[...] = coords
     swarm_parent_cell_nums[...] = plex_parent_cell_nums
     field_parent_cell_nums[...] = parent_cell_nums
     field_reference_coords[...] = reference_coords
+    field_global_index[...] = coords_idxs
+    field_rank[...] = ranks
 
     # have to restore fields once accessed to allow access again
+    swarm.restoreField("DMSwarm_rank")
+    swarm.restoreField("globalindex")
     swarm.restoreField("refcoord")
     swarm.restoreField("parentcellnum")
     swarm.restoreField("DMSwarmPIC_coor")
@@ -2884,76 +2894,210 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     sf.setGraph(nroots, None, [])
     swarm.setPointSF(sf)
 
-    return swarm
+    return swarm, n_missing_points
 
 
-def _parent_mesh_embedding(vertex_coords, parent_mesh, tolerance):
-    """Find the parent cells and local coords for vertices on this rank.
+def _mpi_array_lexicographic_min(x, y, datatype):
+    """MPI operator for lexicographic minimum of arrays.
 
-    Vertices not located in cells owned by this rank are discarded.
+    This compares two arrays of shape (N, 2) lexicographically, i.e. first
+    comparing the two arrays by their first column, returning the element-wise
+    minimum, with ties broken by comparing the second column element wise.
+
+    Parameters
+    ----------
+    x : ``np.ndarray``
+        The first array to compare of shape (N, 2).
+    y : ``np.ndarray``
+        The second array to compare of shape (N, 2).
+    datatype : ``MPI.Datatype``
+        The datatype of the arrays.
+
+    Returns
+    -------
+    ``np.ndarray``
+        The lexicographically lowest array of shape (N, 2).
+
     """
-    vertex_coords = _on_rank_vertices(vertex_coords, parent_mesh, tolerance)
+    # Check the first column
+    min_idxs = np.where(x[:, 0] < y[:, 0])[0]
+    result = np.copy(y)
+    result[min_idxs, :] = x[min_idxs, :]
 
-    num_vertices = len(vertex_coords)
-    max_num_vertices = parent_mesh._comm.allreduce(num_vertices, op=MPI.MAX)
+    # if necessary, check the second column
+    eq_idxs = np.where(x[:, 0] == y[:, 0])[0]
+    if len(eq_idxs):
+        # We only check where we have equal values to avoid unnecessary work
+        min_idxs = np.where(x[eq_idxs, 1] < y[eq_idxs, 1])[0]
+        result[eq_idxs[min_idxs], :] = x[eq_idxs[min_idxs], :]
+    return result
 
-    gdim = parent_mesh.geometric_dimension()
-    tdim = parent_mesh.topological_dimension()
 
-    parent_cell_nums = np.empty(num_vertices, dtype=IntType)
-    reference_coords = np.empty((num_vertices, tdim), dtype=RealType)
-    valid = np.full(num_vertices, False)
+array_lexicographic_mpi_op = MPI.Op.Create(_mpi_array_lexicographic_min, commute=True)
 
-    if parent_mesh.extruded:
-        if parent_mesh.variable_layers:
-            # The below could work as a hack but for now raise notimplementederror
-            # import firedrake.functionspace as functionspace
-            # import firedrake.function as function
-            # pm_local_size_wo_halos = len(function.Function(functionspace.FunctionSpace(parent_mesh, "DG", 0)).dat.data_ro)
-            raise NotImplementedError("Not implemented for ExtrudedMesh with variable layers.")
-        pm_local_size_wo_halos = parent_mesh.cell_set.size * (parent_mesh.layers - 1)
+
+def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_halos):
+    """Find the parent mesh cells containing the given coordinates.
+
+    Parameters
+    ----------
+    parent_mesh : ``Mesh``
+        The parent mesh to embed in.
+    coords : ``np.ndarray``
+        The coordinates to embed of (npoints, coordsdim) shape.
+    tolerance : ``float``
+        The relative tolerance (i.e. as defined on the reference cell) for the
+        distance a point can be from a cell and still be considered to be in
+        the cell. Note that this tolerance uses an L1
+        distance (aka 'manhatten', 'taxicab' or rectilinear distance) so
+        will scale with the dimension of the mesh. The default is the parent
+        mesh's ``tolerance`` property. Changing this from default will
+        cause the parent mesh's spatial index to be rebuilt which can take some
+        time.
+    redundant : ``bool``
+        If True, the embedding will be done using only the points specified on
+        MPI rank 0.
+    exclude_halos : ``bool``
+        If True, the embedding will be done using only the points specified on
+        the locally owned mesh partition.
+
+    Returns
+    -------
+    coords : ``np.ndarray``
+        The coordinates of the points that were embedded.
+    coords_idxs : ``np.ndarray``
+        The indices of the points that were embedded.
+    reference_coords : ``np.ndarray``
+        The reference coordinates of the points that were embedded.
+    parent_cell_nums : ``np.ndarray``
+        The parent cell indices (as given by ``locate_cell``) of the points
+        that were embedded.
+    ranks : ``np.ndarray``
+        The MPI rank of the process that owns the parent cell of the points.
+    missing_coords_idxs : ``np.ndarray``
+        The indices of the points in the input coords array that were not
+        embedded. See note below.
+
+    Notes
+    -----
+    When redundant is False, it is assumed that all points given are unique.
+    If, however, any detected points are not identified as being in the locally
+    owned mesh partition (i.e. not in the halo) then an error is raised. This
+    is because we do not have point redistribution implemented yet.
+    """
+
+    import firedrake.functionspace as functionspace
+    import firedrake.constant as constant
+    import firedrake.interpolation as interpolation
+
+    # In parallel, we need to make sure we know which point is which and save
+    # it.
+    if redundant:
+        # rank 0 broadcasts coords to all ranks
+        coords_local = parent_mesh._comm.bcast(coords, root=0)
+        ncoords_local = coords_local.shape[0]
+        coords_global = coords_local
+        ncoords_global = coords_global.shape[0]
+        coords_idxs = np.arange(coords_global.shape[0])
     else:
-        pm_local_size_wo_halos = parent_mesh.cell_set.size
+        # Here, we have to assume that all points we can see are unique.
+        # We therefore gather all points on all ranks in rank order: if rank 0
+        # has 10 points, rank 1 has 20 points, and rank 3 has 5 points, then
+        # rank 0's points have global numbering 0-9, rank 1's points have
+        # global numbering 10-29, and rank 3's points have global numbering
+        # 30-34.
+        coords_local = coords
+        ncoords_local = coords.shape[0]
+        ncoords_local_allranks = parent_mesh._comm.allgather(ncoords_local)
+        ncoords_global = sum(ncoords_local_allranks)
+        # The below code looks complicated but it's just an allgather of the
+        # (variable length) coords_local array such that they are concatenated.
+        coords_local_size = np.array(coords_local.size)
+        coords_local_sizes = np.empty(parent_mesh._comm.size, dtype=int)
+        parent_mesh._comm.Allgatherv(coords_local_size, coords_local_sizes)
+        coords_global = np.empty(
+            (ncoords_global, coords.shape[1]), dtype=coords_local.dtype
+        )
+        parent_mesh._comm.Allgatherv(coords_local, (coords_global, coords_local_sizes))
+        # # ncoords_local_allranks is in rank order so we can just sum up the
+        # # previous ranks to get the starting index for the global numbering.
+        # # For rank 0 we make use of the fact that sum([]) = 0.
+        # startidx = sum(ncoords_local_allranks[:parent_mesh._comm.rank])
+        # endidx = startidx + ncoords_local
+        # coords_idxs = np.arange(startidx, endidx)
+        coords_idxs = np.arange(coords_global.shape[0])
 
-    # Create an out of mesh point to use in locate_cell when needed
-    out_of_mesh_point = np.full((1, gdim), np.inf)
+    # Get parent mesh rank ownership information:
+    # Interpolating Constant(parent_mesh.comm.rank) into P0DG cleverly creates
+    # a Function whose dat contains rank ownership information in an ordering
+    # that is accessible using Firedrake's cell numbering. This is because, on
+    # each rank, parent_mesh.comm.rank creates a Constant with the local rank
+    # number, and halo exchange ensures that this information is visible, as
+    # nessesary, to other processes.
+    P0DG = functionspace.FunctionSpace(parent_mesh, "DG", 0)
+    visible_ranks = interpolation.interpolate(
+        constant.Constant(parent_mesh.comm.rank), P0DG
+    ).dat.data_ro_with_halos.real
 
-    for i in range(max_num_vertices):
-        if i < num_vertices:
-            parent_cell_num, reference_coord = \
-                parent_mesh.locate_cell_and_reference_coordinate(vertex_coords[i], tolerance)
-            # At the moment we discard vertices in parent mesh halos
-            if parent_cell_num is not None and parent_cell_num < pm_local_size_wo_halos:
-                valid[i] = True
-                parent_cell_nums[i] = parent_cell_num
-                reference_coords[i] = reference_coord
-        else:
-            parent_mesh.locate_cell(out_of_mesh_point, tolerance)  # should return None
+    locally_visible = np.full(ncoords_global, False)
+    parent_cell_nums = np.empty(ncoords_global, dtype=int)
+    reference_coords = np.empty(
+        (ncoords_global, parent_mesh.topological_dimension()), dtype=RealType
+    )
+    # See below for why np.inf is used here.
+    ref_cell_dists_l1_and_ranks = np.full((ncoords_global, 2), np.inf)
 
-    vertex_coords = np.compress(valid, vertex_coords, axis=0)
-    reference_coords = np.compress(valid, reference_coords, axis=0)
-    parent_cell_nums = np.compress(valid, parent_cell_nums, axis=0)
+    # TODO: Move this loop into C: it's a bottleneck for lots of coords.
+    for i in range(ncoords_global):
+        (
+            parent_cell_num,
+            reference_coord,
+            ref_cell_dist_l1,
+        ) = parent_mesh.locate_cell_and_reference_coordinate(
+            coords_global[i], tolerance
+        )
+        if parent_cell_num is not None:
+            locally_visible[i] = True
+            parent_cell_nums[i] = parent_cell_num
+            reference_coords[i] = reference_coord
+            ref_cell_dists_l1_and_ranks[i, 0] = ref_cell_dist_l1
+            ref_cell_dists_l1_and_ranks[i, 1] = visible_ranks[parent_cell_num]
 
-    return vertex_coords, reference_coords, parent_cell_nums
+    # In parallel there will regularly be disagreements about which cell owns a
+    # point when those points are close to mesh partition boundaries.
+    # We now have the reference cell l1 distance and ranks being np.inf for any
+    # point which is not locally visible. By collectively taking the minimum
+    # of the reference cell l1 distance, which is tied to the rank via
+    # ref_cell_dists_l1_and_ranks, we both check which cell the coordinate is
+    # closest to and find out which rank owns that cell.
+    # In cases where the reference cell l1 distance is the same for a
+    # particular coordinate, we break the tie by choosing the lowest rank.
+    # This turns out to be a lexicographic row-wise minimum of the
+    # ref_cell_dists_l1_and_ranks array: we minimise the distance first and
+    # break ties by minimising the distance.
+    ref_cell_dists_l1_and_ranks = parent_mesh.comm.allreduce(
+        ref_cell_dists_l1_and_ranks, op=array_lexicographic_mpi_op
+    )
 
+    ranks = ref_cell_dists_l1_and_ranks[:, 1]
 
-def _on_rank_vertices(vertex_coords, parent_mesh, tolerance):
-    """Discard those vertices that are definitely not on this MPI rank."""
-    bounding_box_min = parent_mesh.coordinates.dat.data_ro_with_halos.min(axis=0, initial=np.inf) - tolerance
-    bounding_box_max = parent_mesh.coordinates.dat.data_ro_with_halos.max(axis=0, initial=-np.inf) + tolerance
-    if len(vertex_coords) == 0:
-        # Can skip the rest of the work if there are no vertices, but have to
-        # make sure we ask for the bounding box minima and maxima on all ranks.
-        return vertex_coords
-    length_scale = (bounding_box_max - bounding_box_min).max()
-    # This is basically to avoid roundoff, so 1% is very conservative.
-    bounding_box_min -= 0.01 * length_scale
-    bounding_box_max += 0.01 * length_scale
+    # Any ranks which are still np.inf are not in the mesh
+    missing_coords_idxs = np.where(ranks == np.inf)[0]
 
-    on_rank = (vertex_coords < bounding_box_max).all(axis=1) \
-        | (vertex_coords > bounding_box_min).all(axis=1)
+    off_rank_coords_idxs = np.where(ranks != parent_mesh.comm.rank)[0]
+    if exclude_halos:
+        locally_visible[off_rank_coords_idxs] = False
 
-    return np.compress(on_rank, vertex_coords, axis=0)
+    # Drop points which are not locally visible but leave the missing coords
+    # indices intact for inspection (so that we can tell how many are lost)
+    return (
+        np.compress(locally_visible, coords_global, axis=0),
+        np.compress(locally_visible, coords_idxs, axis=0),
+        np.compress(locally_visible, reference_coords, axis=0),
+        np.compress(locally_visible, parent_cell_nums, axis=0),
+        np.compress(locally_visible, ranks, axis=0),
+        missing_coords_idxs,
+    )
 
 
 def RelabeledMesh(mesh, indicator_functions, subdomain_ids, **kwargs):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2524,7 +2524,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
 
 
 @PETSc.Log.EventDecorator()
-def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour=None,
+def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
                    tolerance=None, redundant=True):
     """
     Create a vertex only mesh, immersed in a given mesh, with vertices defined

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -137,8 +137,9 @@ static inline void wrap_evaluate(%(scalar_type)s* const result, %(scalar_type)s*
 int evaluate(struct Function *f, double *x, %(scalar_type)s *result)
 {
     /* The type definitions and arguments used here are defined as statics in pointquery_utils.py */
+    double found_ref_cell_dist_l1 = DBL_MAX;
     struct ReferenceCoords temp_reference_coords, found_reference_coords;
-    %(IntType)s cell = locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &temp_reference_coords, &found_reference_coords);
+    %(IntType)s cell = locate_cell(f, x, %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &temp_reference_coords, &found_reference_coords, &found_ref_cell_dist_l1);
     if (cell == -1) {
         return -1;
     }

--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -118,7 +118,7 @@ def pseudo_random_coords(size):
 # NOTE: these _spatialcoordinate tests should be equivalent to some kind of
 # interpolation from a CG1 VectorFunctionSpace (I think)
 def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     # Reshaping because for all meshes, we want (-1, gdim) but
     # when gdim == 1 PyOP2 doesn't distinguish between dats with shape
     # () and shape (1,).
@@ -130,7 +130,7 @@ def test_scalar_spatialcoordinate_interpolation(parentmesh, vertexcoords):
 
 
 def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro.reshape(-1, parentmesh.geometric_dimension())
     fs_fam, fs_deg, fs_typ = fs
     if (
@@ -158,7 +158,7 @@ def test_scalar_function_interpolation(parentmesh, vertexcoords, fs):
 
 
 def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro
     W = VectorFunctionSpace(vm, "DG", 0)
     expr = 2 * SpatialCoordinate(parentmesh)
@@ -168,7 +168,7 @@ def test_vector_spatialcoordinate_interpolation(parentmesh, vertexcoords):
 
 def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
     vfs_fam, vfs_deg, vfs_typ = vfs
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro
     if (
         parentmesh.coordinates.function_space().ufl_element().family()
@@ -194,7 +194,7 @@ def test_vector_function_interpolation(parentmesh, vertexcoords, vfs):
 
 
 def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro
     W = TensorFunctionSpace(vm, "DG", 0)
     x = SpatialCoordinate(parentmesh)
@@ -210,7 +210,7 @@ def test_tensor_spatialcoordinate_interpolation(parentmesh, vertexcoords):
 
 def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
     tfs_fam, tfs_deg, tfs_typ = tfs
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro
     if (
         parentmesh.coordinates.function_space().ufl_element().family()
@@ -244,7 +244,7 @@ def test_tensor_function_interpolation(parentmesh, vertexcoords, tfs):
 @pytest.mark.xfail(raises=NotImplementedError, reason="Interpolation of UFL expressions into mixed functions not supported")
 def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
     tfs_fam, tfs_deg, tfs_typ = tfs
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     vertexcoords = vm.coordinates.dat.data_ro.reshape(-1, parentmesh.geometric_dimension())
     V1 = tfs_typ(parentmesh, tfs_fam, tfs_deg)
     V2 = FunctionSpace(parentmesh, "CG", 1)
@@ -285,7 +285,7 @@ def test_mixed_function_interpolation(parentmesh, vertexcoords, tfs):
 
 
 def test_scalar_real_interpolation(parentmesh, vertexcoords):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     W = FunctionSpace(vm, "DG", 0)
     V = FunctionSpace(parentmesh, "Real", 0)
     # Remove below when interpolating constant onto Real works for extruded
@@ -300,7 +300,7 @@ def test_scalar_real_interpolation(parentmesh, vertexcoords):
 
 def test_scalar_real_interpolator(parentmesh, vertexcoords):
     # try and make reusable Interpolator from V to W
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     W = FunctionSpace(vm, "DG", 0)
     V = FunctionSpace(parentmesh, "Real", 0)
     # Remove below when interpolating constant onto Real works for extruded
@@ -327,8 +327,8 @@ def test_extruded_cell_parent_cell_list():
     # we are not at the cell midpoints
     coords = np.array([[0.2, 0.1], [0.5, 0.2], [0.7, 0.1], [0.2, 0.4], [0.4, 0.4], [0.8, 0.5], [0.1, 0.7], [0.5, 0.9], [0.9, 0.8]])
 
-    vms = VertexOnlyMesh(ms, coords)
-    vmx = VertexOnlyMesh(mx, coords)
+    vms = VertexOnlyMesh(ms, coords, missing_points_behaviour=None)
+    vmx = VertexOnlyMesh(mx, coords, missing_points_behaviour=None)
     assert vms.num_cells() == len(coords)
     assert vmx.num_cells() == len(coords)
     assert np.equal(vms.coordinates.dat.data_ro, coords).all()

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -35,8 +35,61 @@ def cell_midpoints(m):
     return midpoints, local_midpoints
 
 
+def cell_ownership(m):
+    """Determine the MPI rank that the local partition thinks "owns" each cell
+    in the mesh.
+
+    :param m: The mesh to generate cell ownership for.
+
+    :returns: A numpy array of MPI ranksl, indexed by cell number as given by
+    m.locate_cell(point).
+
+    """
+    m.init()
+    # Interpolating Constant(parent_mesh.comm.rank) into P0DG cleverly creates
+    # a Function whose dat contains rank ownership information in an ordering
+    # that is accessible using Firedrake's cell numbering. This is because, on
+    # each rank, parent_mesh.comm.rank creates a Constant with the local rank
+    # number, and halo exchange ensures that this information is visible, as
+    # nessesary, to other processes.
+    P0DG = FunctionSpace(m, "DG", 0)
+    return interpolate(Constant(m.comm.rank), P0DG).dat.data_ro_with_halos
+
+
+def point_ownership(m, points, localpoints):
+    """Determine the MPI rank that the local partition thinks "owns" the given
+    points array.
+
+    If the points are not in the local mesh partition or the halo, then the
+    returned rank will be -1.
+
+    :param m: The mesh to generate point ownership for.
+    :param points: A numpy array of all points across all MPI ranks.
+    :param localpoints: A numpy array of points that are known to be rank-local.
+
+    :returns: A numpy array of MPI ranks, indexed by point number as given by
+    m.locate_cell(point).
+
+    """
+    out_of_mesh_point = np.full((1, m.geometric_dimension()), np.inf)
+    cell_numbers = np.empty(len(localpoints), dtype=int)
+    i = 0
+    for point in points:
+        if any(np.array_equal(point, localpoint) for localpoint in localpoints):
+            cell_numbers[i] = m.locate_cell(point)
+            i += 1
+        else:
+            # need to still call locate_cell since it's collective
+            m.locate_cell(out_of_mesh_point)
+    # shouldn't find any Nones: all points should be in the local mesh partition
+    assert all(cell_numbers != None)  # noqa: E711
+    ownership = cell_ownership(m)
+    return ownership[cell_numbers]
+
+
 @pytest.fixture(params=["interval",
                         "square",
+                        "squarequads",
                         "extruded",
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
@@ -49,6 +102,8 @@ def parentmesh(request):
         return UnitIntervalMesh(1)
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
+    elif request.param == "squarequads":
+        return UnitSquareMesh(2, 2, quadrilateral=True)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "extrudedvariablelayers":
@@ -82,8 +137,11 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     swarm is created in plex."""
 
     # Setup
+
     parentmesh.init()
     inputpointcoords, inputlocalpointcoords = cell_midpoints(parentmesh)
+    inputcoordindices = np.arange(len(inputpointcoords))
+    inputlocalpointcoordranks = point_ownership(parentmesh, inputpointcoords, inputlocalpointcoords)
     plex = parentmesh.topology.topology_dm
     from firedrake.petsc import PETSc
     fields = [("fieldA", 1, PETSc.IntType), ("fieldB", 2, PETSc.ScalarType)]
@@ -93,14 +151,14 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         # global cell midpoints only on rank 0. Note that this is the default
         # behaviour so it needn't be specified explicitly.
         if MPI.COMM_WORLD.rank == 0:
-            swarm = mesh._pic_swarm_in_mesh(parentmesh, inputpointcoords, fields=fields)
+            swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputpointcoords, fields=fields)
         else:
-            swarm = mesh._pic_swarm_in_mesh(parentmesh, np.empty(inputpointcoords.shape), fields=fields)
+            swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, np.empty(inputpointcoords.shape), fields=fields)
     else:
         # When redundant == False we expect the same behaviour by only
         # supplying the local cell midpoints on each MPI ranks. Note that this
         # is not the default behaviour so it must be specified explicitly.
-        swarm = mesh._pic_swarm_in_mesh(parentmesh, inputlocalpointcoords, fields=fields, redundant=redundant)
+        swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputlocalpointcoords, fields=fields, redundant=redundant)
 
     # Get point coords on current MPI rank
     localpointcoords = np.copy(swarm.getField("DMSwarmPIC_coor"))
@@ -116,7 +174,15 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     localparentcellindices = np.copy(swarm.getField("DMSwarm_cellid"))
     swarm.restoreField("DMSwarm_cellid")
 
+    # also get the global coordinate numbering
+    globalindices = np.copy(swarm.getField("globalindex"))
+    swarm.restoreField("globalindex")
+
     # Tests
+
+    # Since we have specified points at cell midpoints, we should have no
+    # missing points
+    assert n_missing_coords == 0
 
     # get custom fields on swarm - will fail if didn't get created
     for name, size, dtype in fields:
@@ -162,6 +228,19 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         else:
             assert np.any(index == cell_indexes)
 
+    # since we know all points are in the mesh, we can check that the global
+    # indices are correct (i.e. they should be in rank order)
+    assert np.array_equal(
+        inputcoordindices, np.concatenate(parentmesh.comm.allgather(globalindices))
+    )
+
+    # Check that the rank numbering is correct. Since we know all points are at
+    # the midpoints of cells, there should be no disagreement about cell
+    # ownership and the voting algorithm should have no effect.
+    ranks = np.copy(swarm.getField("DMSwarm_rank"))
+    swarm.restoreField("DMSwarm_rank")
+    assert np.array_equal(ranks, inputlocalpointcoordranks)
+
     # Now have DMPLex compute the cell IDs in cases where it can:
     if (
         parentmesh.coordinates.ufl_element().family() != "Discontinuous Lagrange"
@@ -173,6 +252,10 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         petsclocalparentcellindices = np.copy(swarm.getField("DMSwarm_cellid"))
         swarm.restoreField("DMSwarm_cellid")
         assert np.all(petsclocalparentcellindices == localparentcellindices)
+
+    # out_of_mesh_point = np.full((2, parentmesh.geometric_dimension()), np.inf)
+    # swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, out_of_mesh_point, fields=fields)
+    # assert n_missing_coords == 2
 
 
 @pytest.mark.parallel
@@ -189,4 +272,4 @@ def test_pic_swarm_in_mesh_2d_2procs():
 @pytest.mark.parallel(nprocs=3)  # nprocs > total number of mesh cells
 def test_pic_swarm_in_mesh_2d_3procs():
     test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False)
-    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -147,6 +147,8 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     fields = [("fieldA", 1, PETSc.IntType), ("fieldB", 2, PETSc.ScalarType)]
 
     if redundant:
+        if MPI.COMM_WORLD.size == 1:
+            pytest.skip("Testing redundant in serial isn't worth the time")
         # check redundant argument broadcasts from rank 0 by only supplying the
         # global cell midpoints only on rank 0. Note that this is the default
         # behaviour so it needn't be specified explicitly.

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -83,12 +83,6 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
 
     # Setup
     parentmesh.init()
-    # The coords dat version is > 0 for a shifted mesh. We need to save the it
-    # here because a bug somewhere in the kernel generation of
-    # MeshGeometry.locate_cell_and_reference_coordinate changes its value.
-    # Accessing the coordinates ought to be a read only operation but, for some
-    # reason, it increments the dat version.
-    coords_dat_version = parentmesh.coordinates.dat.dat_version
     inputpointcoords, inputlocalpointcoords = cell_midpoints(parentmesh)
     plex = parentmesh.topology.topology_dm
     from firedrake.petsc import PETSc
@@ -163,7 +157,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     # parent mesh is shifted, in which case they should all be -1
     cell_indexes = parentmesh.cell_closure[:, -1]
     for index in localparentcellindices:
-        if coords_dat_version > 0:
+        if parentmesh.coordinates.dat.dat_version > 0:
             assert index == -1
         else:
             assert np.any(index == cell_indexes)
@@ -172,7 +166,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     if (
         parentmesh.coordinates.ufl_element().family() != "Discontinuous Lagrange"
         and not parentmesh.extruded
-        and not coords_dat_version > 0
+        and not parentmesh.coordinates.dat.dat_version > 0
     ):
         swarm.setPointCoordinates(localpointcoords, redundant=False,
                                   mode=PETSc.InsertMode.INSERT_VALUES)

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -8,6 +8,7 @@ from mpi4py import MPI
 
 @pytest.fixture(params=["interval",
                         "square",
+                        "squarequads",
                         "extruded",
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
@@ -20,6 +21,8 @@ def parentmesh(request):
         return UnitIntervalMesh(1)
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
+    elif request.param == "squarequads":
+        return UnitSquareMesh(2, 2, quadrilateral=True)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "extrudedvariablelayers":

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -139,7 +139,7 @@ def vectorfunctionspace_tests(vm):
 
 
 def test_functionspaces(parentmesh, vertexcoords):
-    vm = VertexOnlyMesh(parentmesh, vertexcoords)
+    vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     functionspace_tests(vm)
     vectorfunctionspace_tests(vm)
 

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -37,6 +37,7 @@ def cell_midpoints(m):
 
 @pytest.fixture(params=["interval",
                         "square",
+                        "squarequads",
                         "extruded",
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
@@ -49,6 +50,8 @@ def parentmesh(request):
         return UnitIntervalMesh(1)
     elif request.param == "square":
         return UnitSquareMesh(1, 1)
+    elif request.param == "squarequads":
+        return UnitSquareMesh(2, 2, quadrilateral=True)
     elif request.param == "extruded":
         return ExtrudedMesh(UnitSquareMesh(2, 2), 3)
     elif request.param == "extrudedvariablelayers":
@@ -67,12 +70,14 @@ def parentmesh(request):
         return m
 
 
-@pytest.fixture(params=["redundant", "nonredundant"])
+@pytest.fixture(params=["redundant", "nonredundant", "redistribute"])
 def redundant(request):
     if request.param == "redundant":
         return True
-    else:
+    elif request.param == "nonredundant":
         return False
+    else:
+        return "redistribute"
 
 
 @pytest.fixture(params=[0, 1, 100], ids=lambda x: f"{x}-coords")
@@ -110,26 +115,50 @@ def verify_vertexonly_mesh(m, vm, inputvertexcoords):
     vm.init()
     # Find in-bounds and non-halo-region input coordinates
     in_bounds = []
+    ref_cell_dists_l1 = []
     # this method of getting owned cells works for all mesh types
     owned_cells = len(Function(FunctionSpace(m, "DG", 0)).dat.data_ro)
     for i in range(len(inputvertexcoords)):
-        cell_num = m.locate_cell(inputvertexcoords[i])
+        cell_num, _, ref_cell_dist_l1 = m.locate_cell_and_reference_coordinate(inputvertexcoords[i])
         if cell_num is not None and cell_num < owned_cells:
             in_bounds.append(i)
-    # Correct coordinates (though not guaranteed to be in same order)
-    np.allclose(np.sort(vm.coordinates.dat.data_ro), np.sort(inputvertexcoords[in_bounds]))
+            ref_cell_dists_l1.append(ref_cell_dist_l1)
+    # In parallel locate_cell_and_reference_coordinate might give point
+    # duplication: the voting algorithm in VertexOnlyMesh should remove these.
+    # We can check that this is the case by seeing if all the missing
+    # coordinates have positive distances from the reference cell but this is a
+    # faff. For now just check that, where point duplication occurs, we have
+    # some ref_cell_dists_l1 over half the mesh tolerance (i.e. where I'd
+    # expect this to start ocurring).
+    total_cells = MPI.COMM_WORLD.allreduce(len(vm.coordinates.dat.data_ro), op=MPI.SUM)
+    total_in_bounds = MPI.COMM_WORLD.allreduce(len(in_bounds), op=MPI.SUM)
+    skip_in_bounds_checks = False
+    if total_cells != total_in_bounds:
+        assert MPI.COMM_WORLD.size > 1  # i.e. we're in parallel
+        assert total_cells < total_in_bounds  # i.e. some points are duplicated
+        local_cells = len(vm.coordinates.dat.data_ro)
+        local_in_bounds = len(in_bounds)
+        if not local_cells == local_in_bounds and local_in_bounds > 0:
+            assert max(ref_cell_dists_l1) > 0.5*m.tolerance
+            skip_in_bounds_checks = True
+    # Correct local coordinates (though not guaranteed to be in same order)
+    if not skip_in_bounds_checks:
+        # Correct local coordinates (though not guaranteed to be in same order)
+        np.allclose(np.sort(vm.coordinates.dat.data_ro), np.sort(inputvertexcoords[in_bounds]))
     # Correct parent topology
     assert vm._parent_mesh is m
     assert vm.topology._parent_mesh is m.topology
     # Correct generic cell properties
-    assert vm.cell_closure.shape == (len(inputvertexcoords[in_bounds]), 1)
+    if not skip_in_bounds_checks:
+        assert vm.cell_closure.shape == (len(inputvertexcoords[in_bounds]), 1)
     with pytest.raises(AttributeError):
         vm.exterior_facets()
     with pytest.raises(AttributeError):
         vm.interior_facets()
     with pytest.raises(AttributeError):
         vm.cell_to_facets
-    assert vm.num_cells() == len(inputvertexcoords[in_bounds]) == vm.cell_set.size
+    if not skip_in_bounds_checks:
+        assert vm.num_cells() == len(inputvertexcoords[in_bounds]) == vm.cell_set.size
     assert vm.num_facets() == 0
     assert vm.num_faces() == vm.num_entities(2) == 0
     assert vm.num_edges() == vm.num_entities(1) == 0
@@ -151,18 +180,31 @@ def test_generate_cell_midpoints(parentmesh, redundant):
     """
     inputcoords, inputcoordslocal = cell_midpoints(parentmesh)
     if redundant:
-        # check redundant argument broadcasts from rank 0 by only supplying the
-        # global cell midpoints only on rank 0. Note that this is the default
-        # behaviour so it needn't be specified explicitly.
-        if MPI.COMM_WORLD.rank == 0:
-            vm = VertexOnlyMesh(parentmesh, inputcoords)
+        if redundant == "redistribute":
+            # We set redunant to False (which stops broadcasting from rank 0)
+            # and supply the global cell midpoints only on rank 0 to check they
+            # are redistributed correctly.
+            if MPI.COMM_WORLD.rank == 0:
+                vm = VertexOnlyMesh(parentmesh, inputcoords, redundant=False)
+            else:
+                vm = VertexOnlyMesh(parentmesh, np.empty(shape=(0, inputcoords.shape[1])), redundant=False)
         else:
-            vm = VertexOnlyMesh(parentmesh, np.empty(inputcoords.shape))
+            # Otherwise we check redundant argument broadcasts from rank 0 by only
+            # supplying the global cell midpoints only on rank 0. Note that this is
+            # the default behaviour so it needn't be specified explicitly.
+            if MPI.COMM_WORLD.rank == 0:
+                vm = VertexOnlyMesh(parentmesh, inputcoords)
+            else:
+                vm = VertexOnlyMesh(parentmesh, np.empty(inputcoords.shape))
     else:
         # When redundant == False we expect the same behaviour by only
         # supplying the local cell midpoints on each MPI ranks. Note that this
         # is not the default behaviour so it must be specified explicitly.
         vm = VertexOnlyMesh(parentmesh, inputcoordslocal, redundant=False)
+
+    # Have correct number of vertices
+    total_cells = MPI.COMM_WORLD.allreduce(len(vm.coordinates.dat.data_ro), op=MPI.SUM)
+    assert total_cells == len(inputcoords)
 
     # Midpoints located in correct cells of parent mesh
     V = VectorFunctionSpace(parentmesh, "DG", 0)
@@ -200,6 +242,22 @@ def test_extrude(parentmesh):
     inputcoords, inputcoordslocal = cell_midpoints(parentmesh)
     vm = VertexOnlyMesh(parentmesh, inputcoords)
     ExtrudedMesh(vm, 1)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_redistribution():
+    m = UnitSquareMesh(1, 1)
+    with pytest.warns(UserWarning):
+        vm1 = VertexOnlyMesh(m, np.array([[0.1, 0.1], [0.9, 0.9], [0.1, 0.9], [0.9, 0.1], [2, 3]]), missing_points_behaviour='warn')
+    if m.comm.rank == 0:
+        # rank 0 should still raise a warning because rank 1 specifies a point
+        # that is not in the mesh
+        with pytest.warns(UserWarning):
+            vm2 = VertexOnlyMesh(m, np.array([[0.1, 0.1], [0.9, 0.9]]), missing_points_behaviour='warn', redundant=False)
+    else:
+        with pytest.warns(UserWarning):
+            vm2 = VertexOnlyMesh(m, np.array([[0.1, 0.9], [0.9, 0.1], [2, 3]]), missing_points_behaviour='warn', redundant=False)
+    assert np.allclose(vm1.coordinates.dat.data_ro, vm2.coordinates.dat.data_ro)
 
 
 def test_point_tolerance():
@@ -263,6 +321,15 @@ def test_outside_boundary_behaviour(parentmesh):
     # by 2 orders of magnitude for this to work consistently
     vm = VertexOnlyMesh(parentmesh, inputcoord, tolerance=1e-13, missing_points_behaviour=None)
     assert vm.cell_set.size == 1
+
+
+@pytest.mark.parallel
+def test_on_boundary_behaviour():
+    coords = np.array([[0.4, 0.2, 0.3]])
+    mesh = UnitCubeMesh(10, 10, 10)
+    vm = VertexOnlyMesh(mesh, coords, missing_points_behaviour='error')
+    total_num_cells = MPI.COMM_WORLD.allreduce(len(vm.coordinates.dat.data_ro_with_halos), op=MPI.SUM)
+    assert total_num_cells == 1
 
 
 @pytest.mark.parallel(nprocs=2)  # nprocs == total number of mesh cells

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -164,7 +164,6 @@ def test_generate_cell_midpoints(parentmesh, redundant):
         # is not the default behaviour so it must be specified explicitly.
         vm = VertexOnlyMesh(parentmesh, inputcoordslocal, redundant=False)
 
-    vm = VertexOnlyMesh(parentmesh, inputcoords)
     # Midpoints located in correct cells of parent mesh
     V = VectorFunctionSpace(parentmesh, "DG", 0)
     f = Function(V).interpolate(SpatialCoordinate(parentmesh))

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -119,11 +119,11 @@ def verify_vertexonly_mesh(m, vm, inputvertexcoords):
     # this method of getting owned cells works for all mesh types
     owned_cells = len(Function(FunctionSpace(m, "DG", 0)).dat.data_ro)
     for i in range(len(inputvertexcoords)):
-        cell_num, _, ref_cell_dist_l1 = m.locate_cell_and_reference_coordinate(inputvertexcoords[i])
-        if cell_num is not None and cell_num < owned_cells:
+        cell_num, _, ref_cell_dist_l1 = m.locate_cells_ref_coords_and_dists(inputvertexcoords[i].reshape(1, gdim))
+        if cell_num != -1 and cell_num < owned_cells:
             in_bounds.append(i)
             ref_cell_dists_l1.append(ref_cell_dist_l1)
-    # In parallel locate_cell_and_reference_coordinate might give point
+    # In parallel locate_cells_ref_coords_and_dists might give point
     # duplication: the voting algorithm in VertexOnlyMesh should remove these.
     # We can check that this is the case by seeing if all the missing
     # coordinates have positive distances from the reference cell but this is a

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -180,6 +180,8 @@ def test_generate_cell_midpoints(parentmesh, redundant):
     """
     inputcoords, inputcoordslocal = cell_midpoints(parentmesh)
     if redundant:
+        if MPI.COMM_WORLD.size == 1:
+            pytest.skip("Testing redundant or redistribution in serial isn't worth the time")
         if redundant == "redistribute":
             # We set redunant to False (which stops broadcasting from rank 0)
             # and supply the global cell midpoints only on rank 0 to check they


### PR DESCRIPTION
Fixes the VertexOnlyMesh part of #2790. To fix `.at` we need to make a VertexOnlyMesh when doing the point location.

Note this fixes #2178 - points will now redistribute to their appropriate location when `redundant=False`

This also changes the default VertexOnlyMesh creation behaviour to throw a `ValueError` when points are lost.