### PR TITLE
Ksagiyam/fix io manifold

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -17,6 +17,7 @@ from firedrake import (extrusion_utils as eutils, matrix, parameters, solving,
                        tsfc_interface, utils)
 from firedrake.adjoint import annotate_assemble
 from firedrake.bcs import DirichletBC, EquationBC, EquationBCSplit
+from firedrake.functionspaceimpl import WithGeometry, FunctionSpace
 from firedrake.functionspacedata import entity_dofs_key, entity_permutations_key
 from firedrake.petsc import PETSc
 from firedrake.slate import slac, slate
@@ -1102,7 +1103,7 @@ class ParloopBuilder:
 
     def _get_map(self, V):
         """Return the appropriate PyOP2 map for a given function space."""
-        assert isinstance(V, ufl.FunctionSpace)
+        assert isinstance(V, (WithGeometry, FunctionSpace))
 
         if self._integral_type in {"cell", "exterior_facet_top",
                                    "exterior_facet_bottom", "interior_facet_horiz"}:

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -41,6 +41,9 @@ r"""The prefix attached to the name of the Firedrake objects when saving them wi
 PREFIX_EXTRUDED = "_".join([PREFIX, "extruded"])
 r"""The prefix attached to the attributes associated with extruded meshes."""
 
+PREFIX_IMMERSED = "_".join([PREFIX, "immersed"])
+r"""The prefix attached to the attributes associated with immersed meshes."""
+
 PREFIX_EMBEDDED = "_".join([PREFIX, "embedded"])
 r"""The prefix attached to the DG function resulting from projecting the original function to the embedding DG space."""
 
@@ -624,6 +627,29 @@ class CheckpointFile(object):
                 with self.opts.inserted_options():
                     tmesh.topology_dm.coordinatesView(viewer=self.viewer)
                 self._update_mesh_name_topology_name_map({mesh.name: tmesh.name})
+                # Save cell_orientations for immersed meshes.
+                if hasattr(mesh, "_cell_orientations"):
+                    path = self._path_to_mesh_immersed(tmesh.name, mesh.name)
+                    self.require_group(path)
+                    self.set_attr(path, PREFIX_IMMERSED + "_cell_orientations", mesh._cell_orientations.name())
+                    cell_orientations_tV = mesh._cell_orientations.function_space()
+                    self._save_function_space_topology(cell_orientations_tV)
+                    # Compute "canonical" cell_orientations array.
+                    # This is the mesh._cell_orientations array (for manifold orientation) that the mesh would
+                    # have if all cell orientations of the reference-physical cell mappings were "0" (matching
+                    # plex cone ordering).
+                    # This can be done by flipping values (0 <-> 1) for cells for which "reflection" have been
+                    # introduced relative to orientation 0.
+                    canonical_cell_orientations = np.copy(mesh._cell_orientations.dat.data_ro[:tmesh.cell_set.size])
+                    o_r_map = np.array(list(cell_orientations_tV.finat_element.cell.cell_orientation_reflection_map().values()), dtype=np.int32)
+                    reflected = o_r_map[tmesh.entity_orientations[:tmesh.cell_set.size, -1]]
+                    reflected_indices = (reflected == 1)
+                    canonical_cell_orientations[reflected_indices] = 1 - canonical_cell_orientations[reflected_indices]
+                    cell_orientations_iset = PETSc.IS().createGeneral(canonical_cell_orientations, comm=tmesh._comm)
+                    cell_orientations_iset.setName("_".join([PREFIX_IMMERSED, "cell_orientations_iset"]))
+                    self.viewer.pushGroup(path)
+                    cell_orientations_iset.view(self.viewer)
+                    self.viewer.popGroup()
 
     @PETSc.Log.EventDecorator("SaveMeshTopology")
     def _save_mesh_topology(self, tmesh):
@@ -786,9 +812,9 @@ class CheckpointFile(object):
             tf = f.topological
             tV = tf.function_space()
             tmesh = tV.mesh()
-            element = tV.ufl_element()
             self._update_function_name_function_space_name_map(tmesh.name, mesh.name, {f.name(): V_name})
             # Embed if necessary
+            element = V.ufl_element()
             _element = get_embedding_element_for_checkpointing(element)
             if _element != element:
                 path = self._path_to_function_embedded(tmesh.name, mesh.name, V_name, f.name())
@@ -925,6 +951,37 @@ class CheckpointFile(object):
             mesh = make_mesh_from_coordinates(coordinates, name)
             # Load plex coordinates for a complete representation of plex.
             tmesh.topology_dm.coordinatesLoad(self.viewer, tmesh.sfXC)
+            # Load cell_orientations for immersed meshes.
+            path = self._path_to_mesh_immersed(tmesh.name, name)
+            if path in self.h5pyfile:
+                cell = tmesh.ufl_cell()
+                element = ufl.FiniteElement("DP" if cell.is_simplex() else "DQ", cell, 0)
+                cell_orientations_tV = self._load_function_space_topology(tmesh, element)
+                tmesh_key = self._generate_mesh_key_from_names(tmesh.name,
+                                                               tmesh._distribution_name,
+                                                               tmesh._permutation_name)
+                sd_key = self._get_shared_data_key_for_checkpointing(tmesh, element)
+                _, _, lsf = self._function_load_utils[tmesh_key + sd_key]
+                nroots, _, _ = lsf.getGraph()
+                cell_orientations_a = np.empty(nroots, dtype=utils.IntType)
+                cell_orientations_a_iset = PETSc.IS().createGeneral(cell_orientations_a, comm=self._comm)
+                cell_orientations_a_iset.setName("_".join([PREFIX_IMMERSED, "cell_orientations_iset"]))
+                self.viewer.pushGroup(path)
+                cell_orientations_a_iset.load(self.viewer)
+                self.viewer.popGroup()
+                cell_orientations_a = cell_orientations_a_iset.getIndices()
+                cell_orientations = np.empty((tmesh.cell_set.total_size, ), dtype=utils.IntType)
+                unit = MPI._typedict[np.dtype(utils.IntType).char]
+                lsf.bcastBegin(unit, cell_orientations_a, cell_orientations, MPI.REPLACE)
+                lsf.bcastEnd(unit, cell_orientations_a, cell_orientations, MPI.REPLACE)
+                # Convert the loaded ("canonical") cell_orientations array for use on the loaded mesh
+                # by flipping the values (0 <-> 1) for cells that are mapped "reflected" relative to orientation 0.
+                o_r_map = np.array(list(cell_orientations_tV.finat_element.cell.cell_orientation_reflection_map().values()), dtype=np.int32)
+                reflected = o_r_map[tmesh.entity_orientations[:, -1]]
+                reflected_indices = (reflected == 1)
+                cell_orientations[reflected_indices] = 1 - cell_orientations[reflected_indices]
+                cell_orientations_name = self.get_attr(path, PREFIX_IMMERSED + "_cell_orientations")
+                mesh._cell_orientations = CoordinatelessFunction(cell_orientations_tV, val=cell_orientations, name=cell_orientations_name, dtype=np.int32)
         return mesh
 
     @PETSc.Log.EventDecorator("LoadMeshTopology")
@@ -1274,6 +1331,9 @@ class CheckpointFile(object):
 
     def _path_to_mesh(self, tmesh_name, mesh_name):
         return os.path.join(self._path_to_meshes(tmesh_name), mesh_name)
+
+    def _path_to_mesh_immersed(self, tmesh_name, mesh_name):
+        return os.path.join(self._path_to_mesh(tmesh_name, mesh_name), PREFIX_IMMERSED)
 
     def _path_to_function_spaces(self, tmesh_name, mesh_name):
         return os.path.join(self._path_to_mesh(tmesh_name, mesh_name), PREFIX + "_function_spaces")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -41,6 +41,12 @@ _cells = {
 }
 
 
+_supported_embedded_cell_types = [ufl.Cell('interval', 2),
+                                  ufl.Cell('triangle', 3),
+                                  ufl.Cell("quadrilateral", 3),
+                                  ufl.TensorProductCell(ufl.Cell('interval'), ufl.Cell('interval'), geometric_dimension=3)]
+
+
 unmarked = -1
 """A mesh marker that selects all entities that are not explicitly marked."""
 
@@ -2172,11 +2178,7 @@ values from f.)"""
         import firedrake.function as function
         import firedrake.functionspace as functionspace
 
-        if self.ufl_cell() not in (ufl.Cell('interval', 2),
-                                   ufl.Cell('triangle', 3),
-                                   ufl.Cell("quadrilateral", 3),
-                                   ufl.TensorProductCell(ufl.Cell('interval'), ufl.Cell('interval'),
-                                                         geometric_dimension=3)):
+        if self.ufl_cell() not in _supported_embedded_cell_types:
             raise NotImplementedError('Only implemented for intervals embedded in 2d and triangles and quadrilaterals embedded in 3d')
 
         if hasattr(self.topology, '_cell_orientations'):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -682,14 +682,6 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     def _order_data_by_cell_index(self, column_list, cell_data):
         return cell_data[column_list]
 
-    def cell_orientations(self):
-        """Return the orientation of each cell in the mesh.
-
-        Use :meth:`.init_cell_orientations` on the mesh *geometry* to initialise."""
-        if not hasattr(self, '_cell_orientations'):
-            raise RuntimeError("No cell orientations found, did you forget to call init_cell_orientations?")
-        return self._cell_orientations
-
     @abc.abstractmethod
     def num_cells(self):
         pass
@@ -2167,6 +2159,28 @@ values from f.)"""
             locator.restype = ctypes.c_int
             return cache.setdefault(tolerance, locator)
 
+    def cell_orientations(self):
+        """Return the orientation of each cell in the mesh.
+
+        Use :meth:`.init_cell_orientations` to initialise."""
+        # View `_cell_orientations` (`CoordinatelessFunction`) as a property of
+        # `MeshGeometry` as opposed to one of `MeshTopology`, and treat it just like
+        # `_coordinates` (`CoordinatelessFunction`) so that we have:
+        # -- Regular MeshGeometry  = MeshTopology + `_coordinates`,
+        # -- Immersed MeshGeometry = MeshTopology + `_coordinates` + `_cell_orientations`.
+        # Here, `_coordinates` and `_cell_orientations` both represent some geometric
+        # properties (i.e., "coordinates" and "cell normals").
+        #
+        # Two `MeshGeometry`s can share the same `MeshTopology` and `_coordinates` while
+        # having distinct definition of "cell normals"; they are then simply regarded as two
+        # distinct meshes as `dot(expr, cell_normal) * dx` in general gives different results.
+        #
+        # Storing `_cell_orientations` in `MeshTopology` would make the `MeshTopology`
+        # object only useful for specific definition of "cell normals".
+        if not hasattr(self, '_cell_orientations'):
+            raise RuntimeError("No cell orientations found, did you forget to call init_cell_orientations?")
+        return self._cell_orientations
+
     @PETSc.Log.EventDecorator()
     def init_cell_orientations(self, expr):
         """Compute and initialise meth:`cell_orientations` relative to a specified orientation.
@@ -2181,7 +2195,7 @@ values from f.)"""
         if self.ufl_cell() not in _supported_embedded_cell_types:
             raise NotImplementedError('Only implemented for intervals embedded in 2d and triangles and quadrilaterals embedded in 3d')
 
-        if hasattr(self.topology, '_cell_orientations'):
+        if hasattr(self, '_cell_orientations'):
             raise RuntimeError("init_cell_orientations already called, did you mean to do so again?")
 
         if not isinstance(expr, ufl.classes.Expr):
@@ -2203,7 +2217,7 @@ values from f.)"""
 
         cell_orientations = function.Function(fs, name="cell_orientations", dtype=np.int32)
         cell_orientations.dat.data[:] = (f.dat.data_ro < 0)
-        self.topology._cell_orientations = cell_orientations
+        self._cell_orientations = cell_orientations.topological
 
     def __getattr__(self, name):
         val = getattr(self._topology, name)


### PR DESCRIPTION
Fix `CheckpointFile` for immersed meshes.

`mesh._cell_orientations` encodes manifold orientations (`0` or `1` for each cell). For each cell, the value (`0` or `1`) depends on the orientation of the mapping (call this "map orientation" to distinguish this from "manifold orientation") from the reference cell to that physical cell; we would get different values depending on if the map orientation introduces "reflection" or not.

For a given cell, the map orientation is in general different after loading, so, for checkpointing, we save `canonical_cell_orientations` instead of `mesh._cell_orientations`, where `canonical_cell_orientations` is what the mesh would have if map orientations were `0` for all cells.
`canonical_cell_orientations` can be computed by flipping `0` <-> `1` in `mesh._cell_orientations` for cells with map orientations that introduce reflection relative to map orientation `0`.

map orientations are stored in `mesh.entity_orientations[:, -1]`, and whether each map orientation introduces reflection or not can be checked with `fiat_cell.cell_orientation_reflection_map` (see the fiat PR).

## Associated Pull Requests:

Depends on:

https://github.com/FInAT/FInAT/pull/108
https://github.com/firedrakeproject/fiat/pull/37

These two PRs can be merged independently of this PR.

## Fixes Issues:
https://github.com/firedrakeproject/firedrake/discussions/2843

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
