### PR TITLE
Suppress link error for dubious ieee link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,6 +146,7 @@ linkcheck_ignore = [
     r'https://epubs\.siam\.org/doi/.*',
     r'https://www\.apl\.washington\.edu/',
     r'https://asmedigitalcollection\.asme\.org/',
+    r'https://ieeexplore\.ieee\.org/document/1634311/',
 ]
 linkcheck_timeout = 10
 


### PR DESCRIPTION
Bug fix

# Description
The IEEE is clearly an organisation with no understanding of how the internet works. Consequently they can't even keep their website up sufficiently reliably that our link checker works.

This will suppress lots of spurious build fails.

## Associated Pull Requests:


## Fixes Issues:


# Checklist for author:

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] ~I have added tests specific to the issues fixed in this PR.~
- [ ] ~I have added tests that exercise the new functionality I have introduced~
- [ ] ~Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).~
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [x ] Docstrings present
- [ ] ~New tests present~
- [ ] ~Code correctly commented~
- [ ] ~No bad "code smells"~
- [ ] ~No issues in parallel~
- [] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] ~Upstream/dependent branches and PRs are ready~

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

