### PR TITLE
Adding tensor box mesh and tests

### DIFF
--- a/tests/regression/test_mesh_generation.py
+++ b/tests/regression/test_mesh_generation.py
@@ -67,6 +67,13 @@ def test_unit_cube():
     assert abs(integrate_one(UnitCubeMesh(3, 3, 3)) - 1) < 1e-3
 
 
+def test_tensor_box():
+    xcoords = [0.0, 0.2, 0.8, 1.2]
+    ycoords = [1.0, 1.4, 2.0]
+    zcoords = [0.5, 0.6, 0.7, 1.0]
+    assert abs(integrate_one(TensorBoxMesh(xcoords, ycoords, zcoords)) - 0.6) < 1e-3
+
+
 def run_one_element_advection():
     nx = 20
     m = PeriodicRectangleMesh(nx, 1, 1.0, 1.0, quadrilateral=True)
@@ -222,6 +229,14 @@ def test_tensor_rectangle_parallel():
 @pytest.mark.parallel
 def test_unit_cube_parallel():
     assert abs(integrate_one(UnitCubeMesh(3, 3, 3)) - 1) < 1e-3
+
+
+@pytest.mark.parallel
+def test_tensor_box_parallel():
+    xcoords = [0.0, 0.2, 0.8, 1.2]
+    ycoords = [1.0, 1.4, 2.0]
+    zcoords = [0.5, 0.6, 0.7, 1.0]
+    assert abs(integrate_one(TensorBoxMesh(xcoords, ycoords, zcoords)) - 0.6) < 1e-3
 
 
 @pytest.mark.parallel


### PR DESCRIPTION
---
name: "New feature"
description: 'Add a utility mesh for a tensor-product mesh in 3D, generalizing BoxMesh'
title: ''
labels: ''
assignees: ''

---

# Description
This replaces the tetrahedral code in `BoxMesh` with a generalization for arbitrary tensor-product meshes on 3D boxes.  Note that this leads to a small amount of code duplication, since the PETSc code for uniform hexahedral meshes in 3D is not similarly capable, so I've left that in place under `BoxMesh`.



# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [x] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [x] My changes generate no new warnings.
- [x] All of my functions and classes have appropriate docstrings.
- [x] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [x] I have added tests that exercise the new functionality I have introduced
- [x] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
