### PR TITLE
Ksagiyam/allow overlapping subdomains

### DIFF
--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -1853,36 +1853,6 @@ def get_facet_ordering(PETSc.DM plex, PETSc.Section facet_numbering):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_facet_markers(PETSc.DM dm, np.ndarray[PetscInt, ndim=1, mode="c"] facets):
-    """Get an array of facet labels in the mesh.
-
-    :arg dm: The DM that contains labels.
-    :arg facets: The array of facet points.
-    :returns: a numpy array of facet ids (or None if all facets had
-        the default marker).
-    """
-    cdef:
-        PetscInt nfacet, f, val
-        np.ndarray[PetscInt, ndim=1, mode="c"] ids
-        DMLabel label = NULL
-        PetscBool all_default = PETSC_TRUE
-
-    ids = np.empty_like(facets)
-    nfacet = facets.shape[0]
-    CHKERR(DMGetLabel(dm.dm, FACE_SETS_LABEL.encode(), &label))
-    for f in range(nfacet):
-        CHKERR(DMLabelGetValue(label, facets[f], &val))
-        if val != -1:
-            all_default = PETSC_FALSE
-        ids[f] = val
-    if all_default:
-        return None
-    else:
-        return ids
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
 def get_facets_by_class(PETSc.DM plex, label,
                         np.ndarray[PetscInt, ndim=1, mode="c"] ordering):
     """Builds a list of all facets ordered according to PyOP2 entity


### PR DESCRIPTION
Currently we implicitly assume that boundary subdomains (represented by `FACE_SETS_LABEL ` values) do not overlap with each other. This restriction is encoded in `_Facets.markers` object, which assigns one`FACE_SETS_LABEL ` value to each facet. If we have overlapping subdomains, `_Facets.marker` silently picks one value for each facet in the intersection.

Example:
```
FACE_SETS_LABEL value = 100: [0, 1, 2, 3]  <- facet IDs
FACE_SETS_LABEL value = 200: [2, 3]
FACE_SETS_LABEL value = 300: [4, 5]

# facet IDs         0    1    2    3    4    5 
_Facets.markers = [100, 100, 100, 100, 300, 300]
```
where facets `2` and `3` are labeled with `100` and `200`, but `_Facets.markers` ignores `200`, and, if we tried to do integration with `ds(200)`, say, the result would be `0` as Firedrake would not be able to find facets marked with `200` via `_Facets.markers`.

This PR attempts to fix this.

Tests are included in https://github.com/firedrakeproject/firedrake/pull/2682.