### PR TITLE
Correct number of candidates for prolong/restrict on extruded meshes

### DIFF
--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -214,10 +214,8 @@ def prolong_kernel(expression):
     if meshc.cell_set._extruded:
         idx = levelf * hierarchy.refinements_per_level
         assert idx == int(idx)
-        level_ratio = (hierarchy._meshes[int(idx)].layers - 1) // (meshc.layers - 1)
-    else:
-        level_ratio = 1
-    key = (("prolong", level_ratio)
+        assert hierarchy._meshes[int(idx)].cell_set._extruded
+    key = (("prolong",)
            + expression.ufl_element().value_shape()
            + entity_dofs_key(expression.function_space().finat_element.entity_dofs())
            + entity_dofs_key(coordinates.function_space().finat_element.entity_dofs()))
@@ -280,7 +278,7 @@ def prolong_kernel(expression):
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": eval_code,
                "spacedim": element.cell.get_spatial_dimension(),
-               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1] * level_ratio,
+               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
                "Rdim": numpy.prod(element.value_shape),
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
@@ -298,10 +296,7 @@ def restrict_kernel(Vf, Vc):
     coordinates = Vc.ufl_domain().coordinates
     if Vf.extruded:
         assert Vc.extruded
-        level_ratio = (Vf.mesh().layers - 1) // (Vc.mesh().layers - 1)
-    else:
-        level_ratio = 1
-    key = (("restrict", level_ratio)
+    key = (("restrict",)
            + Vf.ufl_element().value_shape()
            + entity_dofs_key(Vf.finat_element.entity_dofs())
            + entity_dofs_key(Vc.finat_element.entity_dofs())
@@ -366,7 +361,7 @@ def restrict_kernel(Vf, Vc):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": evaluate_code,
-               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1]*level_ratio,
+               "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
                "Xc_cell_inc": coords_element.space_dimension(),

--- a/tests/multigrid/test_grid_transfer.py
+++ b/tests/multigrid/test_grid_transfer.py
@@ -252,18 +252,17 @@ def deformed_transfer_type(request, deformed_hierarchy):
 
 
 def test_grid_transfer_deformed(deformed_hierarchy, deformed_transfer_type):
-    vector = False
     space = "Lagrange"
-    degrees = (1,)
-
+    degrees = (1, 2)
+    vector = False
     if not deformed_hierarchy.nested and deformed_transfer_type == "injection":
         pytest.skip("Not implemented")
     if deformed_transfer_type == "injection":
         if space in {"DG", "DQ"} and complex_mode:
             with pytest.raises(NotImplementedError):
-                run_injection(deformed_hierarchy, vector, space, degrees)
+                run_injection(deformed_hierarchy, vector, space, degrees[:1])
         else:
-            run_injection(deformed_hierarchy, vector, space, degrees)
+            run_injection(deformed_hierarchy, vector, space, degrees[:1])
     elif deformed_transfer_type == "restriction":
         run_restriction(deformed_hierarchy, vector, space, degrees)
     elif deformed_transfer_type == "prolongation":


### PR DESCRIPTION
---
name: "Bug fix or new feature"
description: ''
title: ''
labels: ''
assignees: ''

---

# Description
Prolongation and restriction kernels were incorrectly looping into out of bounds coarse basis functions in the extruded case. The logic added in https://github.com/firedrakeproject/firedrake/commit/86e6ca3f342813e52bc0e8a4b39190db83a966a3 was only correct for the injection kernel. So far the tests only considered cases that terminated the loop before going out of bounds. When the children cells fall out of the parent coarse cell, we access out of bounds memory, which utimately causes a `nan` to be returned on these cases.

I also added a test with a deformed mesh hierarchy, although `inject` still breaks  without producing `nan` for degree > 1 and only on some types of cells (works on interval x interval).

## Associated Pull Requests:
- Make a list (with links!)

## Fixes Issues:
- Make a list of issues (with links!)

If issues are fixed by this PR, prepend each of them with the word
"fixes", so they are automatically closed when this PR is merged. For
example "fixes #123, fixes #456".

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [x] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
