### PR TITLE
Fix Jacobian of FormSum residual

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -77,7 +77,7 @@ class NonlinearVariationalProblem(NonlinearVariationalProblemMixin):
             raise TypeError("Provided solution is a '%s', not a Function" % type(self.u).__name__)
         # Use the user-provided Jacobian. If none is provided, derive
         # the Jacobian from the residual.
-        self.J = J or ufl_expr.derivative(F, u)
+        self.J = J or ufl.lhs(ufl_expr.derivative(F, u))
 
         # Argument checking
         check_pde_args(self.F, self.J, self.Jp)

--- a/tests/regression/test_solving_interface.py
+++ b/tests/regression/test_solving_interface.py
@@ -221,7 +221,7 @@ def test_constant_jacobian_lvs():
     assert not (norm(assemble(out*5 - f)) < 2e-7)
 
 
-def test_linear_solve_cofunction_rhs():
+def test_solve_cofunction_rhs():
     mesh = UnitSquareMesh(10, 10)
     V = FunctionSpace(mesh, "CG", 1)
 
@@ -240,7 +240,7 @@ def test_linear_solve_cofunction_rhs():
     assert np.allclose(Aw.dat.data_ro, L.dat.data_ro)
 
 
-def test_nonlinear_solve_cofunction_rhs():
+def test_solve_cofunction_lhs():
     mesh = UnitSquareMesh(10, 10)
     V = FunctionSpace(mesh, "CG", 1)
 

--- a/tests/regression/test_solving_interface.py
+++ b/tests/regression/test_solving_interface.py
@@ -221,7 +221,7 @@ def test_constant_jacobian_lvs():
     assert not (norm(assemble(out*5 - f)) < 2e-7)
 
 
-def test_solve_cofunction_rhs():
+def test_linear_solve_cofunction_rhs():
     mesh = UnitSquareMesh(10, 10)
     V = FunctionSpace(mesh, "CG", 1)
 
@@ -234,6 +234,26 @@ def test_solve_cofunction_rhs():
 
     w = Function(V)
     solve(a == L, w)
+
+    Aw = assemble(action(a, w))
+    assert isinstance(Aw, Cofunction)
+    assert np.allclose(Aw.dat.data_ro, L.dat.data_ro)
+
+
+def test_nonlinear_solve_cofunction_rhs():
+    mesh = UnitSquareMesh(10, 10)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = inner(u, v) * dx
+
+    L = Cofunction(V.dual())
+    L.vector()[:] = 1.
+
+    w = Function(V)
+    F = action(a, w) - L
+    solve(F == 0, w)
 
     Aw = assemble(action(a, w))
     assert isinstance(Aw, Cofunction)


### PR DESCRIPTION
# Description
Suppose that we provide a residual `F` as `FormSum` consisting of a `action(form, u)` + other `BaseForms`  independent of  `u`.

The derivative of a `FormSum` is always a `FormSum`, and at the moment assembly we are always expecting a `Form`, so we get this error #3206.

Constructing the Jacobian as `J = lhs(derivative(F, u))` will eagerly expand derivatives to gives us the `Form`, maybe earlier than we would like, so perhaps this is not the best solution. Maybe this could be better fixed in ufl, perhaps by not returning a `FormSum` if the derivative has only one term, for example [ufl PR #45](https://github.com/firedrakeproject/ufl/pull/45/files).


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
