### PR TITLE
`WithGeometryBase.__dir__` fix

### DIFF
--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -288,7 +288,7 @@ class WithGeometryBase(object):
         return val
 
     def __dir__(self):
-        current = super(type(self), self).__dir__()
+        current = super().__dir__()
         return list(OrderedDict.fromkeys(dir(self.topological) + current))
 
     def boundary_nodes(self, sub_domain):

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -122,3 +122,7 @@ def test_VV_ne_VVV():
     W0 = V * V
     W1 = V * V * V
     assert W0 != W1
+
+
+def test_function_space_dir(cg1):
+    dir(cg1)


### PR DESCRIPTION
# Description

Bugfix to `dir(FunctionSpace(...))`.

Fixes infinite recursion caused by the use of `super(type(self), self)` in a base class.
