### PR TITLE
Fix names in subfunctions.

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -110,7 +110,7 @@ class CoordinatelessFunction(ufl.Coefficient):
     def subfunctions(self):
         r"""Extract any sub :class:`Function`\s defined on the component spaces
         of this this :class:`Function`'s :class:`.FunctionSpace`."""
-        return tuple(CoordinatelessFunction(fs, dat, name="%s[%d]" % (self.name(), i))
+        return tuple(CoordinatelessFunction(fs, dat, name="%s" % (self.name()[i]))
                      for i, (fs, dat) in
                      enumerate(zip(self.function_space(), self.dat)))
 


### PR DESCRIPTION


---
name: "Fix names in subfunctions."
description: 'Now each subfunction gets its name'
title: ''
labels: ''
assignees: ''

---

# Description
The motivation for this commit is to get the name of the subfunctions directly.

For example, adding names in the function w of the "Mixed formulation for the Poisson equation" example [1] (line 133):
`w = Function(W, name=["flux", "sol"])`

It gives a bogus name with the previous version:
```
$ ipython
In [1]: %run poisson_mixed.py

In [2]: u.name()
Out[2]: "['flux', 'solution'][1]"
```

While it gives the expected name with this version:
```
$ ipython
In [1]: %run poisson_mixed.py

In [2]: u.name()
Out[2]: 'solution'
```

[1] https://firedrakeproject.org/demos/poisson_mixed.py.html

## Associated Pull Requests:
- None

## Fixes Issues:
- None

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [X] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [X] My changes generate no new warnings.
- ~[ ] All of my functions and classes have appropriate docstrings.~
- ~[ ] I have commented my code where its purpose may be unclear.~
- ~[ ] I have included and updated any relevant documentation.~
- ~[ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)~
- ~[ ] I have added tests specific to the issues fixed in this PR.~
- ~[ ] I have added tests that exercise the new functionality I have introduced~
- ~[ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).~
- ~[ ] I have performed a self-review of my own code using the below guidelines.~

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
