### PR TITLE
Fix using relative tolerance for absolute tolerance

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -503,7 +503,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         :kwarg tolerance: The relative tolerance (i.e. as defined on the
             reference cell) for the distance a point can be from a cell and
             still be considered to be in the cell. Note that
-            this tolerance uses an L1 distance (aka 'manhatten', 'taxicab' or
+            this tolerance uses an L1 distance (aka 'manhattan', 'taxicab' or
             rectilinear distance) so will scale with the dimension of the mesh.
         """
 
@@ -884,7 +884,7 @@ class MeshTopology(AbstractMeshTopology):
         :kwarg tolerance: The relative tolerance (i.e. as defined on the
             reference cell) for the distance a point can be from a cell and
             still be considered to be in the cell. Note that
-            this tolerance uses an L1 distance (aka 'manhatten', 'taxicab' or
+            this tolerance uses an L1 distance (aka 'manhattan', 'taxicab' or
             rectilinear distance) so will scale with the dimension of the mesh.
         """
 
@@ -1313,7 +1313,7 @@ class ExtrudedMeshTopology(MeshTopology):
                              reference cell) for the distance a point can be
                              from a cell and still be considered to be in the
                              cell. Note that this tolerance
-                             uses an L1 distance (aka 'manhatten', 'taxicab' or
+                             uses an L1 distance (aka 'manhattan', 'taxicab' or
                              rectilinear distance) so will scale with the
                              dimension of the mesh.
         """
@@ -1937,7 +1937,7 @@ values from f.)"""
         Increase this if points at mesh boundaries (either rank local or
         global) are reported as being outside the mesh, for example when
         creating a :class:`VertexOnlyMesh`. Note that this tolerance uses an L1
-        distance (aka 'manhatten', 'taxicab' or rectilinear distance) so will
+        distance (aka 'manhattan', 'taxicab' or rectilinear distance) so will
         scale with the dimension of the mesh.
 
         If this property is not set (i.e. set to ``None``) no tolerance is
@@ -2362,7 +2362,7 @@ def Mesh(meshfile, **kwargs):
            this if point at mesh boundaries (either rank local or global) are
            reported as being outside the mesh, for example when creating a
            :class:`VertexOnlyMesh`. Note that this tolerance uses an L1
-           distance (aka 'manhatten', 'taxicab' or rectilinear distance) so
+           distance (aka 'manhattan', 'taxicab' or rectilinear distance) so
            will scale with the dimension of the mesh.
 
     When the mesh is read from a file the following mesh formats
@@ -2517,7 +2517,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
                          reference cell) for the distance a point can be from a
                          cell and still be considered to be in the cell.
                          Note that this tolerance uses an L1
-                         distance (aka 'manhatten', 'taxicab' or rectilinear
+                         distance (aka 'manhattan', 'taxicab' or rectilinear
                          distance) so will scale with the dimension of the
                          mesh.
 
@@ -2651,7 +2651,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
     :kwarg tolerance: The relative tolerance (i.e. as defined on the reference
         cell) for the distance a point can be from a mesh cell and still be
         considered to be in the cell. Note that this tolerance uses an L1
-        distance (aka 'manhatten', 'taxicab' or rectilinear distance) so
+        distance (aka 'manhattan', 'taxicab' or rectilinear distance) so
         will scale with the dimension of the mesh. The default is the parent
         mesh's ``tolerance`` property. Changing this from default will
         cause the parent mesh's spatial index to be rebuilt which can take some
@@ -2801,7 +2801,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     :kwarg tolerance: The relative tolerance (i.e. as defined on the reference
         cell) for the distance a point can be from a cell and still be
         considered to be in the cell. Note that this tolerance uses an L1
-        distance (aka 'manhatten', 'taxicab' or rectilinear distance) so
+        distance (aka 'manhattan', 'taxicab' or rectilinear distance) so
         will scale with the dimension of the mesh. The default is the parent
         mesh's ``tolerance`` property. Changing this from default will
         cause the parent mesh's spatial index to be rebuilt which can take some
@@ -3061,7 +3061,7 @@ def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_ha
         The relative tolerance (i.e. as defined on the reference cell) for the
         distance a point can be from a cell and still be considered to be in
         the cell. Note that this tolerance uses an L1
-        distance (aka 'manhatten', 'taxicab' or rectilinear distance) so
+        distance (aka 'manhattan', 'taxicab' or rectilinear distance) so
         will scale with the dimension of the mesh. The default is the parent
         mesh's ``tolerance`` property. Changing this from default will
         cause the parent mesh's spatial index to be rebuilt which can take some

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -94,7 +94,7 @@ def inside_check(fiat_cell, eps, X="X"):
 
 def celldist_l1_c_expr(fiat_cell, X="X"):
     """Generate a C expression of type `PetscReal` to compute the L1 distance
-    (aka 'manhatten', 'taxicab' or rectilinear distance) to a FIAT reference
+    (aka 'manhattan', 'taxicab' or rectilinear distance) to a FIAT reference
     cell.
 
     Parameters


### PR DESCRIPTION
# Description
Fixes the performance bug found in discussion #2902 . Also correctly spells Manhattan (sorry @stephankramer ...)

Running the code from #2902 
```python3
from firedrake import *

nx, ny = 100, 100
mesh = UnitSquareMesh(nx, ny, quadrilateral=False)
Q = FunctionSpace(mesh, "CG", 2)
u1 = Function(Q)
u2 = Function(Q)

def interpolate_between(source, target):
    from firedrake.mg.utils import physical_node_locations
    target_fs = target.function_space()
    target_locations = physical_node_locations(target_fs).dat.data[:]
    vom = VertexOnlyMesh(source.function_space().mesh(), target_locations, redundant=False)
    if isinstance(target_fs.ufl_element(), VectorElement):
        vom_space = VectorFunctionSpace(vom, "DG", 0)
    else:
        vom_space = FunctionSpace(vom, "DG", 0)
    target_vom_f = interpolate(source, vom_space)
    target.dat.data[:] = target_vom_f.dat.data

interpolate_between(u1, u2)
```
gives me a flamegraph where I spend **65x less time** in `locate_cell_and_reference_coordinate`! Oops.


## Fixes Issues:
- Performance bug found in discussion #2902 

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x]  ~I have included and updated any relevant documentation.~
- [x] ~Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)~
- [x] ~I have added tests specific to the issues fixed in this PR.~ Hard to test for a performance bug...
- [x] ~I have added tests that exercise the new functionality I have introduced~
- [x] ~Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).~
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [x] ~Docstrings present~
- [x] ~New tests present~
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [x] ~Upstream/dependent branches and PRs are ready~

<!--
Thanks for contributing!
-->
