### PR TITLE
Parallel Compatible Cross-Mesh Interpolation

### DIFF
--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -108,6 +108,120 @@ in the dual space to `V` to assembled 1-forms in the dual space to
 `W`.
 
 
+Interpolation across meshes
+---------------------------
+
+The interpolation API supports interpolation between meshes where the target
+function space has finite elements (as given in the list of
+:ref:`supported elements <supported_elements>`)
+
+* **Lagrange/CG** (also known a Continuous Galerkin or P elements),
+* **Q** (i.e. Lagrange/CG on lines, quadrilaterals and hexahedra),
+* **Discontinuous Lagrange/DG** (also known as Discontinuous Galerkin or DP elements) and
+* **DQ** (i.e. Discontinuous Lagrange/DG on lines, quadrilaterals and hexahedra).
+
+Vector, tensor and mixed function spaces can also be interpolated into from
+other meshes as long as they are constructed from these spaces.
+
+.. note::
+
+   The list of supported elements above is only for *target* function spaces.
+   Function spaces on the *source* mesh can be built from most of the supported
+   elements.
+
+There are few constraints on the meshes involved: the target mesh can have a
+different cell shape, topological dimension, or resolution to the source mesh.
+There are many use cases for this: For example, two solutions to the same
+problem calculated on meshes with different resolutions or cell shapes can be
+interpolated onto one another, or onto a third, finer mesh, and be directly
+compared.
+
+
+Interpolating onto sub-domain meshes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The target mesh for a cross-mesh interpolation need not cover the full domain
+of the source mesh. Volume, surface and line integrals can therefore be
+calculated by interpolating onto the mesh or
+:ref:`immersed manifold <immersed_manifolds>` which defines the volume,
+surface or line of interest in the domain. The integral itself is calculated
+by calling :py:func:`~.assemble` on an approriate form over the target mesh
+function space:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 11-18, 31-40
+
+For more on forms, see :ref:`this section of the manual <more_complicated_forms>`.
+
+
+Interpolating onto other meshes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   Interpolation *from* :ref:`immersed manifolds <immersed_manifolds>` and
+   :ref:`high-order meshes <changing_coordinate_fs>` is currently not supported.
+
+If the target mesh extends outside the source mesh domain, then cross-mesh
+interpolation will raise a :py:class:`~.DofNotDefinedError`.
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 46-58, 64-65
+
+This can be overriden with the optional ``allow_missing_dofs`` keyword
+argument:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 72-73, 80
+
+By default the missing degrees of freedom (DoFs, the global basis function
+coefficients which could not be set) are zero:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 85
+
+We can optionally specify a value to use for our missing DoFs. Here
+we set them to be ``nan`` ('not a number') for easy identification:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 90-93
+
+When using :py:class:`~.Interpolator`\s, the ``allow_missing_dofs`` keyword
+argument is set at construction:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 100
+
+The ``default_missing_val`` keyword argument is then set whenever we call
+:py:meth:`~.Interpolator.interpolate`:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 103
+
+If we supply an output :py:class:`~.Function` and don't set
+``default_missing_val`` then any missing DoFs are left as they were prior to
+interpolation:
+
+.. literalinclude:: ../../tests/regression/test_interpolation_manual.py
+   :language: python3
+   :dedent:
+   :lines: 107-110, 113-115, 124-126
+
+
 Interpolation from external data
 --------------------------------
 

--- a/docs/source/mesh-coordinates.rst
+++ b/docs/source/mesh-coordinates.rst
@@ -36,6 +36,8 @@ This can also be used if `f` is a solution to a PDE.
    This will be fixed in a future Firedrake update.
 
 
+.. _changing_coordinate_fs:
+
 Changing the coordinate function space
 --------------------------------------
 

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -217,9 +217,10 @@ duplication.
 Points outside the domain
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Be default points outside the domain  by more than the :ref:`specified
-tolerance <tolerance>` will generate a ``ValueError``. This can be switched
-to a warning or switched off entirely:
+Be default points outside the domain by more than the :ref:`specified
+tolerance <tolerance>` will generate
+a :class:`~.VertexOnlyMeshMissingPointsError`. This can be switched to a
+warning or switched off entirely:
 
 .. literalinclude:: ../../tests/vertexonly/test_vertex_only_manual.py
    :language: python3

--- a/docs/source/variational-problems.rst
+++ b/docs/source/variational-problems.rst
@@ -77,6 +77,7 @@ of standard shapes.  1-dimensional intervals may be constructed with
 example to build unit square meshes).  See
 :mod:`~firedrake.utility_meshes` for full details.
 
+.. _immersed_manifolds:
 
 Immersed manifolds
 ~~~~~~~~~~~~~~~~~~
@@ -259,6 +260,9 @@ extruded ("vertical") space.  Firedrake allows us to separately choose
 the horizontal and vertical spaces when building a function space on
 an extruded mesh.  We refer the reader to the :doc:`manual section on
 extrusion <extruded-meshes>` for details.
+
+
+.. _supported_elements:
 
 Supported finite elements
 -------------------------
@@ -631,6 +635,8 @@ we can write:
        solve(F == 0, bcs=[bc])
        t += dt
        c.assign(t)
+
+.. _more_complicated_forms:
 
 More complicated forms
 ----------------------

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -367,14 +367,47 @@ class Function(ufl.Coefficient, FunctionMixin):
         return vector.Vector(self)
 
     @PETSc.Log.EventDecorator()
-    def interpolate(self, expression, subset=None, ad_block_tag=None):
+    def interpolate(
+        self,
+        expression,
+        subset=None,
+        allow_missing_dofs=False,
+        default_missing_val=None,
+        ad_block_tag=None,
+    ):
         r"""Interpolate an expression onto this :class:`Function`.
 
         :param expression: a UFL expression to interpolate
-        :param ad_block_tag: string for tagging the resulting block on the Pyadjoint tape
+        :kwarg subset: An optional :class:`pyop2.types.set.Subset` to apply the
+            interpolation over. Cannot, at present, be used when interpolating
+            across meshes unless the target mesh is a :func:`.VertexOnlyMesh`.
+        :kwarg allow_missing_dofs: For interpolation across meshes: allow
+            degrees of freedom (aka DoFs/nodes) in the target mesh that cannot be
+            defined on the source mesh. For example, where nodes are point
+            evaluations, points in the target mesh that are not in the source mesh.
+            When ``False`` this raises a ``ValueError`` should this occur. When
+            ``True`` the corresponding values are set to zero or to the value
+            ``default_missing_val`` if given. Ignored if interpolating within the
+            same mesh or onto a :func:`.VertexOnlyMesh` (the behaviour of a
+            :func:`.VertexOnlyMesh` in this scenario is, at present, set when
+            it is created).
+        :kwarg default_missing_val: For interpolation across meshes: the optional
+            value to assign to DoFs in the target mesh that are outside the source
+            mesh. If this is not set then zero is used. Ignored if interpolating
+            within the same mesh or onto a :func:`.VertexOnlyMesh`.
+        :kwarg ad_block_tag: An optional string for tagging the resulting block on
+            the Pyadjoint tape.
         :returns: this :class:`Function` object"""
         from firedrake import interpolation
-        return interpolation.interpolate(expression, self, subset=subset, ad_block_tag=ad_block_tag)
+
+        return interpolation.interpolate(
+            expression,
+            self,
+            subset=subset,
+            allow_missing_dofs=allow_missing_dofs,
+            default_missing_val=default_missing_val,
+            ad_block_tag=ad_block_tag,
+        )
 
     def zero(self, subset=None):
         """Set all values to zero.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -276,11 +276,15 @@ def make_interpolator(expr, V, subset, access, bcs=None):
         # (so for vector function spaces in 2 dimensions we might need a
         # concatenation of 2 MPI.DOUBLE types when we are in real mode)
         if tensor is not None:
-            # Callable will do interpolation into tensor (which is a Dat) when
-            # it is called.
-            wrapper.mpi_type, _ = get_dat_mpi_type(tensor)
+            # Callable will do interpolation into our pre-supplied function f
+            # when it is called.
+            assert f.dat is tensor
+            wrapper.mpi_type, _ = get_dat_mpi_type(f.dat)
             assert not len(arguments)
-            callable = partial(wrapper.forward_operation, tensor)
+
+            def callable():
+                wrapper.forward_operation(f.dat)
+                return f
         else:
             assert len(arguments) == 1
             assert tensor is None

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -2,6 +2,7 @@ import numpy
 from functools import partial, singledispatch
 import os
 import tempfile
+import abc
 
 import FIAT
 import ufl
@@ -21,6 +22,7 @@ import finat
 
 import firedrake
 from firedrake import tsfc_interface, utils
+from firedrake.mesh import MissingPointsBehaviour, VertexOnlyMeshMissingPointsError
 from firedrake.adjoint_utils import annotate_interpolate
 from firedrake.petsc import PETSc
 from firedrake.halo import _get_mtype as get_dat_mpi_type
@@ -28,7 +30,13 @@ from mpi4py import MPI
 
 from pyadjoint import stop_annotating
 
-__all__ = ("interpolate", "Interpolator")
+__all__ = (
+    "interpolate",
+    "Interpolator",
+    "DofNotDefinedError",
+    "CrossMeshInterpolator",
+    "SameMeshInterpolator",
+)
 
 
 # Current behaviour of interpolation in Firedrake:
@@ -68,16 +76,43 @@ __all__ = ("interpolate", "Interpolator")
 
 
 @PETSc.Log.EventDecorator()
-def interpolate(expr, V, subset=None, access=op2.WRITE, ad_block_tag=None):
+def interpolate(
+    expr,
+    V,
+    subset=None,
+    access=op2.WRITE,
+    allow_missing_dofs=False,
+    default_missing_val=None,
+    ad_block_tag=None,
+):
     """Interpolate an expression onto a new function in V.
 
     :arg expr: a UFL expression.
     :arg V: the :class:`.FunctionSpace` to interpolate into (or else
         an existing :class:`.Function`).
     :kwarg subset: An optional :class:`pyop2.types.set.Subset` to apply the
-        interpolation over.
-    :kwarg access: The access descriptor for combining updates to shared dofs.
-    :kwarg ad_block_tag: string for tagging the resulting block on the Pyadjoint tape
+        interpolation over. Cannot, at present, be used when interpolating
+        across meshes unless the target mesh is a :func:`.VertexOnlyMesh`.
+    :kwarg access: The pyop2 access descriptor for combining updates to shared
+        DoFs. Possible values include ``WRITE`` and ``INC``. Only ``WRITE`` is
+        supported at present when interpolating across meshes unless the target
+        mesh is a :func:`.VertexOnlyMesh`. See note below.
+    :kwarg allow_missing_dofs: For interpolation across meshes: allow
+        degrees of freedom (aka DoFs/nodes) in the target mesh that cannot be
+        defined on the source mesh. For example, where nodes are point
+        evaluations, points in the target mesh that are not in the source mesh.
+        When ``False`` this raises a ``ValueError`` should this occur. When
+        ``True`` the corresponding values are set to zero or to the value
+        ``default_missing_val`` if given. Ignored if interpolating within the
+        same mesh or onto a :func:`.VertexOnlyMesh` (the behaviour of a
+        :func:`.VertexOnlyMesh` in this scenario is, at present, set when
+        it is created).
+    :kwarg default_missing_val: For interpolation across meshes: the optional
+        value to assign to DoFs in the target mesh that are outside the source
+        mesh. If this is not set then zero is used. Ignored if interpolating
+        within the same mesh or onto a :func:`.VertexOnlyMesh`.
+    :kwarg ad_block_tag: An optional string for tagging the resulting block on
+        the Pyadjoint tape.
     :returns: a new :class:`.Function` in the space ``V`` (or ``V`` if
         it was a Function).
 
@@ -100,19 +135,44 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, ad_block_tag=None):
        performance by using an :class:`Interpolator` instead.
 
     """
-    return Interpolator(expr, V, subset=subset, access=access).interpolate(ad_block_tag=ad_block_tag)
+    return Interpolator(
+        expr, V, subset=subset, access=access, allow_missing_dofs=allow_missing_dofs
+    ).interpolate(default_missing_val=default_missing_val, ad_block_tag=ad_block_tag)
 
 
-class Interpolator(object):
+class Interpolator(abc.ABC):
     """A reusable interpolation object.
 
     :arg expr: The expression to interpolate.
     :arg V: The :class:`.FunctionSpace` or :class:`.Function` to
         interpolate into.
     :kwarg subset: An optional :class:`pyop2.types.set.Subset` to apply the
-        interpolation over.
+        interpolation over. Cannot, at present, be used when interpolating
+        across meshes unless the target mesh is a :func:`.VertexOnlyMesh`.
     :kwarg freeze_expr: Set to True to prevent the expression being
-        re-evaluated on each call.
+        re-evaluated on each call. Cannot, at present, be used when
+        interpolating across meshes unless the target mesh is a
+        :func:`.VertexOnlyMesh`.
+    :kwarg access: The pyop2 access descriptor for combining updates to shared
+        DoFs. Possible values include ``WRITE`` and ``INC``. Only ``WRITE`` is
+        supported at present when interpolating across meshes. See note in
+        :func:`.interpolate` if changing this from default.
+    :kwarg bcs: An optional list of boundary conditions to zero-out in the
+        output function space. Interpolator rows or columns which are
+        associated with boundary condition nodes are zeroed out when this is
+        specified.
+    :kwarg allow_missing_dofs: For interpolation across meshes: allow
+        degrees of freedom (aka DoFs/nodes) in the target mesh that cannot be
+        defined on the source mesh. For example, where nodes are point
+        evaluations, points in the target mesh that are not in the source mesh.
+        When ``False`` this raises a ``ValueError`` should this occur. When
+        ``True`` the corresponding values are either left unchanged in the
+        :class:`.Function` produced by the interpolation, or are set to a
+        default value if one is provided. See the ``default_missing_val`` kwarg
+        of :meth:`interpolate` for more. Ignored if interpolating within the
+        same mesh or onto a :func:`.VertexOnlyMesh` (the behaviour of a
+        :func:`.VertexOnlyMesh` in this scenario is, at present, set when it is
+        created).
 
     This object can be used to carry out the same interpolation
     multiple times (for example in a timestepping loop).
@@ -124,22 +184,41 @@ class Interpolator(object):
        :class:`Interpolator` is also collected).
 
     """
-    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, bcs=None):
-        try:
-            self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs)
-        except FIAT.hdiv_trace.TraceError:
-            raise NotImplementedError("Can't interpolate onto traces sorry")
-        self.arguments = arguments
-        self.nargs = len(arguments)
-        self.freeze_expr = freeze_expr
+
+    def __new__(cls, expr, V, **kwargs):
+        target_mesh = V.ufl_domain()
+        source_mesh = extract_unique_domain(expr) or target_mesh
+        if target_mesh is not source_mesh:
+            if isinstance(target_mesh.topology, firedrake.mesh.VertexOnlyMeshTopology):
+                return object.__new__(SameMeshInterpolator)
+            else:
+                return object.__new__(CrossMeshInterpolator)
+        else:
+            return object.__new__(SameMeshInterpolator)
+
+    def __init__(
+        self,
+        expr,
+        V,
+        subset=None,
+        freeze_expr=False,
+        access=op2.WRITE,
+        bcs=None,
+        allow_missing_dofs=False,
+    ):
         self.expr = expr
         self.V = V
+        self.subset = subset
+        self.freeze_expr = freeze_expr
+        self.access = access
         self.bcs = bcs
+        self._allow_missing_dofs = allow_missing_dofs
+        self.callable = None
 
-    @PETSc.Log.EventDecorator()
-    @annotate_interpolate
-    def interpolate(self, *function, output=None, transpose=False):
-        """Compute the interpolation.
+    @abc.abstractmethod
+    def interpolate(self, *args, **kwargs):
+        """
+        Compute the interpolation.
 
         :arg function: If the expression being interpolated contains an
             :class:`ufl.Argument`, then the :class:`.Function` value to
@@ -147,7 +226,418 @@ class Interpolator(object):
         :kwarg output: Optional. A :class:`.Function` to contain the output.
         :kwarg transpose: Set to true to apply the transpose (adjoint) of the
               interpolation operator.
+        :kwarg default_missing_val: For interpolation across meshes: the
+            optional value to assign to DoFs in the target mesh that are
+            outside the source mesh. If this is not set and an ``output``
+            :class:`.Function` is specified, then such DoF values are left
+            unchanged. If this is not set and no ``output`` :class:`.Function`
+            is specified, then the default value is zero. This does not affect
+            transpose interpolation. Ignored if interpolating within the same
+            mesh or onto a :func:`.VertexOnlyMesh`.
+
         :returns: The resulting interpolated :class:`.Function`.
+        """
+        pass
+
+
+class DofNotDefinedError(Exception):
+    r"""Raised when attempting to interpolate across function spaces where the
+    target function space contains degrees of freedom (i.e. nodes) which cannot
+    be defined in the source function space. This typically occurs when the
+    target mesh covers a larger domain than the source mesh.
+
+    Attributes
+    ----------
+    src_mesh : :func:`.Mesh`
+        The source mesh.
+    dest_mesh : :func:`.Mesh`
+        The destination mesh.
+
+    """
+
+    def __init__(self, src_mesh, dest_mesh):
+        self.src_mesh = src_mesh
+        self.dest_mesh = dest_mesh
+
+    def __str__(self):
+        return (
+            f"The given target function space on domain {repr(self.dest_mesh)} "
+            "contains degrees of freedom which cannot cannot be defined in the "
+            f"source function space on domain {repr(self.src_mesh)}. "
+            "This may be because the target mesh covers a larger domain than the "
+            "source mesh. To disable this error, set allow_missing_dofs=True."
+        )
+
+
+class CrossMeshInterpolator(Interpolator):
+    """
+    Interpolate a function from one mesh and function space to another.
+
+    For arguments, see :class:`.Interpolator`.
+    """
+
+    def __init__(
+        self,
+        expr,
+        V,
+        subset=None,
+        freeze_expr=False,
+        access=op2.WRITE,
+        bcs=None,
+        allow_missing_dofs=False,
+    ):
+        if subset:
+            raise NotImplementedError("subset not implemented")
+        if freeze_expr:
+            # Probably just need to pass freeze_expr to the various
+            # interpolators for this to work.
+            raise NotImplementedError("freeze_expr not implemented")
+        if access != op2.WRITE:
+            raise NotImplementedError("access other than op2.WRITE not implemented")
+        if bcs:
+            raise NotImplementedError("bcs not implemented")
+        if V.ufl_element().mapping() != "identity":
+            # Identity mapping between reference cell and physical coordinates
+            # implies point evaluation nodes. A more general version would
+            # require finding the global coordinates of all quadrature points
+            # of the target function space in the source mesh.
+            raise NotImplementedError(
+                "Can only interpolate into spaces with point evaluation nodes."
+            )
+
+        super().__init__(
+            expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs
+        )
+
+        self.arguments = extract_arguments(expr)
+        self.nargs = len(self.arguments)
+        if self.nargs and self.arguments[0] != self.expr:
+            raise NotImplementedError(
+                "Can't yet create an interpolator from an expression with arguments."
+            )
+
+        if self._allow_missing_dofs:
+            missing_points_behaviour = MissingPointsBehaviour.IGNORE
+        else:
+            missing_points_behaviour = MissingPointsBehaviour.ERROR
+
+        # setup
+        V_dest = V
+        src_mesh = extract_unique_domain(expr)
+        dest_mesh = V_dest.ufl_domain()
+        src_mesh_gdim = src_mesh.geometric_dimension()
+        dest_mesh_gdim = dest_mesh.geometric_dimension()
+        if src_mesh_gdim != dest_mesh_gdim:
+            raise ValueError(
+                "geometric dimensions of source and destination meshes must match"
+            )
+        self.src_mesh = src_mesh
+        self.dest_mesh = dest_mesh
+        if numpy.any(
+            numpy.asarray(src_mesh.coordinates.function_space().ufl_element().degree())
+            > 1
+        ):
+            # Need to implement vertex-only mesh immersion in high order meshes
+            # for this to work.
+            raise NotImplementedError(
+                "Cannot yet interpolate from high order meshes to other meshes."
+            )
+        if src_mesh_gdim != src_mesh.topological_dimension():
+            # Need to implement vertex-only mesh immersion in immersed manifold
+            # meshes for this to work.
+            raise NotImplementedError(
+                "Cannot yet interpolate from immersed manifold meshes."
+            )
+
+        self.sub_interpolators = []
+
+        # Create a VOM at the nodes of V_dest in src_mesh. We don't include halo
+        # node coordinates because interpolation doesn't usually include halos.
+        # NOTE: it is very important to set redundant=False, otherwise the
+        # input ordering VOM will only contain the points on rank 0!
+        # QUESTION: Should any of the below have annotation turned off?
+        ufl_scalar_element = V_dest.ufl_element()
+        if ufl_scalar_element.num_sub_elements():
+            if all(
+                ufl_scalar_element.sub_elements()[0] == e
+                for e in ufl_scalar_element.sub_elements()
+            ):
+                # For a VectorElement or TensorElement the correct
+                # VectorFunctionSpace equivalent is built from the scalar
+                # sub-element.
+                ufl_scalar_element = ufl_scalar_element.sub_elements()[0]
+                if ufl_scalar_element.value_shape() != ():
+                    raise NotImplementedError(
+                        "Can't yet cross-mesh interpolate onto function spaces made from VectorElements or TensorElements made from sub elements with value shape other than ()."
+                    )
+            else:
+                assert type(ufl_scalar_element) is ufl.MixedElement
+                # Build and save an interpolator for each sub-element
+                # separately for MixedFunctionSpaces. NOTE: since we can't have
+                # expressions for MixedFunctionSpaces we know that the input
+                # argument ``expr`` must be a Function. V_dest can be a Function
+                # or a FunctionSpace, and subfunctions works for both.
+                if self.nargs == 1:
+                    # Arguments don't have a subfunctions property so I have to
+                    # make them myself. NOTE: this will not be correct when we
+                    # start allowing interpolators created from an expression
+                    # with arguments, as opposed to just being the argument.
+                    expr_subfunctions = [
+                        firedrake.TestFunction(V_src_sub_func)
+                        for V_src_sub_func in self.expr.function_space().subfunctions
+                    ]
+                elif self.nargs > 1:
+                    raise NotImplementedError(
+                        "Can't yet create an interpolator from an expression with multiple arguments."
+                    )
+                else:
+                    expr_subfunctions = self.expr.subfunctions
+                if len(expr_subfunctions) != len(V_dest.subfunctions):
+                    raise NotImplementedError(
+                        "Can't interpolate from a non-mixed function space into a mixed function space."
+                    )
+                for input_sub_func, target_sub_func in zip(
+                    expr_subfunctions, V_dest.subfunctions
+                ):
+                    sub_interpolator = CrossMeshInterpolator(
+                        input_sub_func,
+                        target_sub_func,
+                        subset=subset,
+                        freeze_expr=freeze_expr,
+                        access=access,
+                        bcs=bcs,
+                        allow_missing_dofs=allow_missing_dofs,
+                    )
+                    self.sub_interpolators.append(sub_interpolator)
+                return
+        V_dest_vec = firedrake.VectorFunctionSpace(dest_mesh, ufl_scalar_element)
+        f_dest_node_coords = interpolate(dest_mesh.coordinates, V_dest_vec)
+        dest_node_coords = f_dest_node_coords.dat.data_ro
+        try:
+            self.vom_dest_node_coords_in_src_mesh = firedrake.VertexOnlyMesh(
+                src_mesh,
+                dest_node_coords,
+                redundant=False,
+                missing_points_behaviour=missing_points_behaviour,
+            )
+        except VertexOnlyMeshMissingPointsError:
+            raise DofNotDefinedError(src_mesh, dest_mesh)
+        # vom_dest_node_coords_in_src_mesh uses the parallel decomposition of
+        # the global node coordinates of V_dest in the SOURCE mesh (src_mesh).
+        # I first point evaluate my expression at these locations, giving a
+        # P0DG function on the VOM. As described in the manual, this is an
+        # interpolation operation.
+        shape = V_dest.ufl_element().value_shape()
+        if len(shape) == 0:
+            fs_type = firedrake.FunctionSpace
+        elif len(shape) == 1:
+            fs_type = firedrake.VectorFunctionSpace
+        else:
+            fs_type = partial(firedrake.TensorFunctionSpace, shape=shape)
+        P0DG_vom = fs_type(self.vom_dest_node_coords_in_src_mesh, "DG", 0)
+        self.point_eval_interpolator = Interpolator(self.expr, P0DG_vom)
+        # The parallel decomposition of the nodes of V_dest in the DESTINATION
+        # mesh (dest_mesh) is retrieved using the input_ordering attribute of the
+        # VOM. This again is an interpolation operation, which, under the hood
+        # is a PETSc SF reduce.
+        P0DG_vom_i_o = fs_type(
+            self.vom_dest_node_coords_in_src_mesh.input_ordering, "DG", 0
+        )
+        self.to_input_ordering_interpolator = Interpolator(
+            firedrake.TrialFunction(P0DG_vom), P0DG_vom_i_o
+        )
+        # The P0DG function outputted by the above interpolation has the
+        # correct parallel decomposition for the nodes of V_dest in dest_mesh so
+        # we can safely assign the dat values. This is all done in the actual
+        # interpolation method below.
+
+    @PETSc.Log.EventDecorator()
+    @annotate_interpolate
+    def interpolate(
+        self,
+        *function,
+        output=None,
+        transpose=False,
+        default_missing_val=None,
+        **kwargs,
+    ):
+        """Compute the interpolation.
+
+        For arguments, see :class:`.Interpolator`.
+        """
+        if transpose and not self.nargs:
+            raise ValueError(
+                "Can currently only apply transpose interpolation with arguments."
+            )
+        if self.nargs != len(function):
+            raise ValueError(
+                "Passed %d Functions to interpolate, expected %d"
+                % (len(function), self.nargs)
+            )
+
+        if self.nargs:
+            (f_src,) = function
+            if not hasattr(f_src, "dat"):
+                raise ValueError(
+                    "The expression had arguments: we therefore need to be given a Function (not an expression) to interpolate!"
+                )
+        else:
+            f_src = self.expr
+
+        if transpose:
+            V_dest = self.expr.function_space()
+        else:
+            if isinstance(self.V, firedrake.Function):
+                V_dest = self.V.function_space()
+            else:
+                V_dest = self.V
+        if output:
+            if output.function_space() != V_dest:
+                raise ValueError("Given output has the wrong function space!")
+        else:
+            if isinstance(self.V, firedrake.Function):
+                output = self.V
+            else:
+                output = firedrake.Function(V_dest).zero()
+
+        if len(self.sub_interpolators):
+            # MixedFunctionSpace case
+            for sub_interpolator, f_src_sub_func, output_sub_func in zip(
+                self.sub_interpolators, f_src.subfunctions, output.subfunctions
+            ):
+                if f_src is self.expr:
+                    # f_src is already contained in self.point_eval_interpolator,
+                    # so the sub_interpolators are already prepared to interpolate
+                    # without needing to be given a Function
+                    assert not self.nargs
+                    sub_interpolator.interpolate(
+                        output=output_sub_func, transpose=transpose, **kwargs
+                    )
+                else:
+                    sub_interpolator.interpolate(
+                        f_src_sub_func,
+                        output=output_sub_func,
+                        transpose=transpose,
+                        **kwargs,
+                    )
+            return output
+
+        if not transpose:
+            if f_src is self.expr:
+                # f_src is already contained in self.point_eval_interpolator
+                assert not self.nargs
+                f_src_at_dest_node_coords_src_mesh_decomp = (
+                    self.point_eval_interpolator.interpolate()
+                )
+            else:
+                f_src_at_dest_node_coords_src_mesh_decomp = (
+                    self.point_eval_interpolator.interpolate(f_src)
+                )
+            f_src_at_dest_node_coords_dest_mesh_decomp = firedrake.Function(
+                self.to_input_ordering_interpolator.V
+            )
+            # We have to create the Function before interpolating so we can
+            # set default missing values (if requested).
+            if default_missing_val:
+                f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_wo[
+                    :
+                ] = default_missing_val
+            elif self._allow_missing_dofs:
+                # If we have allowed missing points we know we might end up
+                # with points in the target mesh that are not in the source
+                # mesh. However, since we haven't specified a default missing
+                # value we expect the interpolation to leave these points
+                # unchanged. By setting the dat values to NaN we can later
+                # identify these points and skip over them when assigning to
+                # the output function.
+                f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_wo[:] = numpy.nan
+
+            self.to_input_ordering_interpolator.interpolate(
+                f_src_at_dest_node_coords_src_mesh_decomp,
+                output=f_src_at_dest_node_coords_dest_mesh_decomp,
+            )
+
+            # we can now confidently assign this to a function on V_dest
+            if self._allow_missing_dofs and default_missing_val is None:
+                indices = numpy.where(
+                    ~numpy.isnan(f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_ro)
+                )[0]
+                output.dat.data_wo[
+                    indices
+                ] = f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_ro[indices]
+            else:
+                output.dat.data_wo[
+                    :
+                ] = f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_ro[:]
+
+        else:
+            # adjoint/transpose interpolation
+
+            # f_src is a cofunction on V_dest.dual as originally specified when
+            # creating the interpolator. Our first adjoint operation is to
+            # assign the dat values to a P0DG cofunction on our input ordering
+            # VOM. This has the parallel decomposition V_dest on our orinally
+            # specified dest_mesh. We can therefore safely create a P0DG
+            # cofunction on the input-ordering VOM (which has this parallel
+            # decomposition and ordering) and assign the dat values. NOTE: we
+            # can't yet use actual cofunctions, so we use Functions in their
+            # place.
+            f_src_at_dest_node_coords_dest_mesh_decomp = firedrake.Function(
+                self.to_input_ordering_interpolator.V
+            )
+            f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_wo[
+                :
+            ] = f_src.dat.data_ro[:]
+
+            # The rest of the transpose interpolation is merely the composition
+            # of the transpose interpolators in the reverse direction. NOTE: I
+            # don't have to worry about skipping over missing points here
+            # because I'm going from the input ordering VOM to the original VOM
+            # and all points from the input ordering VOM are in the original.
+            f_src_at_src_node_coords = self.to_input_ordering_interpolator.interpolate(
+                f_src_at_dest_node_coords_dest_mesh_decomp, transpose=True
+            )
+            # NOTE: if I wanted the default missing value to be applied to
+            # transpose interpolation I would have to do it here. However,
+            # this would require me to implement default missing values for
+            # transpose interpolation from a point evaluation interpolator
+            # which I haven't done. I wonder if it is necessary - perhaps the
+            # adjoint operator always sets all the values of the resulting
+            # cofunction? My initial attempt to insert setting the dat values
+            # prior to performing the multTranspose operation in
+            # SameMeshInterpolator.interpolate did not effect the result. For
+            # now, I say in the docstring that it only applies to forward
+            # interpolation.
+            self.point_eval_interpolator.interpolate(
+                f_src_at_src_node_coords, transpose=True, output=output
+            )
+
+        return output
+
+
+class SameMeshInterpolator(Interpolator):
+    """
+    An interpolator for interpolation within the same mesh or onto a validly-
+    defined :func:`.VertexOnlyMesh`.
+
+    For arguments, see :class:`.Interpolator`.
+    """
+
+    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, bcs=None, **kwargs):
+        super().__init__(expr, V, subset, freeze_expr, access, bcs)
+        try:
+            self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs)
+        except FIAT.hdiv_trace.TraceError:
+            raise NotImplementedError("Can't interpolate onto traces sorry")
+        self.arguments = arguments
+        self.nargs = len(arguments)
+
+    @PETSc.Log.EventDecorator()
+    @annotate_interpolate
+    def interpolate(self, *function, output=None, transpose=False, **kwargs):
+        """Compute the interpolation.
+
+        For arguments, see :class:`.Interpolator`.
         """
         if transpose and not self.nargs:
             raise ValueError("Can currently only apply transpose interpolation with arguments.")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -42,7 +42,8 @@ __all__ = [
     'Mesh', 'ExtrudedMesh', 'VertexOnlyMesh', 'RelabeledMesh',
     'SubDomainData', 'unmarked', 'DistributedMeshOverlapType',
     'DEFAULT_MESH_NAME', 'MeshGeometry', 'MeshTopology',
-    'AbstractMeshTopology', 'ExtrudedMeshTopology', 'VertexOnlyMeshTopology'
+    'AbstractMeshTopology', 'ExtrudedMeshTopology', 'VertexOnlyMeshTopology',
+    'VertexOnlyMeshMissingPointsError',
 ]
 
 
@@ -2745,6 +2746,32 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
     return self
 
 
+class MissingPointsBehaviour(enum.Enum):
+    IGNORE = None
+    ERROR = "error"
+    WARN = "warn"
+
+
+class VertexOnlyMeshMissingPointsError(Exception):
+    """Exception raised when 1 or more points are not found by a
+    :func:`~.VertexOnlyMesh` in its parent mesh.
+
+    Attributes
+    ----------
+    n_missing_points : int
+        The number of points which were not found in the parent mesh.
+    """
+
+    def __init__(self, n_missing_points):
+        self.n_missing_points = n_missing_points
+
+    def __str__(self):
+        return (
+            f"{self.n_missing_points} vertices are outside the mesh and have "
+            "been removed from the VertexOnlyMesh."
+        )
+
+
 @PETSc.Log.EventDecorator()
 def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
                    tolerance=None, redundant=True, name=None):
@@ -2757,7 +2784,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
     :kwarg missing_points_behaviour: optional string argument for what to do
         when vertices which are outside of the mesh are discarded. If
         ``'warn'``, will print a warning. If ``'error'`` will raise a
-        ValueError.
+        :class:`~.VertexOnlyMeshMissingPointsError`.
     :kwarg tolerance: The relative tolerance (i.e. as defined on the reference
         cell) for the distance a point can be from a mesh cell and still be
         considered to be in the cell. Note that this tolerance uses an L1
@@ -2841,16 +2868,18 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
         mesh, vertexcoords, tolerance=tolerance, redundant=redundant, exclude_halos=False
     )
 
-    if missing_points_behaviour:
+    missing_points_behaviour = MissingPointsBehaviour(missing_points_behaviour)
+
+    if missing_points_behaviour != MissingPointsBehaviour.IGNORE:
         if n_missing_points:
-            msg = f"{n_missing_points} vertices are outside the mesh and have been removed from the VertexOnlyMesh"
-            if missing_points_behaviour == 'error':
-                raise ValueError(msg)
-            elif missing_points_behaviour == 'warn':
+            error = VertexOnlyMeshMissingPointsError(n_missing_points)
+            if missing_points_behaviour == MissingPointsBehaviour.ERROR:
+                raise error
+            elif missing_points_behaviour == MissingPointsBehaviour.WARN:
                 from warnings import warn
-                warn(msg)
+                warn(str(error))
             else:
-                raise ValueError("missing_points_behaviour must be None, 'error' or 'warn'")
+                raise ValueError("missing_points_behaviour must be IGNORE, ERROR or WARN")
 
     name = name if name is not None else mesh.name + "_immersed_vom"
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2822,7 +2822,7 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
     # Bendy meshes require a smarter bounding box algorithm at partition and
     # (especially) cell level. Projecting coordinates to Bernstein may be
     # sufficient.
-    if np.any(np.asarray(mesh.coordinates.function_space().ufl_element().degree())) > 1:
+    if np.any(np.asarray(mesh.coordinates.function_space().ufl_element().degree()) > 1):
         raise NotImplementedError("Only straight edged meshes are supported")
 
     # Currently we take responsibility for locating the mesh cells in which the

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -1,0 +1,703 @@
+from firedrake import *
+from ufl.domain import extract_unique_domain
+import numpy as np
+import pytest
+from functools import reduce
+from operator import mul, add
+import subprocess
+
+
+def allgather(comm, coords):
+    """Gather all coordinates from all ranks."""
+    coords = coords.copy()
+    coords = comm.allgather(coords)
+    coords = np.concatenate(coords)
+    return coords
+
+
+def unitsquaresetup():
+    m_src = UnitSquareMesh(2, 3)
+    m_dest = UnitSquareMesh(3, 5, quadrilateral=True)
+    coords = np.array(
+        [[0.56, 0.6], [0.1, 0.9], [0.9, 0.1], [0.9, 0.9], [0.726, 0.6584]]
+    )  # fairly arbitrary
+    # add the coordinates of the mesh vertices to test boundaries
+    vertices_src = allgather(m_src.comm, m_src.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_src))
+    vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_dest))
+    return m_src, m_dest, coords
+
+
+def make_high_order(m_low_order, degree):
+    """Make a higher order mesh from a lower order mesh."""
+    f = Function(VectorFunctionSpace(m_low_order, "CG", degree))
+    f.interpolate(SpatialCoordinate(m_low_order))
+    return Mesh(f)
+
+
+@pytest.fixture(
+    params=[
+        "unitsquare",
+        "circlemanifold",
+        "circlemanifold_to_high_order",
+        pytest.param(
+            "unitsquare_from_high_order",
+            marks=pytest.mark.xfail(
+                # CalledProcessError is so the parallel tests correctly xfail
+                raises=(subprocess.CalledProcessError, NotImplementedError),
+                reason="Cannot yet interpolate from high order meshes to other meshes.",
+            ),
+        ),
+        "unitsquare_to_high_order",
+        "extrudedcube",
+        "unitsquare_vfs",
+        "unitsquare_tfs",
+        "unitsquare_N1curl_source",
+        pytest.param(
+            "unitsquare_SminusDiv_destination",
+            marks=pytest.mark.xfail(
+                # CalledProcessError is so the parallel tests correctly xfail
+                raises=(subprocess.CalledProcessError, NotImplementedError),
+                reason="Can only interpolate into spaces with point evaluation nodes",
+            ),
+        ),
+        "unitsquare_Regge_source",
+        pytest.param(
+            "spheresphere",
+            marks=pytest.mark.xfail(
+                # CalledProcessError is so the parallel tests correctly xfail
+                raises=(subprocess.CalledProcessError, NotImplementedError),
+                reason="Cannot yet interpolate from immersed manifold meshes.",
+            ),
+        ),
+    ]
+)
+def parameters(request):
+    if request.param == "unitsquare":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    elif request.param == "circlemanifold":
+        m_src = UnitSquareMesh(2, 3)
+        # shift to cover the whole circle
+        m_src.coordinates.dat.data[:] *= 2
+        m_src.coordinates.dat.data[:] -= 1
+        m_dest = CircleManifoldMesh(1000)  # want close to actual unit circle
+        coords = np.array(
+            [
+                [0, 1],
+                [1, 0],
+                [-1, 0],
+                [0, -1],
+                [sqrt(2) / 2, sqrt(2) / 2],
+                [-sqrt(3) / 2, 1 / 2],
+            ]
+        )  # points that ought to be on the unit circle
+        # only add target mesh vertices since they are common to both meshes
+        vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+        coords = np.concatenate((coords, vertices_dest))
+        # function.at often gets conflicting answers across boundaries for this
+        # mesh, so we lower the tolerance a bit for this test
+        m_dest.tolerance = 0.5
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    elif request.param == "circlemanifold_to_high_order":
+        m_src = UnitSquareMesh(2, 3)
+        # shift to cover the whole circle
+        m_src.coordinates.dat.data[:] *= 2
+        m_src.coordinates.dat.data[:] -= 1
+        m_dest = CircleManifoldMesh(1000, degree=2)  # note degree!
+        coords = np.array(
+            [
+                [0, 1],
+                [1, 0],
+                [-1, 0],
+                [0, -1],
+                [sqrt(2) / 2, sqrt(2) / 2],
+                [-sqrt(3) / 2, 1 / 2],
+            ]
+        )  # points that ought to be on the unit circle
+        # only add target mesh vertices since they are common to both meshes
+        vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+        coords = np.concatenate((coords, vertices_dest))
+        # function.at often gets conflicting answers across boundaries for this
+        # mesh, so we lower the tolerance a bit for this test
+        m_dest.tolerance = 0.5
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    elif request.param == "unitsquare_from_high_order":
+        m_low_order, m_dest, coords = unitsquaresetup()
+        m_src = make_high_order(m_low_order, 2)
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    elif request.param == "unitsquare_to_high_order":
+        m_src, m_low_order, coords = unitsquaresetup()
+        m_dest = make_high_order(m_low_order, 2)
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    elif request.param == "extrudedcube":
+        m_src = ExtrudedMesh(UnitSquareMesh(2, 3), 2)
+        m_dest = UnitCubeMesh(3, 5, 7)
+        coords = np.array(
+            [
+                [0.56, 0.06, 0.6],
+                [0.726, 0.6584, 0.951],
+            ]
+        )  # fairly arbitrary
+        vertices_src = allgather(m_src.comm, m_src.coordinates.dat.data_ro)
+        coords = np.concatenate((coords, vertices_src))
+        vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+        coords = np.concatenate((coords, vertices_dest))
+        # we use add to avoid TSFC complaints about too many indices for sum
+        # factorisation
+        expr_src = reduce(add, SpatialCoordinate(m_src))
+        expr_dest = reduce(add, SpatialCoordinate(m_dest))
+        expected = reduce(add, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 2)
+        V_dest = FunctionSpace(m_dest, "CG", 3)
+        V_dest_2 = FunctionSpace(m_dest, "CG", 1)
+    elif request.param == "unitsquare_vfs":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = 2 * SpatialCoordinate(m_src)
+        expr_dest = 2 * SpatialCoordinate(m_dest)
+        expected = 2 * coords
+        V_src = VectorFunctionSpace(m_src, "CG", 3)
+        V_dest = VectorFunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = VectorFunctionSpace(m_dest, "DQ", 2)
+    elif request.param == "unitsquare_tfs":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = outer(SpatialCoordinate(m_src), SpatialCoordinate(m_src))
+        expr_dest = outer(SpatialCoordinate(m_dest), SpatialCoordinate(m_dest))
+        expected = np.asarray(
+            [np.outer(coords[i], coords[i]) for i in range(len(coords))]
+        )
+        V_src = TensorFunctionSpace(m_src, "CG", 3)
+        V_dest = TensorFunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = TensorFunctionSpace(m_dest, "DQ", 2)
+    elif request.param == "unitsquare_N1curl_source":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = 2 * SpatialCoordinate(m_src)
+        expr_dest = 2 * SpatialCoordinate(m_dest)
+        expected = 2 * coords
+        V_src = FunctionSpace(m_src, "N1curl", 2)  # Not point evaluation nodes
+        V_dest = VectorFunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = VectorFunctionSpace(m_dest, "DQ", 2)
+    elif request.param == "unitsquare_SminusDiv_destination":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = 2 * SpatialCoordinate(m_src)
+        expr_dest = 2 * SpatialCoordinate(m_dest)
+        expected = 2 * coords
+        V_src = VectorFunctionSpace(m_src, "CG", 2)
+        V_dest = FunctionSpace(m_dest, "SminusDiv", 2)  # Not point evaluation nodes
+        V_dest_2 = VectorFunctionSpace(m_dest, "DQ", 2)
+    elif request.param == "unitsquare_Regge_source":
+        m_src, m_dest, coords = unitsquaresetup()
+        expr_src = outer(SpatialCoordinate(m_src), SpatialCoordinate(m_src))
+        expr_dest = outer(SpatialCoordinate(m_dest), SpatialCoordinate(m_dest))
+        expected = np.asarray(
+            [np.outer(coords[i], coords[i]) for i in range(len(coords))]
+        )
+        V_src = FunctionSpace(m_src, "Regge", 2)  # Not point evaluation nodes
+        V_dest = TensorFunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = TensorFunctionSpace(m_dest, "DQ", 2)
+    elif request.param == "spheresphere":
+        m_src = UnitCubedSphereMesh(5)
+        m_dest = UnitIcosahedralSphereMesh(5)
+        coords = np.array(
+            [
+                [0, 1, 0],
+                [1, 0, 0],
+                [-1, 0, 0],
+                [0, -1, 0],
+                [sqrt(2) / 2, sqrt(2) / 2, 0],
+                [-sqrt(3) / 2, 1 / 2, 0],
+            ]
+        )  # points that ought to be on the unit circle, at z=0
+        # function.at often gets conflicting answers across boundaries for this
+        # mesh, so we lower the tolerance a bit for this test
+        m_dest.tolerance = 0.5
+        expr_src = reduce(mul, SpatialCoordinate(m_src))
+        expr_dest = reduce(mul, SpatialCoordinate(m_dest))
+        expected = reduce(mul, coords.T)
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, "CG", 4)
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+    else:
+        raise ValueError("Unknown mesh pair")
+    return m_src, m_dest, coords, expr_src, expr_dest, expected, V_src, V_dest, V_dest_2
+
+
+def test_interpolate_cross_mesh(parameters):
+    (
+        m_src,
+        m_dest,
+        coords,
+        expr_src,
+        expr_dest,
+        expected,
+        V_src,
+        V_dest,
+        V_dest_2,
+    ) = parameters
+    get_expected_values(
+        m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+    )
+    get_expected_values(
+        m_src, m_dest, V_src, V_dest_2, coords, expected, expr_src, expr_dest
+    )
+
+
+def test_interpolate_unitsquare_mixed():
+    # this has to be in its own test because UFL expressions on mixed function
+    # spaces are not supported.
+
+    m_src = UnitSquareMesh(2, 3)
+    m_dest = UnitSquareMesh(3, 5, quadrilateral=True)
+
+    coords = np.array(
+        [[0.56, 0.6], [0.1, 0.9], [0.9, 0.1], [0.9, 0.9], [0.726, 0.6584]]
+    )  # fairly arbitrary
+    # add the coordinates of the mesh vertices to test boundaries
+    vertices_src = allgather(m_src.comm, m_src.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_src))
+    vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_dest))
+
+    expr_1 = reduce(add, SpatialCoordinate(m_src))
+    expected_1 = reduce(add, coords.T)
+    expr_2 = reduce(mul, SpatialCoordinate(m_src))
+    expected_2 = reduce(mul, coords.T)
+
+    V_1 = FunctionSpace(m_src, "CG", 1)
+    V_2 = FunctionSpace(m_src, "CG", 2)
+    V_src = V_1 * V_2
+    V_3 = FunctionSpace(m_dest, "CG", 3)
+    V_4 = FunctionSpace(m_dest, "CG", 4)
+    V_dest = V_3 * V_4
+    f_src = Function(V_src)
+    f_src.subfunctions[0].interpolate(expr_1)
+    f_src.subfunctions[1].interpolate(expr_2)
+
+    f_dest = interpolate(f_src, V_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = np.asarray(f_dest.at(coords))
+    assert np.allclose(got[:, 0], expected_1)
+    assert np.allclose(got[:, 1], expected_2)
+
+    # can create interpolator and use it
+    interpolator = Interpolator(TestFunction(V_src), V_dest)
+    f_dest = interpolator.interpolate(f_src)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = np.asarray(f_dest.at(coords))
+    assert np.allclose(got[:, 0], expected_1)
+    assert np.allclose(got[:, 1], expected_2)
+    f_dest = Function(V_dest)
+    interpolator.interpolate(f_src, output=f_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = np.asarray(f_dest.at(coords))
+    assert np.allclose(got[:, 0], expected_1)
+    assert np.allclose(got[:, 1], expected_2)
+    cofunc_dest = assemble(inner(f_dest, TestFunction(V_dest)) * dx)
+    cofunc_src = interpolator.interpolate(cofunc_dest, transpose=True)
+    assert not np.allclose(f_src.dat.data_ro[0], cofunc_src.dat.data_ro[0])
+    assert not np.allclose(f_src.dat.data_ro[1], cofunc_src.dat.data_ro[1])
+
+    # Can't go from non-mixed to mixed
+    V_src_2 = VectorFunctionSpace(m_src, "CG", 1)
+    assert V_src_2.ufl_element().value_shape() == V_src.ufl_element().value_shape()
+    f_src_2 = Function(V_src_2)
+    with pytest.raises(NotImplementedError):
+        interpolate(f_src_2, V_dest)
+
+
+def test_exact_refinement():
+    # With an exact mesh refinement, we can do error checks to see if our
+    # forward and transpose interpolations are exact where we expect them to
+    # be.
+    m_coarse = UnitSquareMesh(2, 2)
+    m_fine = UnitSquareMesh(8, 8)
+    V_coarse = FunctionSpace(m_coarse, "CG", 2)
+    V_fine = FunctionSpace(m_fine, "CG", 2)
+    # V_fine entirely spans V_coarse, i.e. V_scr is a subset of V_fine so we
+    # expect no interpolation error.
+
+    # expr_in_V_coarse this is exactly representable in V_coarse
+    x, y = SpatialCoordinate(m_coarse)
+    expr_in_V_coarse = x**2 + y**2 + 1
+    f_coarse = Function(V_coarse).interpolate(expr_in_V_coarse)
+
+    # expr_in_V_fine is also exactly representable in V_fine and is
+    # symbolically the same as expr_in_V_coarse
+    x, y = SpatialCoordinate(m_fine)
+    expr_in_V_fine = x**2 + y**2 + 1
+    f_fine = Function(V_fine).interpolate(expr_in_V_fine)
+
+    # If we now interpolate f_coarse into V_fine we should get a function
+    # which has no interpolation error versus f_fine because we were able to
+    # exactly represent expr_in_V_coarse in V_coarse and V_coarse is a subset
+    # of V_fine
+    interpolator_coarse_to_fine = Interpolator(TestFunction(V_coarse), V_fine)
+    f_coarse_on_fine = interpolator_coarse_to_fine.interpolate(f_coarse)
+    assert np.allclose(f_coarse_on_fine.dat.data_ro, f_fine.dat.data_ro)
+
+    # Transpose interpolation takes us from V_fine^* to V_coarse^* so we should
+    # also get an exact result here.
+    cofunction_coarse = assemble(inner(f_coarse, TestFunction(V_coarse)) * dx)
+    cofunction_fine = assemble(inner(f_fine, TestFunction(V_fine)) * dx)
+    cofunction_fine_on_coarse = interpolator_coarse_to_fine.interpolate(
+        cofunction_fine, transpose=True
+    )
+    assert np.allclose(
+        cofunction_fine_on_coarse.dat.data_ro, cofunction_coarse.dat.data_ro
+    )
+
+    # Now we test with expressions which are NOT exactly representable in the
+    # function spaces by introducing a cube term. This can't be represented
+    # with a 2nd degree polynomial basis
+    x, y = SpatialCoordinate(m_fine)
+    expr_fine = x**3 + x**2 + y**2 + 1
+    f_fine = Function(V_fine).interpolate(expr_fine)
+    x, y = SpatialCoordinate(m_coarse)
+    expr_coarse = x**3 + x**2 + y**2 + 1
+    f_coarse = Function(V_coarse).interpolate(expr_coarse)
+
+    # We still expect interpolation from V_coarse to V_fine to produce a result
+    # which is consistent with building a function in V_coarse by directly
+    # interpolating expr_coarse since V_coarse is a subset of V_fine.
+    interpolator_fine_to_coarse = Interpolator(TestFunction(V_fine), V_coarse)
+    f_fine_on_coarse = interpolator_fine_to_coarse.interpolate(f_fine)
+    assert np.allclose(f_fine_on_coarse.dat.data_ro, f_coarse.dat.data_ro)
+
+    # But transpose interpolation, which takes us from V_coarse^* to V_fine^*
+    # won't exactly reproduce the cofunction of f_coarse, since V_fine^* is a
+    # bigger space than V_coarse^*. This only worked before because we could
+    # exactly represent the expression in V_coarse.
+    cofunction_fine = assemble(inner(f_fine, TestFunction(V_fine)) * dx)
+    cofunction_coarse = assemble(inner(f_coarse, TestFunction(V_coarse)) * dx)
+    cofunction_coarse_on_fine = interpolator_fine_to_coarse.interpolate(
+        cofunction_coarse, transpose=True
+    )
+    assert not np.allclose(
+        cofunction_coarse_on_fine.dat.data_ro, cofunction_fine.dat.data_ro
+    )
+
+    # We get a similar result going in the other direction. Forward
+    # interpolation from V_coarse to V_fine similarly doesn't reproduce the
+    # effect of interpolating expr_fine directly into V_fine
+    interpolator_coarse_to_fine = Interpolator(TestFunction(V_coarse), V_fine)
+    f_course_on_fine = interpolator_coarse_to_fine.interpolate(f_coarse)
+    assert not np.allclose(f_course_on_fine.dat.data_ro, f_fine.dat.data_ro)
+
+    # But the transpose operation, which takes us from V_fine^* to
+    # V_coarse^* correctly reproduces cofunction_coarse from cofunction_fine
+    cofunction_fine_on_coarse = interpolator_coarse_to_fine.interpolate(
+        cofunction_fine, transpose=True
+    )
+    assert not np.allclose(
+        cofunction_fine_on_coarse.dat.data_ro, cofunction_coarse.dat.data_ro
+    )
+
+
+def test_interpolate_unitsquare_tfs_shape():
+    m_src = UnitSquareMesh(2, 3)
+    m_dest = UnitSquareMesh(3, 5, quadrilateral=True)
+    V_src = TensorFunctionSpace(m_src, "CG", 3, shape=(1, 2, 3))
+    V_dest = TensorFunctionSpace(m_dest, "CG", 4, shape=(1, 2, 3))
+    f_src = Function(V_src)
+    interpolate(f_src, V_dest)
+
+
+def test_interpolate_cross_mesh_not_point_eval():
+    m_src = UnitSquareMesh(2, 3)
+    m_dest = UnitSquareMesh(3, 5, quadrilateral=True)
+    coords = np.array(
+        [[0.56, 0.6], [0.1, 0.9], [0.9, 0.1], [0.9, 0.9], [0.726, 0.6584]]
+    )  # fairly arbitrary
+    # add the coordinates of the mesh vertices to test boundaries
+    vertices_src = allgather(m_src.comm, m_src.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_src))
+    vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
+    coords = np.concatenate((coords, vertices_dest))
+    expr_src = 2 * SpatialCoordinate(m_src)
+    expr_dest = 2 * SpatialCoordinate(m_dest)
+    expected = 2 * coords
+    V_src = FunctionSpace(m_src, "RT", 2)
+    V_dest = FunctionSpace(m_dest, "RTCE", 2)
+    # This might not make much mathematical sense, but it should test if we get
+    # the not implemented error for non-point evaluation nodes!
+    with pytest.raises(NotImplementedError):
+        interpolate_function(
+            m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+        )
+
+
+def get_expected_values(
+    m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+):
+    interpolate_function(
+        m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+    )
+    interpolate_expression(
+        m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+    )
+    interpolator, f_src, f_dest, m_src = interpolator_function(
+        m_src,
+        m_dest,
+        V_src,
+        V_dest,
+        coords,
+        expected,
+        expr_src,
+        expr_dest,
+    )
+    cofunction_dest = assemble(inner(f_dest, TestFunction(V_dest)) * dx)
+    interpolator_function_transpose(
+        interpolator, f_src, cofunction_dest, m_src, coords, expected
+    )
+    interpolator_expression(m_src, m_dest, V_src, V_dest, coords, expected, expr_src)
+
+
+def interpolate_function(
+    m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+):
+    f_src = Function(V_src).interpolate(expr_src)
+    f_dest = interpolate(f_src, V_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+
+    f_src = Function(V_src).interpolate(expr_src)
+    f_dest = interpolate(f_src, V_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+
+    f_dest_2 = Function(V_dest).interpolate(expr_dest)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+    # works with Function interpolate method
+    f_dest = Function(V_dest)
+    f_dest.interpolate(f_src)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+    # output argument works
+    f_dest = Function(V_dest)
+    Interpolator(f_src, V_dest).interpolate(output=f_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+
+def interpolate_expression(
+    m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+):
+    f_dest = interpolate(expr_src, V_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+    f_dest_2 = Function(V_dest).interpolate(expr_dest)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+    # output argument works for expressions
+    f_dest = Function(V_dest)
+    Interpolator(expr_src, V_dest).interpolate(output=f_dest)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+
+def interpolator_function(
+    m_src, m_dest, V_src, V_dest, coords, expected, expr_src, expr_dest
+):
+    f_src = Function(V_src).interpolate(expr_src)
+
+    interpolator = Interpolator(TestFunction(V_src), V_dest)
+    assert isinstance(interpolator, Interpolator)
+    assert isinstance(interpolator, interpolation.CrossMeshInterpolator)
+    f_dest = interpolator.interpolate(f_src)
+    assert extract_unique_domain(f_dest) is m_dest
+    got = f_dest.at(coords)
+    assert np.allclose(got, expected)
+    f_dest_2 = Function(V_dest).interpolate(expr_dest)
+    assert np.allclose(f_dest.dat.data_ro, f_dest_2.dat.data_ro)
+
+    with pytest.raises(ValueError):
+        # can't interpolate expressions using an interpolator
+        interpolator.interpolate(2 * f_src)
+    cofunction_dest = assemble(inner(f_dest, TestFunction(V_dest)) * dx)
+    with pytest.raises(ValueError):
+        interpolator.interpolate(2 * cofunction_dest, transpose=True)
+
+    return interpolator, f_src, f_dest, m_src
+
+
+def interpolator_function_transpose(
+    interpolator, f_src, cofunction_dest, m_src, coords, expected
+):
+    cofunction_dest_on_src = interpolator.interpolate(cofunction_dest, transpose=True)
+    assert extract_unique_domain(cofunction_dest_on_src) is m_src
+    # knowing exactly what to expect would require careful analysis of the
+    # behaviour of adjoint interpolation (which is nontrivial for meshes which
+    # are not exact refinements of each other!) For now I check that I don't
+    # get f_src or its equivalent cofunction back!
+    assert not np.allclose(cofunction_dest_on_src.dat.data_ro, f_src.dat.data_ro)
+    V_src = f_src.function_space()
+    cofunction_src = assemble(inner(f_src, TestFunction(V_src)) * dx)
+    assert not np.allclose(
+        cofunction_dest_on_src.dat.data_ro, cofunction_src.dat.data_ro
+    )
+
+
+def interpolator_expression(m_src, m_dest, V_src, V_dest, coords, expected, expr_src):
+    f_src = Function(V_src).interpolate(expr_src)
+
+    with pytest.raises(NotImplementedError):
+        interpolator = Interpolator(2 * TestFunction(V_src), V_dest)
+        f_dest = interpolator.interpolate(f_src)
+        assert extract_unique_domain(f_dest) is m_dest
+        got = f_dest.at(coords)
+        assert np.allclose(got, 2 * expected)
+        cofunction_dest = assemble(inner(f_dest, TestFunction(V_dest)) * dx)
+        cofunction_dest_on_src = interpolator.interpolate(
+            cofunction_dest, transpose=True
+        )
+        assert extract_unique_domain(cofunction_dest_on_src) is m_src
+        assert not np.allclose(f_src.dat.data_ro, cofunction_dest_on_src.dat.data_ro)
+        cofunction_src = assemble(inner(f_src, TestFunction(V_src)) * dx)
+        assert not np.allclose(
+            cofunction_dest_on_src.dat.data_ro, cofunction_src.dat.data_ro
+        )
+
+
+def test_missing_dofs():
+    m_src = UnitSquareMesh(2, 3)
+    m_dest = UnitSquareMesh(4, 5)
+    m_dest.coordinates.dat.data[:] *= 2
+    coords = np.array([[0.5, 0.5], [1.5, 1.5]])
+    x, y = SpatialCoordinate(m_src)
+    expr = x * y
+    V_src = FunctionSpace(m_src, "CG", 2)
+    V_dest = FunctionSpace(m_dest, "CG", 3)
+    with pytest.raises(DofNotDefinedError):
+        Interpolator(TestFunction(V_src), V_dest)
+    interpolator = Interpolator(TestFunction(V_src), V_dest, allow_missing_dofs=True)
+    f_src = Function(V_src).interpolate(expr)
+    f_dest = interpolator.interpolate(f_src)
+    # default value is zero
+    assert np.allclose(f_dest.at(coords), np.array([0.25, 0.0]))
+    f_dest = Function(V_dest).assign(Constant(1.0))
+    # make sure we have actually changed f_dest before checking interpolation
+    assert np.allclose(f_dest.at(coords), np.array([1.0, 1.0]))
+    interpolator.interpolate(f_src, output=f_dest)
+    # assigned value hasn't been changed
+    assert np.allclose(f_dest.at(coords), np.array([0.25, 1.0]))
+    f_dest = interpolator.interpolate(f_src, default_missing_val=2.0)
+    # should take on the default value
+    assert np.allclose(f_dest.at(coords), np.array([0.25, 2.0]))
+    f_dest = Function(V_dest).assign(Constant(1.0))
+    # make sure we have actually changed f_dest before checking interpolation
+    assert np.allclose(f_dest.at(coords), np.array([1.0, 1.0]))
+    interpolator.interpolate(f_src, default_missing_val=2.0, output=f_dest)
+    assert np.allclose(f_dest.at(coords), np.array([0.25, 2.0]))
+
+    # Try the other way around so we can check transpose is unaffected
+    m_src = UnitSquareMesh(4, 5)
+    m_src.coordinates.dat.data[:] *= 2
+    m_dest = UnitSquareMesh(2, 3)
+    coords = np.array([[0.5, 0.5], [1.5, 1.5]])
+    x, y = SpatialCoordinate(m_src)
+    expr = x * y
+    V_src = FunctionSpace(m_src, "CG", 3)
+    V_dest = FunctionSpace(m_dest, "CG", 2)
+    interpolator = Interpolator(TestFunction(V_src), V_dest, allow_missing_dofs=True)
+    cofunction_src = assemble(inner(Function(V_dest), TestFunction(V_dest)) * dx)
+    cofunction_src.dat.data_wo[:] = 1.0
+    cofunction_dest = interpolator.interpolate(
+        cofunction_src, transpose=True, default_missing_val=2.0
+    )
+    assert np.all(cofunction_dest.dat.data_ro != 2.0)
+
+
+def test_line_integral():
+    # start with a simple field exactly represented in the function space
+    m = UnitSquareMesh(2, 2)
+    V = FunctionSpace(m, "CG", 2)
+    x, y = SpatialCoordinate(m)
+    f = Function(V).interpolate(x * y)
+
+    # Create a 1D line mesh in 2D from (0, 0) to (1, 1) with 1 cell
+    cells = np.asarray([[0, 1]])
+    vertex_coords = np.asarray([[0.0, 0.0], [1.0, 1.0]])
+    plex = mesh.plex_from_cell_list(1, cells, vertex_coords, comm=m.comm)
+    line = mesh.Mesh(plex, dim=2)
+    x, y = SpatialCoordinate(line)
+    V_line = FunctionSpace(line, "CG", 2)
+    f_line = Function(V_line).interpolate(x * y)
+    assert np.isclose(assemble(f_line * dx), np.sqrt(2) / 3)  # for sanity
+
+    # Create a 1D line around the unit square (2D) with 4 cells
+    cells = np.asarray([[0, 1], [1, 2], [2, 3], [3, 0]])
+    vertex_coords = np.asarray([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    plex = mesh.plex_from_cell_list(1, cells, vertex_coords, comm=m.comm)
+    line_square = mesh.Mesh(plex, dim=2)
+    x, y = SpatialCoordinate(line_square)
+    V_line_square = FunctionSpace(line_square, "CG", 2)
+    f_line_square = Function(V_line_square).interpolate(x * y)
+    assert np.isclose(assemble(f_line_square * dx), 1.0)  # for sanity
+
+    # See if interpolating onto the lines from a bigger domain gives us the
+    # same answer
+    f_line.zero()
+    assert np.isclose(assemble(f_line * dx), 0)  # sanity again
+    f_line.interpolate(f)
+    assert np.isclose(assemble(f_line * dx), np.sqrt(2) / 3)
+    f_line_square.zero()
+    assert np.isclose(assemble(f_line_square * dx), 0)
+    f_line_square.interpolate(f)
+    assert np.isclose(assemble(f_line_square * dx), 1.0)
+
+
+@pytest.mark.parallel
+def test_interpolate_cross_mesh_parallel(parameters):
+    test_interpolate_cross_mesh(parameters)
+
+
+@pytest.mark.parallel
+def test_interpolate_unitsquare_mixed_parallel():
+    test_interpolate_unitsquare_mixed()
+
+
+@pytest.mark.parallel
+def test_missing_dofs_parallel():
+    test_missing_dofs()
+
+
+@pytest.mark.parallel
+def test_exact_refinement_parallel():
+    test_exact_refinement()

--- a/tests/regression/test_interpolation_manual.py
+++ b/tests/regression/test_interpolation_manual.py
@@ -1,0 +1,129 @@
+from firedrake import *
+import pytest
+import numpy as np
+
+# Ensure that the code shown in the manual runs without error. If you change
+# the code here make sure you update the .. literalinclude:: bits in the manual
+# too!
+
+
+def test_line_integral():
+    # Start with a simple field exactly represented in the function space over
+    # the unit square domain.
+    m = UnitSquareMesh(2, 2)
+    V = FunctionSpace(m, "CG", 2)
+    x, y = SpatialCoordinate(m)
+    f = Function(V).interpolate(x * y)
+
+    # We create a 1D mesh immersed 2D from (0, 0) to (1, 1) which we call "line".
+    # Note that it only has 1 cell
+    cells = np.asarray([[0, 1]])
+    vertex_coords = np.asarray([[0.0, 0.0], [1.0, 1.0]])
+    plex = mesh.plex_from_cell_list(1, cells, vertex_coords, comm=m.comm)
+    line = mesh.Mesh(plex, dim=2)
+    x, y = SpatialCoordinate(line)
+    V_line = FunctionSpace(line, "CG", 2)
+    f_line = Function(V_line).interpolate(x * y)
+    assert np.isclose(assemble(f_line * dx), np.sqrt(2) / 3)  # for sanity
+    f_line.zero()
+    assert np.isclose(assemble(f_line * dx), 0)  # sanity again
+
+    # We want to calculate the line integral of f along it. To do this we
+    # create a function space on the line mesh...
+    V_line = FunctionSpace(line, "CG", 2)
+
+    # ... and interpolate our function f onto it.
+    f_line = interpolate(f, V_line)
+
+    # The integral of f along the line is then a simple form expression which
+    # we assemble:
+    assemble(f_line * dx)  # this outputs sqrt(2) / 3
+    assert np.isclose(assemble(f_line * dx), np.sqrt(2) / 3)
+
+
+def test_cross_mesh():
+    def correct_indent():
+        # These meshes only share some of their domain
+        src_mesh = UnitSquareMesh(2, 2)
+        dest_mesh = UnitSquareMesh(3, 3, quadrilateral=True)
+        dest_mesh.coordinates.dat.data_wo[:] *= 2
+
+        # We consider a simple function on our source mesh...
+        x_src, y_src = SpatialCoordinate(src_mesh)
+        V_src = FunctionSpace(src_mesh, "CG", 2)
+        f_src = Function(V_src).interpolate(x_src**2 + y_src**2)
+
+        # ... and want to interpolate into a function space on our target mesh ...
+        V_dest = FunctionSpace(dest_mesh, "Q", 2)
+
+        return src_mesh, dest_mesh, f_src, V_dest
+
+    src_mesh, dest_mesh, f_src, V_dest = correct_indent()
+
+    with pytest.raises(DofNotDefinedError):
+        # ... but get a DofNotDefinedError if we try
+        f_dest = interpolate(f_src, V_dest)  # raises DofNotDefinedError
+
+    with pytest.raises(DofNotDefinedError):
+        # as will the interpolate method of a Function
+        f_dest = Function(V_dest).interpolate(f_src)
+
+    # Setting the allow_missing_dofs keyword allows the interpolation to proceed.
+    f_dest = interpolate(f_src, V_dest, allow_missing_dofs=True)
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 0.5)
+
+    # or
+    f_dest = Function(V_dest).interpolate(f_src, allow_missing_dofs=True)
+
+    # We get values at the points in the destination mesh as we would expect
+    f_dest.at(0.5, 0.5)  # returns 0.5**2 + 0.5**2 = 0.5
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 0.5)
+
+    # By default the missing points are set to 0.0
+    f_dest.at(1.5, 1.5)  # returns 0.0
+
+    assert np.isclose(f_dest.at(1.5, 1.5), 0.0)
+
+    # We can alternatively specify a value to use for missing points:
+    f_dest = interpolate(
+        f_src, V_dest, allow_missing_dofs=True, default_missing_val=np.nan
+    )
+    f_dest.at(1.5, 1.5)  # returns np.nan
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 0.5)
+    assert np.isnan(f_dest.at(1.5, 1.5))
+
+    # When creating interpolators, the allow_missing_dofs keyword argument is
+    # set when creating the interpolator, rather than when calling interpoalate.
+    interpolator = Interpolator(f_src, V_dest, allow_missing_dofs=True)
+
+    # A default missing value can be specified when calling interpolate.
+    f_dest = interpolator.interpolate(default_missing_val=np.nan)
+
+    # If we supply an output function and don't set default_missing_val
+    # then any points outside the domain are left as they were.
+    x_dest, y_dest = SpatialCoordinate(dest_mesh)
+    f_dest = Function(V_dest).interpolate(x_dest + y_dest)
+    f_dest.at(0.5, 0.5)  # returns x_dest + y_dest = 1.0
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 1.0)
+
+    interpolator.interpolate(output=f_dest)
+    f_dest.at(0.5, 0.5)  # now returns x_src^2 + y_src^2 = 0.5
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 0.5)
+
+    f_dest.at(1.5, 1.5)  # still returns x_dest + y_dest = 3.0
+
+    f_dest.zero()
+    f_dest.interpolate(x_dest + y_dest)
+    assert np.isclose(f_dest.at(0.5, 0.5), 1.0)  # x_dest + y_dest = 1.0
+
+    # Similarly, using the interpolate method on a function will not overwrite
+    # the pre-existing values if default_missing_val is not set
+    f_dest.interpolate(f_src, allow_missing_dofs=True)
+
+    assert np.isclose(f_dest.at(0.5, 0.5), 0.5)  # x_src^2 + y_src^2 = 0.5
+    assert np.isclose(f_dest.at(1.5, 1.5), 3.0)  # x_dest + y_dest = 3.0

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -113,6 +113,15 @@ def functionspace_tests(vm):
     idxs_to_include = input_ordering_parent_cell_nums != -1
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == -1)
+    # check other interpolation APIs work identically
+    h2 = interpolate(g, W)
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
+    I = Interpolator(g, W)
+    h2 = I.interpolate()
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
+    h2.zero()
+    I.interpolate(output=h2)
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
     # check we can interpolate expressions
     h2 = Function(W)
     h2.interpolate(2*g*Constant(1, domain=vm))
@@ -203,6 +212,15 @@ def vectorfunctionspace_tests(vm):
     idxs_to_include = input_ordering_parent_cell_nums != -1
     assert np.allclose(h.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == -1)
+    # check other interpolation APIs work identically
+    h2 = interpolate(g, W)
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
+    I = Interpolator(g, W)
+    h2 = I.interpolate()
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
+    h2.zero()
+    I.interpolate(output=h2)
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
     # check we can interpolate expressions
     h2 = Function(W)
     h2.interpolate(2*g*Constant(1, domain=vm))

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -51,8 +51,8 @@ def test_vom_manual_points_outside_domain():
         points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
 
     vom = True  # avoid flake8 unused variable warning
-    with pytest.raises(ValueError):
-        # This will raise a ValueError
+    with pytest.raises(VertexOnlyMeshMissingPointsError):
+        # This will raise a VertexOnlyMeshMissingPointsError
         vom = VertexOnlyMesh(parent_mesh, points, missing_points_behaviour='error')
 
     def display_correct_indent():

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -345,14 +345,17 @@ def test_missing_points_behaviour(parentmesh):
     vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour=None)
     assert vm.cell_set.size == 0
     # Error by default
-    with pytest.raises(ValueError):
+    with pytest.raises(VertexOnlyMeshMissingPointsError):
         vm = VertexOnlyMesh(parentmesh, inputcoord)
     # Error or warning if specified
-    with pytest.raises(ValueError):
+    with pytest.raises(VertexOnlyMeshMissingPointsError):
         vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour='error')
     with pytest.warns(UserWarning):
         vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour='warn')
         assert vm.cell_set.size == 0
+    with pytest.raises(ValueError) as e:
+        vm = VertexOnlyMesh(parentmesh, inputcoord, missing_points_behaviour='hello')
+    assert "\'hello\'" in str(e.value)
 
 
 def test_outside_boundary_behaviour(parentmesh):


### PR DESCRIPTION
# Description
This implements cross-mesh interpolation for interpolating into function spaces which have point evaluation nodes. This is an attempt to integrate [this gist](https://gist.github.com/ReubenHill/15cb3e7fd16255f966a2cbae80250e24) into Firedrake and makes use of the recent merging of #2936.

We use `VertexOnlyMesh` as an intermediary for the global locations of the point evaluation nodes of the target function space:
 1. We get the point evaluation node locations using the method described in the [interpolation from external data section of the manual](https://www.firedrakeproject.org/interpolation.html#interpolation-from-external-data). **This will have the parallel domain decomposition of the target mesh**.
 2. Next we create a `VertexOnlyMesh` (A) at those locations **within the source mesh** such that we inherit the source mesh's parallel domain decomposition.
 3.  We interpolate our expression in our source function space onto a `P0DG` function space on `VertexOnlyMesh` (A), which has the effect of point evaluating at the target function space node locations.
 4. This `VertexOnlyMesh` (A) has an `input_ordering` `VertexOnlyMesh` (B) whose vertices have the ordering and parallel domain decomposition of the target function space global node locations. We interpolate from `P0DG` on (A) onto `P0DG` on (B). Under the hood, this is an SF reduce operation which moves the point evaluations from (A) to (B).
 5. We now have a `Function` on the `input_ordering` `VertexOnlyMesh` (B) which has point evaluations from our source mesh function space at the target mesh function space node locations. These are in the correct order and have the correct domain decomposition. We can therefore safely set the `dat` of a function in our target function space to the values of this function.

For this to work for the general case, we would need to create a `VertexOnlyMesh` at the global quadrature points of the target function space, which is rather more complicated than the work I've done here.

Some important notes:
 - This does not require one mesh to be a structured refinement of the other. This, for example, should allow you to solve a PDE on two different unstructured meshes, one of which is finer than the other, and directly check the difference in solutions by interpolating from one mesh to the other within Firedrake.
 - The target mesh merely needs to share _some_ of its domain with the source mesh and we should get the results we expect (see to do note below).
 - Crucially, this is entirely parallel compatible!

Other notes:
 - The `VertexOnlyMesh` required is stored in the `Interpolator`, as are the underlying `Interpolator`s
 - For interpolation between mixed spaces, I create `sub_interpolators` for each space and evaluate them as necessary when calling `interpolate`
   - Interpolation into a mixed space therefore requires the function space being interpolated from to be another mixed space. I throw a `NotImplementedError` if not.

To do:
- [x] Test with more meshes
  - [x] ~This ought to work with meshes of different geometric dimensions as long as the target mesh is fully within the source mesh. I should check this, because this would be really cool!~ You need the geometric dimensions to match or you would need to manually specify where the lower dimensional mesh was within the higher dimensional one! This is the whole point of immersed meshes and there's no reason why an immersed mesh wouldn't work as expected methinks.
  - [x] Check that meshes with different domains work as expected.
    - [x] ~Decide whether to optionally allow interpolation into a mesh with extent beyond the target mesh - I think this is possible with how I've implemented `VertexOnlyMesh`'s `input_ordering` property, so long as I switch off giving an error when not all the points are found, and would result in a `Function` with some values that are unchanged by the interpolation operation.~ Implemented!
- [x] Work out how to ensure we only try to interpolate into point evaluation function spaces
- [x] ~Test the adjoint - since this uses pure Firedrake, I think it ought to work fine. But perhaps setting the dat values will cause an issue?~ EDIT: Testing adjoint looks to be too tricky
- [x] Implement tests for exact interpolation and transpose interpolation by using meshes which are refinements of each other
- [ ] Document in the manual

## Associated Pull Requests:
None

## Fixes Issues:
None, this is a new feature.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [x] Upstream/dependent branches and PRs are ready
