### PR TITLE
Make pytorch optional when building docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = FIREDRAKE_BUILDING_DOCS=1 sphinx-build
 PAPER         =
 BUILDDIR      = build
 

--- a/firedrake/ml/pytorch.py
+++ b/firedrake/ml/pytorch.py
@@ -1,7 +1,19 @@
+import os
 try:
     import torch
 except ImportError:
-    raise ImportError("PyTorch is not installed and is required to use the FiredrakeTorchOperator.")
+    if "FIREDRAKE_BUILDING_DOCS" in os.environ:
+        # If building docs and pytorch is not installed, produce a mock
+        # torch.autograd.Function class with the correct `__module__`
+        # attribute. This is sufficient for the intersphinx reference to
+        # resolve.
+        from types import SimpleNamespace, new_class
+        torch = SimpleNamespace()
+        torch.autograd = SimpleNamespace()
+        torch.autograd.Function = new_class("Function")
+        torch.autograd.Function.__module__ = "torch.autograd"
+    else:
+        raise ImportError("PyTorch is not installed and is required to use the FiredrakeTorchOperator.")
 
 import collections
 from functools import partial


### PR DESCRIPTION
Make PyTorch optional when building the documentation.  If torch is not successfully imported when building the docs, we mock up a class that enables the `firedrake.ml.pytorch` module to be imported and causes the intersphinx link to PyTorch to resolve properly.

I am fully aware of how 😈 this is.

This should fix the recent issues with the website builder action, as well as satisfy user demand to build docs without installing PyTorch.