### PR TITLE
Fix locate_cell changing coordinates dat version

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -456,9 +456,9 @@ class Function(ufl.Coefficient, FunctionMixin):
         else:
             c_function.extruded = 0
             c_function.n_layers = 1
-        c_function.coords = coordinates.dat.data.ctypes.data_as(c_void_p)
+        c_function.coords = coordinates.dat.data_ro.ctypes.data_as(c_void_p)
         c_function.coords_map = coordinates_space.cell_node_list.ctypes.data_as(POINTER(as_ctypes(IntType)))
-        c_function.f = self.dat.data.ctypes.data_as(c_void_p)
+        c_function.f = self.dat.data_ro.ctypes.data_as(c_void_p)
         c_function.f_map = function_space.cell_node_list.ctypes.data_as(POINTER(as_ctypes(IntType)))
         return c_function
 


### PR DESCRIPTION
At present, running this
```python
m = UnitSquareMesh(10, 10)
print(m.coordinates.dat.dat_version)
m.locate_cell([0.5, 0.5])
print(m.coordinates.dat.dat_version)
```
prints
```
0
2
```

This incrementation by two happens in `MeshGeometry.locate_cell_and_reference_coordinate` when accessing `self.coordinates._ctypes`
https://github.com/firedrakeproject/firedrake/blob/191c339e4bcdc0841709f9cc30226340fe1f0d0a/firedrake/mesh.py#L1892

The root cause of this is at this line
https://github.com/firedrakeproject/firedrake/blob/191c339e4bcdc0841709f9cc30226340fe1f0d0a/firedrake/function.py#L459
and this line
https://github.com/firedrakeproject/firedrake/blob/191c339e4bcdc0841709f9cc30226340fe1f0d0a/firedrake/function.py#L459

This PR fixes this by switching to accessing `data_ro` instead of `data`.