### PR TITLE
only linkcheck master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,11 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           cd docs
-          make linkcheck
           make html
           make latex
           make latexpdf
+      - name: Check documentation links
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          cd docs
+          make linkcheck


### PR DESCRIPTION
# Description

Link checking causes frequent spurious fails on PRs because external websites are unreliable. This PR works around this by only link checking master.

