### PR TITLE
Remove ml from PETSc external deps

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -753,15 +753,10 @@ def get_petsc_options(minimal=False):
             # Non-free license.
             petsc_options.add("--download-parmetis")
 
-    if options["petsc_int_type"] == "int32":
-        if not options["minimal_petsc"]:
-            # AMG
-            petsc_options.add("--download-ml")
-    else:
+    if options["petsc_int_type"] != "int32":
         petsc_options.add("--with-64-bit-indices")
 
     if options["complex"]:
-        petsc_options -= {'--download-ml'}
         petsc_options.add('--with-scalar-type=complex')
 
     if options.get("mpiexec") is not None:


### PR DESCRIPTION
# Description

We have been warned that ML installed by PETSc is not current and subject to breakages here:
https://gitlab.com/petsc/petsc/-/issues/1475#note_1596065130

This is a bug fix that removes it from Firedrake install by default