### PR TITLE
Dolci/fix bug deleg diffmesh

### DIFF
--- a/firedrake/adjoint/function.py
+++ b/firedrake/adjoint/function.py
@@ -122,7 +122,8 @@ class FunctionMixin(FloatingType):
                 block.add_output(block_var)
 
                 if isinstance(other, type(self)):
-                    block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
+                    if self.function_space().mesh() == other.function_space().mesh():
+                        block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
 
             return ret
 

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -656,6 +656,7 @@ def test_init_constant():
     rf = ReducedFunctional(J, Control(c1))
     assert np.isclose(rf(-1.0), -1.0)
 
+
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
 def test_init_constant_diff_mesh():
     from firedrake_adjoint import ReducedFunctional, Control
@@ -666,8 +667,7 @@ def test_init_constant_diff_mesh():
     c2.assign(c1)
     J = assemble(c2*dx(domain=mesh0))
     rf = ReducedFunctional(J, Control(c1))
-    rf(Constant(3.0, domain=mesh))
-    assert np.isclose(rf(-1.0), -1.0)
+    assert np.isclose(rf(Constant(-1.0, domain=mesh)), -1.0)
 
 
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -656,6 +656,19 @@ def test_init_constant():
     rf = ReducedFunctional(J, Control(c1))
     assert np.isclose(rf(-1.0), -1.0)
 
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+def test_init_constant_diff_mesh():
+    from firedrake_adjoint import ReducedFunctional, Control
+    mesh = UnitSquareMesh(1, 1)
+    mesh0 = UnitSquareMesh(2, 2)
+    c1 = Constant(1.0, domain=mesh)
+    c2 = Constant(0.0, domain=mesh0)
+    c2.assign(c1)
+    J = assemble(c2*dx(domain=mesh0))
+    rf = ReducedFunctional(J, Control(c1))
+    rf(Constant(3.0, domain=mesh))
+    assert np.isclose(rf(-1.0), -1.0)
+
 
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
 def test_copy_function():


### PR DESCRIPTION
---
name: "Bug fix"
description: ''
title: ''
labels: ''
assignees: ''

---

# Description
PR to fixe the bug associated to the delegated checkpoint in assign operation for different mesh

## Associated Pull Requests:

## Fixes Issues:
- [#3009](https://github.com/firedrakeproject/firedrake/issues/3009)
"fixes #3009" 

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
