### PR TITLE
Fix function spaces check in linear solver

### DIFF
--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -142,8 +142,8 @@ pass in.  In the pre-assembled case, we are solving a linear system:
 Where :math:`A` is a known matrix, :math:`\vec{b}` is a known right
 hand side vector and :math:`\vec{x}` is the unknown solution vector.
 In Firedrake, :math:`A` is represented as a
-:py:class:`~.Matrix`, while :math:`\vec{b}` and
-:math:`\vec{x}` are both :py:class:`~.Function`\s.
+:py:class:`~.MatrixBase`, while :math:`\vec{b}` and
+:math:`\vec{x}` can be :py:class:`~.Function`\s or :py:class:`~.Cofunction`\s.
 We build these values by calling ``assemble`` on the UFL forms that
 define our problem, which, as before are denoted ``a`` and ``L``.
 Similarly to the linear variational case, we first need a function in

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -250,7 +250,8 @@ class WithGeometryBase(object):
 
     def __eq__(self, other):
         try:
-            return self.topological == other.topological and \
+            return type(self) == type(other) and \
+                self.topological == other.topological and \
                 self.mesh() is other.mesh()
         except AttributeError:
             return False

--- a/firedrake/linear_solver.py
+++ b/firedrake/linear_solver.py
@@ -151,6 +151,11 @@ class LinearSolver(OptionsManager):
         if not isinstance(b, (function.Function, cofunction.Cofunction)):
             raise TypeError("Provided RHS is a '%s', not a Function or Cofunction" % type(b).__name__)
 
+        if x.function_space() != self.trial_space or b.function_space() != self.test_space.dual():
+            # When solving `Ax = b`, with A: V x U -> R, or equivalently A: V -> U*,
+            # we need to make sure that x and b belong to V and U*, respectively.
+            raise ValueError("Mismatching function spaces.")
+
         if len(self.trial_space) > 1 and self.nullspace is not None:
             self.nullspace._apply(self.trial_space.dof_dset.field_ises)
         if len(self.test_space) > 1 and self.transpose_nullspace is not None:

--- a/tests/regression/test_solving_interface.py
+++ b/tests/regression/test_solving_interface.py
@@ -238,3 +238,24 @@ def test_solve_cofunction_rhs():
     Aw = assemble(action(a, w))
     assert isinstance(Aw, Cofunction)
     assert np.allclose(Aw.dat.data_ro, L.dat.data_ro)
+
+
+def test_linear_solver_check_spaces():
+    mesh = UnitSquareMesh(10, 10)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = inner(u, v) * dx
+    A = assemble(a)
+
+    L = Cofunction(V.dual())
+    L.vector()[:] = 1.
+
+    Lf = L.riesz_representation(riesz_map="l2")
+
+    w = Function(V)
+    solve(A, w, L)
+
+    with pytest.raises(ValueError):
+        solve(A, w, Lf)


### PR DESCRIPTION
# Description

This PR: 1) updates the `LinearSolver`'s check on the solution and the rhs, and 2) fixes `__eq__` for function spaces. This fixes the issues #3203 and #3130.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
