### PR TITLE
Retrieve original VOM decomposition

### DIFF
--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -149,6 +149,9 @@ This will also work in parallel, as the interpolation will occur on
 each process, and Firedrake will take care of the halo updates before
 the next operation using ``f``.
 
+For interaction with external point data, see the
+:ref:`corresponding manual section <external-point-data>`.
+
 
 C string expressions
 --------------------

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -267,8 +267,8 @@ Using the input ordering property
 
 Any set of points with associated data in our domain can be expressed as a
 P0DG function on a :func:`~.VertexOnlyMesh`. The recommended way to import data
-from an external source is via the :py:attr:`~.MeshGeometry.input_ordering`
-method: this produces another vertex-only mesh which has points in the order
+from an external source is via the :py:attr:`~.VertexOnlyMeshTopology.input_ordering`
+property: this produces another vertex-only mesh which has points in the order
 and MPI rank that they were specified when first creating the original
 vertex-only mesh. For example:
 
@@ -279,7 +279,7 @@ vertex-only mesh. For example:
 
 This is entirely parallel safe.
 
-Similarly, we can use :py:attr:`~.MeshGeometry.input_ordering` to get data out
+Similarly, we can use :py:attr:`~.VertexOnlyMeshTopology.input_ordering` to get data out
 of a vertex-only mesh in a parallel-safe way. If we return to our example from
 :ref:`the section where we introduced vertex only meshes <primary-api>`, we
 had
@@ -292,7 +292,7 @@ had
 In parallel, this will print the values of ``f`` at the given ``points`` list
 **after the points have been distributed over the parent mesh**. If we want the
 values of ``f`` at the ``points`` list **before the points have been
-distributed** we can use :py:attr:`~.MeshGeometry.input_ordering` as follows:
+distributed** we can use :py:attr:`~.VertexOnlyMeshTopology.input_ordering` as follows:
 
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
@@ -303,7 +303,7 @@ distributed** we can use :py:attr:`~.MeshGeometry.input_ordering` as follows:
 
    When a a vertex-only mesh is created with ``redundant = True`` (which is the
    default when creating a :func:`~.VertexOnlyMesh`) the
-   :py:attr:`~.MeshGeometry.input_ordering` method will return a vertex-only
+   :py:attr:`~.VertexOnlyMeshTopology.input_ordering` method will return a vertex-only
    mesh with all points on rank 0.
 
 If we ran the example in parallel, the above code would print
@@ -326,7 +326,7 @@ a good idea to set the values to ``nan`` before the interpolation:
 More ways to interact with external data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Aside from :py:attr:`~.MeshGeometry.input_ordering`, we can use
+Aside from :py:attr:`~.VertexOnlyMeshTopology.input_ordering`, we can use
 :func:`~.interpolate` to interact with external data to, for example,
 compare a PDE solution with the point data. The :math:`l_2` error norm
 (euclidean norm) of a function :math:`f` (which may be a PDE solution)
@@ -346,7 +346,7 @@ We can express this in Firedrake as
    # or equivalently
    error = errornorm(interpolate(f, P0DG), y_pts)
 
-We can then use the :py:attr:`~.MeshGeometry.input_ordering` vertex-only mesh
+We can then use the :py:attr:`~.VertexOnlyMeshTopology.input_ordering` vertex-only mesh
 to safely check the values of ``error`` at the points
 :math:`\{x_i\}_{i=0}^{N-1}`.
 

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -92,13 +92,18 @@ moved.
 Evaluation with a distributed mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is limited support for point evaluation when running Firedrake
+There is limited support for :meth:`~.Function.at` when running Firedrake
 in parallel. There is no special API, but there are some restrictions:
 
 * Point evaluation is a *collective* operation.
 * Each process must ask for the same list of points.
 * Each process will get the same values.
 
+If ``RuntimeError: Point evaluation gave different results across processes.``
+is raised, try lowering the :ref:`mesh tolerance <tolerance>`.
+
+
+.. _primary-api:
 
 Primary API: Interpolation onto a vertex-only mesh
 --------------------------------------------------
@@ -126,10 +131,12 @@ evaluation of a function :math:`f` defined in a function space
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 7-26
+   :lines: 9-28
 
-will print ``[0.02, 0.08, 0.18]``, the values of :math:`x^2 + y^2` at the
-points :math:`(0.1, 0.1)`, :math:`(0.2, 0.2)` and :math:`(0.3, 0.3)`.
+will print ``[0.02, 0.08, 0.18]`` when running in serial, the values of
+:math:`x^2 + y^2` at the points :math:`(0.1, 0.1)`, :math:`(0.2, 0.2)` and
+:math:`(0.3, 0.3)`. For details on viewing the outputs in parallel, see the
+:ref:`section on the input ordering property. <input_ordering>`
 
 Note that ``f_at_points`` is a :py:class:`~.Function` which takes
 on *all* the values of ``f`` evaluated at ``points``. The cell ordering of a
@@ -217,7 +224,7 @@ to a warning or switched off entirely:
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 31-35,37-44
+   :lines: 50-52,55-57,59-63
 
 
 Expressions with point evaluations
@@ -246,31 +253,81 @@ Firedrake using :func:`~.VertexOnlyMesh` and :func:`~.interpolate` as
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 50-64
+   :lines: 72-86
+
+.. _external-point-data:
 
 Interacting with external point data
 ------------------------------------
 
-.. warning::
+.. _input_ordering:
 
-   The examples given in the following section use an internal Firedrake API
-   ``Function.dat.data`` which could change in the future.
-
-.. warning::
-
-   The examples given in the following section will not work in parallel. A
-   parallel safe way of interacting with external data will be available soon.
+Using the input ordering property
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any set of points with associated data in our domain can be expressed as a
-P0DG function on a :func:`~.VertexOnlyMesh`.
+P0DG function on a :func:`~.VertexOnlyMesh`. The recommended way to import data
+from an external source is via the :py:attr:`~.MeshGeometry.input_ordering`
+method: this produces another vertex-only mesh which has points in the order
+and MPI rank that they were specified when first creating the original
+vertex-only mesh. For example:
 
-.. code-block:: python3
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 158-172
 
-   vom = VertexOnlyMesh(parent_mesh, point_locations_from_elsewhere)
-   P0DG = FunctionSpace(vom, "DG", 0)
-   y_pts = Function(P0DG).dat.data[:] = point_data_values_from_elsewhere
+This is entirely parallel safe.
 
-We can use :func:`~.interpolate` to interact with this data to, for example,
+Similarly, we can use :py:attr:`~.MeshGeometry.input_ordering` to get data out
+of a vertex-only mesh in a parallel-safe way. If we return to our example from
+:ref:`the section where we introduced vertex only meshes <primary-api>`, we
+had
+
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 26-28
+
+In parallel, this will print the values of ``f`` at the given ``points`` list
+**after the points have been distributed over the parent mesh**. If we want the
+values of ``f`` at the ``points`` list **before the points have been
+distributed** we can use :py:attr:`~.MeshGeometry.input_ordering` as follows:
+
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 30-37
+
+.. note::
+
+   When a a vertex-only mesh is created with ``redundant = True`` (which is the
+   default when creating a :func:`~.VertexOnlyMesh`) the
+   :py:attr:`~.MeshGeometry.input_ordering` method will return a vertex-only
+   mesh with all points on rank 0.
+
+If we ran the example in parallel, the above code would print
+``[0.02, 0.08, 0.18]`` on rank 0 and ``[]`` on all other ranks. If we set
+``redundant = False`` when creating the vertex-only mesh, the above code would
+print ``[0.02, 0.08, 0.18]`` on all ranks and we would have point duplication.
+
+If any of the specified points were not found in the mesh, the value on the
+input ordering vertex-only mesh will not be effected by the interpolation from
+the original vertex-only mesh. In the above example, the values would be zero
+at those points. To make it more obvious that those points were not found, it's
+a good idea to set the values to ``nan`` before the interpolation:
+
+.. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
+   :language: python3
+   :dedent:
+   :lines: 39-43
+
+
+More ways to interact with external data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Aside from :py:attr:`~.MeshGeometry.input_ordering`, we can use
+:func:`~.interpolate` to interact with external data to, for example,
 compare a PDE solution with the point data. The :math:`l_2` error norm
 (euclidean norm) of a function :math:`f` (which may be a PDE solution)
 evaluated against a set of point data :math:`\{y_i\}_{i=0}^{N-1}` at points
@@ -289,6 +346,10 @@ We can express this in Firedrake as
    # or equivalently
    error = errornorm(interpolate(f, P0DG), y_pts)
 
+We can then use the :py:attr:`~.MeshGeometry.input_ordering` vertex-only mesh
+to safely check the values of ``error`` at the points
+:math:`\{x_i\}_{i=0}^{N-1}`.
+
 .. _tolerance:
 
 Mesh tolerance
@@ -301,7 +362,7 @@ the mesh cells and is a property of the mesh itself
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 70-90
+   :lines: 92-112
 
 Keyword arguments
 ~~~~~~~~~~~~~~~~~
@@ -318,7 +379,7 @@ vertex-only mesh. This will modify the tolerance property of the parent mesh.
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3
    :dedent:
-   :lines: 100-117
+   :lines: 122-139
 
 Note that since our tolerance is relative, the number of cells in a mesh
 dictates the point loss behaviour close to cell edges. So the mesh
@@ -326,8 +387,8 @@ dictates the point loss behaviour close to cell edges. So the mesh
 :math:`(1.1, 1.0)` by default.
 
 Changing mesh tolerance only affects point location after it has been changed.
-To apply the new tolerance to a vertex-only mesh, a new vertex-only mesh must 
-be created. Any existing immersed vertex-only mesh will have been created 
+To apply the new tolerance to a vertex-only mesh, a new vertex-only mesh must
+be created. Any existing immersed vertex-only mesh will have been created
 using the previous tolerance and will be unaffected by the change.
 
 

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -33,9 +33,9 @@ def get_topological_dimension(PETSc.DM dm):
 
     :returns: For a DMPlex ``dm.getDimension()``, for a DMSwarm ``0``.
     """
-    if type(dm) is PETSc.DMPlex:
+    if isinstance(dm, PETSc.DMPlex):
         return dm.getDimension()
-    elif type(dm) is PETSc.DMSwarm:
+    elif isinstance(dm, PETSc.DMSwarm):
         return 0
     else:
         raise ValueError("dm must be a DMPlex or DMSwarm")
@@ -605,7 +605,7 @@ def closure_ordering(PETSc.DM dm,
 
         # Find all edges (dim=1) (only relevant for `DMPlex`)
         if dim > 2:
-            assert type(dm) is PETSc.DMPlex
+            assert isinstance(dm, PETSc.DMPlex)
             nfaces = 0
             for ci in range(nclosure):
                 if eStart <= closure[2*ci] < eEnd:
@@ -1163,7 +1163,7 @@ def create_section(mesh, nodes_per_entity, on_base=False, block_size=1):
 
     dm = mesh.topology_dm
 
-    if type(dm) is PETSc.DMSwarm and on_base:
+    if isinstance(dm, PETSc.DMSwarm) and on_base:
         raise NotImplementedError("Vertex Only Meshes cannot be extruded.")
 
     variable = mesh.variable_layers
@@ -1186,7 +1186,7 @@ def create_section(mesh, nodes_per_entity, on_base=False, block_size=1):
 
     get_chart(dm.dm, &pStart, &pEnd)
     section.setChart(pStart, pEnd)
-    if type(dm) is PETSc.DMPlex:
+    if isinstance(dm, PETSc.DMPlex):
         # Renumbering only implemented for DMPlex
         renumbering = mesh._plex_renumbering
         CHKERR(PetscSectionSetPermutation(section.sec, renumbering.iset))
@@ -1249,7 +1249,7 @@ def get_cell_nodes(mesh,
         bint is_swarm, variable, extruded_periodic_1_layer
 
     dm = mesh.topology_dm
-    is_swarm = type(dm) is PETSc.DMSwarm
+    is_swarm = isinstance(dm, PETSc.DMSwarm)
     variable = mesh.variable_layers
     cell_closures = mesh.cell_closure
     entity_orientations = mesh.entity_orientations
@@ -1640,7 +1640,7 @@ def reordered_coords(PETSc.DM dm, PETSc.Section global_numbering, shape):
 
     get_depth_stratum(dm.dm, 0, &vStart, &vEnd)
 
-    if type(dm) is PETSc.DMPlex:
+    if isinstance(dm, PETSc.DMPlex):
         dm_sec = dm.getCoordinateSection()
         dm_coords = dm.getCoordinatesLocal().array.reshape(shape)
         coords = np.empty_like(dm_coords)
@@ -1650,7 +1650,7 @@ def reordered_coords(PETSc.DM dm, PETSc.Section global_numbering, shape):
             dm_offset = dm_offset//dim
             for i in range(dim):
                 coords[offset, i] = dm_coords[dm_offset, i]
-    elif type(dm) is PETSc.DMSwarm:
+    elif isinstance(dm, PETSc.DMSwarm):
         # NOTE DMSwarm coords field isn't copied so make sure
         # dm.restoreField is called too!
         # NOTE DMSwarm coords field DMSwarmPIC_coor always stored as real

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -1709,7 +1709,12 @@ def mark_entity_classes(PETSc.DM dm):
         point_sf = dm.getPointSF()
         CHKERR(PetscSFGetGraph(point_sf.sf, NULL, &nleaves, &ilocal, NULL))
         for p in range(nleaves):
-            CHKERR(DMLabelSetValue(lbl_ghost, ilocal[p], 1))
+            # If ilocal is NULL but we have leaves then ilocal is contiguous
+            # (0, 1, 2...)
+            if ilocal:
+                CHKERR(DMLabelSetValue(lbl_ghost, ilocal[p], 1))
+            else:
+                CHKERR(DMLabelSetValue(lbl_ghost, p, 1))
     else:
         # If sequential mark all points as core
         for p in range(pStart, pEnd):
@@ -3117,7 +3122,7 @@ def fill_reference_coordinates_function(reference_coordinates_f):
     reference_coords = swarm.getField("refcoord").reshape(shape)
 
     # store reference coord field in Function Dat.
-    reference_coordinates_f.dat.data[:] = reference_coords[:]
+    reference_coordinates_f.dat.data_with_halos[:] = reference_coords[:]
 
     # have to restore fields once accessed to allow access again
     swarm.restoreField("refcoord")

--- a/firedrake/cython/petschdr.pxi
+++ b/firedrake/cython/petschdr.pxi
@@ -63,6 +63,7 @@ cdef extern from "petscdm.h" nogil:
 
 cdef extern from "petscdmswarm.h" nogil:
     int DMSwarmGetLocalSize(PETSc.PetscDM,PetscInt*)
+    int DMSwarmGetCellDM(PETSc.PetscDM, PETSc.PetscDM*)
 
 cdef extern from "petscvec.h" nogil:
     int VecGetArray(PETSc.PetscVec,PetscScalar**)
@@ -75,6 +76,7 @@ cdef extern from "petscis.h" nogil:
     int PetscSectionGetMaxDof(PETSc.PetscSection,PetscInt*)
     int PetscSectionSetPermutation(PETSc.PetscSection,PETSc.PetscIS)
     int ISGetIndices(PETSc.PetscIS,PetscInt*[])
+    int ISGetSize(PETSc.PetscIS,PetscInt*)
     int ISRestoreIndices(PETSc.PetscIS,PetscInt*[])
     int ISGeneralSetIndices(PETSc.PetscIS,PetscInt,PetscInt[],PetscCopyMode)
     int ISLocalToGlobalMappingCreateIS(PETSc.PetscIS,PETSc.PetscLGMap*)

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -11,6 +11,8 @@ from pyop2.utils import flatten
 from firedrake import functionspaceimpl as impl
 from firedrake.petsc import PETSc
 
+import numbers
+
 
 __all__ = ("MixedFunctionSpace", "FunctionSpace",
            "VectorFunctionSpace", "TensorFunctionSpace")
@@ -169,7 +171,10 @@ def VectorFunctionSpace(mesh, family, degree=None, dim=None,
 
     """
     sub_element = make_scalar_element(mesh, family, degree, vfamily, vdegree)
-    dim = dim or mesh.ufl_cell().geometric_dimension()
+    if dim is None:
+        dim = mesh.ufl_cell().geometric_dimension()
+    if not isinstance(dim, numbers.Integral) and dim > 0:
+        raise ValueError(f"Can't make VectorFunctionSpace with dim={dim}")
     element = ufl.VectorElement(sub_element, dim=dim)
     return FunctionSpace(mesh, element, name=name)
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -739,17 +739,17 @@ class VomOntoVomCallable(object):
 
     Parameters
     ----------
-    V : :class:`.FunctionSpace`
+    V : `.FunctionSpace`
         The P0DG function space (which may be vector or tensor valued) on the
-        source ``VertexOnlyMesh``.
-    source_vom : :class:`.VertexOnlyMesh`
-        The ``VertexOnlyMesh`` we interpolate from.
-    target_vom : :class:`.VertexOnlyMesh`
-        The ``VertexOnlyMesh`` we interpolate to.
-    expr : :class:`ufl.Expr`
+        source vertex-only mesh.
+    source_vom : `.VertexOnlyMesh`
+        The vertex-only mesh we interpolate from.
+    target_vom : `.VertexOnlyMesh`
+        The vertex-only mesh we interpolate to.
+    expr : `ufl.Expr`
         The expression to interpolate. If ``arguments`` is not empty, those
         arguments must be present within it.
-    arguments : list of :class:`ufl.Argument`
+    arguments : list of `ufl.Argument`
         The arguments in the expression. These are not extracted from expr here
         since, where we use this, we already have them.
     """
@@ -787,9 +787,9 @@ class VomOntoVomCallable(object):
 
         Parameters
         ----------
-        target_dat : :class:`pyop2.Dat`
+        target_dat : `pyop2.Dat`
             The target dat to interpolate into.
-        source_dat : :class:`pyop2.Dat`, optional
+        source_dat : `pyop2.Dat`, optional
             The source dat to interpolate from if the expression contained
             an argument. Set to ``None`` if the expression contained no
             arguments.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -762,20 +762,12 @@ class VomOntoVomWrapper(object):
 
     def __init__(self, V, source_vom, target_vom, expr, arguments):
         reduce = False
-        broadcast = False
-        try:
-            if source_vom.input_ordering is target_vom:
-                reduce = True
-                original_vom = source_vom
-        except AttributeError:
-            pass
-        try:
-            if target_vom.input_ordering is source_vom:
-                broadcast = True
-                original_vom = target_vom
-        except AttributeError:
-            pass
-        if not (reduce or broadcast):
+        if source_vom.input_ordering is target_vom:
+            reduce = True
+            original_vom = source_vom
+        elif target_vom.input_ordering is source_vom:
+            original_vom = target_vom
+        else:
             raise ValueError(
                 "The target vom and source vom must be linked by input ordering!"
             )

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -171,7 +171,7 @@ class Interpolator(object):
         if self.nargs:
             function, = function
             if not hasattr(function, "dat"):
-                raise ValueError("The expression had arguments: we therefore need to be given a function (not an expression) to interpolate!")
+                raise ValueError("The expression had arguments: we therefore need to be given a Function (not an expression) to interpolate!")
             if not self.vom_onto_other_vom:
                 if transpose:
                     mul = assembled_interpolator.handle.multTranspose

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -617,10 +617,10 @@ def vom_cell_parent_node_map_extruded(vertex_only_mesh, extruded_cell_node_map):
     dofs_per_target_cell = cnm.arity
     base_cells = vmx.cell_parent_base_cell_list
     heights = vmx.cell_parent_extrusion_height_list
-    assert cnm.values.shape[1] == dofs_per_target_cell
+    assert cnm.values_with_halo.shape[1] == dofs_per_target_cell
     assert len(cnm.offset) == dofs_per_target_cell
     target_cell_parent_node_list = [
-        cnm.values[base_cell, :] + height * cnm.offset[:]
+        cnm.values_with_halo[base_cell, :] + height * cnm.offset[:]
         for base_cell, height in zip(base_cells, heights)
     ]
     return op2.Map(

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -23,8 +23,47 @@ import firedrake
 from firedrake import tsfc_interface, utils
 from firedrake.adjoint import annotate_interpolate
 from firedrake.petsc import PETSc
+from firedrake.halo import _get_mtype as get_dat_mpi_type
+from mpi4py import MPI
+
+from pyadjoint import stop_annotating
 
 __all__ = ("interpolate", "Interpolator")
+
+
+# Current behaviour of interpolation in Firedrake:
+# - v.interpolate(expr),
+#   interpolate(expr, v),
+#   Interpolator(expr, v).interpolate(),
+#   v = interpolate(expr, V) and
+#   Interpolator(expr, V).interpolate(v)
+#   - Works with UFL expressions which contain no UFL Arguments. The
+#     expression can contain functions (UFL Coefficients) from other
+#     function spaces which will be interpolated into V.
+#   - Either operates on a function v in V (UFL Coefficient) or outputs a
+#     function in V.
+#   - Maths: v = A(expr) where A : W_0 x ... x W_n-1 -> V
+#   - NOTE: this will seem to work on assembled 1-forms (cofunctions) but
+#     is mathematical nonsense due to the absence of UFL Cofunctions in
+#     Firedrake. See
+#     https://github.com/firedrakeproject/firedrake/issues/3017
+# - B = Interpolator(expr_1_argument, V)
+#   - creates the linear interpolation operator B : W -> V where the UFL
+#     Argument is linear in the expression and is in W.
+#   - The rest of the expression, including any functions (UFL
+#     Coefficients), are already interpolated into V and are encorporated
+#     in the operator.
+#   - NOTE: Nonlinear Arguments are currently allowed in the expression and
+#     shouldn't be. See
+#     https://github.com/firedrakeproject/firedrake/issues/3018
+# - w = B.interpolate(v)
+#   - v is a function in V (NOT an expression).
+#   - w is a function in W.
+#   - Maths: v = Bw
+# - v_star = B.interpolate(w_star, transpose = True)
+#   - w_star us a cofunction in W^* (such as an assembled 1-form).
+#   - v_star is a cofunction in V^*.
+#   - Maths: v^* = B^* w^*
 
 
 @PETSc.Log.EventDecorator()
@@ -86,7 +125,7 @@ class Interpolator(object):
     """
     def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, bcs=None):
         try:
-            self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs)
+            self.callable, arguments, self.vom_onto_other_vom = make_interpolator(expr, V, subset, access, bcs=bcs)
         except FIAT.hdiv_trace.TraceError:
             raise NotImplementedError("Can't interpolate onto traces sorry")
         self.arguments = arguments
@@ -130,16 +169,27 @@ class Interpolator(object):
 
         if self.nargs:
             function, = function
-            if transpose:
-                mul = assembled_interpolator.handle.multTranspose
-                V = self.arguments[0].function_space()
+            if not hasattr(function, "dat"):
+                raise ValueError("The expression had arguments: we therefore need to be given a function (not an expression) to interpolate!")
+            if not self.vom_onto_other_vom:
+                if transpose:
+                    mul = assembled_interpolator.handle.multTranspose
+                    V = self.arguments[0].function_space()
+                else:
+                    mul = assembled_interpolator.handle.mult
+                    V = self.V
+                result = output or firedrake.Function(V)
+                with function.dat.vec_ro as x, result.dat.vec_wo as out:
+                    mul(x, out)
+                return result
             else:
-                mul = assembled_interpolator.handle.mult
-                V = self.V
-            result = output or firedrake.Function(V)
-            with function.dat.vec_ro as x, result.dat.vec_wo as out:
-                mul(x, out)
-            return result
+                if transpose:
+                    V = self.arguments[0].function_space()
+                else:
+                    V = self.V
+                result = output or firedrake.Function(V)
+                assembled_interpolator(result.dat, function.dat, transpose)
+                return result
 
         else:
             if output:
@@ -161,7 +211,14 @@ def make_interpolator(expr, V, subset, access, bcs=None):
     assert isinstance(expr, ufl.classes.Expr)
 
     arguments = extract_arguments(expr)
+    target_mesh = V.ufl_domain()
     if len(arguments) == 0:
+        source_mesh = extract_unique_domain(expr) or target_mesh
+        vom_onto_other_vom = (
+            isinstance(target_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology)
+            and isinstance(source_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology)
+            and target_mesh is not source_mesh
+        )
         if isinstance(V, firedrake.Function):
             f = V
             V = f.function_space()
@@ -179,10 +236,14 @@ def make_interpolator(expr, V, subset, access, bcs=None):
         if isinstance(V, firedrake.Function):
             raise ValueError("Cannot interpolate an expression with an argument into a Function")
         argfs = arguments[0].function_space()
-        target_mesh = V.ufl_domain()
         source_mesh = argfs.mesh()
         argfs_map = argfs.cell_node_map()
-        if target_mesh is not source_mesh:
+        vom_onto_other_vom = (
+            isinstance(target_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology)
+            and isinstance(source_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology)
+            and target_mesh is not source_mesh
+        )
+        if target_mesh is not source_mesh and not vom_onto_other_vom:
             if not isinstance(target_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology):
                 raise NotImplementedError("Can only interpolate onto a Vertex Only Mesh")
             if target_mesh.geometric_dimension() != source_mesh.geometric_dimension():
@@ -201,39 +262,60 @@ def make_interpolator(expr, V, subset, access, bcs=None):
                     argfs_map = vom_cell_parent_node_map_extruded(target_mesh, argfs_map)
                 else:
                     argfs_map = compose_map_and_cache(target_mesh.cell_parent_cell_map, argfs_map)
-        sparsity = op2.Sparsity((V.dof_dset, argfs.dof_dset),
-                                ((V.cell_node_map(), argfs_map),),
-                                name="%s_%s_sparsity" % (V.name, argfs.name),
-                                nest=False,
-                                block_sparse=True)
-        tensor = op2.Mat(sparsity)
+        if vom_onto_other_vom:
+            # We make our own linear operator for this case using PETSc SFs
+            tensor = None
+        else:
+            sparsity = op2.Sparsity((V.dof_dset, argfs.dof_dset),
+                                    ((V.cell_node_map(), argfs_map),),
+                                    name="%s_%s_sparsity" % (V.name, argfs.name),
+                                    nest=False,
+                                    block_sparse=True)
+            tensor = op2.Mat(sparsity)
         f = tensor
     else:
         raise ValueError("Cannot interpolate an expression with %d arguments" % len(arguments))
 
-    # Make sure we have an expression of the right length i.e. a value for
-    # each component in the value shape of each function space
-    dims = [numpy.prod(fs.ufl_element().value_shape(), dtype=int)
-            for fs in V]
-    loops = []
-    if numpy.prod(expr.ufl_shape, dtype=int) != sum(dims):
-        raise RuntimeError('Expression of length %d required, got length %d'
-                           % (sum(dims), numpy.prod(expr.ufl_shape, dtype=int)))
+    if vom_onto_other_vom:
+        # To interpolate between vertex-only meshes we use a PETSc SF
+        if tensor is not None:
+            assert not len(arguments)
+            # Do interpolation into tensor (which is a Dat) now.
+            callable = partial(VomOntoVomCallable(V, source_mesh, target_mesh, expr, arguments), tensor)
+        else:
+            assert len(arguments) == 1
+            # Leave operator as a callable that takes source and target dats.
 
-    if len(V) > 1:
-        raise NotImplementedError(
-            "UFL expressions for mixed functions are not yet supported.")
-    loops.extend(_interpolator(V, tensor, expr, subset, arguments, access, bcs=bcs))
+            def callable():
+                # need to wrap this in a callable to work as expected with
+                # Interpolator.interpolate()
+                return VomOntoVomCallable(V, source_mesh, target_mesh, expr, arguments)
 
-    if bcs and len(arguments) == 0:
-        loops.extend([partial(bc.apply, f) for bc in bcs])
+        return callable, arguments, vom_onto_other_vom
+    else:
+        # Make sure we have an expression of the right length i.e. a value for
+        # each component in the value shape of each function space
+        dims = [numpy.prod(fs.ufl_element().value_shape(), dtype=int)
+                for fs in V]
+        loops = []
+        if numpy.prod(expr.ufl_shape, dtype=int) != sum(dims):
+            raise RuntimeError('Expression of length %d required, got length %d'
+                               % (sum(dims), numpy.prod(expr.ufl_shape, dtype=int)))
 
-    def callable(loops, f):
-        for l in loops:
-            l()
-        return f
+        if len(V) > 1:
+            raise NotImplementedError(
+                "UFL expressions for mixed functions are not yet supported.")
+        loops.extend(_interpolator(V, tensor, expr, subset, arguments, access, bcs=bcs))
 
-    return partial(callable, loops, f), arguments
+        if bcs and len(arguments) == 0:
+            loops.extend([partial(bc.apply, f) for bc in bcs])
+
+        def callable(loops, f):
+            for l in loops:
+                l()
+            return f
+
+        return partial(callable, loops, f), arguments, vom_onto_other_vom
 
 
 @utils.known_pyop2_safe
@@ -648,3 +730,161 @@ def hash_expr(expr):
     return compute_expression_signature(
         expr, {**domain_numbering, **coefficient_numbering, **constant_numbering}
     )
+
+
+class VomOntoVomCallable(object):
+    """Callable that maps from one ``VertexOnlyMesh`` to it's intput ordering
+    ``VertexOnlyMesh``, or vice versa.
+
+    Parameters
+    ----------
+    V : :class:`.FunctionSpace`
+        The P0DG function space (which may be vector or tensor valued) on the
+        source ``VertexOnlyMesh``.
+    source_vom : :class:`.VertexOnlyMesh`
+        The ``VertexOnlyMesh`` we interpolate from.
+    target_vom : :class:`.VertexOnlyMesh`
+        The ``VertexOnlyMesh`` we interpolate to.
+    expr : :class:`ufl.Expr`
+        The expression to interpolate. If ``arguments`` is not empty, those
+        arguments must be present within it.
+    arguments : list of :class:`ufl.Argument`
+        The arguments in the expression. These are not extracted from expr here
+        since, where we use this, we already have them.
+    """
+
+    def __init__(self, V, source_vom, target_vom, expr, arguments):
+        source_vom = source_vom
+        reduce = False
+        broadcast = False
+        try:
+            if source_vom.input_ordering is target_vom:
+                reduce = True
+                original_vom = source_vom
+        except AttributeError:
+            pass
+        try:
+            if target_vom.input_ordering is source_vom:
+                broadcast = True
+                original_vom = target_vom
+        except AttributeError:
+            pass
+        if not (reduce or broadcast):
+            raise ValueError(
+                "The target vom and source vom must be linked by input ordering!"
+            )
+        self.arguments = arguments
+        self.V = V
+        self.source_vom = source_vom
+        self.original_vom = original_vom
+        self.expr = expr
+        self.reduce = reduce
+
+    def __call__(self, target_dat, source_dat=None, transpose=False):
+        """
+        Perform the interpolation.
+
+        Parameters
+        ----------
+        target_dat : :class:`pyop2.Dat`
+            The target dat to interpolate into.
+        source_dat : :class:`pyop2.Dat`, optional
+            The source dat to interpolate from if the expression contained
+            an argument. Set to ``None`` if the expression contained no
+            arguments.
+        transpose : bool
+            If ``True``, the adjoint interpolation operator is applied. The
+            expression must contain an argument and the source dat must
+            correspond to a cofunction.
+
+        Returns
+        -------
+        None
+        """
+        if not isinstance(target_dat, op2.Dat):
+            raise ValueError("The target dat is not a pyop2 Dat!")
+        if source_dat is not None and not isinstance(source_dat, op2.Dat):
+            raise ValueError("If the source dat is specified, it must be a pyop2 Dat!")
+        if transpose and source_dat is None:
+            raise ValueError(
+                "If the transpose is True, the source dat must be specified!"
+            )
+
+        # Since we always output a coefficient when we don't have arguments in
+        # the expression, I should evaluate the expression on the source mesh
+        # so its dat can be sent to the target mesh.
+        if not transpose:
+            with stop_annotating():
+                element = self.V.ufl_element()  # Could be vector/tensor valued
+                P0DG = firedrake.FunctionSpace(self.source_vom, element)
+                # if we have any arguments in the expression we need to replace
+                # them with equivalent coefficients now
+                coeff_expr = self.expr
+                if len(self.arguments):
+                    if len(self.arguments) > 1:
+                        raise NotImplementedError(
+                            "Can only interpolate expressions with one argument!"
+                        )
+                    if source_dat is None:
+                        raise ValueError(
+                            "Need to provide a source dat for the argument!"
+                        )
+                    arg = self.arguments[0]
+                    arg_coeff = firedrake.Function(arg.function_space())
+                    arg_coeff.dat.data_wo_with_halos[:] = source_dat.data_ro_with_halos
+                    coeff_expr = ufl.replace(self.expr, {arg: arg_coeff})
+                coeff = firedrake.Function(P0DG).interpolate(coeff_expr)
+                coeff_dat = coeff.dat
+                reduce = self.reduce
+        else:
+            # can only do transpose if our expression exclusively contains a
+            # single argument, making the application of the adjoint operator
+            # straightforward (haven't worked out how to do this otherwise!)
+            if not len(self.arguments) == 1:
+                raise NotImplementedError(
+                    "Can only apply transpose to expressions with one argument!"
+                )
+            if self.arguments[0] is not self.expr:
+                raise NotImplementedError(
+                    "Can only apply transpose to expressions consisting of a single argument at the moment."
+                )
+            coeff_dat = source_dat
+            reduce = not self.reduce
+
+        sf = self.original_vom.input_ordering_sf
+        # Functions on input ordering VOM are roots of the SF
+        # Functions on original VOM are leaves of the SF
+        # Reduce therefore sends data from original VOM to input ordering VOM
+        # NOTE: get_dat_mpi_type ensures we get the correct MPI type for the
+        # data, including the correct data size and dimensional information
+        # (so for vector function spaces in 2 dimensions we might need a
+        # concatenation of 2 MPI.DOUBLE types when we are in real mode)
+        mpi_type, _ = get_dat_mpi_type(target_dat)
+        if reduce:
+            sf.reduceBegin(
+                mpi_type,
+                coeff_dat.data_ro_with_halos,
+                target_dat.data_wo_with_halos,
+                MPI.REPLACE,
+            )
+            sf.reduceEnd(
+                mpi_type,
+                coeff_dat.data_ro_with_halos,
+                target_dat.data_wo_with_halos,
+                MPI.REPLACE,
+            )
+        else:  # broadcast
+            sf.bcastBegin(
+                mpi_type,
+                coeff_dat.data_ro_with_halos,
+                target_dat.data_wo_with_halos,
+                MPI.REPLACE,
+            )
+            sf.bcastEnd(
+                mpi_type,
+                coeff_dat.data_ro_with_halos,
+                target_dat.data_wo_with_halos,
+                MPI.REPLACE,
+            )
+
+        return

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -49,7 +49,8 @@ __all__ = ("interpolate", "Interpolator")
 #     https://github.com/firedrakeproject/firedrake/issues/3017
 # - B = Interpolator(expr_1_argument, V)
 #   - creates the linear interpolation operator B : W -> V where the UFL
-#     Argument is linear in the expression and is in W.
+#     Argument is linear in the expression and is in W. The UFL Argument must
+#     be number 0 (i.e. TestFunction(W) rather than TrialFunction(W)).
 #   - The rest of the expression, including any functions (UFL
 #     Coefficients), are already interpolated into V and are encorporated
 #     in the operator.
@@ -61,7 +62,7 @@ __all__ = ("interpolate", "Interpolator")
 #   - w is a function in W.
 #   - Maths: v = Bw
 # - v_star = B.interpolate(w_star, transpose = True)
-#   - w_star us a cofunction in W^* (such as an assembled 1-form).
+#   - w_star is a cofunction in W^* (such as an assembled 1-form).
 #   - v_star is a cofunction in V^*.
 #   - Maths: v^* = B^* w^*
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2335,7 +2335,8 @@ values from f.)"""
     def input_ordering_sf(self):
         """
         Return a PETSc SF which has :func:`~.VertexOnlyMesh` input ordering
-        vertices as roots and this mesh's vertices as leaves.
+        vertices as roots and this mesh's vertices (including any halo cells)
+        as leaves.
 
         Only available for vertex-only meshes.
         """
@@ -2345,13 +2346,38 @@ values from f.)"""
         nroots = self.input_ordering.num_cells()
         input_ranks = self.topology_dm.getField("inputrank")
         self.topology_dm.restoreField("inputrank")
-        parent_cell_nums = self.topology_dm.getField("parentcellnum")
-        self.topology_dm.restoreField("parentcellnum")
+        input_indices = self.topology_dm.getField("inputindex")
+        self.topology_dm.restoreField("inputindex")
+        nleaves = len(input_ranks)
+        input_ranks_and_idxs = np.empty(2 * nleaves, dtype=IntType)
+        input_ranks_and_idxs[0::2] = input_ranks
+        input_ranks_and_idxs[1::2] = input_indices
+        # local looks like the below, which means we can just pass in None
+        # local = numpy.arange(nleaves, dtype=IntType)
+        sf.setGraph(nroots, None, input_ranks_and_idxs)
+        return sf
+
+    @utils.cached_property  # TODO: Recalculate if mesh moves
+    def input_ordering_without_halos_sf(self):
+        """
+        Return a PETSc SF which has :func:`~.VertexOnlyMesh` input ordering
+        vertices as roots and this mesh's non-halo vertices as leaves.
+
+        Only available for vertex-only meshes.
+        """
+        if not isinstance(self.topology, VertexOnlyMeshTopology):
+            raise AttributeError("Input ordering is only defined for vertex-only meshes.")
+        sf = PETSc.SF().create(comm=self.comm)
+        nroots = self.input_ordering.num_cells()
+        ranks = self.topology_dm.getField("DMSwarm_rank")
+        self.topology_dm.restoreField("DMSwarm_rank")
+        input_ranks = self.topology_dm.getField("inputrank")
+        self.topology_dm.restoreField("inputrank")
         input_index = self.topology_dm.getField("inputindex")
         self.topology_dm.restoreField("inputindex")
-        # only include leaves where points were successfully embedded in the
-        # original VOM (i.e. where they were given a parent cell number)
-        idxs_to_include = parent_cell_nums != -1
+        # only include leaves where points are on this rank. This will exclude
+        # any points where the point was not found on the mesh.
+        idxs_to_include = ranks == self.comm.rank
         input_ranks = input_ranks[idxs_to_include]
         input_indices = input_index[idxs_to_include]
         nleaves = len(input_ranks)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2313,9 +2313,9 @@ values from f.)"""
     @utils.cached_property  # TODO: Recalculate if mesh moves
     def input_ordering(self):
         """
-        Return the input ordering of the mesh vertices as a VertexOnlyMesh
-        whilst preserving other information, such as the global indices and
-        parent mesh cell information.
+        Return the input ordering of the mesh vertices as a
+        :func:`~.VertexOnlyMesh` whilst preserving other information, such as
+        the global indices and parent mesh cell information.
 
         Only available for vertex-only meshes.
 
@@ -2334,8 +2334,8 @@ values from f.)"""
     @utils.cached_property  # TODO: Recalculate if mesh moves
     def input_ordering_sf(self):
         """
-        Return a PETSc SF which has VertexOnlyMesh input ordering vertices as
-        roots and this mesh's vertices as leaves.
+        Return a PETSc SF which has :func:`~.VertexOnlyMesh` input ordering
+        vertices as roots and this mesh's vertices as leaves.
 
         Only available for vertex-only meshes.
         """

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2927,6 +2927,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
         name + "_input_ordering",
         use_cell_dm_marking=False,
     )
+    vmesh_out._input_ordering._input_ordering = None
 
     return vmesh_out
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2808,7 +2808,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
 
     mesh.init()
 
-    vertexcoords = np.asarray(vertexcoords, dtype=np.double)
+    vertexcoords = np.asarray(vertexcoords, dtype=RealType)
     gdim = mesh.geometric_dimension()
     tdim = mesh.topological_dimension()
     _, pdim = vertexcoords.shape

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2918,6 +2918,10 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
            cannot be set.
         #. ``inputrank`` which contains the MPI rank at which the ``coords``
            argument was specified. For ``redundant=True`` this is always 0.
+        #. ``inputindex`` which contains the index of the point in the
+           originally supplied ``coords`` array after it has been redistributed
+           to the correct rank. For ``redundant=True`` this is always the same
+           as ``globalindex`` since we only use the points on rank 0.
 
         If the parent mesh is extruded, two more fields are created:
 
@@ -2958,6 +2962,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         ("refcoord", parent_mesh.topological_dimension(), RealType),
         ("globalindex", 1, IntType),
         ("inputrank", 1, IntType),
+        ("inputindex", 1, IntType),
     ]
 
     other_fields = fields
@@ -2971,6 +2976,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
         parent_cell_nums,
         ranks,
         input_ranks,
+        input_coords_ixs,
         missing_coords_idxs,
     ) = _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_halos=True)
 
@@ -3049,6 +3055,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     field_global_index = swarm.getField("globalindex")
     field_rank = swarm.getField("DMSwarm_rank")
     field_input_rank = swarm.getField("inputrank")
+    field_input_index = swarm.getField("inputindex")
 
     swarm_coords[...] = coords
     swarm_parent_cell_nums[...] = plex_parent_cell_nums
@@ -3057,8 +3064,10 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     field_global_index[...] = coords_idxs
     field_rank[...] = ranks
     field_input_rank[...] = input_ranks
+    field_input_index[...] = input_coords_ixs
 
     # have to restore fields once accessed to allow access again
+    swarm.restoreField("inputindex")
     swarm.restoreField("inputrank")
     swarm.restoreField("DMSwarm_rank")
     swarm.restoreField("globalindex")
@@ -3243,6 +3252,9 @@ def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_ha
         The MPI rank of the process that owns the parent cell of the points.
     input_ranks : ``np.ndarray``
         The MPI rank of the process that specified the input ``coords``.
+    input_coords_idxs : ``np.ndarray``
+        The indices of the points in the input ``coords`` array that were
+        embedded.
     missing_coords_idxs : ``np.ndarray``
         The indices of the points in the input coords array that were not
         embedded. See note below.
@@ -3268,6 +3280,8 @@ def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_ha
         coords_global = coords_local
         ncoords_global = coords_global.shape[0]
         coords_idxs = np.arange(coords_global.shape[0])
+        input_coords_idxs_local = np.arange(ncoords_local)
+        input_coords_idxs_global = input_coords_idxs_local
         input_ranks_local = np.zeros(ncoords_local, dtype=int)
         input_ranks_global = input_ranks_local
     else:
@@ -3297,6 +3311,11 @@ def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_ha
         # endidx = startidx + ncoords_local
         # coords_idxs = np.arange(startidx, endidx)
         coords_idxs = np.arange(coords_global.shape[0])
+        input_coords_idxs_local = np.arange(ncoords_local)
+        input_coords_idxs_global = np.empty(ncoords_global, dtype=int)
+        parent_mesh._comm.Allgatherv(
+            input_coords_idxs_local, (input_coords_idxs_global, ncoords_local_allranks)
+        )
         input_ranks_local = np.full(ncoords_local, parent_mesh._comm.rank, dtype=int)
         input_ranks_global = np.empty(ncoords_global, dtype=int)
         parent_mesh._comm.Allgatherv(
@@ -3369,6 +3388,7 @@ def _parent_mesh_embedding(parent_mesh, coords, tolerance, redundant, exclude_ha
         np.compress(locally_visible, parent_cell_nums, axis=0),
         np.compress(locally_visible, ranks, axis=0),
         np.compress(locally_visible, input_ranks_global, axis=0),
+        np.compress(locally_visible, input_coords_idxs_global, axis=0),
         missing_coords_idxs,
     )
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2776,9 +2776,8 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
 
     if pdim != gdim:
         raise ValueError(f"Mesh geometric dimension {gdim} must match point list dimension {pdim}")
-
     swarm, original_swarm, n_missing_points = _pic_swarm_in_mesh(
-        mesh, vertexcoords, tolerance=tolerance, redundant=redundant, exclude_halos=True
+        mesh, vertexcoords, tolerance=tolerance, redundant=redundant, exclude_halos=False
     )
     # NOTE: If exclude_halos=False, then I need to update the SF to advertise
     # shared points.
@@ -3100,7 +3099,7 @@ def _pic_swarm_in_mesh(
     is_halo = ~is_owned
     npts_owned = sum(is_owned)
     npts_halo = sum(is_halo)
-    nroots = npts_owned  # roots should be owned
+    nroots = npts_owned + npts_halo  # roots should be all points
     nleaves = npts_halo
     local_halo_idxs = np.where(is_halo)[0].astype(IntType)  # what we pass as 'local' to the SF
     remote_ranks = owned_ranks_local_visible[local_halo_idxs]

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3218,7 +3218,7 @@ def _reorder_halos(
     # set all off rank points which aren't equal to comm.size + 1 to comm.size
     owned_ranks_local_tosort[owned_ranks_local != comm.rank] = comm.size
     # now a sort by rank will give us the ordering we want
-    idxs = np.argsort(owned_ranks_local_tosort)
+    idxs = np.argsort(owned_ranks_local_tosort, kind='stable')
     coords_local = coords_local[idxs]
     global_idxs_local = global_idxs_local[idxs]
     reference_coords_local = reference_coords_local[idxs]

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2194,6 +2194,9 @@ values from f.)"""
             statics in pointquery_utils.py */
             struct ReferenceCoords temp_reference_coords, found_reference_coords;
 
+            /* to_reference_coords and to_reference_coords_xtr are defined in
+            pointquery_utils.py. If they contain python calls, this loop will
+            not run at c-loop speed. */
             cells[i] = locate_cell(f, &x[j], %(geometric_dimension)d, &to_reference_coords, &to_reference_coords_xtr, &temp_reference_coords, &found_reference_coords, &ref_cell_dists_l1[i]);
 
             for (int k = 0; k < %(geometric_dimension)d; k++) {

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2314,6 +2314,8 @@ values from f.)"""
         whilst preserving other information, such as the global indices and
         parent mesh cell information.
 
+        Only available for vertex-only meshes.
+
         Notes
         -----
         If ``redundant=True`` at mesh creation, all the vertices will
@@ -2331,6 +2333,8 @@ values from f.)"""
         """
         Return a PETSc SF which has VertexOnlyMesh input ordering vertices as
         roots and this mesh's vertices as leaves.
+
+        Only available for vertex-only meshes.
         """
         if not isinstance(self.topology, VertexOnlyMeshTopology):
             raise AttributeError("Input ordering is only defined for vertex-only meshes.")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3144,7 +3144,7 @@ def _pic_swarm_in_mesh(
     remote_ranks_and_idxs[0::2] = remote_ranks
     remote_ranks_and_idxs[1::2] = remote_idxs
     sf = swarm.getPointSF()
-    sf.setGraph(nroots, local_halo_idxs, remote_ranks_and_idxs)  # I need to move halo points to ends of the local indexing
+    sf.setGraph(nroots, local_halo_idxs, remote_ranks_and_idxs) # Note, could pass None for local_halo_idxs since we know the halo indices are contiguous.
     swarm.setPointSF(sf)
 
     # Note when getting original ordering for extruded meshes we recalculate
@@ -3632,7 +3632,7 @@ def _parent_mesh_embedding(
         reference_coords[missing_coords_idxs_on_rank, :] = np.nan
         owned_ranks[missing_coords_idxs_on_rank] = parent_mesh.comm.size + 1
 
-    if exclude_halos:
+    if exclude_halos and parent_mesh.comm.size > 1:
         off_rank_coords_idxs = np.where(
             (owned_ranks != parent_mesh.comm.rank)
             & (owned_ranks != parent_mesh.comm.size + 1)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3240,6 +3240,65 @@ def _dmswarm_create(
     gdim,
 ):
 
+    """
+    Create a PIC DMSwarm (or DMSwarm that looks like it's a PIC DMSwarm) using
+    the given data.
+
+    Parameters
+    ----------
+
+    fields : list of tuples
+        List of tuples of the form (name, number of components, type) for any
+        additional fields to be added to the DMSwarm. The default fields are
+        automatically added and do not need to be specified here. Can be an
+        empty list if no additional fields are required.
+    comm : MPI communicator
+        The MPI communicator to use when creating the DMSwarm.
+    plex : PETSc DM
+        The DM to set as the "CellDM" of the DMSwarm - i.e. the DMPlex or
+        DMSwarm of the parent mesh.
+    coords : numpy array of RealType with shape (npoints, gdim)
+        The coordinates of the particles in the DMSwarm.
+    plex_parent_cell_nums : numpy array of IntType with shape (npoints,)
+        Array to be used as the "parentcellnum" field of the DMSwarm.
+    coords_idxs : numpy array of IntType with shape (npoints,)
+        Array to be used as the "globalindex" field of the DMSwarm.
+    reference_coords : numpy array of RealType with shape (npoints, tdim)
+        Array to be used as the "refcoord" field of the DMSwarm.
+    parent_cell_nums : numpy array of IntType with shape (npoints,)
+        Array to be used as the "parentcellnum" field of the DMSwarm.
+    ranks : numpy array of IntType with shape (npoints,)
+        Array to be used as the "DMSwarm_rank" field of the DMSwarm.
+    input_ranks : numpy array of IntType with shape (npoints,)
+        Array to be used as the "inputrank" field of the DMSwarm.
+    input_coords_idxs : numpy array of IntType with shape (npoints,)
+        Array to be used as the "inputindex" field of the DMSwarm.
+    base_parent_cell_nums : numpy array of IntType with shape (npoints,) (or None)
+        Optional array to be used as the "parentcellbasenum" field of the
+        DMSwarm. Must be provided if extruded=True.
+    extrusion_heights : numpy array of IntType with shape (npoints,) (or None)
+        Optional array to be used as the "parentcellextrusionheight" field of
+        the DMSwarm. Must be provided if extruded=True.
+    extruded : bool
+        Whether the parent mesh is extruded.
+    tdim : int
+        The topological dimension of the parent mesh.
+    gdim : int
+        The geometric dimension of the parent mesh.
+
+    Returns
+    -------
+    swarm : PETSc DMSwarm
+        The created DMSwarm.
+
+    Notes
+    -----
+    When the `plex` is a DMSwarm, the created DMSwarm isn't actually a PIC
+    DMSwarm, but it has all the associated fields of a PIC DMSwarm. This is
+    because PIC DMSwarms cannot have their "CellDM" set to a DMSwarm, so we
+    fake it!
+    """
+
     # These are created by default for a PIC DMSwarm
     default_fields = [
         ("DMSwarmPIC_coor", gdim, RealType),

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1576,7 +1576,8 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
 
         # Mark OP2 entities and derive the resulting Swarm numbering
         with PETSc.Log.Event("Mesh: numbering"):
-            dmcommon.mark_entity_classes(self.topology_dm)
+            dmcommon.mark_entity_classes_using_cell_dm(self.topology_dm)
+
             self._entity_classes = dmcommon.get_entity_classes(self.topology_dm).astype(int)
 
             # Derive a cell numbering from the Swarm numbering

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2794,6 +2794,57 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
     return vmesh
 
 
+class FiredrakeDMSwarm(PETSc.DMSwarm):
+    """A DMSwarm with a saved list of added fields"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fields = None
+        self._default_fields = None
+        self._default_extra_fields = None
+        self._other_fields = None
+
+    @property
+    def fields(self):
+        return self._fields
+
+    @fields.setter
+    def fields(self, fields):
+        if self._fields:
+            raise ValueError("Fields have already been set")
+        self._fields = fields
+
+    @property
+    def default_fields(self):
+        return self._default_fields
+
+    @default_fields.setter
+    def default_fields(self, fields):
+        if self._default_fields:
+            raise ValueError("Default fields have already been set")
+        self._default_fields = fields
+
+    @property
+    def default_extra_fields(self):
+        return self._default_extra_fields
+
+    @default_extra_fields.setter
+    def default_extra_fields(self, fields):
+        if self._default_extra_fields:
+            raise ValueError("Default extra fields have already been set")
+        self._default_extra_fields = fields
+
+    @property
+    def other_fields(self):
+        return self._other_fields
+
+    @other_fields.setter
+    def other_fields(self, fields):
+        if self._other_fields:
+            raise ValueError("Other fields have already been set")
+        self._other_fields = fields
+
+
 def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redundant=True):
     """Create a Particle In Cell (PIC) DMSwarm immersed in a Mesh
 
@@ -2866,6 +2917,13 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
            be ``DMSwarmField_pid`` but a bug in petsc4py means that this field
            cannot be set.
 
+        If the parent mesh is extruded, two more fields are created:
+
+        #. ``parentcellbasenum`` which contains the firedrake cell number of the
+            base cell of the immersed vertex and
+        #. ``parentcellextrusionheight`` which contains the extrusion height of
+            the immersed vertex in the parent mesh cell.
+
         Another three are required for proper functioning of the DMSwarm:
 
         #. ``DMSwarmPIC_coor`` which contains the coordinates of the point.
@@ -2886,9 +2944,22 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     tdim = parent_mesh.topological_dimension()
     gdim = parent_mesh.geometric_dimension()
 
-    if fields is None:
-        fields = []
-    fields += [("parentcellnum", 1, IntType), ("refcoord", tdim, RealType), ("globalindex", 1, IntType)]
+    # These are created by default for a PIC DMSwarm
+    default_fields = [
+        ("DMSwarmPIC_coor", parent_mesh.geometric_dimension(), RealType),
+        ("DMSwarm_cellid", 1, IntType),
+        ("DMSwarm_rank", 1, IntType),
+    ]
+
+    default_extra_fields = [
+        ("parentcellnum", 1, IntType),
+        ("refcoord", parent_mesh.topological_dimension(), RealType),
+        ("globalindex", 1, IntType),
+    ]
+
+    other_fields = fields
+    if other_fields is None:
+        other_fields = []
 
     (
         coords,
@@ -2941,7 +3012,13 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     _, coordsdim = coords.shape
 
     # Create a DMSWARM
-    swarm = PETSc.DMSwarm().create(comm=parent_mesh._comm)
+    swarm = FiredrakeDMSwarm().create(comm=parent_mesh._comm)
+
+    # save the fields on the swarm
+    swarm.fields = default_fields + default_extra_fields + other_fields
+    swarm.default_fields = default_fields
+    swarm.default_extra_fields = default_extra_fields
+    swarm.other_fields = other_fields
 
     plexdim = plex.getDimension()
     if plexdim != tdim:
@@ -2970,7 +3047,7 @@ def _pic_swarm_in_mesh(parent_mesh, coords, fields=None, tolerance=None, redunda
     swarm.setType(PETSc.DMSwarm.Type.PIC)
 
     # Register any fields
-    for name, size, dtype in fields:
+    for name, size, dtype in swarm.default_extra_fields + swarm.other_fields:
         swarm.registerField(name, size, dtype=dtype)
     swarm.finalizeFieldRegister()
     # Note that no new fields can now be associated with the DMSWARM.

--- a/tests/vertexonly/test_poisson_inverse_conductivity.py
+++ b/tests/vertexonly/test_poisson_inverse_conductivity.py
@@ -44,6 +44,10 @@ def test_poisson_inverse_conductivity(num_points):
     # Use pyadjoint to estimate an unknown conductivity in a
     # poisson-like forward model from point measurements
     m = UnitSquareMesh(2, 2)
+    if m.comm.size > 1:
+        # lower tolerance avoids issues with .at getting different results
+        # across ranks
+        m.tolerance = 1e-10
     V = FunctionSpace(m, family='CG', degree=2)
     Q = FunctionSpace(m, family='CG', degree=2)
 
@@ -65,10 +69,11 @@ def test_poisson_inverse_conductivity(num_points):
     # Generate random point cloud
     np.random.seed(0)
     xs = np.random.random_sample((num_points, 2))
-    point_cloud = VertexOnlyMesh(m, xs)
+    # we set redundant to False to ensure that we put points on all ranks
+    point_cloud = VertexOnlyMesh(m, xs, redundant=False)
 
-    # Prove the the point cloud coordinates are correct
-    assert (point_cloud.coordinates.dat.data_ro == xs).all()
+    # Check the point cloud coordinates are correct
+    assert (point_cloud.input_ordering.coordinates.dat.data_ro == xs).all()
 
     # Generate "observed" data
     generator = np.random.default_rng(0)
@@ -79,10 +84,15 @@ def test_poisson_inverse_conductivity(num_points):
     ζ = generator.standard_normal(len(xs))
     u_obs_vals = np.array(u_true.at(xs)) + float(σ) * ζ
 
-    # Store data on the point_cloud
+    # Store data on the point_cloud by setting input ordering dat
+    P0DG_input_ordering = FunctionSpace(point_cloud.input_ordering, 'DG', 0)
+    u_obs_input_ordering = Function(P0DG_input_ordering)
+    u_obs_input_ordering.dat.data_wo[:] = u_obs_vals
+
+    # Interpolate onto the point_cloud to get it in the right place
     P0DG = FunctionSpace(point_cloud, 'DG', 0)
     u_obs = Function(P0DG)
-    u_obs.dat.data[:] = u_obs_vals
+    u_obs.interpolate(u_obs_input_ordering)
 
     # Run the forward model
     u = Function(V)
@@ -103,3 +113,9 @@ def test_poisson_inverse_conductivity(num_points):
 
     # Estimate q using Newton-CG which evaluates the hessian action
     minimize(Ĵ, method='Newton-CG', options={'disp': True})
+
+
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+@pytest.mark.parallel
+def test_poisson_inverse_conductivity_parallel(num_points):
+    test_poisson_inverse_conductivity(num_points)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -280,26 +280,17 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
             # meshes as the cell_set.size is the number of base mesh cells.
             assert len(localpointcoords) == parentmesh.cell_set.size
         elif parentmesh.comm.size > 1:
-            # If we have any points, there should be more cell set size
-            if len(localpointcoords):
-                assert len(localpointcoords) > parentmesh.cell_set.size
-            else:
-                # otherwise there should be none
-                assert len(localpointcoords) == parentmesh.cell_set.size
+            # parentmesh.cell_set.total_size is the sum of owned and halo
+            # points. We have a point in each cell, hence the below.
+            assert len(localpointcoords) == parentmesh.cell_set.total_size
     else:
         if parentmesh.variable_layers:
-            ncells = sum(height - 1 for _, height in parentmesh.layers)
-        else:
+            pytest.skip("Don't know how to calculate number of cells for variable layers")
+        elif exclude_halos:
             ncells = parentmesh.cell_set.size * (parentmesh.layers - 1)
-        if exclude_halos:
-            assert len(localpointcoords) == ncells
-        elif parentmesh.comm.size > 1:
-            # If we have any points, there should be more than the ncells
-            if len(localpointcoords):
-                assert len(localpointcoords) > ncells
-            else:
-                # otherwise there should be none
-                assert len(localpointcoords) == ncells
+        else:
+            ncells = parentmesh.cell_set.total_size * (parentmesh.layers - 1)
+        assert len(localpointcoords) == ncells
     if exclude_halos:
         # Check total number of points on all MPI ranks is correct
         # (excluding ghost cells in the halo)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -242,7 +242,6 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
         ("globalindex", 1, IntType),
         ("inputrank", 1, IntType),
         ("inputindex", 1, IntType),
-        ("onrank", 1, IntType),
     ]
     if parentmesh.extruded:
         default_extra_fields.append(("parentcellbasenum", 1, IntType))
@@ -329,17 +328,6 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
     elif parentmesh.comm.size > 1:
         # The input ranks should be a subset of the owned ranks on the swarm
         assert np.all(np.isin(inputlocalpointcoordranks, owned_ranks))
-
-    on_ranks = np.copy(swarm.getField("onrank"))
-    swarm.restoreField("onrank")
-    if exclude_halos:
-        assert np.array_equal(on_ranks, owned_ranks)
-    elif parentmesh.comm.size > 1:
-        # On ranks should match this rank
-        assert np.all(on_ranks == parentmesh.comm.rank)
-        # The ranks which the points are on should be a superset of the owned
-        # ranks on the swarm
-        assert np.all(np.isin(on_ranks, owned_ranks))
 
     # check that the input rank is correct
     input_ranks = np.copy(swarm.getField("inputrank"))

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -304,14 +304,10 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
             assert nptsglobal == len(inputpointcoords)
     assert nptsglobal == swarm.getSize()
 
-    # Check the parent cell indexes match those in the parent mesh unless
-    # parent mesh is shifted, in which case they should all be -1
+    # Check the parent cell indexes match those in the parent mesh
     cell_indexes = parentmesh.cell_closure[:, -1]
     for index in localparentcellindices:
-        if parentmesh.coordinates.dat.dat_version > 0:
-            assert index == -1
-        else:
-            assert np.any(index == cell_indexes)
+        assert np.any(index == cell_indexes)
 
     # since we know all points are in the mesh, we can check that the global
     # indices are correct (i.e. they should be in rank order)
@@ -368,13 +364,13 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
         # The input indices should be a subset of the indices on the swarm
         assert np.all(np.isin(input_local_coord_indices, input_indices))
         if redundant:
-            assert np.array_equal(np.unique(input_indices), globalindices)
+            assert np.array_equal(np.unique(input_indices), np.sort(globalindices))
 
     # Now have DMPLex compute the cell IDs in cases where it can:
     if (
         parentmesh.coordinates.ufl_element().family() != "Discontinuous Lagrange"
         and not parentmesh.extruded
-        and not parentmesh.coordinates.dat.dat_version > 0
+        and not parentmesh.coordinates.dat.dat_version > 0  # shifted mesh
     ):
         swarm.setPointCoordinates(localpointcoords, redundant=False,
                                   mode=PETSc.InsertMode.INSERT_VALUES)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -131,11 +131,22 @@ def redundant(request):
         return False
 
 
+@pytest.fixture(params=["exclude_halos", "include_halos"])
+def exclude_halos(request):
+    if request.param == "exclude_halos":
+        return True
+    else:
+        return False
+
+
 # pic swarm tests
 
-def test_pic_swarm_in_mesh(parentmesh, redundant):
+def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
     """Generate points in cell midpoints of mesh `parentmesh` and check correct
     swarm is created in plex."""
+
+    if not exclude_halos and parentmesh.comm.size == 1:
+        pytest.skip("Testing halo behaviour in parallel isn't worth the time")
 
     # Setup
 
@@ -154,9 +165,9 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         # global cell midpoints only on rank 0. Note that this is the default
         # behaviour so it needn't be specified explicitly.
         if MPI.COMM_WORLD.rank == 0:
-            swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputpointcoords, fields=other_fields)
+            swarm, original_swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputpointcoords, fields=other_fields, exclude_halos=exclude_halos)
         else:
-            swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, np.empty(inputpointcoords.shape), fields=other_fields)
+            swarm, original_swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, np.empty(inputpointcoords.shape), fields=other_fields, exclude_halos=exclude_halos)
         input_rank = 0
         # inputcoordindices is the correct set of input indices for
         # redundant==True but I need to work out where they will be after
@@ -175,9 +186,17 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         # When redundant == False we expect the same behaviour by only
         # supplying the local cell midpoints on each MPI ranks. Note that this
         # is not the default behaviour so it must be specified explicitly.
-        swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputlocalpointcoords, fields=other_fields, redundant=redundant)
+        swarm, original_swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputlocalpointcoords, fields=other_fields, redundant=redundant, exclude_halos=exclude_halos)
         input_rank = parentmesh.comm.rank
         input_local_coord_indices = np.arange(len(inputlocalpointcoords))
+
+    have_halos = len(parentmesh.coordinates.dat.data_ro_with_halos) > len(parentmesh.coordinates.dat.data_ro)
+    # collect from all ranks
+    have_halos = MPI.COMM_WORLD.allreduce(have_halos, op=MPI.SUM)
+    if not have_halos and not exclude_halos:
+        # We can treat this as though we set exclude_halos=True. This should
+        # happen in parallel with a mesh with 1 cell.
+        exclude_halos = True
 
     # Get point coords on current MPI rank
     localpointcoords = np.copy(swarm.getField("DMSwarmPIC_coor"))
@@ -223,6 +242,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         ("globalindex", 1, IntType),
         ("inputrank", 1, IntType),
         ("inputindex", 1, IntType),
+        ("onrank", 1, IntType),
     ]
     if parentmesh.extruded:
         default_extra_fields.append(("parentcellbasenum", 1, IntType))
@@ -239,27 +259,60 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     # check local points are found in list of input points
     for p in localpointcoords:
         assert np.any(np.isclose(p, inputpointcoords))
-    # check local points are correct local points given mesh
-    # partitioning (but don't require ordering to be maintained)
-    assert np.allclose(np.sort(inputlocalpointcoords, axis=0),
-                       np.sort(localpointcoords, axis=0))
+    if exclude_halos:
+        # check local points are correct local points given mesh
+        # partitioning (but don't require ordering to be maintained)
+        assert np.allclose(np.sort(inputlocalpointcoords, axis=0),
+                           np.sort(localpointcoords, axis=0))
+    elif parentmesh.comm.size > 1:
+        # If we have any points, there should be more than the input points
+        if len(localpointcoords):
+            assert len(localpointcoords) > len(inputlocalpointcoords)
+        else:
+            # otherwise there should be none
+            assert len(localpointcoords) == len(inputlocalpointcoords)
     # Check methods for checking number of points on current MPI rank
     assert len(localpointcoords) == swarm.getLocalSize()
     if not parentmesh.extruded:
-        # Check there are as many local points as there are local cells
-        # (excluding ghost cells in the halo). This won't be true for extruded
-        # meshes as the cell_set.size is the number of base mesh cells.
-        assert len(localpointcoords) == parentmesh.cell_set.size
+        if exclude_halos:
+            # Check there are as many local points as there are local cells
+            # (excluding ghost cells in the halo). This won't be true for extruded
+            # meshes as the cell_set.size is the number of base mesh cells.
+            assert len(localpointcoords) == parentmesh.cell_set.size
+        elif parentmesh.comm.size > 1:
+            # If we have any points, there should be more cell set size
+            if len(localpointcoords):
+                assert len(localpointcoords) > parentmesh.cell_set.size
+            else:
+                # otherwise there should be none
+                assert len(localpointcoords) == parentmesh.cell_set.size
     else:
         if parentmesh.variable_layers:
             ncells = sum(height - 1 for _, height in parentmesh.layers)
         else:
             ncells = parentmesh.cell_set.size * (parentmesh.layers - 1)
-        assert len(localpointcoords) == ncells
-    # Check total number of points on all MPI ranks is correct
-    # (excluding ghost cells in the halo)
-    assert nptsglobal == len(inputpointcoords)
+        if exclude_halos:
+            assert len(localpointcoords) == ncells
+        elif parentmesh.comm.size > 1:
+            # If we have any points, there should be more than the ncells
+            if len(localpointcoords):
+                assert len(localpointcoords) > ncells
+            else:
+                # otherwise there should be none
+                assert len(localpointcoords) == ncells
+    if exclude_halos:
+        # Check total number of points on all MPI ranks is correct
+        # (excluding ghost cells in the halo)
+        assert nptsglobal == len(inputpointcoords)
+    elif parentmesh.comm.size > 1:
+        # If there are any points, there should be more than the input points
+        if nptsglobal:
+            assert nptsglobal > len(inputpointcoords)
+        else:
+            # otherwise there should be none
+            assert nptsglobal == len(inputpointcoords)
     assert nptsglobal == swarm.getSize()
+
     # Check the parent cell indexes match those in the parent mesh unless
     # parent mesh is shifted, in which case they should all be -1
     cell_indexes = parentmesh.cell_closure[:, -1]
@@ -271,28 +324,60 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
 
     # since we know all points are in the mesh, we can check that the global
     # indices are correct (i.e. they should be in rank order)
-    assert np.array_equal(
-        inputcoordindices, np.concatenate(parentmesh.comm.allgather(globalindices))
-    )
+    allglobalindices = np.concatenate(parentmesh.comm.allgather(globalindices))
+    if exclude_halos:
+        assert np.array_equal(inputcoordindices, allglobalindices)
+        _, idxs = np.unique(allglobalindices, return_index=True)
+        assert len(idxs) == len(allglobalindices)
+    else:
+        assert np.array_equal(inputcoordindices, np.unique(allglobalindices))
 
     # Check that the rank numbering is correct. Since we know all points are at
     # the midpoints of cells, there should be no disagreement about cell
     # ownership and the voting algorithm should have no effect.
-    ranks = np.copy(swarm.getField("DMSwarm_rank"))
+    owned_ranks = np.copy(swarm.getField("DMSwarm_rank"))
     swarm.restoreField("DMSwarm_rank")
-    assert np.array_equal(ranks, inputlocalpointcoordranks)
+    if exclude_halos:
+        assert np.array_equal(owned_ranks, inputlocalpointcoordranks)
+    elif parentmesh.comm.size > 1:
+        # The input ranks should be a subset of the owned ranks on the swarm
+        assert np.all(np.isin(inputlocalpointcoordranks, owned_ranks))
+
+    on_ranks = np.copy(swarm.getField("onrank"))
+    swarm.restoreField("onrank")
+    if exclude_halos:
+        assert np.array_equal(on_ranks, owned_ranks)
+    elif parentmesh.comm.size > 1:
+        # On ranks should match this rank
+        assert np.all(on_ranks == parentmesh.comm.rank)
+        # The ranks which the points are on should be a superset of the owned
+        # ranks on the swarm
+        assert np.all(np.isin(on_ranks, owned_ranks))
 
     # check that the input rank is correct
     input_ranks = np.copy(swarm.getField("inputrank"))
     swarm.restoreField("inputrank")
-    assert np.all(input_ranks == input_rank)
+    if exclude_halos:
+        assert np.all(input_ranks == input_rank)
+    elif parentmesh.comm.size > 1:
+        # The input rank should be a within the input ranks array on the swarm
+        # and we shouldn't have ranks which are greater than the comm size
+        if len(input_ranks):
+            assert np.isin(input_rank, input_ranks)
+        assert np.all(input_ranks < parentmesh.comm.size)
 
     # check that the input index is correct
     input_indices = np.copy(swarm.getField("inputindex"))
     swarm.restoreField("inputindex")
-    assert np.array_equal(input_indices, input_local_coord_indices)
-    if redundant:
-        assert np.array_equal(input_indices, globalindices)
+    if exclude_halos:
+        assert np.array_equal(input_indices, input_local_coord_indices)
+        if redundant:
+            assert np.array_equal(input_indices, globalindices)
+    elif parentmesh.comm.size > 1:
+        # The input indices should be a subset of the indices on the swarm
+        assert np.all(np.isin(input_local_coord_indices, input_indices))
+        if redundant:
+            assert np.array_equal(np.unique(input_indices), globalindices)
 
     # Now have DMPLex compute the cell IDs in cases where it can:
     if (
@@ -304,7 +389,19 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
                                   mode=PETSc.InsertMode.INSERT_VALUES)
         petsclocalparentcellindices = np.copy(swarm.getField("DMSwarm_cellid"))
         swarm.restoreField("DMSwarm_cellid")
-        assert np.all(petsclocalparentcellindices == localparentcellindices)
+        if exclude_halos:
+            assert np.all(petsclocalparentcellindices == localparentcellindices)
+        elif parentmesh.comm.size > 1:
+            # setPointCoordinates doesn't let us have points in halos so we
+            # have to check for a subset
+            assert np.all(np.isin(petsclocalparentcellindices, localparentcellindices))
+
+    # check original swarm has correct properties
+    assert original_swarm.fields != swarm.fields  # We don't currently rearrange custom fields
+    assert original_swarm.default_fields == swarm.default_fields
+    assert original_swarm.default_extra_fields == swarm.default_extra_fields
+    assert original_swarm.other_fields != swarm.other_fields
+    assert isinstance(original_swarm.getCellDM(), PETSc.DMSwarm)
 
     # out_of_mesh_point = np.full((2, parentmesh.geometric_dimension()), np.inf)
     # swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, out_of_mesh_point, fields=fields)
@@ -312,17 +409,21 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
 
 
 @pytest.mark.parallel
-def test_pic_swarm_in_mesh_parallel(parentmesh, redundant):
-    test_pic_swarm_in_mesh(parentmesh, redundant)
+def test_pic_swarm_in_mesh_parallel(parentmesh, redundant, exclude_halos):
+    test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos)
 
 
 @pytest.mark.parallel(nprocs=2)  # nprocs == total number of mesh cells
 def test_pic_swarm_in_mesh_2d_2procs():
-    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False)
-    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False, exclude_halos=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True, exclude_halos=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False, exclude_halos=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True, exclude_halos=True)
 
 
 @pytest.mark.parallel(nprocs=3)  # nprocs > total number of mesh cells
 def test_pic_swarm_in_mesh_2d_3procs():
-    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False)
-    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False, exclude_halos=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True, exclude_halos=True)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=False, exclude_halos=False)
+    test_pic_swarm_in_mesh(UnitSquareMesh(1, 1), redundant=True, exclude_halos=False)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -157,11 +157,13 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
             swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputpointcoords, fields=other_fields)
         else:
             swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, np.empty(inputpointcoords.shape), fields=other_fields)
+        input_rank = 0
     else:
         # When redundant == False we expect the same behaviour by only
         # supplying the local cell midpoints on each MPI ranks. Note that this
         # is not the default behaviour so it must be specified explicitly.
         swarm, n_missing_coords = mesh._pic_swarm_in_mesh(parentmesh, inputlocalpointcoords, fields=other_fields, redundant=redundant)
+        input_rank = parentmesh.comm.rank
 
     # Get point coords on current MPI rank
     localpointcoords = np.copy(swarm.getField("DMSwarmPIC_coor"))
@@ -205,6 +207,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
         ("parentcellnum", 1, IntType),
         ("refcoord", parentmesh.topological_dimension(), RealType),
         ("globalindex", 1, IntType),
+        ("inputrank", 1, IntType),
     ]
     if parentmesh.extruded:
         default_extra_fields.append(("parentcellbasenum", 1, IntType))
@@ -263,6 +266,11 @@ def test_pic_swarm_in_mesh(parentmesh, redundant):
     ranks = np.copy(swarm.getField("DMSwarm_rank"))
     swarm.restoreField("DMSwarm_rank")
     assert np.array_equal(ranks, inputlocalpointcoordranks)
+
+    # check that the input rank is correct
+    input_ranks = np.copy(swarm.getField("inputrank"))
+    swarm.restoreField("inputrank")
+    assert np.all(input_ranks == input_rank)
 
     # Now have DMPLex compute the cell IDs in cases where it can:
     if (

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -146,7 +146,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
     swarm is created in plex."""
 
     if not exclude_halos and parentmesh.comm.size == 1:
-        pytest.skip("Testing halo behaviour in parallel isn't worth the time")
+        pytest.skip("Testing halo behaviour in serial isn't worth the time")
 
     # Setup
 

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -99,8 +99,7 @@ def functionspace_tests(vm):
     f.interpolate(Constant(2, domain=vm))
     assert np.isclose(assemble(f*dx), 2*num_cells_mpi_global)
     if "input_ordering" in vm.name:
-        with pytest.raises(AttributeError):
-            W = FunctionSpace(vm.input_ordering, "DG", 0)
+        assert vm.input_ordering is None
         return
     # Can interpolate onto the input ordering VOM and we retain values from the
     # expresson on the main VOM
@@ -190,8 +189,7 @@ def vectorfunctionspace_tests(vm):
     f.interpolate(Constant([1] * gdim, domain=vm))
     assert np.isclose(assemble(inner(f, f)*dx), num_cells_mpi_global*gdim)
     if "input_ordering" in vm.name:
-        with pytest.raises(AttributeError):
-            W = FunctionSpace(vm.input_ordering, "DG", 0)
+        assert vm.input_ordering is None
         return
     # Can interpolate onto the input ordering VOM and we retain values from the
     # expresson on the main VOM

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -119,7 +119,6 @@ def vectorfunctionspace_tests(vm):
     f.interpolate(2*x)
     g.project(2*x)
     # Should have 1 DOF per cell so check DOF DataSet
-        # Should have 1 DOF per cell so check DOF DataSet
     assert f.dof_dset.size == g.dof_dset.size == vm.cell_set.size == num_cells
     assert f.dof_dset.total_size == g.dof_dset.total_size == vm.cell_set.total_size == num_cells + num_cells_halo
     # The function should take on the value of the expression applied to
@@ -141,6 +140,8 @@ def test_functionspaces(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
     functionspace_tests(vm)
     vectorfunctionspace_tests(vm)
+    functionspace_tests(vm.input_ordering)
+    vectorfunctionspace_tests(vm.input_ordering)
 
 
 @pytest.mark.parallel
@@ -151,7 +152,7 @@ def test_functionspaces_parallel(parentmesh, vertexcoords):
 @pytest.mark.parallel(nprocs=2)
 def simple_line_test():
     m = UnitIntervalMesh(4)
-    points = np.asarray([[0.125], [0.375], [0.625]])#, [0.875]])
+    points = np.asarray([[0.125], [0.375], [0.625]])
     vm = VertexOnlyMesh(m, points, redundant=True)
     V = FunctionSpace(vm, "DG", 0)
     f = Function(V)
@@ -166,4 +167,3 @@ def simple_line_test():
     # Galerkin Projection of expression is the same as interpolation of
     # that expression since both exactly point evaluate the expression.
     assert np.allclose(f.dat.data_ro, g.dat.data_ro)
-

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -40,7 +40,7 @@ def test_vertex_only_mesh_manual_example():
     f_at_input_points.dat.data_wo[:] = np.nan
     f_at_input_points.interpolate(f_at_points)
 
-    print(f_at_input_points.dat.data_ro)  # any points not found will be nan
+    print(f_at_input_points.dat.data_ro)  # any points not found will be NaN
 
 
 def test_vom_manual_points_outside_domain():

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -1,6 +1,8 @@
 from firedrake import *
 import pytest
-# Ensure that the code shown in the manual runs without error.
+# Ensure that the code shown in the manual runs without error. If you change
+# the code here make sure you update the .. literalinclude:: bits in the manual
+# too!
 
 
 def test_vertex_only_mesh_manual_example():
@@ -23,7 +25,22 @@ def test_vertex_only_mesh_manual_example():
     # Interpolation performs point evaluation
     f_at_points = interpolate(f, P0DG)
 
-    print(f_at_points.dat.data)
+    print(f_at_points.dat.data_ro)
+
+    # Make a P0DG function on the input ordering vertex-only mesh again
+    P0DG_input_ordering = FunctionSpace(vom.input_ordering, "DG", 0)
+    f_at_input_points = Function(P0DG_input_ordering)
+
+    # We interpolate the other way this time
+    f_at_input_points.interpolate(f_at_points)
+
+    print(f_at_input_points.dat.data_ro)  # will print the values at the input points
+
+    import numpy as np
+    f_at_input_points.dat.data_wo[:] = np.nan
+    f_at_input_points.interpolate(f_at_points)
+
+    print(f_at_input_points.dat.data_ro)  # any points not found will be nan
 
 
 def test_vom_manual_points_outside_domain():
@@ -33,17 +50,22 @@ def test_vom_manual_points_outside_domain():
         # point (1.1, 1.0) is outside the mesh
         points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
 
+    vom = True  # avoid flake8 unused variable warning
     with pytest.raises(ValueError):
         # This will raise a ValueError
         vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
 
-    # This will generate a warning and the point will be lost
-    vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
+    def display_correct_indent():
+        # This will generate a warning and the point will be lost
+        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='warn')
 
-    # This will cause the point to be silently lost
-    vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
+        # This will cause the point to be silently lost
+        vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour=None)
 
-    assert vom  # Just here to shut up flake8 unused variable warning.
+        assert vom  # Just here to shut up flake8 unused variable warning.
+
+    assert vom  # here too
+    display_correct_indent()
 
 
 def test_vom_manual_keyword_arguments():
@@ -117,3 +139,38 @@ def test_mesh_tolerance_change():
         print(parent_mesh.tolerance)
 
     assert vom
+
+
+@pytest.mark.parallel
+def test_input_ordering_input():
+    parent_mesh = UnitSquareMesh(100, 100, quadrilateral=True)
+    if parent_mesh.comm.rank == 0:
+        point_locations_from_elsewhere = [[0.1, 0.1], [0.2, 0.2], [1.0, 1.0]]
+        point_data_values_from_elsewhere = [1.0, 2.0, 3.0]
+    elif parent_mesh.comm.rank == 1:
+        point_locations_from_elsewhere = [[0.3, 0.3], [0.4, 0.4], [0.9, 0.9]]
+        point_data_values_from_elsewhere = [4.0, 5.0, 6.0]
+    else:
+        import numpy as np
+        point_locations_from_elsewhere = np.array([]).reshape(0, 2)
+        point_data_values_from_elsewhere = []
+
+    # We have a set of points with corresponding data from elsewhere which vary
+    # from rank to rank
+    vom = VertexOnlyMesh(parent_mesh, point_locations_from_elsewhere, redundant=False)
+    P0DG = FunctionSpace(vom, "DG", 0)
+
+    # Create a P0DG function on the input ordering vertex-only mesh
+    P0DG_input_ordering = FunctionSpace(vom.input_ordering, "DG", 0)
+    point_data_input_ordering = Function(P0DG_input_ordering)
+
+    # We can safely set the values of this function, knowing that the data will
+    # be in the same order and on the same MPI rank as point_locations_from_elsewhere
+    point_data_input_ordering.dat.data_wo[:] = point_data_values_from_elsewhere
+
+    # Interpolate puts this data onto the original vertex-only mesh
+    point_data = interpolate(point_data_input_ordering, P0DG)
+
+    assert vom
+    if point_data:  # in case point data is None for some reason - apparently it can be in complex mode without an error occuring?
+        assert point_data  # avoid flake8 unused variable warning

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -233,8 +233,7 @@ def test_generate_cell_midpoints(parentmesh, redundant):
 
     # More vm_input checks
     vm_input._parent_mesh is vm
-    with pytest.raises(AttributeError):
-        vm_input.input_ordering  # Shouldn't have one!
+    vm_input.input_ordering is None
 
     # Have correct number of vertices
     total_cells = MPI.COMM_WORLD.allreduce(len(vm.coordinates.dat.data_ro), op=MPI.SUM)

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -152,7 +152,7 @@ def verify_vertexonly_mesh(m, vm, inputvertexcoords, name):
     assert vm.topology._parent_mesh is m.topology
     # Correct generic cell properties
     if not skip_in_bounds_checks:
-        assert vm.cell_closure.shape == (len(inputvertexcoords[in_bounds]), 1)
+        assert vm.cell_closure.shape == (len(vm.coordinates.dat.data_ro_with_halos), 1)
     with pytest.raises(AttributeError):
         vm.exterior_facets()
     with pytest.raises(AttributeError):
@@ -160,7 +160,8 @@ def verify_vertexonly_mesh(m, vm, inputvertexcoords, name):
     with pytest.raises(AttributeError):
         vm.cell_to_facets
     if not skip_in_bounds_checks:
-        assert vm.num_cells() == len(inputvertexcoords[in_bounds]) == vm.cell_set.size
+        assert vm.num_cells() == vm.cell_closure.shape[0] == len(vm.coordinates.dat.data_ro_with_halos) == vm.cell_set.total_size
+        assert vm.cell_set.size == len(inputvertexcoords[in_bounds]) == len(vm.coordinates.dat.data_ro)
     assert vm.num_facets() == 0
     assert vm.num_faces() == vm.num_entities(2) == 0
     assert vm.num_edges() == vm.num_entities(1) == 0
@@ -432,6 +433,7 @@ def test_inside_boundary_behaviour(parentmesh):
     vm = VertexOnlyMesh(parentmesh, inputcoord, tolerance=1e-16, missing_points_behaviour=None)
     assert vm.cell_set.size == 0 or vm.cell_set.size == 1
 
+
 @pytest.mark.parallel(nprocs=2)
 def test_pyop2_labelling():
     m = UnitIntervalMesh(4)
@@ -444,3 +446,6 @@ def test_pyop2_labelling():
     points = np.asarray([[0.125], [0.125], [0.375], [0.375], [0.625], [0.625], [0.875], [0.875]])
     vm = VertexOnlyMesh(m, points, redundant=True)
     assert vm.cell_set.total_size == 2*m.cell_set.total_size
+    points = np.asarray([[-5.0]])
+    vm = VertexOnlyMesh(m, points, redundant=False, missing_points_behaviour=None)
+    assert vm.cell_set.total_size == 0


### PR DESCRIPTION
# Description
Allow the retrieval of the original decomposition of a `VertexOnlyMesh` to, eventually, allow arbitrary mesh-to-mesh interpolation where we have point evaluation nodes.

Also put VertexOnlyMesh points in parent mesh halos, with appropriate PETSc SF set up and pyop2 labelling (core, owned and ghost) inherited from the parent mesh.

## Associated Pull Requests:
- None yet

## Fixes Issues:
- Allows parallel safe I/O
- Global index is now the unique identifier of a point meaning that we can have points in halos without issue. This will make checkpointing `VertexOnlyMesh` easier.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready
