### PR TITLE
Add test for MixedDat halo exchanges in a parloop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
             --install icepack \
             --install irksome \
             --install femlium \
-            --package-branch pyop2 connorjward/fix-mixed-halos \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
             --install icepack \
             --install irksome \
             --install femlium \
+            --package-branch pyop2 connorjward/fix-mixed-halos \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/tests/regression/test_par_loops.py
+++ b/tests/regression/test_par_loops.py
@@ -273,3 +273,24 @@ def test_par_loop_respects_shape():
 
     par_loop((domain, instructions), dx, {'A': (f_scalar, WRITE)})
     assert np.allclose(f_scalar.dat.data, 1.0)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_mixed_dat_performs_halo_exchange():
+    # TODO This is actualy a PyOP2 test but PyOP2 does not (!!!) have either
+    # parallel tests or a halo implementation. When pyop3 lands this test should
+    # be moved there.
+
+    mesh = UnitSquareMesh(2, 2)
+    V = FunctionSpace(mesh, "CG", 1)
+    W = V * V
+    iterset = mesh.cell_set
+    mdat = Function(W).dat
+    mmap = W.cell_node_map()
+
+    mdat[0].data_wo[...] = 1
+    assert not mdat.halo_valid
+
+    kernel = """static void k(double *x) { }"""
+    op2.par_loop(op2.Kernel(kernel, "k"), iterset, mdat(op2.READ, mmap))
+    assert mdat.halo_valid


### PR DESCRIPTION
This is awful but PyOP2 does not have parallel testing so this test cannot live there.

Needs to land after https://github.com/OP2/PyOP2/pull/710.

[Related issue](https://github.com/firedrakeproject/firedrake/issues/3150)