### PR TITLE
Make subclasses of Constant use the same numbering

### DIFF
--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -94,7 +94,7 @@ class Constant(ufl.constantvalue.ConstantValue, ConstantMixin, TSFCConstantMixin
         self.name = name or 'constant_%d' % self.uid
 
         super().__init__()
-        Counted.__init__(self, count)
+        Counted.__init__(self, count, Counted)
 
     def __repr__(self):
         return f"Constant({self.dat.data_ro}, {self.count()})"

--- a/tests/regression/test_constant.py
+++ b/tests/regression/test_constant.py
@@ -184,3 +184,15 @@ def test_constants_are_renumbered_in_form_signature():
 
     assert c.count() != d.count()
     assert (c*dx(domain=mesh)).signature() == (d*dx(domain=mesh)).signature()
+
+
+def test_constant_subclasses_are_correctly_numbered():
+    class CustomConstant(Constant):
+        pass
+
+    const1 = CustomConstant(1.0)
+    const2 = Constant(1.0)
+    const3 = CustomConstant(1.0)
+
+    assert const2.count() == const1.count() + 1
+    assert const3.count() == const1.count() + 2


### PR DESCRIPTION
```py
from firedrake import *

mesh = UnitIntervalMesh(1.0)


class CustomConstant(Constant):
    pass


e = CustomConstant(2.0) / Constant(1.0)
v = assemble(e * dx(mesh))
print(f"{v=}")
```

Fixes an obscure error where running this program a second time (with a populated cache) would produce `0.5` instead of `2`.

I don't know precisely where this error was occurring but the issue will have been coming from the fact that previously both the `CustomConstant` and the `Constant` will have had the same number. This fixes that.

Thanks @jrmaddison for finding this.