### PR TITLE
Reintroduce `to_petsc_local_numbering`

### DIFF
--- a/docs/source/petsc-interface.rst
+++ b/docs/source/petsc-interface.rst
@@ -354,17 +354,17 @@ DMPlex then we must first establish a mapping between
 `its numbering`_ and the coordinates in the Firedrake mesh. This is done
 by establishing a 'section'. A section provides a way of associating
 data with the mesh - in this case, coordinate field data.
-For a $d$-dimensional mesh, we seek to establish offsets to recover
-$d$-tuple coordinates for the degrees of freedom.
+For a :math:`d`-dimensional mesh, we seek to establish offsets to recover
+:math:`d`-tuple coordinates for the degrees of freedom.
 
-For a linear mesh, we seek $d$ values at each vertex and no values for
+For a linear mesh, we seek :math:`d` values at each vertex and no values for
 entities of higher dimension. In 2D, for example, this corresponds to the array
 
 .. math::
 
    (d, 0, 0).
 
-For an order $p$ Lagrange mesh, it is a little more complicated. In
+For an order :math:`p` Lagrange mesh, it is a little more complicated. In
 the 2D triangular case, we require the following entities:
 
 .. math::
@@ -387,9 +387,7 @@ section to establish the mapping:
 
 .. code-block:: python3
 
-    from firedrake.cython.dmcommon import create_section
-
-    coord_section = create_section(mesh, entity_dofs)
+    coord_section = mesh.create_section(entity_dofs)
     plex = mesh.topology_dm
     plex_coords = plex.getCoordinateDM()
     plex_coords.setDefaultSection(coord_section)

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -3193,11 +3193,11 @@ def mark_points_with_function_array(PETSc.DM plex,
 def to_petsc_local_numbering(PETSc.Vec vec, V):
     """
     Reorder a PETSc Vec corresponding to a Firedrake Function w.r.t.
-    the initial PETSc numbering.
+    the PETSc natural numbering.
 
-    :arg vec: the PETSc Vec to reorder
+    :arg vec: the PETSc Vec to reorder; must be a global vector
     :arg V: the FunctionSpace of the Function which the Vec comes from
-    :ret out: a copy of the Vec, ordered with the PETSc numbering
+    :ret out: a copy of the Vec, ordered with the PETSc natural numbering
     """
     cdef int dim, idx, start, end, p, d, k
     cdef PetscInt dof, off

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -3188,3 +3188,39 @@ def mark_points_with_function_array(PETSc.DM plex,
         CHKERR(PetscSectionGetOffset(section.sec, p, &offset))
         if array[offset] == 1:
             CHKERR(DMLabelSetValue(<DMLabel>dmlabel.dmlabel, p, label_value))
+
+
+def to_petsc_local_numbering(PETSc.Vec vec, V):
+    """
+    Reorder a PETSc Vec corresponding to a Firedrake Function w.r.t.
+    the initial PETSc numbering.
+
+    :arg vec: the PETSc Vec to reorder
+    :arg V: the FunctionSpace of the Function which the Vec comes from
+    :ret out: a copy of the Vec, ordered with the PETSc numbering
+    """
+    cdef int dim, idx, start, end, p, d, k
+    cdef PetscInt dof, off
+    cdef PETSc.Vec out
+    cdef PETSc.Section section
+    cdef np.ndarray[PetscReal, mode="c", ndim=1] varray, oarray
+
+    section = V.dm.getGlobalSection()
+    out = vec.duplicate()
+    varray = vec.array_r
+    oarray = out.array
+    dim = V.value_size
+    idx = 0
+    start, end = vec.getOwnershipRange()
+    for p in range(*section.getChart()):
+        CHKERR(PetscSectionGetDof(section.sec, p, &dof))
+        if dof > 0:
+            CHKERR(PetscSectionGetOffset(section.sec, p, &off))
+            assert off >= 0
+            off *= dim
+            for d in range(dof):
+                for k in range(dim):
+                    oarray[idx] = varray[off + dim * d + k - start]
+                    idx += 1
+    assert idx == (end - start)
+    return out


### PR DESCRIPTION
Hi all. I decided to take the metric-based mesh adaptation stuff out of #2796 and put it in a new repo: https://github.com/pyroteus/animate. However, it will still need the `to_petsc_local_numbering` function that was removed from Firedrake at some point. Would you be willing to put this updated version back in?

The PR also contains some minor fixes for the PETSc interface docs (introduced by me I think).