### PR TITLE
Add ASMPointPC

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -143,8 +143,6 @@ class ASMPointPC(ASMPatchPC):
 
         # Obtain the topological entities to use to construct the patches
         depth = PETSc.Options().getInt(self.prefix+"construct_dim", default=0)
-        ordering = PETSc.Options().getString(self.prefix+"mat_ordering_type",
-                                             default="natural")
         # Accessing .indices causes the allocation of a global array,
         # so we need to cache these for efficiency
         V_local_ises_indices = []
@@ -240,7 +238,6 @@ class ASMVankaPC(ASMPatchPC):
     ASMVankaPC is an additive Schwarz preconditioner where each patch
     consists of all DoFs on the closure of the star of the mesh entity
     specified by `pc_vanka_construct_dim` (or codim).
-
     '''
 
     _prefix = "pc_vanka_"

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -14,7 +14,7 @@ except ImportError:
     have_tinyasm = False
 
 
-__all__ = ("ASMPatchPC", "ASMStarPC", "ASMVankaPC", "ASMLinesmoothPC", "ASMExtrudedStarPC")
+__all__ = ("ASMPatchPC", "ASMPointPC", "ASMStarPC", "ASMVankaPC", "ASMLinesmoothPC", "ASMExtrudedStarPC")
 
 
 class ASMPatchPC(PCBase):
@@ -123,8 +123,61 @@ class ASMPatchPC(PCBase):
             self.asmpc.destroy()
 
 
+class ASMPointPC(ASMPatchPC):
+    '''Patch-based PC using mesh entities at single points implemented as
+    an :class:`ASMPatchPC`.
+
+    ASMPointPC is an additive Schwarz preconditioner where each patch
+    consists of all DoFs at the topological point of the mesh entity
+    specified by `pc_star_construct_dim`.
+
+    '''
+
+    _prefix = "pc_point_"
+
+    def get_patches(self, V):
+        mesh = V._mesh
+        mesh_dm = mesh.topology_dm
+        if mesh.cell_set._extruded:
+            warning("applying ASMStarPC on an extruded mesh")
+
+        # Obtain the topological entities to use to construct the patches
+        depth = PETSc.Options().getInt(self.prefix+"construct_dim", default=0)
+        ordering = PETSc.Options().getString(self.prefix+"mat_ordering_type",
+                                             default="natural")
+        # Accessing .indices causes the allocation of a global array,
+        # so we need to cache these for efficiency
+        V_local_ises_indices = []
+        for (i, W) in enumerate(V):
+            V_local_ises_indices.append(V.dof_dset.local_ises[i].indices)
+
+        # Build index sets for the patches
+        ises = []
+        (start, end) = mesh_dm.getDepthStratum(depth)
+        for seed in range(start, end):
+            # Only build patches over owned DoFs
+            if mesh_dm.getLabelValue("pyop2_ghost", seed) != -1:
+                continue
+
+            # Get DoF indices for patch
+            indices = []
+            for (i, W) in enumerate(V):
+                section = W.dm.getDefaultSection()
+                dof = section.getDof(seed)
+                if dof <= 0:
+                    continue
+                off = section.getOffset(seed)
+                # Local indices within W
+                W_indices = slice(off*W.value_size, W.value_size * (off + dof))
+                indices.extend(V_local_ises_indices[i][W_indices])
+            iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
+            ises.append(iset)
+
+        return ises
+
+
 class ASMStarPC(ASMPatchPC):
-    '''Patch-based PC using Star of mesh entities implmented as an
+    '''Patch-based PC using Star of mesh entities implemented as an
     :class:`ASMPatchPC`.
 
     ASMStarPC is an additive Schwarz preconditioner where each patch
@@ -181,12 +234,13 @@ class ASMStarPC(ASMPatchPC):
 
 
 class ASMVankaPC(ASMPatchPC):
-    '''Patch-based PC using closure of star of mesh entities implmented as an
-    :class:`ASMPatchPC`.
+    '''Patch-based PC using closure of star of mesh entities implemented
+    as an :class:`ASMPatchPC`.
 
     ASMVankaPC is an additive Schwarz preconditioner where each patch
     consists of all DoFs on the closure of the star of the mesh entity
     specified by `pc_vanka_construct_dim` (or codim).
+
     '''
 
     _prefix = "pc_vanka_"
@@ -353,7 +407,7 @@ def get_basemesh_nodes(W):
 
 
 class ASMExtrudedStarPC(ASMStarPC):
-    '''Patch-based PC using Star of mesh entities implmented as an
+    '''Patch-based PC using Star of mesh entities implemented as an
     :class:`ASMPatchPC`.
 
     ASMExtrudedStarPC is an additive Schwarz preconditioner where each patch

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -303,3 +303,113 @@ def test_vanka_equivalence(problem_type):
     comp_its = comp_solver.snes.getLinearSolveIterations()
 
     assert star_its == comp_its
+
+
+def test_point_equivalence(problem_type):
+    distribution_parameters = {"partition": True,
+                               "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+
+    if problem_type == "scalar":
+        base = UnitSquareMesh(10, 10, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 2, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = FunctionSpace(mesh, "CG", 1)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        a = inner(grad(u), grad(v))*dx - inner(Constant(1), v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        point_params = {"mat_type": "aij",
+                        "snes_type": "ksponly",
+                        "ksp_type": "richardson",
+                        "pc_type": "mg",
+                        "pc_mg_type": "multiplicative",
+                        "pc_mg_cycles": "v",
+                        "mg_levels_ksp_type": "richardson",
+                        "mg_levels_ksp_richardson_scale": 1/10,
+                        "mg_levels_ksp_max_it": 1,
+                        "mg_levels_pc_type": "python",
+                        "mg_levels_pc_python_type": "firedrake.ASMPointPC",
+                        "mg_levels_pc_vanka_construct_dim": 0,
+                        "mg_coarse_pc_type": "python",
+                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "richardson",
+                       "pc_type": "mg",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycles": "v",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 1/10,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "jacobi",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    elif problem_type == "vector":
+        base = UnitSquareMesh(2, 2, distribution_parameters=distribution_parameters)
+        mh = MeshHierarchy(base, 1, distribution_parameters=distribution_parameters)
+        mesh = mh[-1]
+        V = VectorFunctionSpace(mesh, "CG", 1)
+
+        u = Function(V)
+        v = TestFunction(V)
+
+        (x, y) = SpatialCoordinate(mesh)
+        f = as_vector([x*(1-x), y*(1-y)])
+        a = inner(grad(u), grad(v))*dx + inner(u, v)*dx - inner(f, v)*dx
+        bcs = DirichletBC(V, 0, "on_boundary")
+        nsp = None
+
+        point_params = {"mat_type": "aij",
+                        "snes_type": "ksponly",
+                        "ksp_type": "cg",
+                        "pc_type": "mg",
+                        "pc_mg_type": "full",
+                        "mg_levels_ksp_type": "richardson",
+                        "mg_levels_ksp_richardson_scale": 3/10,
+                        "mg_levels_ksp_max_it": 1,
+                        "mg_levels_pc_type": "python",
+                        "mg_levels_pc_python_type": "firedrake.ASMPointPC",
+                        "mg_levels_pc_vanka_construct_dim": 0,
+                        "mg_coarse_pc_type": "python",
+                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+        comp_params = {"mat_type": "aij",
+                       "snes_type": "ksponly",
+                       "ksp_type": "cg",
+                       "pc_type": "mg",
+                       "pc_mg_type": "full",
+                       "mg_levels_ksp_type": "richardson",
+                       "mg_levels_ksp_richardson_scale": 3/10,
+                       "mg_levels_ksp_max_it": 1,
+                       "mg_levels_pc_type": "pbjacobi",
+                       "mg_coarse_pc_type": "python",
+                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                       "mg_coarse_assembled_pc_type": "lu",
+                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+
+    elif problem_type == "mixed":
+        return
+
+    nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
+    star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=point_params, nullspace=nsp)
+    star_solver.solve()
+    star_its = star_solver.snes.getLinearSolveIterations()
+
+    u.assign(0)
+    comp_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=comp_params, nullspace=nsp)
+    comp_solver.solve()
+    comp_its = comp_solver.snes.getLinearSolveIterations()
+
+    assert star_its == comp_its

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -333,7 +333,7 @@ def test_point_equivalence(problem_type):
                         "mg_levels_ksp_max_it": 1,
                         "mg_levels_pc_type": "python",
                         "mg_levels_pc_python_type": "firedrake.ASMPointPC",
-                        "mg_levels_pc_vanka_construct_dim": 0,
+                        "mg_levels_pc_point_construct_dim": 0,
                         "mg_coarse_pc_type": "python",
                         "mg_coarse_pc_python_type": "firedrake.AssembledPC",
                         "mg_coarse_assembled_pc_type": "lu",
@@ -358,7 +358,7 @@ def test_point_equivalence(problem_type):
         base = UnitSquareMesh(2, 2, distribution_parameters=distribution_parameters)
         mh = MeshHierarchy(base, 1, distribution_parameters=distribution_parameters)
         mesh = mh[-1]
-        V = VectorFunctionSpace(mesh, "CG", 1)
+        V = VectorFunctionSpace(mesh, "CG", 2)
 
         u = Function(V)
         v = TestFunction(V)
@@ -377,9 +377,13 @@ def test_point_equivalence(problem_type):
                         "mg_levels_ksp_type": "richardson",
                         "mg_levels_ksp_richardson_scale": 3/10,
                         "mg_levels_ksp_max_it": 1,
-                        "mg_levels_pc_type": "python",
-                        "mg_levels_pc_python_type": "firedrake.ASMPointPC",
-                        "mg_levels_pc_vanka_construct_dim": 0,
+                        "mg_levels_pc_type": "composite",
+                        "mg_levels_pc_composite_type": "additive",
+                        "mg_levels_pc_composite_pcs": "python,python",
+                        "mg_levels_sub_0_pc_python_type": "firedrake.ASMPointPC",
+                        "mg_levels_sub_0_pc_point_construct_dim": 0,
+                        "mg_levels_sub_1_pc_python_type": "firedrake.ASMPointPC",
+                        "mg_levels_sub_1_pc_point_construct_dim": 1,
                         "mg_coarse_pc_type": "python",
                         "mg_coarse_pc_python_type": "firedrake.AssembledPC",
                         "mg_coarse_assembled_pc_type": "lu",


### PR DESCRIPTION
Following a slack discussion on how it would be nice to do block Jacobi on mixed function spaces, defining blocks based on grouping DoFs at the same point(s) on the mesh, this seems like a potentially useful function.  This provides another variant on `ASMPatchPC`, where the patches are defined based on a specified topological entity (nodes, edges, faces, volumes).  So, not quite point-block Jacobi that we can do on VFS, but closer to it...