### PR TITLE
Fix mumps options for test with nullspace

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1940,6 +1940,9 @@ if mode == "install":
     for p in packages:
         pip_requirements(p, compiler_env)
 
+    # FIAT requires recursivenodes, but does not include a requirements.txt
+    run_pip_install(["recursivenodes"])
+
     with environment(**compiler_env):
         build_and_install_h5py()
         build_and_install_libsupermesh()

--- a/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
+++ b/tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
@@ -91,6 +91,7 @@ def test_fieldsplit_fieldsplit_aux_multigrid():
                            "mat_type": "aij",
                            "pc_type": "lu",
                            "pc_factor_mat_solver_type": "mumps",
+                           "mat_mumps_icntl_24": 1,
                            "snes_monitor": None}
     nsp_guess = MixedVectorSpaceBasis(G, [G.sub(0), VectorSpaceBasis(constant=True)])
     solve(F_guess == 0, g, bcs=Gbcs, nullspace=nsp_guess, solver_parameters=solver_params_guess)


### PR DESCRIPTION
# Description
The first solve in `tests/regression/test_fieldsplit_fieldsplit_aux_multigrid.py` was fine without knowing how mumps should deal with the nullspace. However, after messing up a bit with FIAT, and introducing new basis function tabulation algorithms that produce results that only differ by O(1E-15) this test failed because of the lack of nullspace options.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
