### PR TITLE
Fixing the error for the cases where rhs is Cofunction

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -79,7 +79,7 @@ class GenericSolveBlock(Block, Backend):
         else:
             raise NotImplementedError(
                 "The self.rhs type is not supported in this method yet."
-                )
+            )
 
     def _create_F_form(self):
         # Process the equation forms, replacing values with checkpoints,

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -1,3 +1,4 @@
+from numbers import Number
 import numpy
 import ufl
 from ufl import replace
@@ -69,8 +70,16 @@ class GenericSolveBlock(Block, Backend):
         self.assemble_kwargs = {}
 
     def __str__(self):
-        return "solve({} = {})".format(ufl2unicode(self.lhs),
-                                       ufl2unicode(self.rhs))
+        if isinstance(self.rhs, ufl.Form) or isinstance(self.rhs, Number):
+            return "solve({} = {})".format(ufl2unicode(self.lhs),
+                                           ufl2unicode(self.rhs))
+        elif isinstance(self.rhs, firedrake.Cofunction):
+            return "solve({} = {})".format(ufl2unicode(self.lhs),
+                                           str(self.rhs))
+        else:
+            raise NotImplementedError(
+                "The self.rhs type is not supported in this method yet."
+                )
 
     def _create_F_form(self):
         # Process the equation forms, replacing values with checkpoints,


### PR DESCRIPTION
# Description

This PR aims to fix errors for the cases in which `self.rhs` is a `Cofunction` type. 

In this code I assumed the `self.rhs` type to be `ufl.Form`, `Number` or `Cofunction`.  If the`self.rhs` type is not in these cases, I added `NotImplementedError`. 

I also considered the code below by assuming that the unique constraint on using `ufl2unicode` is for the case where  the `self.rhs` type is a`Cofunction`.  However, I am not sure if this assumption make sense. Certainly, the reviewers know more about this. :)
```
if isinstance(self.rhs, firedrake.Cofunction):
   return "solve({} = {})".format(ufl2unicode(self.lhs),
                                           str(self.rhs))
else:
  return "solve({} = {})".format(ufl2unicode(self.lhs),
                                             ufl2unicode(self.rhs))
```
