### PR TITLE
Add ufl hexahedron for pvd plotting

### DIFF
--- a/firedrake/output.py
+++ b/firedrake/output.py
@@ -53,6 +53,8 @@ cells = {
     (ufl_wedge, True): VTK_LAGRANGE_WEDGE,
     (ufl_hex, False): VTK_HEXAHEDRON,
     (ufl_hex, True): VTK_LAGRANGE_HEXAHEDRON,
+    (ufl.Cell("hexahedron"), False): VTK_HEXAHEDRON,
+    (ufl.Cell("hexahedron"), True): VTK_LAGRANGE_HEXAHEDRON,
 }
 
 


### PR DESCRIPTION
This allows saving pvds from imported hex gmsh meshes.