### PR TITLE
Don't fail for empty real component assembly

### DIFF
--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -226,6 +226,11 @@ def compile_form(form, name, parameters=None, split=True, interface=None, coffee
         iterable = ([(None, )*nargs, form], )
     for idx, f in iterable:
         f = _real_mangle(f)
+        if not f.integrals():
+            # If we're assembling the R space component of a mixed argument,
+            # and that component doesn't actually appear in the form then we
+            # have an empty form, which we should not attempt to assemble.
+            continue
         # Map local coefficient numbers (as seen inside the
         # compiler) to the global coefficient numbers
         number_map = tuple(coefficient_numbers[c] for c in f.coefficients())

--- a/tests/regression/test_real_space.py
+++ b/tests/regression/test_real_space.py
@@ -117,6 +117,19 @@ def test_real_mixed_monolithic_two_form_assembly():
 
 
 @pytest.mark.skipcomplex
+def test_real_mixed_empty_component_assembly():
+    mesh = UnitSquareMesh(2, 2)
+    V = VectorFunctionSpace(mesh, 'CG', 1)
+    R = FunctionSpace(mesh, 'R', 0)
+    W = V * R
+    w = Function(W)
+    v, _ = split(w)
+    # This assembly has an empty block since the R component doesn't appear.
+    # The test passes if the empty block doesn't cause the assembly to fail.
+    assemble(derivative(inner(grad(v), grad(v)) * dx, w))
+
+
+@pytest.mark.skipcomplex
 def test_real_extruded_mixed_two_form_assembly():
     m = UnitIntervalMesh(3)
     mesh = ExtrudedMesh(m, 10)


### PR DESCRIPTION
---
name: Bug fix

---

# Description

Assembling forms on mixed function spaces involving real blocks previously fails if the real components don't actually appear in the form (and hence the relevant blocks are empty.

## Fixes Issues:

Fixes #2830 

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [ ] ~All of my functions and classes have appropriate docstrings.~
- [x] I have commented my code where its purpose may be unclear.
- [ ] ~I have included and updated any relevant documentation.~
- [ ] ~Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)~
- [x] I have added tests specific to the issues fixed in this PR.
- [ ] ~I have added tests that exercise the new functionality I have introduced~
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [x] New tests present
- [x] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
