### PR TITLE
Inject everything on level 1

### DIFF
--- a/tests/multigrid/test_reuse_gmg_solver.py
+++ b/tests/multigrid/test_reuse_gmg_solver.py
@@ -1,0 +1,71 @@
+from firedrake import *
+import pytest
+
+
+def run_helmholtz(typ):
+    if typ == "mg":
+        parameters = {"ksp_type": "cg",
+                      "pc_type": "mg",
+                      "ksp_monitor": None,
+                      "mg_levels_ksp_type": "chebyshev",
+                      "mg_levels_ksp_max_it": 2,
+                      "mg_levels_pc_type": "jacobi"}
+    elif typ == "mgmatfree":
+        parameters = {"ksp_type": "cg",
+                      "ksp_monitor": None,
+                      "mat_type": "matfree",
+                      "pc_type": "mg",
+                      "mg_coarse_ksp_type": "preonly",
+                      "mg_coarse_pc_type": "python",
+                      "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+                      "mg_coarse_assembled_pc_type": "lu",
+                      "mg_levels_ksp_type": "chebyshev",
+                      "mg_levels_ksp_max_it": 2,
+                      "mg_levels_pc_type": "jacobi"}
+    else:
+        raise RuntimeError("Unknown parameter set '%s' request", typ)
+
+    mesh = UnitSquareMesh(10, 10)
+
+    nlevel = 4
+
+    mh = MeshHierarchy(mesh, nlevel)
+    mesh = mh[-1]
+    R = FunctionSpace(mesh, 'R', 0)
+    V = FunctionSpace(mesh, 'CG', 1)
+    v = TestFunction(V)
+    u = TrialFunction(V)
+    uh = function.Function(V)
+    alpha = function.Function(R)
+
+    # Choose a forcing function such that the exact solution is not an
+    # eigenmode.  This stresses the preconditioner much more.  e.g. 10
+    # iterations of ilu fails to converge this problem sufficiently.
+    x = SpatialCoordinate(V.mesh())
+    uexact = sin(pi*x[0])*tan(pi*x[0]*0.25)*sin(pi*x[1])
+
+    # The problem is parametrized such that
+    # alpha = 0 gives the mass matrix, and alpha = 1 gives Poisson
+    a = inner(v, (1-alpha)*u)*dx + inner(grad(v), alpha*grad(u))*dx
+    L = a(v, uexact)
+    bcs = DirichletBC(V, 0.0, (1, 2, 3, 4))
+
+    problem = LinearVariationalProblem(a, L, uh, bcs=bcs)
+    solver = LinearVariationalSolver(problem, solver_parameters=parameters)
+    for val in (0.0, 1.0):
+        alpha.assign(val)
+        uh.assign(0)
+        solver.solve()
+        its_reused = solver.snes.ksp.getIterationNumber()
+
+    new_solver = LinearVariationalSolver(problem, solver_parameters=parameters)
+    uh.assign(0)
+    new_solver.solve()
+    its_new = new_solver.snes.ksp.getIterationNumber()
+    assert its_reused == its_new
+
+
+@pytest.mark.parametrize("typ",
+                         ["mg", "mgmatfree"])
+def test_poisson_gmg(typ):
+    run_helmholtz(typ)


### PR DESCRIPTION
---
name: "MG: Inject coefficients"
description: ''
title: ''
labels: ''
assignees: ''

---

# Description
Things were breaking when a solver is reused for a bilinear form with a coefficient that is not a `Constant` , e.g. functions in R or DG0, after updating that coefficient.
Turns out that we also need to manually inject everything in `problem.F.coefficients()`.
But wait, there's also another issue. The manual injection has to ensure that the level above the current one is up-to-date with respect to the finest level, an assumption that only holds in the two-level case. PCMG will traverse the levels in the order [1, 2, 3, ..., finest,  0 = coarsest]. So we should inject all coefficients across the hierarchy the first time we are reassembling the problem.

## Fixes Issues:
- TODO report the issue


# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
