### PR TITLE
Cross-mesh interpolation extrusion fix and extra tests

### DIFF
--- a/tests/vertexonly/test_interpolation_from_parent.py
+++ b/tests/vertexonly/test_interpolation_from_parent.py
@@ -16,6 +16,7 @@ import subprocess
                         "cube",
                         "tetrahedron",
                         "immersedsphere",
+                        "immersedsphereextruded",
                         "periodicrectangle",
                         "shiftedmesh"],
                 ids=lambda x: f"{x}-mesh")
@@ -37,6 +38,11 @@ def parentmesh(request):
     elif request.param == "immersedsphere":
         m = UnitIcosahedralSphereMesh(refinement_level=2, name='immersedsphere')
         m.init_cell_orientations(SpatialCoordinate(m))
+        return m
+    elif request.param == "immersedsphereextruded":
+        m = UnitIcosahedralSphereMesh()
+        m.init_cell_orientations(SpatialCoordinate(m))
+        m = ExtrudedMesh(m, 3, extrusion_type="radial")
         return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -96,6 +96,7 @@ def point_ownership(m, points, localpoints):
                         "cube",
                         "tetrahedron",
                         "immersedsphere",
+                        "immersedsphereextruded",
                         "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
@@ -116,6 +117,11 @@ def parentmesh(request):
     elif request.param == "immersedsphere":
         m = UnitIcosahedralSphereMesh()
         m.init_cell_orientations(SpatialCoordinate(m))
+        return m
+    elif request.param == "immersedsphereextruded":
+        m = UnitIcosahedralSphereMesh()
+        m.init_cell_orientations(SpatialCoordinate(m))
+        m = ExtrudedMesh(m, 3, extrusion_type="radial")
         return m
     elif request.param == "periodicrectangle":
         return PeriodicRectangleMesh(3, 3, 1, 1)

--- a/tests/vertexonly/test_vertex_only_fs.py
+++ b/tests/vertexonly/test_vertex_only_fs.py
@@ -14,6 +14,7 @@ from mpi4py import MPI
                         "cube",
                         "tetrahedron",
                         "immersedsphere",
+                        "immersedsphereextruded",
                         "periodicrectangle",
                         "shiftedmesh"])
 def parentmesh(request):
@@ -32,6 +33,10 @@ def parentmesh(request):
     elif request.param == "tetrahedron":
         return UnitTetrahedronMesh()
     elif request.param == "immersedsphere":
+        m = UnitIcosahedralSphereMesh(refinement_level=2, name='immersedsphere')
+        m.init_cell_orientations(SpatialCoordinate(m))
+        return m
+    elif request.param == "immersedsphereextruded":
         m = UnitIcosahedralSphereMesh(refinement_level=2, name='immersedsphere')
         m.init_cell_orientations(SpatialCoordinate(m))
         return m


### PR DESCRIPTION
# Description
This adds some extra tests and fixes cross mesh interpolation from radially extruded spheres (which I now test for).

In the latter case I hadn't accounted for tensor product elements not always having the same sub elements, as ocurrs when, say, interpolating onto a function space on a radially extruded `IcosohedralSphereMesh`. In that case the sub elements of the tensor product element are an interval element and a triangle element.

Fortunately I can validly create a `VectorFunctionSpace` with a `TensorProductElement` as the base element and get the correct value shape (I think!).


## Associated Pull Requests:
None

## Fixes Issues:
See above

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
