### PR TITLE
WTF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
           . ../firedrake_venv/bin/activate
           echo OMP_NUM_THREADS is "$OMP_NUM_THREADS"
           echo OPENBLAS_NUM_THREADS is "$OPENBLAS_NUM_THREADS"
+          python -m pytest -v tests/test_0init.py
           python -m pytest \
             --durations=200 \
             --cov firedrake \

--- a/tests/test_0init.py
+++ b/tests/test_0init.py
@@ -1,6 +1,14 @@
+import pytest
+import os
 from firedrake import *
 
 
+# See https://pytest-xdist.readthedocs.io/en/stable/how-to.html#identifying-the-worker-process-during-a-test
+@pytest.mark.skipif(
+    "PYTEST_XDIST_WORKER_COUNT" in os.environ.keys()
+    and int(os.environ["PYTEST_XDIST_WORKER_COUNT"]) > 1,
+    reason="Must be run first"
+)
 def test_pyop2_not_initialised():
     """Check that PyOP2 has not been initialised yet.
        The test fails if another test builds a firedrake object not in a fixture."""


### PR DESCRIPTION
What the actual flip!

https://github.com/firedrakeproject/firedrake/actions/runs/6274692914/job/17040567188?pr=3041

The current test suite depends on the order in which tests are run!

This PR should fix the behaviour unsafely hacked around with `test_0init.py`.