### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET default

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1155,9 +1155,8 @@ def build_and_install_petsc():
         petsc_options = get_petsc_options()
         # Set MACOSX_DEPLOYMENT_TARGET to the current macos version
         # to workaround issues configuring PETSc on macos.
-        #
-        # Choosing 10.15 as the oldest MacOS version supported as at 2022-04-07
-        macosx_deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "10.15")
+        # Choosing 11.0 as the oldest MacOS version supported as at 2023-03-22
+        macosx_deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "11.0")
         with environment(MACOSX_DEPLOYMENT_TARGET=macosx_deployment_target):
             check_call([python, "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + petsc_options)
             check_call(["make", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch), "all"])


### PR DESCRIPTION
10.15 is now [out of support](https://endoflife.date/macos) so this bumps things to 11.0 which is still supported.