### PR TITLE
Smaclachlan/add asm vanka exclude

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -203,6 +203,7 @@ class ASMVankaPC(ASMPatchPC):
         if (depth == -1 and height == -1) or (depth != -1 and height != -1):
             raise ValueError(f"Must set exactly one of {self.prefix}construct_dim or {self.prefix}construct_codim")
 
+        exclude_subspace = int(PETSc.Options().getString(self.prefix+"exclude_subspace", default=-1))
         ordering = PETSc.Options().getString(self.prefix+"mat_ordering_type", default="natural")
         # Accessing .indices causes the allocation of a global array,
         # so we need to cache these for efficiency
@@ -234,7 +235,11 @@ class ASMVankaPC(ASMPatchPC):
             indices = []
             for (i, W) in enumerate(V):
                 section = W.dm.getDefaultSection()
-                for p in pt_array:
+                if i == exclude_subspace:
+                    loop_list = [seed]
+                else:
+                    loop_list = pt_array
+                for p in loop_list:
                     dof = section.getDof(p)
                     if dof <= 0:
                         continue

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -301,7 +301,7 @@ def test_vanka_equivalence(problem_type):
         (z, p) = split(u)
         (v, q) = split(TestFunction(V))
 
-        a = inner(grad(z), grad(v))*dx + inner(p, q)*dx
+        a = inner(grad(z), grad(v))*dx + inner(p, div(v))*dx + inner(q,div(z))*dx
 
         bcs = DirichletBC(V.sub(0), Constant((1., 0.)), "on_boundary")
         nsp = MixedVectorSpaceBasis(V, [V.sub(0), VectorSpaceBasis(constant=True)])
@@ -322,7 +322,8 @@ def test_vanka_equivalence(problem_type):
                        "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
                        "mg_coarse_pc_type": "python",
                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                       "mg_coarse_assembled_pc_type": "lu"}
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
@@ -344,7 +345,8 @@ def test_vanka_equivalence(problem_type):
                        "mg_levels_patch_sub_pc_type": "lu",
                        "mg_coarse_pc_type": "python",
                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                       "mg_coarse_assembled_pc_type": "lu"}
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=vanka_params, nullspace=nsp)

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -290,7 +290,61 @@ def test_vanka_equivalence(problem_type):
                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
     elif problem_type == "mixed":
-        return
+        base = UnitSquareMesh(5, 5, distribution_parameters=distribution_parameters, quadrilateral=True)
+        mh = MeshHierarchy(base, 1, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V1 = VectorFunctionSpace(mesh, "CG", 2)
+        V2 = FunctionSpace(mesh, "CG", 1)
+        V = MixedFunctionSpace([V1, V2])
+
+        u = Function(V)
+        (z, p) = split(u)
+        (v, q) = split(TestFunction(V))
+
+        a = inner(grad(z), grad(v))*dx + inner(p, q)*dx
+
+        bcs = DirichletBC(V.sub(0), Constant((1., 0.)), "on_boundary")
+        nsp = MixedVectorSpaceBasis(V, [V.sub(0), VectorSpaceBasis(constant=True)])
+
+        vanka_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "chebyshev",
+                       "mg_levels_ksp_max_it": 2,
+                       "mg_levels_ksp_convergence_test": "skip",
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
+                       "mg_levels_pc_vanka_construct_dim": 0,
+                       "mg_levels_pc_vanka_exclude_subspace": 1,
+                       "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "chebyshev",
+                       "mg_levels_ksp_max_it": 2,
+                       "mg_levels_ksp_convergence_test": "skip",
+                       "mg_levels_pc_type": "python",
+                       "mg_levels_pc_python_type": "firedrake.PatchPC",
+                       "mg_levels_patch_pc_patch_save_operators": True,
+                       "mg_levels_patch_pc_patch_construct_type": "vanka",
+                       "mg_levels_patch_pc_patch_construct_dim": 0,
+                       "mg_levels_patch_pc_patch_exclude_subspaces": "1",
+                       "mg_levels_patch_pc_patch_sub_mat_type": "seqdense",
+                       "mg_levels_patch_sub_ksp_type": "preonly",
+                       "mg_levels_patch_sub_pc_type": "lu",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu"}
 
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=vanka_params, nullspace=nsp)

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -301,29 +301,29 @@ def test_vanka_equivalence(problem_type):
         (z, p) = split(u)
         (v, q) = split(TestFunction(V))
 
-        a = inner(grad(z), grad(v))*dx + inner(p, div(v))*dx + inner(q,div(z))*dx
+        a = inner(grad(z), grad(v))*dx + inner(p, div(v))*dx + inner(q, div(z))*dx
 
         bcs = DirichletBC(V.sub(0), Constant((1., 0.)), "on_boundary")
         nsp = MixedVectorSpaceBasis(V, [V.sub(0), VectorSpaceBasis(constant=True)])
 
         vanka_params = {"mat_type": "aij",
-                       "snes_type": "ksponly",
-                       "ksp_type": "richardson",
-                       "pc_type": "mg",
-                       "pc_mg_type": "multiplicative",
-                       "pc_mg_cycles": "v",
-                       "mg_levels_ksp_type": "chebyshev",
-                       "mg_levels_ksp_max_it": 2,
-                       "mg_levels_ksp_convergence_test": "skip",
-                       "mg_levels_pc_type": "python",
-                       "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
-                       "mg_levels_pc_vanka_construct_dim": 0,
-                       "mg_levels_pc_vanka_exclude_subspace": 1,
-                       "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
-                       "mg_coarse_pc_type": "python",
-                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                       "mg_coarse_assembled_pc_type": "lu",
-                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+                        "snes_type": "ksponly",
+                        "ksp_type": "richardson",
+                        "pc_type": "mg",
+                        "pc_mg_type": "multiplicative",
+                        "pc_mg_cycles": "v",
+                        "mg_levels_ksp_type": "chebyshev",
+                        "mg_levels_ksp_max_it": 2,
+                        "mg_levels_ksp_convergence_test": "skip",
+                        "mg_levels_pc_type": "python",
+                        "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
+                        "mg_levels_pc_vanka_construct_dim": 0,
+                        "mg_levels_pc_vanka_exclude_subspace": 1,
+                        "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
+                        "mg_coarse_pc_type": "python",
+                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",


### PR DESCRIPTION
Excluding subspaces from a Vanka patch is key to achieving good performance for some mixed problems, such as Taylor-Hood Stokes.  This adds that functionality to `ASMVankaPC`, as well as a corresponding test on the Taylor-Hood discretization of Stokes to make sure that it has the same effect as the option to do so in `PCPatch`.