### PR TITLE
JDBetteridge/fix docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,7 @@ linkcheck_ignore = [
     r'https://www\.apl\.washington\.edu/',
     r'https://asmedigitalcollection\.asme\.org/',
 ]
-linkcheck_timeout = 10
+linkcheck_timeout = 30
 
 # -- Options for HTML output ---------------------------------------------
 

--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -112,9 +112,10 @@ Firedrake tutorial at CNRS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Firedrake team presented a Firedrake tutorial at CNRS in
-Paris. See `this web page
-<https://calcul.math.cnrs.fr/spip.php?article274>`_.  The tutorial
-materials are accessible as part of the :doc:`firedrake documentation
+Paris. See ``this web page
+<https://calcul.math.cnrs.fr/spip.php?article274>`` [broken link].  The
+tutorial materials are accessible as part of the :doc:`firedrake
+documentation
 <documentation>`.
 
 FEniCS '15

--- a/docs/source/optimising.rst
+++ b/docs/source/optimising.rst
@@ -235,9 +235,10 @@ across ranks or plot them separately. For example:
 Score-P
 ~~~~~~~
 
-`Score-P <https://www.vi-hps.org/projects/score-p/>`_ is a tool aimed
-at HPC users. We found it to provide some useful insight into MPI
-considerations such as load balancing and communication overhead.
+``Score-P <https://www.vi-hps.org/projects/score-p/>`` [broken link] is
+a tool aimed at HPC users. We found it to provide some useful insight
+into MPI considerations such as load balancing and communication
+overhead.
 
 To use it with Firedrake, users will also need to install Score-P's
 `Python bindings <https://github.com/score-p/scorep_binding_python>`_.


### PR DESCRIPTION
What should our policy be on broken external URLs?

My thoughts:
- Old articles: Just remove
- Flakey websites: Add exception in `conf.py` (currently done for doi redirects, SIAM etc...)