### PR TITLE
Make tests basis-independent

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -151,8 +151,8 @@ class BCBase(object):
                 # take intersection of facet nodes, and add it to bcnodes
                 # i, j, k can also be strings.
                 bcnodes1 = []
-                if len(s) > 1 and not isinstance(self._function_space.finat_element, finat.Lagrange):
-                    raise TypeError("Currently, edge conditions have only been tested with Lagrange elements")
+                if len(s) > 1 and not isinstance(self._function_space.finat_element, (finat.Lagrange, finat.GaussLobattoLegendre)):
+                    raise TypeError("Currently, edge conditions have only been tested with CG Lagrange elements")
                 for ss in s:
                     # intersection of facets
                     # Edge conditions have only been tested with Lagrange elements.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -493,7 +493,7 @@ class CrossMeshInterpolator(Interpolator):
                             "Can't transpose interpolate an expression with no coefficients or arguments."
                         )
         else:
-            if isinstance(self.V, firedrake.Function):
+            if isinstance(self.V, (firedrake.Function, firedrake.Cofunction)):
                 V_dest = self.V.function_space()
             else:
                 V_dest = self.V
@@ -501,7 +501,7 @@ class CrossMeshInterpolator(Interpolator):
             if output.function_space() != V_dest:
                 raise ValueError("Given output has the wrong function space!")
         else:
-            if isinstance(self.V, (firedrake.Function, function.Cofunction)):
+            if isinstance(self.V, (firedrake.Function, firedrake.Cofunction)):
                 output = self.V
             else:
                 output = firedrake.Function(V_dest)
@@ -585,9 +585,7 @@ class CrossMeshInterpolator(Interpolator):
             # VOM. This has the parallel decomposition V_dest on our orinally
             # specified dest_mesh. We can therefore safely create a P0DG
             # cofunction on the input-ordering VOM (which has this parallel
-            # decomposition and ordering) and assign the dat values. NOTE: we
-            # can't yet use actual cofunctions, so we use Functions in their
-            # place.
+            # decomposition and ordering) and assign the dat values.
             f_src_at_dest_node_coords_dest_mesh_decomp = firedrake.Cofunction(
                 self.to_input_ordering_interpolator.V.dual()
             )

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -617,6 +617,9 @@ class CrossMeshInterpolator(Interpolator):
             self.point_eval_interpolator.interpolate(
                 f_src_at_src_node_coords, transpose=True, output=output
             )
+            # FIXME we cannot yet use actual cofunctions, see the note above
+            if not isinstance(output, firedrake.Cofunction):
+                output = output.riesz_representation("l2")
 
         return output
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1031,6 +1031,7 @@ def rebuild(element, expr, rt_var_name):
     raise NotImplementedError(f"Cross mesh interpolation not implemented for a {element} element.")
 
 
+@rebuild.register(finat.GaussLegendre)
 @rebuild.register(finat.DiscontinuousLagrange)
 def rebuild_dg(element, expr, rt_var_name):
     # To tabulate on the given element (which is on a different mesh to the

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1031,8 +1031,7 @@ def rebuild(element, expr, rt_var_name):
     raise NotImplementedError(f"Cross mesh interpolation not implemented for a {element} element.")
 
 
-@rebuild.register(finat.GaussLegendre)
-@rebuild.register(finat.DiscontinuousLagrange)
+@rebuild.register(finat.fiat_elements.ScalarFiatElement)
 def rebuild_dg(element, expr, rt_var_name):
     # To tabulate on the given element (which is on a different mesh to the
     # expression) we must do so at runtime. We therefore create a quadrature

--- a/tests/equation_bcs/test_equation_bcs.py
+++ b/tests/equation_bcs/test_equation_bcs.py
@@ -285,7 +285,7 @@ def test_EquationBC_mixedpoisson_matrix(eq_type):
         for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
-    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03
+    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.05
 
 
 def test_EquationBC_mixedpoisson_matrix_fieldsplit():
@@ -315,7 +315,7 @@ def test_EquationBC_mixedpoisson_matrix_fieldsplit():
         for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
-    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03
+    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.05
 
 
 def test_EquationBC_mixedpoisson_matfree_fieldsplit():
@@ -350,4 +350,4 @@ def test_EquationBC_mixedpoisson_matfree_fieldsplit():
         for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
-    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03
+    assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.05

--- a/tests/equation_bcs/test_equation_bcs.py
+++ b/tests/equation_bcs/test_equation_bcs.py
@@ -209,25 +209,25 @@ def test_EquationBC_poisson_matrix(eq_type, with_bbc):
                          'ksp_type': 'preonly',
                          'pc_type': 'lu'}
     err = []
-
+    mesh_sizes = [8, 16]
     if with_bbc:
         # test bcs for bcs
         if eq_type == "linear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(linear_poisson_bbc(solver_parameters, mesh_num, porder))
         elif eq_type == "nonlinear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(nonlinear_poisson_bbc(solver_parameters, mesh_num, porder))
     else:
         # test bcs for bcs
         if eq_type == "linear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(linear_poisson(solver_parameters, mesh_num, porder))
         elif eq_type == "nonlinear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(nonlinear_poisson(solver_parameters, mesh_num, porder))
 
-    assert abs(math.log2(err[0]) - math.log2(err[1]) - (porder+1)) < 0.01
+    assert abs(math.log2(err[0]) - math.log2(err[1]) - (porder+1)) < 0.05
 
 
 @pytest.mark.parametrize("with_bbc", [False, True])
@@ -246,29 +246,29 @@ def test_EquationBC_poisson_matfree(with_bbc):
                          'ksp_max_it': 200000,
                          'ksp_divtol': 1e8}
     err = []
-
+    mesh_sizes = [8, 16]
     if with_bbc:
         if eq_type == "linear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(linear_poisson_bbc(solver_parameters, mesh_num, porder))
         elif eq_type == "nonlinear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(nonlinear_poisson_bbc(solver_parameters, mesh_num, porder))
     else:
         if eq_type == "linear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(linear_poisson(solver_parameters, mesh_num, porder))
         elif eq_type == "nonlinear":
-            for mesh_num in [8, 16]:
+            for mesh_num in mesh_sizes:
                 err.append(nonlinear_poisson(solver_parameters, mesh_num, porder))
 
-    assert abs(math.log2(err[0]) - math.log2(err[1]) - (porder+1)) < 0.01
+    assert abs(math.log2(err[0]) - math.log2(err[1]) - (porder+1)) < 0.05
 
 
 @pytest.mark.parametrize("eq_type", ["linear", "nonlinear"])
 def test_EquationBC_mixedpoisson_matrix(eq_type):
     mat_type = "aij"
-    porder = 1
+    porder = 2
     # Mixed poisson with EquationBCs
     # aij
 
@@ -277,12 +277,12 @@ def test_EquationBC_mixedpoisson_matrix(eq_type):
                          "pc_type": "lu",
                          "pc_factor_mat_solver_type": "mumps"}
     err = []
-
+    mesh_sizes = [16, 32]
     if eq_type == "linear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(linear_poisson_mixed(solver_parameters, mesh_num, porder))
     elif eq_type == "nonlinear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
     assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03
@@ -291,13 +291,13 @@ def test_EquationBC_mixedpoisson_matrix(eq_type):
 def test_EquationBC_mixedpoisson_matrix_fieldsplit():
     mat_type = "aij"
     eq_type = "linear"
-    porder = 1
+    porder = 2
     # Mixed poisson with EquationBCs
     # aij with fieldsplit pc
 
     solver_parameters = {"mat_type": mat_type,
                          "ksp_type": "fgmres",
-                         "ksp_rtol": 1.e-11,
+                         "ksp_rtol": 1.e-8,
                          "ksp_max_it": 200,
                          "pc_type": "fieldsplit",
                          "pc_fieldsplit_type": "schur",
@@ -305,15 +305,14 @@ def test_EquationBC_mixedpoisson_matrix_fieldsplit():
                          "fieldsplit_0_ksp_type": "preonly",
                          "fieldsplit_0_pc_type": "lu",
                          "fieldsplit_1_ksp_type": "cg",
-                         "fieldsplit_1_ksp_max_it": 20,
                          "fieldsplit_1_pc_type": "none"}
     err = []
-
+    mesh_sizes = [16, 32]
     if eq_type == "linear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(linear_poisson_mixed(solver_parameters, mesh_num, porder))
     elif eq_type == "nonlinear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
     assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03
@@ -322,7 +321,7 @@ def test_EquationBC_mixedpoisson_matrix_fieldsplit():
 def test_EquationBC_mixedpoisson_matfree_fieldsplit():
     mat_type = "matfree"
     eq_type = "linear"
-    porder = 1
+    porder = 2
     # Mixed poisson with EquationBCs
     # matfree with fieldsplit pc
 
@@ -338,15 +337,17 @@ def test_EquationBC_mixedpoisson_matfree_fieldsplit():
                          'fieldsplit_0_pc_python_type': 'firedrake.AssembledPC',
                          'fieldsplit_0_assembled_pc_type': 'lu',
                          'fieldsplit_1_ksp_type': 'cg',
-                         'fieldsplit_1_ksp_max_it': 20,
-                         'fieldsplit_1_pc_type': 'none'}
+                         'fieldsplit_1_pc_use_amat': True,
+                         'fieldsplit_1_pc_type': 'python',
+                         'fieldsplit_1_pc_python_type': 'firedrake.MassInvPC',
+                         'fieldsplit_1_Mp_pc_type': 'icc'}
     err = []
-
+    mesh_sizes = [16, 32]
     if eq_type == "linear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(linear_poisson_mixed(solver_parameters, mesh_num, porder))
     elif eq_type == "nonlinear":
-        for i, mesh_num in enumerate([8, 16]):
+        for i, mesh_num in enumerate(mesh_sizes):
             err.append(nonlinear_poisson_mixed(solver_parameters, mesh_num, porder))
 
     assert abs(math.log2(err[0][0]) - math.log2(err[1][0]) - (porder+1)) < 0.03

--- a/tests/regression/test_aw.py
+++ b/tests/regression/test_aw.py
@@ -62,8 +62,7 @@ def test_aw_convergence(stress_element, mesh_hierarchy):
     l2_u = []
     l2_sigma = []
     l2_div_sigma = []
-
-    element = MixedElement([stress_element, VectorElement("DG", mesh.ufl_cell(), 1)])
+    element = MixedElement([stress_element, VectorElement("DG", cell=mesh.ufl_cell(), degree=1)])
     for msh in mesh_hierarchy[1:]:
         x, y = SpatialCoordinate(msh)
         uex = as_vector([sin(pi*x)*sin(pi*y), sin(pi*x)*sin(pi*y)])
@@ -80,6 +79,7 @@ def test_aw_convergence(stress_element, mesh_hierarchy):
 
         (sigh, uh) = split(Uh)
         (tau, v) = TestFunctions(V)
+        (sig, u) = TrialFunctions(V)
 
         n = FacetNormal(msh)
 
@@ -93,20 +93,25 @@ def test_aw_convergence(stress_element, mesh_hierarchy):
             - inner(uex, dot(tau, n))*ds
             )  # noqa: E123
 
-        params = {"snes_type": "newtonls",
-                  "snes_linesearch_type": "basic",
-                  "snes_monitor": None,
-                  "mat_type": "aij",
-                  "snes_max_it": 10,
-                  "snes_lag_jacobian": -2,
-                  "snes_lag_preconditioner": -2,
-                  "ksp_type": "preonly",
-                  "pc_type": "lu",
-                  "pc_factor_shift_type": "inblocks",
-                  "snes_rtol": 1e-16,
-                  "snes_atol": 1e-25}
+        # Riesz map preconditioner
+        Jp = (inner(A(sig), tau) + inner(div(sig), div(tau)) + inner(u, v)) * dx
 
-        solve(F == 0, Uh, solver_parameters=params)
+        params = {"mat_type": "matfree",
+                  "pmat_type": "nest",
+                  "snes_type": "ksponly",
+                  "snes_monitor": None,
+                  "ksp_monitor": None,
+                  "ksp_type": "minres",
+                  "ksp_norm_type": "preconditioned",
+                  "pc_type": "fieldsplit",
+                  "pc_fieldsplit_type": "additive",
+                  "fieldsplit_0_pc_type": "cholesky",
+                  "fieldsplit_1_pc_type": "icc",
+                  "ksp_rtol": 1e-16,
+                  "ksp_atol": 1e-25,
+                  "ksp_max_it": 10}
+
+        solve(F == 0, Uh, Jp=Jp, solver_parameters=params)
 
         error_u = sqrt(assemble(inner(uex - uh, uex - uh)*dx))
         error_sigma = sqrt(assemble(inner(sigh - sigex, sigh - sigex)*dx))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -231,7 +231,7 @@ def test_cellvolume():
 
 def test_cellvolume_higher_order_coords():
     m = UnitTriangleMesh()
-    V = VectorFunctionSpace(m, "CG", 3)
+    V = VectorFunctionSpace(m, 'P', 3)
     f = Function(V)
     f.interpolate(m.coordinates)
 

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -231,7 +231,7 @@ def test_cellvolume():
 
 def test_cellvolume_higher_order_coords():
     m = UnitTriangleMesh()
-    V = VectorFunctionSpace(m, FiniteElement("CG", cell=m.ufl_cell(), degree=3, variant="equispaced"))
+    V = VectorFunctionSpace(m, "CG", 3)
     f = Function(V)
     f.interpolate(m.coordinates)
 
@@ -240,8 +240,7 @@ def test_cellvolume_higher_order_coords():
     def warp(x):
         return x * (x - 1)*(x + 19/12.0)
 
-    f.dat.data[1, 1] = warp(1.0/3.0)
-    f.dat.data[2, 1] = warp(2.0/3.0)
+    f.dat.data[1:3, 1] = warp(f.dat.data[1:3, 0])
 
     mesh = Mesh(f)
     g = interpolate(CellVolume(mesh), FunctionSpace(mesh, 'DG', 0))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -231,7 +231,7 @@ def test_cellvolume():
 
 def test_cellvolume_higher_order_coords():
     m = UnitTriangleMesh()
-    V = VectorFunctionSpace(m, 'P', 3)
+    V = VectorFunctionSpace(m, FiniteElement("CG", cell=m.ufl_cell(), degree=3, variant="equispaced"))
     f = Function(V)
     f.interpolate(m.coordinates)
 

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -595,28 +595,21 @@ def interpolator_function(
 def interpolator_function_transpose(
     interpolator, f_src, cofunction_dest, m_src, m_dest, coords, expected, atol
 ):
+    f_dest = interpolator.interpolate(f_src)
     cofunction_dest_on_src = interpolator.interpolate(cofunction_dest, transpose=True)
-    assert extract_unique_domain(cofunction_dest_on_src) is m_src
-    # knowing exactly what to expect would require careful analysis of the
-    # behaviour of adjoint interpolation (which is nontrivial for meshes which
-    # are not exact refinements of each other!) For now I check that I don't
-    # get f_src or its equivalent cofunction back!
-    assert not np.allclose(
-        cofunction_dest_on_src.dat.data_ro, f_src.dat.data_ro, atol=atol
+    assert cofunction_dest_on_src.function_space().mesh() is m_src
+    assert np.isclose(
+        assemble(action(cofunction_dest_on_src, f_src)),
+        assemble(action(cofunction_dest, f_dest)), atol=atol
     )
-    V_src = f_src.function_space()
-    cofunction_src = assemble(inner(f_src, TestFunction(V_src)) * dx)
     if m_src.name == "src_sphere" and m_dest.name == "dest_sphere" and atol > 1e-8:
-        # In the spheresphere case we need to make sure our tolerance is back
-        # to default, since we actually DO get the same cofunction back with an
+        # In the spheresphere case we actually DO get the same cofunction back with an
         # atol of 1e-3
+        V_src = f_src.function_space()
+        cofunction_src = assemble(inner(f_src, TestFunction(V_src)) * dx)
         assert np.allclose(
             cofunction_dest_on_src.dat.data_ro, cofunction_src.dat.data_ro, atol=atol
         )
-        atol = 1e-8
-    assert not np.allclose(
-        cofunction_dest_on_src.dat.data_ro, cofunction_src.dat.data_ro, atol=atol
-    )
 
 
 def interpolator_expression(
@@ -631,17 +624,10 @@ def interpolator_expression(
     assert np.allclose(got, 2 * expected, atol=2 * atol)
     cofunction_dest = assemble(inner(f_dest, TestFunction(V_dest)) * dx)
     cofunction_dest_on_src = interpolator.interpolate(cofunction_dest, transpose=True)
-    with cofunction_dest.dat.vec_ro as c:
-        _, cmax = c.max()
-        _, cmin = c.min()
-    ctol = 2 * atol * max(abs(cmax), abs(cmin))
-    assert extract_unique_domain(cofunction_dest_on_src) is m_src
-    assert not np.allclose(
-        f_src.dat.data_ro, cofunction_dest_on_src.dat.data_ro, atol=ctol
-    )
-    cofunction_src = assemble(inner(f_src, TestFunction(V_src)) * dx)
-    assert not np.allclose(
-        cofunction_dest_on_src.dat.data_ro, cofunction_src.dat.data_ro, atol=ctol
+    assert cofunction_dest_on_src.function_space().mesh() is m_src
+    assert np.isclose(
+        assemble(action(cofunction_dest_on_src, f_src)),
+        assemble(action(cofunction_dest, f_dest)), atol=atol
     )
 
 

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -213,6 +213,11 @@ def parameters(request):
     elif request.param == "spheresphere":
         m_src = UnitCubedSphereMesh(5, name="src_sphere")
         m_dest = UnitIcosahedralSphereMesh(5, name="dest_sphere")
+        # Align m_dest with the z axis
+        phi = (1 + 5 ** 0.5) / 2
+        Q, _ = np.linalg.qr([[1, phi, 0], [phi, 0, 1], [0, 1, phi]])
+        x_dest = m_dest.coordinates.dat.data_with_halos
+        x_dest[:] = np.dot(x_dest, Q[:, ::-1])
         coords = np.array(
             [
                 [0, 1, 0],
@@ -235,9 +240,9 @@ def parameters(request):
         expr_src = reduce(add, SpatialCoordinate(m_src))
         expr_dest = reduce(add, SpatialCoordinate(m_dest))
         expected = reduce(add, coords.T)
-        V_src = FunctionSpace(m_src, FiniteElement("CG", m_src.ufl_cell(), degree=3, variant="equispaced"))
-        V_dest = FunctionSpace(m_dest, FiniteElement("CG", m_dest.ufl_cell(), degree=4, variant="equispaced"))
-        V_dest_2 = FunctionSpace(m_dest, FiniteElement("DG", m_dest.ufl_cell(), degree=2, variant="equispaced"))
+        V_src = FunctionSpace(m_src, "CG", 3)
+        V_dest = FunctionSpace(m_dest, FiniteElement("CG", cell=m_dest.ufl_cell(), degree=4, variant="equispaced"))
+        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
     elif request.param == "sphereextrudedsphereextruded":
         m_src = ExtrudedMesh(UnitIcosahedralSphereMesh(1), 2, extrusion_type="radial")
         # Note we need to use the same base sphere otherwise it's hard to check

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -235,9 +235,9 @@ def parameters(request):
         expr_src = reduce(add, SpatialCoordinate(m_src))
         expr_dest = reduce(add, SpatialCoordinate(m_dest))
         expected = reduce(add, coords.T)
-        V_src = FunctionSpace(m_src, "CG", 3)
-        V_dest = FunctionSpace(m_dest, "CG", 4)
-        V_dest_2 = FunctionSpace(m_dest, "DG", 2)
+        V_src = FunctionSpace(m_src, FiniteElement("CG", m_src.ufl_cell(), degree=3, variant="equispaced"))
+        V_dest = FunctionSpace(m_dest, FiniteElement("CG", m_dest.ufl_cell(), degree=4, variant="equispaced"))
+        V_dest_2 = FunctionSpace(m_dest, FiniteElement("DG", m_dest.ufl_cell(), degree=2, variant="equispaced"))
     elif request.param == "sphereextrudedsphereextruded":
         m_src = ExtrudedMesh(UnitIcosahedralSphereMesh(1), 2, extrusion_type="radial")
         # Note we need to use the same base sphere otherwise it's hard to check

--- a/tests/regression/test_line_smoother_periodic.py
+++ b/tests/regression/test_line_smoother_periodic.py
@@ -5,7 +5,8 @@ import pytest
 
 # Useful for making a periodic hierarchy
 def periodise(m):
-    coord_fs = VectorFunctionSpace(m, "DG", 1, dim=2)
+    element = BrokenElement(FiniteElement("CG", cell=m.ufl_cell(), degree=1))
+    coord_fs = VectorFunctionSpace(m, element, dim=2)
     old_coordinates = m.coordinates
     new_coordinates = Function(coord_fs)
     domain = "{[i, j]: 0 <= i < old_coords.dofs and 0 <= j < new_coords.dofs}"

--- a/tests/regression/test_vertex_based_limiter.py
+++ b/tests/regression/test_vertex_based_limiter.py
@@ -16,10 +16,15 @@ def mesh(request):
         return PeriodicUnitSquareMesh(30, 30, quadrilateral=True)
 
 
+def space(m):
+    element = BrokenElement(m.coordinates.function_space().ufl_element().sub_elements()[0])
+    return FunctionSpace(m, element)
+
+
 @pytest.mark.skipcomplex
 def test_constant_field(mesh):
     # test function space
-    v = FunctionSpace(mesh, "DG", 1)
+    v = space(mesh)
 
     # Create limiter
     limiter = VertexBasedLimiter(v)
@@ -39,7 +44,7 @@ def test_step_function_bounds(mesh):
     x = SpatialCoordinate(mesh)
 
     # test function space
-    v = FunctionSpace(mesh, "DG", 1)
+    v = space(mesh)
 
     # Create limiter
     limiter = VertexBasedLimiter(v)
@@ -56,7 +61,7 @@ def test_step_function_bounds(mesh):
 @pytest.mark.skipcomplex
 def test_step_function_loop(mesh, iterations=100):
     # test function space
-    v = FunctionSpace(mesh, "DG", 1)
+    v = space(mesh)
     m = VectorFunctionSpace(mesh, "CG", 1)
 
     # advecting velocity
@@ -121,7 +126,7 @@ def test_step_function_loop(mesh, iterations=100):
 def test_parallel_limiting(tmpdir):
     import pickle
     mesh = RectangleMesh(10, 4, 5000., 1000.)
-    V = FunctionSpace(mesh, 'DG', 1)
+    V = space(mesh)
     f = Function(V)
     x, *_ = SpatialCoordinate(mesh)
     f.project(sin(2*pi*x/3000.))
@@ -138,7 +143,8 @@ def test_parallel_limiting(tmpdir):
 import pickle
 from firedrake import *
 mesh = RectangleMesh(10, 4, 5000., 1000.)
-V = FunctionSpace(mesh, 'DG', 1)
+element = BrokenElement(mesh.coordinates.function_space().ufl_element().sub_elements()[0])
+V = FunctionSpace(mesh, element)
 f = Function(V)
 x, *_ = SpatialCoordinate(mesh)
 f.project(sin(2*pi*x/3000.))


### PR DESCRIPTION
---
name: "Make tests basis-independent"
description: ''
title: ''
labels: ''
assignees: ''

---

# Description
We need to drop the first commit and re-run CI with the equispaced variant.

A few observations: 

1. `VertexLimiter` requires functions in `Broken(mesh.coordinates.function_space()) `
2. Some tests like the one for `EquationBC` use a periodic sine wave manufactured solution, this could show the asymptotic convergence rate sooner with equispaced points (these points have the best approximation properties for periodic functions).
3. The tests for the adjoint of cross-mesh interpolation were testing for inequality of the output against the exact target `Cofunction`, and the source `Function`. The issue with this is that the absolute tolerance used in the dual comparison was the same used for primal comparsion, and the change to the spectral basis was changing the magnitude of the coefficients of the `Cofunctions` below the absolute tolerance. These inequality tests are quite meaningless and should be replaced with the same approach used in the multigrid `restrict` [tests](https://github.com/firedrakeproject/firedrake/blob/a07f37306fa7816b868bd19bd9839e67eb2bf968/tests/multigrid/test_grid_transfer.py#L135). We now test that `<Ix, y> == <x, adjoint(I)y>` for a choice of `x \in V_src` and `y \in V_dest*`.

## Associated Pull Requests:
- Make a list (with links!)
- [Like this PR#691](https://github.com/OP2/PyOP2/pull/691)

## Fixes Issues:
- Make a list of issues (with links!)
- [Like this Issue#2824](https://github.com/firedrakeproject/firedrake/issues/2824)

If issues are fixed by this PR, prepend each of them with the word
"fixes", so they are automatically closed when this PR is merged. For
example "fixes #123, fixes #456".

# Checklist for author:

<!--
If you think an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.
-->

- [ ] I have linted the codebase (`make lint` in the `firedrake` source directory).
- [ ] My changes generate no new warnings.
- [ ] All of my functions and classes have appropriate docstrings.
- [ ] I have commented my code where its purpose may be unclear.
- [ ] I have included and updated any relevant documentation.
- [ ] Documentation builds locally (`make linkcheck; make html; make latexpdf` in `firedrake/docs` directory)
- [ ] I have added tests specific to the issues fixed in this PR.
- [ ] I have added tests that exercise the new functionality I have introduced
- [ ] Tests pass locally (`pytest tests` in the `firedrake` source directory) (useful, but not essential if you don't have suitable hardware).
- [ ] I have performed a self-review of my own code using the below guidelines.

# Checklist for reviewer:

- [ ] Docstrings present
- [ ] New tests present
- [ ] Code correctly commented
- [ ] No bad "code smells"
- [ ] No issues in parallel
- [ ] No CI issues (excessive parallelism/memory usage/time/warnings generated)
- [ ] Upstream/dependent branches and PRs are ready

Feel free to add reviewers if you know there is someone who is already aware of this work.

Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

<!--
Thanks for contributing!
-->
