### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -104,7 +104,7 @@ packages can be installed into an existing Firedrake installation using
 System requirements
 -------------------
 
-Firedrake requires Python 3.7.x to 3.11.x. On MacOS Arm (M1 or M2) Python 3.9.x
+Firedrake requires Python 3.8.x to 3.11.x. On MacOS Arm (M1 or M2) Python 3.9.x
 to 3.11.x is required. Many externally managed dependencies such as VTK
 have yet to create binary wheels for 3.11.x, but we have generated these
 for the major supported platforms.
@@ -126,7 +126,7 @@ they have the system dependencies:
 * A Fortran compiler (for PETSc)
 * Blas and Lapack
 * Git, Mercurial
-* Python version 3.7.x-3.11.x (3.9.x-3.11.x on MacOS Arm)
+* Python version 3.8.x-3.11.x (3.9.x-3.11.x on MacOS Arm)
 * The Python headers
 * autoconf, automake, libtool
 * CMake

--- a/docs/source/install-debug.dot
+++ b/docs/source/install-debug.dot
@@ -8,7 +8,7 @@ digraph triage {
     venv_activated [label="venv activated?"];
     install_script_up_to_date [label="Install script\nup to date?"];
     using_anaconda [label="Using\nAnaconda?"];
-    python_version [label="Python <3.7?"];
+    python_version [label="Python <3.8?"];
     using_macos [label="Using\nMacOS?"];
     using_homebrew [label="Using\nHomebrew?"];
     url_error [label="URL Error with SSL\ncertificate failure?"];
@@ -16,7 +16,7 @@ digraph triage {
 
     activate_venv [label="Activate the\nvenv first."];
     uninstall_anaconda [label="Deactivate\nAnaconda."];
-    update_python [label="Get Python 3.7-3.11"];
+    update_python [label="Get Python 3.8-3.11"];
     update_install_script [label="Fetch new\ninstall script"];
     get_homebrew [label="Use Homebrew."];
     brew_doctor [label="brew doctor"];

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -130,7 +130,7 @@ elif sys.version_info < (3, 9) and osname == "Darwin" and arch == "arm64":
     print("""
 Installing Firedrake on Mac Arm (M1 or M2) requires at least Python 3.9 since
 some required package(s) are not available for earlier Python versions.""")
-elif sys.version_info < (3, 7):
+elif sys.version_info < (3, 8):
     if mode == "install":
         print("""\nInstalling Firedrake requires Python 3, at least version 3.8.
 You should run firedrake-install with python3.""")

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -124,7 +124,7 @@ log.info("Running %s" % " ".join(sys.argv))
 if sys.version_info >= (3, 12):
     print("""\nCan not install Firedrake with Python 3.12 at the moment:
 Some wheels are not yet available for Python 3.12 for some required package(s).
-Please install with Python 3.11 (or an earlier version >= 3.7).""")
+Please install with Python 3.11 (or an earlier version >= 3.8).""")
     sys.exit(1)
 elif sys.version_info < (3, 9) and osname == "Darwin" and arch == "arm64":
     print("""
@@ -132,7 +132,7 @@ Installing Firedrake on Mac Arm (M1 or M2) requires at least Python 3.9 since
 some required package(s) are not available for earlier Python versions.""")
 elif sys.version_info < (3, 7):
     if mode == "install":
-        print("""\nInstalling Firedrake requires Python 3, at least version 3.7.
+        print("""\nInstalling Firedrake requires Python 3, at least version 3.8.
 You should run firedrake-install with python3.""")
     if mode == "update":
         if hasattr(sys, "real_prefix"):


### PR DESCRIPTION
This was discussed in the latest [Firedrake meeting](https://github.com/firedrakeproject/firedrake/wiki/Firedrake-meeting-2023-05-03#cw-ci-issuespython-version-support).

Please can reviewers let me know if I've missed anywhere where we still say that we support 3.7.