### PR TITLE
Add __str__ method for SolverVarFormBlock

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -600,6 +600,10 @@ class SolveVarFormBlock(GenericSolveBlock):
         super()._init_solver_parameters(args, kwargs)
         solve_init_params(self, args, kwargs, varform=True)
 
+    def __str__(self):
+        return "solve({} = {})".format(ufl2unicode(self.lhs),
+                                       ufl2unicode(self.rhs))
+
 
 class NonlinearVariationalSolveBlock(GenericSolveBlock):
     def __init__(self, equation, func, bcs, adj_F, dFdm_cache, problem_J,


### PR DESCRIPTION
# Description
Adding `__str__` method in the `SolverVarFormBlock`. 

The `__str__` is useful to visualise the tape DAG.

**The `ufl2unicode(self.lhs)` is going to fail raised by a ufl bug.  I have opened a UFL [PR](https://github.com/FEniCS/ufl/pull/236) to fix it.** 

Obs:
Thank you Connor for helping me with the UFL fail.:)