### PR TITLE
VertexOnlyMesh in immersed manifold and cross mesh interpolation from immersed manifold

### DIFF
--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -161,8 +161,8 @@ Interpolating onto other meshes
 
 .. note::
 
-   Interpolation *from* :ref:`immersed manifolds <immersed_manifolds>` and
-   :ref:`high-order meshes <changing_coordinate_fs>` is currently not supported.
+   Interpolation *from* :ref:`high-order meshes <changing_coordinate_fs>` is
+   currently not supported.
 
 If the target mesh extends outside the source mesh domain, then cross-mesh
 interpolation will raise a :py:class:`~.DofNotDefinedError`.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -305,9 +305,7 @@ class CrossMeshInterpolator(Interpolator):
                 "Can only interpolate into spaces with point evaluation nodes."
             )
 
-        super().__init__(
-            expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs
-        )
+        super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs)
 
         self.arguments = extract_arguments(expr)
         self.nargs = len(self.arguments)
@@ -341,12 +339,6 @@ class CrossMeshInterpolator(Interpolator):
             # for this to work.
             raise NotImplementedError(
                 "Cannot yet interpolate from high order meshes to other meshes."
-            )
-        if src_mesh_gdim != src_mesh.topological_dimension():
-            # Need to implement vertex-only mesh immersion in immersed manifold
-            # meshes for this to work.
-            raise NotImplementedError(
-                "Cannot yet interpolate from immersed manifold meshes."
             )
 
         self.sub_interpolators = []

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3733,7 +3733,7 @@ def _parent_mesh_embedding(
     # particular coordinate, we break the tie by choosing the lowest rank.
     # This turns out to be a lexicographic row-wise minimum of the
     # ref_cell_dists_l1_and_ranks array: we minimise the distance first and
-    # break ties by minimising the distance.
+    # break ties by choosing the lowest rank.
     owned_ref_cell_dists_l1_and_ranks = parent_mesh.comm.allreduce(
         ref_cell_dists_l1_and_ranks, op=array_lexicographic_mpi_op
     )

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1826,6 +1826,11 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         return sf
 
 
+class CellOrientationsRuntimeError(RuntimeError):
+    """Exception raised when there are problems with cell orientations."""
+    pass
+
+
 class MeshGeometryCargo:
     """Helper class carrying data for a :class:`MeshGeometry`.
 
@@ -2310,7 +2315,7 @@ values from f.)"""
         # Storing `_cell_orientations` in `MeshTopology` would make the `MeshTopology`
         # object only useful for specific definition of "cell normals".
         if not hasattr(self, '_cell_orientations'):
-            raise RuntimeError("No cell orientations found, did you forget to call init_cell_orientations?")
+            raise CellOrientationsRuntimeError("No cell orientations found, did you forget to call init_cell_orientations?")
         return self._cell_orientations
 
     @PETSc.Log.EventDecorator()
@@ -2328,7 +2333,7 @@ values from f.)"""
             raise NotImplementedError('Only implemented for intervals embedded in 2d and triangles and quadrilaterals embedded in 3d')
 
         if hasattr(self, '_cell_orientations'):
-            raise RuntimeError("init_cell_orientations already called, did you mean to do so again?")
+            raise CellOrientationsRuntimeError("init_cell_orientations already called, did you mean to do so again?")
 
         if not isinstance(expr, ufl.classes.Expr):
             raise TypeError("UFL expression expected!")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -502,7 +502,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
 
-    def __init__(self, name, tolerance=1.0):
+    def __init__(self, name, tolerance=0.5):
         """Initialise an abstract mesh topology.
 
         :arg name: name of the mesh
@@ -866,7 +866,7 @@ class MeshTopology(AbstractMeshTopology):
     """A representation of mesh topology implemented on a PETSc DMPlex."""
 
     @PETSc.Log.EventDecorator("CreateMesh")
-    def __init__(self, plex, name, reorder, distribution_parameters, sfXB=None, perm_is=None, distribution_name=None, permutation_name=None, comm=COMM_WORLD, tolerance=1.0):
+    def __init__(self, plex, name, reorder, distribution_parameters, sfXB=None, perm_is=None, distribution_name=None, permutation_name=None, comm=COMM_WORLD, tolerance=0.5):
         """Half-initialise a mesh topology.
 
         :arg plex: PETSc DMPlex representing the mesh topology
@@ -1308,7 +1308,7 @@ class ExtrudedMeshTopology(MeshTopology):
     """Representation of an extruded mesh topology."""
 
     @PETSc.Log.EventDecorator()
-    def __init__(self, mesh, layers, periodic=False, name=None, tolerance=1.0):
+    def __init__(self, mesh, layers, periodic=False, name=None, tolerance=0.5):
         """Build an extruded mesh topology from an input mesh topology
 
         :arg mesh:           the unstructured base mesh topology
@@ -1528,7 +1528,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
     """
 
     @PETSc.Log.EventDecorator()
-    def __init__(self, swarm, parentmesh, name, reorder, use_cell_dm_marking, tolerance=1.0):
+    def __init__(self, swarm, parentmesh, name, reorder, use_cell_dm_marking, tolerance=0.5):
         """
         Half-initialise a mesh topology.
 
@@ -2473,7 +2473,7 @@ def Mesh(meshfile, **kwargs):
 
     :param tolerance: The relative tolerance (i.e. as defined on the reference
            cell) for the distance a point can be from a cell and still be
-           considered to be in the cell. Defaults to 1.0. Increase
+           considered to be in the cell. Defaults to 0.5. Increase
            this if point at mesh boundaries (either rank local or global) are
            reported as being outside the mesh, for example when creating a
            :class:`VertexOnlyMesh`. Note that this tolerance uses an L1
@@ -2525,7 +2525,7 @@ def Mesh(meshfile, **kwargs):
     if coordinates is not None:
         return make_mesh_from_coordinates(coordinates, name)
 
-    tolerance = kwargs.get("tolerance", 1.0)
+    tolerance = kwargs.get("tolerance", 0.5)
 
     utils._init()
 
@@ -2599,7 +2599,7 @@ def Mesh(meshfile, **kwargs):
 
 
 @PETSc.Log.EventDecorator("CreateExtMesh")
-def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', periodic=False, kernel=None, gdim=None, name=None, tolerance=1.0):
+def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', periodic=False, kernel=None, gdim=None, name=None, tolerance=0.5):
     """Build an extruded mesh from an input mesh
 
     :arg mesh:           the unstructured base mesh

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2812,8 +2812,8 @@ def VertexOnlyMesh(mesh, vertexcoords, missing_points_behaviour='error',
 
     .. note::
 
-        Manifold meshes and extruded meshes with variable extrusion layers are
-        not yet supported. See note below about ``VertexOnlyMesh`` as input.
+        Extruded meshes with variable extrusion layers are not yet supported.
+        See note below about ``VertexOnlyMesh`` as input.
 
     .. note::
         When running in parallel with ``redundant = False``, ``vertexcoords``

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -94,9 +94,6 @@ def parameters(request):
         # only add target mesh vertices since they are common to both meshes
         vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
         coords = np.concatenate((coords, vertices_dest))
-        # function.at often gets conflicting answers across boundaries for this
-        # mesh, so we lower the tolerance a bit for this test
-        m_dest.tolerance = 0.5
         expr_src = reduce(mul, SpatialCoordinate(m_src))
         expr_dest = reduce(mul, SpatialCoordinate(m_dest))
         expected = reduce(mul, coords.T)
@@ -122,9 +119,6 @@ def parameters(request):
         # only add target mesh vertices since they are common to both meshes
         vertices_dest = allgather(m_dest.comm, m_dest.coordinates.dat.data_ro)
         coords = np.concatenate((coords, vertices_dest))
-        # function.at often gets conflicting answers across boundaries for this
-        # mesh, so we lower the tolerance a bit for this test
-        m_dest.tolerance = 0.5
         expr_src = reduce(mul, SpatialCoordinate(m_src))
         expr_dest = reduce(mul, SpatialCoordinate(m_dest))
         expected = reduce(mul, coords.T)

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -225,6 +225,9 @@ def parameters(request):
         # We don't add source and target mesh vertices since no amount of mesh
         # tolerance loading allows .at to avoid getting different results on different
         # processes for this mesh pair.
+        # Function.at often gets conflicting answers across boundaries for this
+        # mesh, so we lower the tolerance a bit for this test
+        m_dest.tolerance = 0.1
         # We use add to avoid TSFC complaints about too many indices for sum
         # factorisation when interpolating expressions of SpatialCoordinates(m_src)
         # into V_dest

--- a/tests/vertexonly/test_point_eval_immersed_manifold.py
+++ b/tests/vertexonly/test_point_eval_immersed_manifold.py
@@ -10,14 +10,12 @@ def at(function, point):
 def vertex_only_mesh(function, point):
     vom = VertexOnlyMesh(function.function_space().mesh(), point)
     vom_fs = VectorFunctionSpace(vom, "DG", 0)
-    return interpolate(function, vom_fs).dat.data_ro[0, :]
+    return interpolate(function, vom_fs).dat.data_ro
 
 
 @pytest.mark.parametrize("point_eval", [
     at,
-    pytest.param(vertex_only_mesh, marks=pytest.mark.xfail(
-        reason="Immersed manifold VertexOnlyMesh not implemented."
-    ))
+    vertex_only_mesh,
 ])
 def test_convergence_rate(point_eval):
     """Check points on immersed manifold projects to the correct point

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -116,10 +116,6 @@ def parentmesh(request):
     elif request.param == "immersedsphere":
         m = UnitIcosahedralSphereMesh()
         m.init_cell_orientations(SpatialCoordinate(m))
-        # This mesh is so coarse that we need to reduce the tolerance to get
-        # locate cell to give us the correct answer (the check for all unique
-        # parentcellnum will fail otherwise)
-        m.tolerance = 0.5
         return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -95,7 +95,7 @@ def point_ownership(m, points, localpoints):
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
-                        pytest.param("immersedsphere", marks=pytest.mark.skip(reason="immersed parent meshes not supported and will segfault PETSc when creating the DMSwarm")),
+                        "immersedsphere",
                         "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
@@ -357,6 +357,7 @@ def test_pic_swarm_in_mesh(parentmesh, redundant, exclude_halos):
     # Now have DMPLex compute the cell IDs in cases where it can:
     if (
         parentmesh.coordinates.ufl_element().family() != "Discontinuous Lagrange"
+        and parentmesh.geometric_dimension() == parentmesh.topological_dimension()
         and not parentmesh.extruded
         and not parentmesh.coordinates.dat.dat_version > 0  # shifted mesh
     ):

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -13,7 +13,7 @@ from mpi4py import MPI
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
-                        pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
+                        "immersedsphere",
                         "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
@@ -32,7 +32,9 @@ def parentmesh(request):
     elif request.param == "tetrahedron":
         return UnitTetrahedronMesh()
     elif request.param == "immersedsphere":
-        return UnitIcosahedralSphereMesh()
+        m = UnitIcosahedralSphereMesh(refinement_level=2, name='immersedsphere')
+        m.init_cell_orientations(SpatialCoordinate(m))
+        return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":

--- a/tests/vertexonly/test_vertex_only_manual.py
+++ b/tests/vertexonly/test_vertex_only_manual.py
@@ -94,7 +94,7 @@ def test_mesh_tolerance():
     # point (1.1, 1.0) is outside the mesh
     points = [[0.1, 0.1], [0.2, 0.2], [1.1, 1.0]]
 
-    # This prints 1.0 - points can be up to around 1 mesh cell width away from
+    # This prints 0.5 - points can be up to around half a mesh cell width away from
     # the edge of the mesh and still be considered inside the domain.
     print(parent_mesh.tolerance)
 

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -63,9 +63,6 @@ def parentmesh(request):
     elif request.param == "immersedsphere":
         m = UnitIcosahedralSphereMesh()
         m.init_cell_orientations(SpatialCoordinate(m))
-        # This mesh is so coarse that we need to reduce the tolerance to get
-        # locate cell to give us the correct answer
-        m.tolerance = 0.5
         return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
@@ -315,7 +312,7 @@ def test_redistribution():
 def test_point_tolerance():
     """Test the tolerance parameter of VertexOnlyMesh."""
     m = UnitSquareMesh(1, 1)
-    assert m.tolerance == 1.0
+    assert m.tolerance == 0.5
     assert m.tolerance == m.topology.tolerance
     # Make the mesh non-axis-aligned.
     m.coordinates.dat.data[1, :] = [1.1, 1]

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -42,7 +42,7 @@ def cell_midpoints(m):
                         pytest.param("extrudedvariablelayers", marks=pytest.mark.skip(reason="Extruded meshes with variable layers not supported and will hang when created in parallel")),
                         "cube",
                         "tetrahedron",
-                        pytest.param("immersedsphere", marks=pytest.mark.xfail(reason="immersed parent meshes not supported")),
+                        "immersedsphere",
                         "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -61,7 +61,12 @@ def parentmesh(request):
     elif request.param == "tetrahedron":
         return UnitTetrahedronMesh()
     elif request.param == "immersedsphere":
-        return UnitIcosahedralSphereMesh()
+        m = UnitIcosahedralSphereMesh()
+        m.init_cell_orientations(SpatialCoordinate(m))
+        # This mesh is so coarse that we need to reduce the tolerance to get
+        # locate cell to give us the correct answer
+        m.tolerance = 0.5
+        return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)
     elif request.param == "shiftedmesh":


### PR DESCRIPTION
# Description
Support VertexOnlyMesh on immersed manifolds. Allows cross-mesh interpolation from immersed manifolds.

Todo:
 - [x] Work out why, in parallel, we are getting the `RuntimeError: Some points have been claimed by a cell that we cannot see, but which we think we own. This should not happen.` vertex-only mesh error when interpolating between meshes in parallel using sphere-to-sphere

## Associated Pull Requests:
 - https://github.com/firedrakeproject/fiat/pull/44

## Fixes Issues:
None raised

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [x] I have included and updated any relevant documentation.
- [x] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

