### PR TITLE
.ufl_domain -> extract_unique_domain

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -13,6 +13,7 @@ from pyadjoint.tape import annotate_tape
 from tsfc import kernel_args
 from tsfc.finatinterface import create_element
 import ufl
+from ufl.domain import extract_unique_domain
 from firedrake import (extrusion_utils as eutils, matrix, parameters, solving,
                        tsfc_interface, utils)
 from firedrake.adjoint import annotate_assemble
@@ -461,7 +462,7 @@ class FormAssembler(abc.ABC):
             raise NotImplementedError("All integration domains must share a mesh topology")
 
         for o in itertools.chain(self._form.arguments(), self._form.coefficients()):
-            domain = o.ufl_domain()
+            domain = extract_unique_domain(o)
             if domain is not None and domain.topology != topology:
                 raise NotImplementedError("Assembly with multiple meshes is not supported")
 


### PR DESCRIPTION
# Description
Change a case of `.ufl_domain` to `ufl.domain.extract_unique_domain`. Fixes many `DeprecationWarning`s.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] ~All of my functions and classes have appropriate docstrings.~
- [ ] ~I have commented my code where its purpose may be unclear.~
- [ ] ~I have included and updated any relevant documentation.~
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
 - [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready
