### PR TITLE
Update hypre_ads.py error handling for 2D meshes

### DIFF
--- a/firedrake/preconditioners/hypre_ads.py
+++ b/firedrake/preconditioners/hypre_ads.py
@@ -25,6 +25,8 @@ class HypreADS(PCBase):
             degree = max(degree)
         except TypeError:
             pass
+        if mesh.topological_dimension() != 3:
+            raise ValueError("Hypre ADS only works for meshes of topological dimension 3, (not degree %d)" % (mesh.topological_dimension())) 
         if formdegree != 2 or degree != 1:
             raise ValueError("Hypre ADS requires lowest order RT elements! (not %s of degree %d)" % (family, degree))
 


### PR DESCRIPTION
ADS only supports 2D meshes, the following MWE gives an error message that isn't quite accurate:
```python
from firedrake import *

def test_homogeneous_field_linear():
    mesh = UnitSquareMesh(10, 10)
    V = FunctionSpace(mesh, "RT", 1)

    u = TrialFunction(V)
    v = TestFunction(V)

    a = inner(div(u), div(v))*dx + inner(u, v)*dx
    L = inner(Constant((1, 0.5)), v)*dx

    bc = DirichletBC(V, Constant((1, 0.5)), (1, 2, 3, 4))

    params = {'snes_type': 'ksponly',
              'ksp_type': 'cg',
              "ksp_monitor": None,
              'ksp_max_it': '30',
              'ksp_rtol': '1e-12',
              'pc_type': 'python',
              'pc_python_type': 'firedrake.HypreADS',
              }

    u = Function(V)
    solve(a == L, u, bc, solver_parameters=params)

test_homogeneous_field_linear()
```

```bash
  File "/home/firedrake/firedrake/src/firedrake/firedrake/preconditioners/base.py", line 129, in setUp
    super().setUp(pc)
  File "/home/firedrake/firedrake/src/firedrake/firedrake/preconditioners/base.py", line 45, in setUp
    self.initialize(pc)
  File "/home/firedrake/firedrake/src/firedrake/firedrake/preconditioners/hypre_ads.py", line 29, in initialize
    raise ValueError("Hypre ADS requires lowest order RT elements! (not %s of degree %d)" % (family, degree))
ValueError: Hypre ADS requires lowest order RT elements! (not Raviart-Thomas of degree 1)
```