### PR TITLE
Zenodo search API no longer produces unique results

### DIFF
--- a/.github/workflows/zenodo-canary.yml
+++ b/.github/workflows/zenodo-canary.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
 
 jobs:
   zenodo_canary:

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -157,20 +157,18 @@ def resolve_doi_branches(doi):
     import requests
     import hashlib
     log.info("Installing Firedrake components specified by {}".format(doi))
-    response = requests.get("https://zenodo.org/api/records",
-                            params={"q": "doi:{}".format(doi.replace("/", r"\/"))})
-    if response.status_code >= 400:
+    # Zenodo updated their API to use elastic search so simply querying with
+    # ?q=doi:10.5281/zenodo.<id> now returns multiple results (not ideal)
+    # Instead use
+    # /<id>
+    # as documented here https://developers.zenodo.org/#retrieve
+    id_ = doi.split('.')[-1]
+    response = requests.get("https://zenodo.org/api/records/{}".format(id_))
+    if not response.ok:
         log.error("Unable to obtain Zenodo record for doi {}".format(doi))
         log.error("Response was {}".format(response.json()))
         sys.exit(1)
-    response = response.json()
-    try:
-        record, = response["hits"]["hits"]
-    except ValueError:
-        log.error("Was expecting one record for doi '{doi}', found {num}".format(
-            doi=doi, num=response["hits"]["total"]))
-        log.error("Response was {}".format(response))
-        sys.exit(1)
+    record = response.json()
     files = record["files"]
     try:
         componentjson, = (f for f in files if f["key"] == "components.json")


### PR DESCRIPTION
# Description

Update `firedrake-install` to no longer use search feature of Zenodo RESTful API. Zenodo have updated to use elastic search, but this means that searching for a DOI (supposedly unique) does not produce a unique result. [Zenodo API docs ](https://developers.zenodo.org/#retrieve) suggest that this method of querying is a suitable replacement. 