### PR TITLE
Function.assign adjoint bugfix

### DIFF
--- a/firedrake/adjoint_utils/checkpointing.py
+++ b/firedrake/adjoint_utils/checkpointing.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import atexit
 from abc import ABC, abstractmethod
+from numbers import Number
 _stop_disk_checkpointing = 1
 _checkpoint_init_data = False
 
@@ -322,6 +323,10 @@ class DelegatedFunctionCheckpoint(CheckpointBase):
 
     def restore(self):
         saved_output = self.other.saved_output
-        return type(saved_output)(saved_output.function_space(),
-                                  saved_output.dat,
-                                  count=self.count)
+        if isinstance(saved_output, Number):
+            # Happens if the user calls the ReducedFunctional on a number.
+            return saved_output
+        else:
+            return type(saved_output)(saved_output.function_space(),
+                                      saved_output.dat,
+                                      count=self.count)

--- a/firedrake/adjoint_utils/checkpointing.py
+++ b/firedrake/adjoint_utils/checkpointing.py
@@ -317,6 +317,11 @@ class DelegatedFunctionCheckpoint(CheckpointBase):
     """
     def __init__(self, other):
         self.other = other
+        # Obtain a unique identity for this saved output.
+        self.count = type(other.output)(other.output.function_space()).count()
 
     def restore(self):
-        return self.other.saved_output
+        saved_output = self.other.saved_output
+        return type(saved_output)(saved_output.function_space(),
+                                  saved_output.dat,
+                                  count=self.count)

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -123,7 +123,7 @@ class FunctionMixin(FloatingType):
 
                 if isinstance(other, type(self)):
                     if self.function_space().mesh() == other.function_space().mesh():
-                        block_var._checkpoint = DelegatedFunctionCheckpoint(other.copy(deepcopy=True).block_variable)
+                        block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
 
             return ret
 

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -123,7 +123,7 @@ class FunctionMixin(FloatingType):
 
                 if isinstance(other, type(self)):
                     if self.function_space().mesh() == other.function_space().mesh():
-                        block_var._checkpoint = DelegatedFunctionCheckpoint(other.block_variable)
+                        block_var._checkpoint = DelegatedFunctionCheckpoint(other.copy(deepcopy=True).block_variable)
 
             return ret
 

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -701,3 +701,19 @@ def test_consecutive_nonlinear_solves():
     rf = ReducedFunctional(J, Control(uic))
     h = Constant(0.01, domain=mesh)
     assert taylor_test(rf, uic, h) > 1.9
+
+
+@pytest.mark.skipcomplex
+def test_assign_function():
+    from firedrake.adjoint import ReducedFunctional, Control, taylor_test
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+    uic = Function(V, name="uic").assign(1.0)
+    u0 = Function(V, name="u0")
+    u1 = Function(V, name="u1")
+    u0.assign(uic)
+    u1.assign(2 * u0 + uic)
+    J = assemble(((u1 + Constant(1.0)) ** 2) * dx)
+    rf = ReducedFunctional(J, Control(uic))
+    h = Function(V, name="h").assign(0.01)
+    assert taylor_test(rf, uic, h) > 1.9


### PR DESCRIPTION
# Description

The pattern
```
u0.assign(uic)
u1.assign(2 * u0 + uic)
```
with all variables `Function`s leads to an inconsistent adjoint calculation. The first assignment leads to the `checkpoint` property for `u0` being set to `uic`, which means that the adjoint sees the expression `2 * uic + uic` in the second assignment. 

The PR fixes this by copying `uic` when setting `u0.block_variable._checkpoint`.

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] ~All of my functions and classes have appropriate docstrings.~
- [ ] ~I have commented my code where its purpose may be unclear.~
- [ ] ~I have included and updated any relevant documentation.~
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [ ] ~I have added tests that exercise the new functionality I have introduced~
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [x] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
