### PR TITLE
Explicitly Specify comm in VectorSpaceBasis to Suppress Warnings

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -238,7 +238,7 @@ def coarsen_nlvp(problem, self, coefficient_mapping=None):
 @coarsen.register(firedrake.VectorSpaceBasis)
 def coarsen_vectorspacebasis(basis, self, coefficient_mapping=None):
     coarse_vecs = [self(vec, self, coefficient_mapping=coefficient_mapping) for vec in basis._vecs]
-    vsb = firedrake.VectorSpaceBasis(coarse_vecs, constant=basis._constant)
+    vsb = firedrake.VectorSpaceBasis(coarse_vecs, constant=basis._constant, comm=basis._comm)
     vsb.orthonormalize()
     return vsb
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -346,7 +346,7 @@ class PMGBase(PCSNESBase):
                         # the nullspace basis is in the dual of V
                         interpolate.multTranspose(xf, xc)
                     coarse_vecs.append(wc)
-                coarse_nullspace = VectorSpaceBasis(coarse_vecs, constant=fine_nullspace._constant)
+                coarse_nullspace = VectorSpaceBasis(coarse_vecs, constant=fine_nullspace._constant, comm=fine_nullspace._comm)
                 coarse_nullspace.orthonormalize()
             else:
                 return fine_nullspace


### PR DESCRIPTION
**Overview:**

This minor PR addresses the issue of unspecified `comm` parameters in `VectorSpaceBasis` calls within the multigrid (mg) and p-multigrid (pmg) solvers. The lack of an explicit `comm` argument results in repeated warnings for each hierarchy level:

```python
firedrake:WARNING No comm specified for VectorSpaceBasis, COMM_WORLD assumed
```

**Modifications:**

By explicitly specifying the `comm` argument, the changes introduced in this PR serve two main purposes:
- Eliminate redundant warning messages that clutter the execution output.
- Ensure clarity and intentionality in the selection of communicators for `VectorSpaceBasis`.

**Replication of Warning:**

The warning can be replicated using the code below, which runs the mg and pmg solvers on a singular Poisson problem. Prior to this PR, executing the code results in the mentioned warnings. Post-implementation, these warnings are no longer present.

```python
from firedrake import *
import numpy
import pytest

def run_poisson(typ):
    if typ == 'mg':
        parameters = {
                      "snes_type": "ksponly",
                      "ksp_type": "preonly",
                      "pc_type" : "mg",
                      "pc_mg_type": "full",
                      "pmg_levels_ksp_type": "chebyshev",
                      "pmg_levels_ksp_max_it": 2,
                      "pmg_levels_pc_type": "jacobi"}
    else:
        parameters = {
                      "snes_type": "ksponly",
                      "ksp_type": "preonly",
                      "pc_type" : "python",
                      "pc_python_type": "firedrake.PMGPC",
                      "pmg_levels_ksp_type": "chebyshev",
                      "pmg_levels_ksp_max_it": 2,
                      "pmg_levels_pc_type": "jacobi"}

    mesh = UnitSquareMesh(10, 10)
    nlevel = 3
    mh = MeshHierarchy(mesh, nlevel)
    V = FunctionSpace(mh[-1], 'CG', 2)

    u = function.Function(V)
    f = function.Function(V)
    v = TestFunction(V)
    F = inner(grad(u), grad(v))*dx - inner(f, v)*dx
    bcs = [] # need a problem with null-space 
    
    x = SpatialCoordinate(V.mesh())
    f.interpolate(-0.5*pi*pi*(4*cos(pi*x[0]) - 5*cos(pi*x[0]*0.5) + 2)*sin(pi*x[1]))

    nullspace = VectorSpaceBasis(constant=True, comm=mesh.comm)
    solve(F == 0, u, bcs=bcs, solver_parameters=parameters,
          nullspace=nullspace)

if __name__ == "__main__":
    for typ in ['mg', 'pmg']:
        print(f'Running {typ}:')
        run_poisson('mg')
```
