### PR TITLE
Fix `--tinyasm` on install/update

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1492,9 +1492,12 @@ def create_compiler_env(cc, cxx, f90):
         env["MPI_C_COMPILER"] = cc
         env["CC"] = cc
         # Work around homebrew adding /usr/local/lib to the library search path.
-        env["CFLAGS"] = " ".join((os.environ.get("CFLAGS", ""),
-                                  "-L" + os.path.join(*get_petsc_dir(), "lib"),
-                                  "-I" + os.path.join(*get_petsc_dir(), "include")))
+        if osname == "Darwin":
+            env["CFLAGS"] = " ".join((
+                os.environ.get("CFLAGS", ""),
+                "-L" + os.path.join(*get_petsc_dir(), "lib"),
+                "-I" + os.path.join(*get_petsc_dir(), "include")
+            ))
     if cxx:
         env["MPICXX"] = cxx
         env["MPI_CXX_COMPILER"] = cxx


### PR DESCRIPTION
# Description
Makes homebrew hack in install script MacOS dependent. Currently TinyASM will fail to build on Linux with an external PETSc if CFLAGS is set to workaround a Homebrew issue as it breaks something inside CMake's autodetect PETSc magic.

## Associated Pull Requests:
- N/A

## Fixes Issues:
- Installing TinyASM with external PETSc on not MacOS.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
