### PR TITLE
Bug fix: install torch's dependency for Python 3.10+

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1331,6 +1331,8 @@ def build_and_install_torch():
     log.info("Installing PyTorch (backend: %s)" % args.torch)
     if osname == "Darwin" and args.torch == "cuda":
         raise InstallError("CUDA installation is not available on MacOS.")
+    if sys.version_info >= (3, 10):
+        run_pip_install(["typing_extensions"])
     extra_index_url = ["--extra-index-url", "https://download.pytorch.org/whl/cpu"] if args.torch == "cpu" else []
     run_pip_install(["torch"] + extra_index_url)
 


### PR DESCRIPTION
# Description

PyTorch needs `typing_extensions` for Python 3.10+ which we currently don't install automatically as we need to pip install with `--no-deps` because of numpy installation ownership among other things. This PR simply installs `typing_extensions` when needed. This is not ideal because torch's dependency might change, but apparently, this is in line with what is currently done in our install script.

## Fixes Issues:
- #2942

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.