### PR TITLE
Document VertexOnlyMesh in manual

### DIFF
--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -7,15 +7,17 @@ Point evaluation
 
 Firedrake can evaluate :py:class:`~.Function`\s at arbitrary physical
 points.  This feature can be useful for the evaluation of the result
-of a simulation.  Two APIs are offered to this feature: a
-Firedrake-specific one, and one from UFL.
+of a simulation, or for creating expressions which contain point evaluations.
+Three APIs are offered to this feature: two Firedrake-specific ones, and one
+from UFL.
 
 
-Firedrake API
--------------
+Firedrake API 1: 'at' method
+----------------------------
 
-Firedrake offers a convenient API for evaluating functions at
-arbitrary points via :meth:`~.Function.at`:
+Firedrake's first API for evaluating functions at arbitrary points,
+:meth:`~.Function.at`, is designed for simple interrogation of a function with
+a few points.
 
 .. code-block:: python3
 
@@ -98,6 +100,229 @@ in parallel. There is no special API, but there are some restrictions:
 * Each process will get the same values.
 
 
+Firedrake API 2: Interpolation onto a vertex-only mesh
+------------------------------------------------------
+
+Firedrake's second API for evaluating functions at arbitrary points,
+interpolation onto a :func:`~.VertexOnlyMesh`, is designed for evaluating a
+function at many points and for creating expressions which contain point
+evaluations. It has been designed from the ground up to be entirely parallel
+compatible. Whilst :meth:`~.Function.at` produces a list of values, a
+cross-mesh interpolation onto :func:`~.VertexOnlyMesh` gives Firedrake
+:py:class:`~.Function`\s.
+
+This is discussed in detail in :cite:`nixonhill2023consistent` but, briefly,
+the idea is that the :func:`~.VertexOnlyMesh` is a mesh whose wich represents a
+point cloud domain. Each cell of the mesh is a vertex at a chosen location in
+space. As usual for a mesh, we represent values by creating functions in
+function spaces on it. The only function space that makes sense for a mesh
+whose cells are vertices is the space of piecewise constant functions, also
+known as the Polynomial degree 0 Discontinuous Galerkin (P0DG) space.
+
+Our vertex-only meshes are immersed in some 'parent' mesh. We perform point
+evaluation of a function :math:`f` defined in a function space
+:math:`V` on the parent mesh by interpolating into the P0DG space on the
+:func:`~.VertexOnlyMesh`. For example:
+
+.. code-block:: python3
+
+   parent_mesh = UnitSquareMesh(10, 10)
+
+   V = FunctionSpace(parent_mesh, "CG", 2)
+
+   # Create a function f on the parent mesh to point evaluate
+   x, y = SpatialCoordinate(parent_mesh)
+   f = Function(V).interpolate(x**2 + y**2)
+
+   # 3 points (i.e. vertices) at which to point evaluate f
+   points = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
+
+   vom = VertexOnlyMesh(parent_mesh, points)
+
+   # P0DG is the only function space you can make on a vertex-only mesh
+   P0DG = FunctionSpace(vom, "DG", 0)
+
+   # Interpolation performs point evaluation
+   f_at_points = interpolate(f, P0DG)
+
+   print(f_at_points.dat.data)
+
+will print ``[0.02, 0.08, 0.18]``, the values of :math:`x^2 + y^2` at the
+points :math:`(0.1, 0.1)`, :math:`(0.2, 0.2)` and :math:`(0.3, 0.3)`.
+
+Note that ``f_at_points`` is a :py:class:`~.Function` which takes
+on *all* the values of ``f`` evaluated at ``points``. The cell ordering of a
+:func:`~.VertexOnlyMesh` follows the ordering of the list of points it is given
+at construction. In general :func:`~.VertexOnlyMesh` accepts any numpy array of
+shape ``(num_points, point_dim)`` (or equivalent list) as the set of points to
+create disconnected vertices at.
+
+The operator for evaluation at the points specified can be created can be
+created by making an :py:class:`~.Interpolator` acting on a
+:py:func:`~.TestFunction`
+
+.. code-block:: python3
+
+   u = TestFunction(V)
+   Interpolator(u, P0DG)
+
+For more on :py:class:`~.Interpolator`\s and interpolation see the
+:doc:`interpolation <interpolation>` section.
+
+
+Vector and tensor valued function spaces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When interpolating from vector or tensor valued function spaces, the P0DG
+function space on the vertex-only mesh must be a
+:py:func:`~.VectorFunctionSpace` or :py:func:`~.TensorFunctionSpace`
+respectively. For example:
+
+.. code-block:: python3
+
+   V = VectorFunctionSpace(parent_mesh, "CG", 2)
+
+or
+
+.. code-block:: python3
+
+   V = FunctionSpace(parent_mesh, "N1curl", 2)
+
+each require
+
+.. code-block:: python3
+
+   vom = VertexOnlyMesh(parent_mesh, points)
+   P0DG_vec = VectorFunctionSpace(vom, "DG", 0)
+
+for successful interpolation.
+
+
+Parallel behaviour
+~~~~~~~~~~~~~~~~~~
+
+In parallel the ``points`` given to :func:`~.VertexOnlyMesh` are assumed to be
+the same on each MPI process and are taken from rank 0. To let different ranks
+provide different points to the vertex-only mesh set the keyword argument
+``redundant = False``
+
+.. code-block:: python3
+
+   # Default behaviour
+   vom = VertexOnlyMesh(parent_mesh, points, redundant = True)
+
+   # Different points on each MPI rank to add to the vertex-only mesh
+   vom = VertexOnlyMesh(parent_mesh, points, redundant = False)
+
+In this case, ``points`` will redistribute to the mesh partition where they are
+located. This means that if rank A has ``points`` :math:`\{X\}` that are not
+found in the mesh cells owned by rank A but are found in the mesh cells owned
+by rank B then they will be moved to rank B.
+
+If the same coordinates are supplied more than once, they are always assumed to
+be a new vertex: this is true for both ``redundant = True`` and
+``redunant = False``. So if we have the same set of points on all MPI processes
+and switch from ``redundant = True`` to ``redundant = False`` we will get point
+duplication.
+
+
+Points outside the domain
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Be default points outside the domain will generate a ``ValueError``. This can
+be switched to a warning or switched off entirely
+
+.. code-block:: python3
+
+   parent_mesh = UnitSquareMesh(100, 100, quadrilateral = True)
+
+   # point (1.1, 1.0) is outside the mesh
+   points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
+
+   # This will generate a ValueError
+   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
+
+   # This will generate a warning and the point will be lost
+   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
+
+   # This will cause the point to be silently lost
+   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
+
+
+Expressions with point evaluations
+----------------------------------
+
+In general integrating over a vertex-only mesh is equivalent to summing over
+it. So if we have a vertex-only mesh :math:`\Omega_v` with :math:`N` vertices
+at points :math:`\{x_i\}_{i=0}^{N-1}` and we have interpolated a function
+:math:`f` onto it giving a new function :math:`f_v` then
+
+.. math::
+
+   \int_{\Omega_v} f_v \, dx = \sum_{i=0}^{N-1} f(x_i).
+
+These equivalent expressions for point evaluation
+
+.. math::
+
+   \sum_{i=0}^{N-1} f(x_i) = \sum_{i=0}^{N-1} \int_\Omega f(x) \delta(x - x_i) \, dx
+
+where :math:`N` is the number of points, :math:`x_i` is the :math:`i`\th point,
+:math:`\Omega` is a 'parent' mesh, :math:`f` is a function on that mesh,
+:math:`\delta` is a dirac delta distribition can therefore be written in
+Firedrake using :func:`~.VertexOnlyMesh` and :func:`~.interpolate` as
+
+.. code-block:: python3
+
+   omega = parent_mesh
+   f = Function(V)  # assume V is scalar valued for this example
+
+   # assume we already have our list of points where N = len(points)
+
+   # Create a vertex-only mesh at the points
+   vom = VertexOnlyMesh(omega, points)
+
+   # Create a P0DG function space on the vertex-only mesh
+   P0DG = FunctionSpace(vom, "DG", 0)
+
+   # Interpolating f into the P0DG space on the vertex-only mesh evaluates f at
+   # the points
+   expr = assemble(interpolate(f, P0DG)*dx)
+
+
+Interacting with external point data
+------------------------------------
+
+Any set of points with associated data in our domain can be expressed as a
+P0DG function on a :func:`~.VertexOnlyMesh`.
+
+.. code-block:: python3
+
+   vom = VertexOnlyMesh(parent_mesh, point_locations_from_elsewhere)
+   P0DG = FunctionSpace(vom, "DG", 0)
+   y_pts = Function(P0DG).dat.data[:] = point_data_values_from_elsewhere
+
+We can use :func:`~.interpolate` to interact with this data to, for example,
+compare a PDE solution with the point data. The :math:`l_2` error norm
+(euclidean norm) of a function :math:`f` (which may be a PDE solution)
+evaluated against a set of point data :math:`\{y_i\}_{i=0}^{N-1}` at points
+:math:`\{x_i\}_{i=0}^{N-1}` is defined as
+
+.. math::
+
+   \sqrt{ \sum_{i=0}^{N-1} (f(x_i) - y_i)^2 }.
+
+We can express this in Firedrake as
+
+.. code-block:: python3
+
+   error = sqrt(assemble((interpolate(f, P0DG) - y_pts)**2*dx))
+
+   # or equivalently
+   error = errornorm(interpolate(f, P0DG), y_pts)
+
+
+
 UFL API
 -------
 
@@ -122,5 +347,5 @@ will evaluate :math:`f \cdot \sin(f)` at :math:`(0.2, 0.4)`.
 
    The expression itself is not translated into C code.  While the
    evaluation of a function uses the same infrastructure as the
-   Firedrake API, which uses generated C code, the expression tree is
+   Firedrake APIs, which use generated C code, the expression tree is
    evaluated by UFL in Python.

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -13,7 +13,7 @@ from UFL.
 
 
 Firedrake convenience function
-----------------------------
+------------------------------
 
 Firedrake's first API for evaluating functions at arbitrary points,
 :meth:`~.Function.at`, is designed for simple interrogation of a function with
@@ -101,15 +101,14 @@ in parallel. There is no special API, but there are some restrictions:
 
 
 Primary API: Interpolation onto a vertex-only mesh
-------------------------------------------------------
+--------------------------------------------------
 
 Firedrake's principal API for evaluating functions at arbitrary points,
 interpolation onto a :func:`~.VertexOnlyMesh`, is designed for evaluating a
-function at many points, or repeatedly, and for creating expressions which contain point
-evaluations. It has been designed from the ground up to be entirely parallel
-compatible. Whilst :meth:`~.Function.at` produces a list of values,
-cross-mesh interpolation onto :func:`~.VertexOnlyMesh` gives Firedrake
-:py:class:`~.Function`\s.
+function at many points, or repeatedly, and for creating expressions which
+contain point evaluations. It is parallel-safe. Whilst :meth:`~.Function.at`
+produces a list of values, cross-mesh interpolation onto
+:func:`~.VertexOnlyMesh` gives Firedrake :py:class:`~.Function`\s.
 
 This is discussed in detail in :cite:`nixonhill2023consistent` but, briefly,
 the idea is that the :func:`~.VertexOnlyMesh` is a mesh whose that represents a
@@ -124,28 +123,10 @@ evaluation of a function :math:`f` defined in a function space
 :math:`V` on the parent mesh by interpolating into the P0DG space on the
 :func:`~.VertexOnlyMesh`. For example:
 
-.. code-block:: python3
-
-   parent_mesh = UnitSquareMesh(10, 10)
-
-   V = FunctionSpace(parent_mesh, "CG", 2)
-
-   # Create a function f on the parent mesh to point evaluate
-   x, y = SpatialCoordinate(parent_mesh)
-   f = Function(V).interpolate(x**2 + y**2)
-
-   # 3 points (i.e. vertices) at which to point evaluate f
-   points = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
-
-   vom = VertexOnlyMesh(parent_mesh, points)
-
-   # P0DG is the only function space you can make on a vertex-only mesh
-   P0DG = FunctionSpace(vom, "DG", 0)
-
-   # Interpolation performs point evaluation
-   f_at_points = interpolate(f, P0DG)
-
-   print(f_at_points.dat.data)
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 7-26
 
 will print ``[0.02, 0.08, 0.18]``, the values of :math:`x^2 + y^2` at the
 points :math:`(0.1, 0.1)`, :math:`(0.2, 0.2)` and :math:`(0.3, 0.3)`.
@@ -229,24 +210,14 @@ duplication.
 Points outside the domain
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Be default points outside the domain will generate a ``ValueError``. This can
-be switched to a warning or switched off entirely
+Be default points outside the domain  by more than the :ref:`specified
+tolerance <tolerance>` will generate a ``ValueError``. This can be switched
+to a warning or switched off entirely:
 
-.. code-block:: python3
-
-   parent_mesh = UnitSquareMesh(100, 100, quadrilateral = True)
-
-   # point (1.1, 1.0) is outside the mesh
-   points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
-
-   # This will generate a ValueError
-   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
-
-   # This will generate a warning and the point will be lost
-   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
-
-   # This will cause the point to be silently lost
-   vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 31-35,37-44
 
 
 Expressions with point evaluations
@@ -272,23 +243,10 @@ where :math:`N` is the number of points, :math:`x_i` is the :math:`i`\th point,
 :math:`\delta` is a dirac delta distribition can therefore be written in
 Firedrake using :func:`~.VertexOnlyMesh` and :func:`~.interpolate` as
 
-.. code-block:: python3
-
-   omega = parent_mesh
-   f = Function(V)  # assume V is scalar valued for this example
-
-   # assume we already have our list of points where N = len(points)
-
-   # Create a vertex-only mesh at the points
-   vom = VertexOnlyMesh(omega, points)
-
-   # Create a P0DG function space on the vertex-only mesh
-   P0DG = FunctionSpace(vom, "DG", 0)
-
-   # Interpolating f into the P0DG space on the vertex-only mesh evaluates f at
-   # the points
-   expr = assemble(interpolate(f, P0DG)*dx)
-
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 48-62
 
 Interacting with external point data
 ------------------------------------
@@ -321,6 +279,7 @@ We can express this in Firedrake as
    # or equivalently
    error = errornorm(interpolate(f, P0DG), y_pts)
 
+.. _tolerance:
 
 Mesh tolerance
 --------------

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -322,6 +322,79 @@ We can express this in Firedrake as
    error = errornorm(interpolate(f, P0DG), y_pts)
 
 
+Mesh tolerance
+--------------
+
+If points are outside the mesh domain but ought to still be found a
+``tolerance`` parameter can be set. The tolerance is relative to the size of
+the mesh cells and is a property of the mesh itself
+
+.. code-block:: python3
+
+   parent_mesh = UnitSquareMesh(100, 100, quadrilateral = True)
+
+   # point (1.1, 1.0) is outside the mesh
+   points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
+
+   # This prints 1.0 - points can be up to around 1 mesh cell width away from
+   # the edge of the mesh and still be considered inside the domain.
+   print(parent_mesh.tolerance)
+
+   # This changes the tolerance and will cause the spatial index of the mesh
+   # to be rebuilt when first performing point evaluation which can take some
+   # time
+   parent_mesh.tolerance = 20.0
+
+   # This will now include the point (1.1, 1.0) in the mesh since each mesh
+   # cell is 1.0/100.0 wide.
+   vom = VertexOnlyMesh(parent_mesh, points)
+
+   # Similarly .at will not generate an error
+   V = FunctionSpace(parent_mesh, 'CG', 2)
+   Function(V).at((1.1, 1.0))
+
+
+Keyword arguments
+~~~~~~~~~~~~~~~~~
+
+Alternatively we can modify the tolerance by providing it as an argument to the
+vertex-only mesh. This will modify the tolerance property of the parent mesh.
+
+.. warning::
+
+   To avoid confusion, it is recommended that the tolerance be set for a mesh
+   before any point evaluations are performed, rather than making use of these
+   keyword arguments.
+
+.. code-block:: python3
+
+   # The point (1.1, 1.0) will still be included in the vertex-only mesh
+   vom = VertexOnlyMesh(parent_mesh, points, tolerance=30.0)
+
+   # The tolerance property has been changed - this will print 30.0
+   print(parent_mesh.tolerance)
+
+   # This doesn't generate an error
+   Function(V).at((1.1, 1.0), tolerance = 20.0)
+
+   # The tolerance property has been changed again - this will print 20.0
+   print(parent_mesh.tolerance)
+
+   try:
+      # This generates an error
+      Function(V).at((1.1, 1.0), tolerance = 1.0)
+   except :
+      # But the tolerance property has still been changed - this will print 1.0
+      print(parent_mesh.tolerance)
+
+Note that since our tolerance is relative, the number of cells in a mesh
+dictates the point loss behaviour close to cell edges. So the mesh
+``UnitSquareMesh(5, 5, quadrilateral = True)`` will include the point
+:math:`(1.1, 1.0)` by default.
+
+If a mesh tolerance changes where we already have an immersed vertex-only mesh,
+such that the new tolerance ought to cause points to disappear, they will not.
+
 
 UFL API
 -------

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -251,6 +251,16 @@ Firedrake using :func:`~.VertexOnlyMesh` and :func:`~.interpolate` as
 Interacting with external point data
 ------------------------------------
 
+.. warning::
+
+   The examples given in the following section use an internal Firedrake API
+   ``Function.dat.data`` which could change in the future.
+
+.. warning::
+
+   The examples given in the following section will not work in parallel. A
+   parallel safe way of interacting with external data will be available soon.
+
 Any set of points with associated data in our domain can be expressed as a
 P0DG function on a :func:`~.VertexOnlyMesh`.
 

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -12,7 +12,7 @@ Three APIs are offered to this feature: two Firedrake-specific ones, and one
 from UFL.
 
 
-Firedrake API 1: 'at' method
+Firedrake convenience function
 ----------------------------
 
 Firedrake's first API for evaluating functions at arbitrary points,
@@ -100,19 +100,19 @@ in parallel. There is no special API, but there are some restrictions:
 * Each process will get the same values.
 
 
-Firedrake API 2: Interpolation onto a vertex-only mesh
+Primary API: Interpolation onto a vertex-only mesh
 ------------------------------------------------------
 
-Firedrake's second API for evaluating functions at arbitrary points,
+Firedrake's principal API for evaluating functions at arbitrary points,
 interpolation onto a :func:`~.VertexOnlyMesh`, is designed for evaluating a
-function at many points and for creating expressions which contain point
+function at many points, or repeatedly, and for creating expressions which contain point
 evaluations. It has been designed from the ground up to be entirely parallel
-compatible. Whilst :meth:`~.Function.at` produces a list of values, a
+compatible. Whilst :meth:`~.Function.at` produces a list of values,
 cross-mesh interpolation onto :func:`~.VertexOnlyMesh` gives Firedrake
 :py:class:`~.Function`\s.
 
 This is discussed in detail in :cite:`nixonhill2023consistent` but, briefly,
-the idea is that the :func:`~.VertexOnlyMesh` is a mesh whose wich represents a
+the idea is that the :func:`~.VertexOnlyMesh` is a mesh whose that represents a
 point cloud domain. Each cell of the mesh is a vertex at a chosen location in
 space. As usual for a mesh, we represent values by creating functions in
 function spaces on it. The only function space that makes sense for a mesh
@@ -252,7 +252,7 @@ be switched to a warning or switched off entirely
 Expressions with point evaluations
 ----------------------------------
 
-In general integrating over a vertex-only mesh is equivalent to summing over
+Integrating over a vertex-only mesh is equivalent to summing over
 it. So if we have a vertex-only mesh :math:`\Omega_v` with :math:`N` vertices
 at points :math:`\{x_i\}_{i=0}^{N-1}` and we have interpolated a function
 :math:`f` onto it giving a new function :math:`f_v` then

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -325,8 +325,10 @@ dictates the point loss behaviour close to cell edges. So the mesh
 ``UnitSquareMesh(5, 5, quadrilateral = True)`` will include the point
 :math:`(1.1, 1.0)` by default.
 
-If a mesh tolerance changes where we already have an immersed vertex-only mesh,
-such that the new tolerance ought to cause points to disappear, they will not.
+Changing mesh tolerance only affects point location after it has been changed.
+To apply the new tolerance to a vertex-only mesh, a new vertex-only mesh must 
+be created. Any existing immersed vertex-only mesh will have been created 
+using the previous tolerance and will be unaffected by the change.
 
 
 UFL API

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -111,7 +111,7 @@ produces a list of values, cross-mesh interpolation onto
 :func:`~.VertexOnlyMesh` gives Firedrake :py:class:`~.Function`\s.
 
 This is discussed in detail in :cite:`nixonhill2023consistent` but, briefly,
-the idea is that the :func:`~.VertexOnlyMesh` is a mesh whose that represents a
+the idea is that the :func:`~.VertexOnlyMesh` is a mesh that represents a
 point cloud domain. Each cell of the mesh is a vertex at a chosen location in
 space. As usual for a mesh, we represent values by creating functions in
 function spaces on it. The only function space that makes sense for a mesh
@@ -138,7 +138,7 @@ at construction. In general :func:`~.VertexOnlyMesh` accepts any numpy array of
 shape ``(num_points, point_dim)`` (or equivalent list) as the set of points to
 create disconnected vertices at.
 
-The operator for evaluation at the points specified can be created can be
+The operator for evaluation at the points specified can be
 created by making an :py:class:`~.Interpolator` acting on a
 :py:func:`~.TestFunction`
 

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -246,7 +246,7 @@ Firedrake using :func:`~.VertexOnlyMesh` and :func:`~.interpolate` as
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 48-62
+   :lines: 50-64
 
 Interacting with external point data
 ------------------------------------
@@ -288,30 +288,10 @@ If points are outside the mesh domain but ought to still be found a
 ``tolerance`` parameter can be set. The tolerance is relative to the size of
 the mesh cells and is a property of the mesh itself
 
-.. code-block:: python3
-
-   parent_mesh = UnitSquareMesh(100, 100, quadrilateral = True)
-
-   # point (1.1, 1.0) is outside the mesh
-   points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
-
-   # This prints 1.0 - points can be up to around 1 mesh cell width away from
-   # the edge of the mesh and still be considered inside the domain.
-   print(parent_mesh.tolerance)
-
-   # This changes the tolerance and will cause the spatial index of the mesh
-   # to be rebuilt when first performing point evaluation which can take some
-   # time
-   parent_mesh.tolerance = 20.0
-
-   # This will now include the point (1.1, 1.0) in the mesh since each mesh
-   # cell is 1.0/100.0 wide.
-   vom = VertexOnlyMesh(parent_mesh, points)
-
-   # Similarly .at will not generate an error
-   V = FunctionSpace(parent_mesh, 'CG', 2)
-   Function(V).at((1.1, 1.0))
-
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 70-90
 
 Keyword arguments
 ~~~~~~~~~~~~~~~~~
@@ -325,26 +305,10 @@ vertex-only mesh. This will modify the tolerance property of the parent mesh.
    before any point evaluations are performed, rather than making use of these
    keyword arguments.
 
-.. code-block:: python3
-
-   # The point (1.1, 1.0) will still be included in the vertex-only mesh
-   vom = VertexOnlyMesh(parent_mesh, points, tolerance=30.0)
-
-   # The tolerance property has been changed - this will print 30.0
-   print(parent_mesh.tolerance)
-
-   # This doesn't generate an error
-   Function(V).at((1.1, 1.0), tolerance = 20.0)
-
-   # The tolerance property has been changed again - this will print 20.0
-   print(parent_mesh.tolerance)
-
-   try:
-      # This generates an error
-      Function(V).at((1.1, 1.0), tolerance = 1.0)
-   except :
-      # But the tolerance property has still been changed - this will print 1.0
-      print(parent_mesh.tolerance)
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 100-117
 
 Note that since our tolerance is relative, the number of cells in a mesh
 dictates the point loss behaviour close to cell edges. So the mesh

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2693,8 +2693,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
         will redistribute to the mesh partition where they are located. This
         means that if rank A has ``vertexcoords`` {X} that are not found in the
         mesh cells owned by rank A but are found in the mesh cells owned by
-        rank B, **and rank B has not been supplied with those**, then they will
-        be moved to rank B.
+        rank B, then they will be moved to rank B.
 
     .. note::
         If the same coordinates are supplied more than once, they are always

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -37,13 +37,13 @@ def test_vom_manual_points_outside_domain():
         # This will raise a ValueError
         vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
 
-        # This will generate a warning and the point will be lost
-        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
+    # This will generate a warning and the point will be lost
+    vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
 
-        # This will cause the point to be silently lost
-        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
+    # This will cause the point to be silently lost
+    vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
 
-        assert vom  # Just here to shut up flake8 unused variable warning.
+    assert vom  # Just here to shut up flake8 unused variable warning.
 
 
 def test_vom_manual_keyword_arguments():

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -43,6 +43,8 @@ def test_vom_manual_points_outside_domain():
         # This will cause the point to be silently lost
         vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
 
+        assert vom  # Just here to shut up flake8 unused variable warning.
+
 
 def test_vom_manual_keyword_arguments():
     omega = UnitSquareMesh(100, 100, quadrilateral=True)
@@ -60,3 +62,58 @@ def test_vom_manual_keyword_arguments():
     # Interpolating f into the P0DG space on the vertex-only mesh evaluates f at
     # the points
     expr = assemble(interpolate(f, P0DG)*dx)
+
+    assert expr == 0.0
+
+
+def test_mesh_tolerance():
+    parent_mesh = UnitSquareMesh(100, 100, quadrilateral=True)
+
+    # point (1.1, 1.0) is outside the mesh
+    points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
+
+    # This prints 1.0 - points can be up to around 1 mesh cell width away from
+    # the edge of the mesh and still be considered inside the domain.
+    print(parent_mesh.tolerance)
+
+    # This changes the tolerance and will cause the spatial index of the mesh
+    # to be rebuilt when first performing point evaluation which can take some
+    # time
+    parent_mesh.tolerance = 20.0
+
+    # This will now include the point (1.1, 1.0) in the mesh since each mesh
+    # cell is 1.0/100.0 wide.
+    vom = VertexOnlyMesh(parent_mesh, points)
+
+    # Similarly .at will not generate an error
+    V = FunctionSpace(parent_mesh, 'CG', 2)
+    Function(V).at((1.1, 1.0))
+
+    assert vom
+
+
+def test_mesh_tolerance_change():
+    parent_mesh = UnitSquareMesh(100, 100, quadrilateral=True)
+    points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
+    V = FunctionSpace(parent_mesh, 'CG', 2)
+
+    # The point (1.1, 1.0) will still be included in the vertex-only mesh
+    vom = VertexOnlyMesh(parent_mesh, points, tolerance=30.0)
+
+    # The tolerance property has been changed - this will print 30.0
+    print(parent_mesh.tolerance)
+
+    # This doesn't generate an error
+    Function(V).at((1.1, 1.0), tolerance=20.0)
+
+    # The tolerance property has been changed again - this will print 20.0
+    print(parent_mesh.tolerance)
+
+    try:
+        # This generates an error
+        Function(V).at((1.1, 1.0), tolerance=1.0)
+    except PointNotInDomainError:
+        # But the tolerance property has still been changed - this will print 1.0
+        print(parent_mesh.tolerance)
+
+    assert vom

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -1,0 +1,62 @@
+from firedrake import *
+import pytest
+# Ensure that the code shown in the manual runs without error.
+
+
+def test_vertex_only_mesh_manual_example():
+    parent_mesh = UnitSquareMesh(10, 10)
+
+    V = FunctionSpace(parent_mesh, "CG", 2)
+
+    # Create a function f on the parent mesh to point evaluate
+    x, y = SpatialCoordinate(parent_mesh)
+    f = Function(V).interpolate(x**2 + y**2)
+
+    # 3 points (i.e. vertices) at which to point evaluate f
+    points = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
+
+    vom = VertexOnlyMesh(parent_mesh, points)
+
+    # P0DG is the only function space you can make on a vertex-only mesh
+    P0DG = FunctionSpace(vom, "DG", 0)
+
+    # Interpolation performs point evaluation
+    f_at_points = interpolate(f, P0DG)
+
+    print(f_at_points.dat.data)
+
+
+def test_vom_manual_points_outside_domain():
+    for i in [0]:
+        parent_mesh = UnitSquareMesh(100, 100, quadrilateral=True)
+
+        # point (1.1, 1.0) is outside the mesh
+        points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
+
+    with pytest.raises(ValueError):
+        # This will raise a ValueError
+        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
+
+        # This will generate a warning and the point will be lost
+        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
+
+        # This will cause the point to be silently lost
+        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
+
+
+def test_vom_manual_keyword_arguments():
+    omega = UnitSquareMesh(100, 100, quadrilateral=True)
+
+    V = FunctionSpace(omega, "CG", 2)
+    f = Function(V)
+
+    points = [[0.1, 0.1], [0.2, 0.2], [1.0, 1.0]]
+    # Create a vertex-only mesh at the points
+    vom = VertexOnlyMesh(omega, points)
+
+    # Create a P0DG function space on the vertex-only mesh
+    P0DG = FunctionSpace(vom, "DG", 0)
+
+    # Interpolating f into the P0DG space on the vertex-only mesh evaluates f at
+    # the points
+    expr = assemble(interpolate(f, P0DG)*dx)


### PR DESCRIPTION
# Description
Added documentation of VertexOnlyMesh to the manual pages on point evaluation.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [] ~All of my functions and classes have appropriate docstrings.~
- [ ] ~I have commented my code where its purpose may be unclear.~
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] ~I have added tests specific to the issues fixed in this PR.~
- [ ] ~I have added tests that exercise the new functionality I have introduced~
- [ ] ~Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).~
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] ~Docstrings present~
- [ ] ~New tests present~
- [ ] ~Code correctly commented~
- [ ] ~No bad "code smells"~
- [ ] ~No issues in parallel~
- [ ] ~No CI issues (excessive parallelism/memory usage/time/warnings generated)~
- [ ] ~Upstream/dependent branches and PRs are ready~

