### PR TITLE
Calling a Cofunction to compute duality pairing

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -79,6 +79,18 @@ class Cofunction(ufl.Cofunction, FunctionMixin):
         if hasattr(self, "_comm"):
             mpi.decref(self._comm)
 
+    def __call__(self, primal):
+        r"""Compute the duality pairing, this is to evaluate this
+        :class:`.Cofunction` at a :class:`.Function`, equivalent to taking the
+        dot product of the vectors of coefficients of the dual and primal
+        arguments.
+
+        :arg primal: the :class:`.Function` to be paired with this :class:`.Cofunction`.
+
+        :returns: the scalar result of the duality pairing.
+        """
+        return firedrake.assemble(ufl.action(self, primal))
+
     def copy(self, deepcopy=True):
         r"""Return a copy of this :class:`firedrake.function.CoordinatelessFunction`.
 

--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -80,16 +80,16 @@ class Cofunction(ufl.Cofunction, FunctionMixin):
             mpi.decref(self._comm)
 
     def __call__(self, primal):
-        r"""Compute the duality pairing, this is to evaluate this
+        r"""Return the symbolic duality pairing, this is to evaluate this
         :class:`.Cofunction` at a :class:`.Function`, equivalent to taking the
         dot product of the vectors of coefficients of the dual and primal
         arguments.
 
         :arg primal: the :class:`.Function` to be paired with this :class:`.Cofunction`.
 
-        :returns: the scalar result of the duality pairing.
+        :returns: the symbolic duality pairing.
         """
-        return firedrake.assemble(ufl.action(self, primal))
+        return ufl.action(self, primal)
 
     def copy(self, deepcopy=True):
         r"""Return a copy of this :class:`firedrake.function.CoordinatelessFunction`.

--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -79,17 +79,20 @@ class Cofunction(ufl.Cofunction, FunctionMixin):
         if hasattr(self, "_comm"):
             mpi.decref(self._comm)
 
-    def __call__(self, primal):
+    def __call__(self, expr):
         r"""Return the symbolic duality pairing, this is to evaluate this
-        :class:`.Cofunction` at a :class:`.Function`, equivalent to taking the
-        dot product of the vectors of coefficients of the dual and primal
-        arguments.
+        :class:`.Cofunction` at an expression in the primal space, equivalent to
+        taking the dot product of the vectors of coefficients of the dual and
+        primal arguments.
 
-        :arg primal: the :class:`.Function` to be paired with this :class:`.Cofunction`.
+        :arg expr: a UFL expression to be paired with this :class:`.Cofunction`.
 
         :returns: the symbolic duality pairing.
         """
-        return ufl.action(self, primal)
+        try:
+            return ufl.action(self, expr)
+        except TypeError:
+            return ufl.action(self, ufl.Interpolate(expr, self.function_space().dual()))
 
     def copy(self, deepcopy=True):
         r"""Return a copy of this :class:`firedrake.function.CoordinatelessFunction`.

--- a/tests/regression/test_assemble_baseform.py
+++ b/tests/regression/test_assemble_baseform.py
@@ -125,6 +125,14 @@ def test_assemble_action(M, f):
             assert abs(f.dat.data.sum() - 0.5*f.function_space().value_size) < 1.0e-12
 
 
+def test_duality_pairing(a, f):
+    c = assemble(a)
+    with f.dat.vec_ro as x, c.dat.vec_ro as y:
+        expected = x.dot(y)
+    assert np.isclose(assemble(action(c, f)), expected)
+    assert np.isclose(c(f), expected)
+
+
 def test_vector_formsum(a):
     res = assemble(a)
     preassemble = assemble(a + a)

--- a/tests/regression/test_assemble_baseform.py
+++ b/tests/regression/test_assemble_baseform.py
@@ -129,8 +129,9 @@ def test_duality_pairing(a, f):
     c = assemble(a)
     with f.dat.vec_ro as x, c.dat.vec_ro as y:
         expected = x.dot(y)
-    assert np.isclose(assemble(action(c, f)), expected)
-    assert np.isclose(c(f), expected)
+    assert np.isclose(assemble(a(f)), expected, rtol=1e-14)
+    assert np.isclose(assemble(action(c, f)), expected, rtol=1e-14)
+    assert np.isclose(assemble(c(f)), expected, rtol=1e-14)
 
 
 def test_vector_formsum(a):


### PR DESCRIPTION
# Description
Implement `__call__` method on `Cofunction` to compute the duality paring against a `Function`. Also added tests.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
