### PR TITLE
Suppress missing UFL docs warning.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,6 +125,7 @@ nitpick_ignore_regex = [
     (r'py:.*', r'dolfin_adjoint_common\..*'),
     (r'py:.*', r'pyadjoint\..*'),
     (r'py:.*', r'tsfc\..*'),
+    (r'py:.*', r'ufl\..*'),
     (r'py:.*', r'PETSc\..*'),
     (r'py:.*', r'progress\..*'),
     # Ignore undocumented PyOP2

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -83,6 +83,8 @@ class Constant(ufl.constantvalue.ConstantValue, ConstantMixin, TSFCConstantMixin
 
     @ConstantMixin._ad_annotate_init
     def __init__(self, value, domain=None, name=None, count=None):
+        """"""
+
         # Init also called in mesh constructor, but constant can be built without mesh
         utils._init()
 


### PR DESCRIPTION
A recent change to Constant is causing build fails. The cause of this is that Constant inherits from `ufl.utils.Counted`, which is not in the ufl documentation. This PR suppresses errors for missing ufl docs. We do the same for other external packages.

Along the way I have given `Constant.__init__` a blank docstring in order to prevent it inheriting from `ufl.utils.Counted`.