### PR TITLE
Improve halo logic for `assign`

### DIFF
--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -128,7 +128,7 @@ class Assigner:
 
     _coefficient_collector = CoefficientCollector()
 
-    def __init__(self, assignee, expression, subset=None, subset_includes_halo=False):
+    def __init__(self, assignee, expression, subset=None):
         if isinstance(expression, Vector):
             expression = expression.function
         expression = as_ufl(expression)
@@ -148,14 +148,9 @@ class Assigner:
             raise ValueError("Subset is not a valid argument for assigning to a mixed "
                              "element including a real element")
 
-        if subset_includes_halo and not subset:
-            raise ValueError(
-                "subset_includes_halo only makes sense if a subset is provided")
-
         self._assignee = assignee
         self._expression = expression
         self._subset = subset
-        self._subset_includes_halo = subset_includes_halo
 
     def __str__(self):
         return f"{self._assignee} {self.symbol} {self._expression}"

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -174,7 +174,8 @@ class Assigner:
         # * We can also write to the halo if we are assigning to a subset provided
         #   that the assignee halo is not dirty to start with.
         # * If we are assigning to a subset where the assignee dat has a dirty halo,
-        #   then we must only write to the owned values (marking the halo as dirty).
+        #   then we should only write to the owned values. There is no point in
+        #   writing to the halo since a full halo exchange is still required.
         # * If any of the functions in the expression do not have valid halos then
         #   we only write to the owned values in the assignee. Otherwise we might
         #   end up doing a lot of halo exchanges for the expression just to avoid

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -188,19 +188,16 @@ class Assigner:
         if assign_to_halos:
             subset_indices = self._subset.indices if self._subset else ...
             data_ro = operator.attrgetter("data_ro_with_halos")
-            data_wo = operator.attrgetter("data_wo_with_halos")
         else:
             subset_indices = self._subset.owned_indices if self._subset else ...
             data_ro = operator.attrgetter("data_ro")
-            data_wo = operator.attrgetter("data_wo")
 
         # If mixed, loop over individual components
         for lhs_dat, *func_dats in zip(self._assignee.dat.split,
                                        *(f.dat.split for f in self._functions)):
             func_data = np.array([data_ro(f)[subset_indices] for f in func_dats])
             rvalue = self._compute_rvalue(func_data)
-            lhs_data = data_wo(lhs_dat)
-            self._assign_single_dat(lhs_data, subset_indices, rvalue)
+            self._assign_single_dat(lhs_dat, subset_indices, rvalue, assign_to_halos)
 
         # if we have bothered writing to halo it naturally must not be dirty
         if assign_to_halos:
@@ -226,8 +223,11 @@ class Assigner:
         return tuple(w for (c, w) in self._weighted_coefficients
                      if isinstance(c, Function))
 
-    def _assign_single_dat(self, lhs_data, indices, rvalue):
-        lhs_data[indices] = rvalue
+    def _assign_single_dat(self, lhs_dat, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs_dat.data_wo_with_halos[indices] = rvalue
+        else:
+            lhs_dat.data_wo[indices] = rvalue
 
     def _compute_rvalue(self, func_data):
         # There are two components to the rvalue: weighted functions (in the same function space),
@@ -249,33 +249,47 @@ class IAddAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__iadd__``."""
     symbol = "+="
 
-    def _assign_single_dat(self, lhs, indices, rvalue):
-        lhs[indices] += rvalue
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs.data_with_halos[indices] += rvalue
+        else:
+            lhs.data[indices] += rvalue
 
 
 class ISubAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__isub__``."""
     symbol = "-="
 
-    def _assign_single_dat(self, lhs, indices, rvalue):
-        lhs[indices] -= rvalue
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs.data_with_halos[indices] -= rvalue
+        else:
+            lhs.data[indices] -= rvalue
 
 
 class IMulAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__imul__``."""
     symbol = "*="
 
-    def _assign_single_dat(self, lhs, indices, rvalue):
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
         if self._functions:
             raise ValueError("Only multiplication by scalars is supported")
-        lhs[indices] *= rvalue
+
+        if assign_to_halos:
+            lhs.data_with_halos[indices] *= rvalue
+        else:
+            lhs.data[indices] *= rvalue
 
 
 class IDivAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__itruediv__``."""
     symbol = "/="
 
-    def _assign_single_dat(self, lhs, indices, rvalue):
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
         if self._functions:
             raise ValueError("Only division by scalars is supported")
-        lhs[indices] /= rvalue
+
+        if assign_to_halos:
+            lhs.data_with_halos[indices] /= rvalue
+        else:
+            lhs.data[indices] /= rvalue

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -185,17 +185,22 @@ class Assigner:
         assign_to_halos = (
             func_halos_valid and (not self._subset or self._assignee.dat.halo_valid))
 
+        if assign_to_halos:
+            subset_indices = self._subset.indices if self._subset else ...
+            data_ro = operator.attrgetter("data_ro_with_halos")
+            data_wo = operator.attrgetter("data_wo_with_halos")
+        else:
+            subset_indices = self._subset.owned_indices if self._subset else ...
+            data_ro = operator.attrgetter("data_ro")
+            data_wo = operator.attrgetter("data_wo")
+
         # If mixed, loop over individual components
         for lhs_dat, *func_dats in zip(self._assignee.dat.split,
                                        *(f.dat.split for f in self._functions)):
-            if assign_to_halos:
-                idxs = self._subset.indices if self._subset else ...
-                func_data = np.array([f.data_ro_with_halos[idxs] for f in func_dats])
-            else:
-                idxs = self._subset.owned_indices if self._subset else ...
-                func_data = np.array([f.data_ro[idxs] for f in func_dats])
+            func_data = np.array([data_ro(f)[subset_indices] for f in func_dats])
             rvalue = self._compute_rvalue(func_data)
-            self._assign_single_dat(lhs_dat, idxs, rvalue, assign_to_halos)
+            lhs_data = data_wo(lhs_dat)
+            self._assign_single_dat(lhs_data, subset_indices, rvalue)
 
         # if we have bothered writing to halo it naturally must not be dirty
         if assign_to_halos:
@@ -221,11 +226,8 @@ class Assigner:
         return tuple(w for (c, w) in self._weighted_coefficients
                      if isinstance(c, Function))
 
-    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
-        if assign_to_halos:
-            lhs.data_with_halos[indices] = rvalue
-        else:
-            lhs.data[indices] = rvalue
+    def _assign_single_dat(self, lhs_data, indices, rvalue):
+        lhs_data[indices] = rvalue
 
     def _compute_rvalue(self, func_data):
         # There are two components to the rvalue: weighted functions (in the same function space),
@@ -247,47 +249,33 @@ class IAddAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__iadd__``."""
     symbol = "+="
 
-    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
-        if assign_to_halos:
-            lhs.data_with_halos[indices] += rvalue
-        else:
-            lhs.data[indices] += rvalue
+    def _assign_single_dat(self, lhs, indices, rvalue):
+        lhs[indices] += rvalue
 
 
 class ISubAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__isub__``."""
     symbol = "-="
 
-    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
-        if assign_to_halos:
-            lhs.data_with_halos[indices] -= rvalue
-        else:
-            lhs.data[indices] -= rvalue
+    def _assign_single_dat(self, lhs, indices, rvalue):
+        lhs[indices] -= rvalue
 
 
 class IMulAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__imul__``."""
     symbol = "*="
 
-    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+    def _assign_single_dat(self, lhs, indices, rvalue):
         if self._functions:
             raise ValueError("Only multiplication by scalars is supported")
-
-        if assign_to_halos:
-            lhs.data_with_halos[indices] *= rvalue
-        else:
-            lhs.data[indices] *= rvalue
+        lhs[indices] *= rvalue
 
 
 class IDivAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__itruediv__``."""
     symbol = "/="
 
-    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+    def _assign_single_dat(self, lhs, indices, rvalue):
         if self._functions:
             raise ValueError("Only division by scalars is supported")
-
-        if assign_to_halos:
-            lhs.data_with_halos[indices] /= rvalue
-        else:
-            lhs.data[indices] /= rvalue
+        lhs[indices] /= rvalue

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -128,7 +128,7 @@ class Assigner:
 
     _coefficient_collector = CoefficientCollector()
 
-    def __init__(self, assignee, expression, subset=None):
+    def __init__(self, assignee, expression, subset=None, subset_includes_halo=False):
         if isinstance(expression, Vector):
             expression = expression.function
         expression = as_ufl(expression)
@@ -148,9 +148,14 @@ class Assigner:
             raise ValueError("Subset is not a valid argument for assigning to a mixed "
                              "element including a real element")
 
+        if subset_includes_halo and not subset:
+            raise ValueError(
+                "subset_includes_halo only makes sense if a subset is provided")
+
         self._assignee = assignee
         self._expression = expression
         self._subset = subset
+        self._subset_includes_halo = subset_includes_halo
 
     def __str__(self):
         return f"{self._assignee} {self.symbol} {self._expression}"
@@ -167,12 +172,40 @@ class Assigner:
                 "Use Function.assign instead."
             )
 
+        # To minimize communication during assignment we perform a number of tricks:
+        # * If we are not assigning to a subset then we can always write to the
+        #   halo. The validity of the original assignee dat halo does not matter
+        #   since we are overwriting it entirely.
+        # * We can also write to the halo if we are assigning to a subset provided
+        #   that the assignee halo is not dirty to start with.
+        # * If we are assigning to a subset where the assignee dat has a dirty halo,
+        #   then we must only write to the owned values (marking the halo as dirty).
+        # * If any of the functions in the expression do not have valid halos then
+        #   we only write to the owned values in the assignee. Otherwise we might
+        #   end up doing a lot of halo exchanges for the expression just to avoid
+        #   a single halo exchange for the assignee.
+        # * If we do write to the halo then the resulting halo will never be dirty.
+
+        func_halos_valid = all(f.dat.halo_valid for f in self._functions)
+        assign_to_halos = (
+            func_halos_valid and (not self._subset or self._assignee.dat.halo_valid))
+
         # If mixed, loop over individual components
-        for assignee_dat, *func_dats in zip(self._assignee.dat.split,
-                                            *(f.dat.split for f in self._functions)):
-            self._assign_single_dat(assignee_dat, func_dats)
-            # Halo values are also updated
-            assignee_dat.halo_valid = True
+        for lhs_dat, *func_dats in zip(self._assignee.dat.split,
+                                       *(f.dat.split for f in self._functions)):
+            if assign_to_halos:
+                idxs = self._subset.indices if self._subset else ...
+                func_data = np.array([f.data_ro_with_halos[idxs] for f in func_dats])
+            else:
+                idxs = self._subset.owned_indices if self._subset else ...
+                func_data = np.array([f.data_ro[idxs] for f in func_dats])
+            rvalue = self._compute_rvalue(func_data)
+            self._assign_single_dat(lhs_dat, idxs, rvalue, assign_to_halos)
+
+        # if we have bothered writing to halo it naturally must not be dirty
+        assert all(not dat.halo_valid for dat in self._assignee.dat.split)
+        if assign_to_halos:
+            self._assignee.dat.halo_valid = True
 
     @cached_property
     def _constants(self):
@@ -194,18 +227,15 @@ class Assigner:
         return tuple(w for (c, w) in self._weighted_coefficients
                      if isinstance(c, Function))
 
-    @property
-    def _indices(self):
-        return self._subset.indices if self._subset else ...
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs.data_with_halos[indices] = rvalue
+        else:
+            lhs.data[indices] = rvalue
 
-    # TODO: It would be more efficient in permissible cases to use VecMAXPY instead of numpy operations.
-    def _assign_single_dat(self, assignee_dat, function_dats):
-        assignee_dat.data_with_halos[self._indices] = self._compute_rvalue(function_dats)
-
-    def _compute_rvalue(self, function_dats=()):
+    def _compute_rvalue(self, func_data):
         # There are two components to the rvalue: weighted functions (in the same function space),
         # and constants (e.g. u.assign(2*v + 3)).
-        func_data = np.array([f.data_ro_with_halos[self._indices] for f in function_dats])
         func_rvalue = (func_data.T @ self._function_weights).T
         const_data = np.array([c.dat.data_ro for c in self._constants], dtype=ScalarType)
         const_rvalue = const_data.T @ self._constant_weights
@@ -223,33 +253,47 @@ class IAddAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__iadd__``."""
     symbol = "+="
 
-    def _assign_single_dat(self, assignee_dat, function_dats):
-        assignee_dat.data_with_halos[self._indices] += self._compute_rvalue(function_dats)
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs.data_with_halos[indices] += rvalue
+        else:
+            lhs.data[indices] += rvalue
 
 
 class ISubAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__isub__``."""
     symbol = "-="
 
-    def _assign_single_dat(self, assignee_dat, function_dats):
-        assignee_dat.data_with_halos[self._indices] -= self._compute_rvalue(function_dats)
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if assign_to_halos:
+            lhs.data_with_halos[indices] -= rvalue
+        else:
+            lhs.data[indices] -= rvalue
 
 
 class IMulAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__imul__``."""
     symbol = "*="
 
-    def _assign_single_dat(self, assignee_dat, function_dats):
-        if function_dats:
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if self._functions:
             raise ValueError("Only multiplication by scalars is supported")
-        assignee_dat.data_with_halos[self._indices] *= self._compute_rvalue()
+
+        if assign_to_halos:
+            lhs.data_with_halos[indices] *= rvalue
+        else:
+            lhs.data[indices] *= rvalue
 
 
 class IDivAssigner(Assigner):
     """Assigner class for ``firedrake.function.Function.__itruediv__``."""
     symbol = "/="
 
-    def _assign_single_dat(self, assignee_dat, function_dats):
-        if function_dats:
+    def _assign_single_dat(self, lhs, indices, rvalue, assign_to_halos):
+        if self._functions:
             raise ValueError("Only division by scalars is supported")
-        assignee_dat.data_with_halos[self._indices] /= self._compute_rvalue()
+
+        if assign_to_halos:
+            lhs.data_with_halos[indices] /= rvalue
+        else:
+            lhs.data[indices] /= rvalue

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -198,7 +198,6 @@ class Assigner:
             self._assign_single_dat(lhs_dat, idxs, rvalue, assign_to_halos)
 
         # if we have bothered writing to halo it naturally must not be dirty
-        assert all(not dat.halo_valid for dat in self._assignee.dat.split)
         if assign_to_halos:
             self._assignee.dat.halo_valid = True
 


### PR DESCRIPTION
# Description
Following some fruitful discussions with @pbrubeck and @wence- I've modified some of the logic for `assign` to do a minimal number of halo exchanges.

@pbrubeck this looks to have addressed your concerns regarding excessive halo exchanges when applying boundary conditions.

## Fixes Issues:
Fixes #2857 

## Linked PRs
https://github.com/OP2/PyOP2/pull/695

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready