### PR TITLE
Fix extraction of form coefficients in MG

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -206,19 +206,19 @@ def coarsen_nlvp(problem, self, coefficient_mapping=None):
         forms = (finectx.F, finectx.J, finectx.Jp)
         coefficients = unique(chain.from_iterable(form.coefficients()
                               for form in forms if form is not None))
-        for fine in coefficients:
-            if hasattr(fine, '_child'):
-                if is_dual(fine):
-                    manager.restrict(fine, fine._child)
+        for c in coefficients:
+            if hasattr(c, '_child'):
+                if is_dual(c):
+                    manager.restrict(c, c._child)
                 else:
-                    manager.inject(fine, fine._child)
+                    manager.inject(c, c._child)
         # Apply bcs and also inject them
         for bc in chain(*finectx._problem.bcs):
             if isinstance(bc, DirichletBC):
                 bc.apply(finectx._x)
-                fine = bc.function_arg
-                if isinstance(fine, firedrake.Function) and hasattr(fine, "_child"):
-                    manager.inject(fine, fine._child)
+                g = bc.function_arg
+                if isinstance(g, firedrake.Function) and hasattr(g, "_child"):
+                    manager.inject(g, g._child)
 
     V = problem.u.function_space()
     if not hasattr(V, "_coarse"):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -22,7 +22,7 @@ from ufl import Constant
 from ufl.coefficient import BaseCoefficient
 
 from firedrake.function import Function, Cofunction
-from firedrake.utils import cached_property
+from firedrake.utils import cached_property, unique
 
 from itertools import chain, count
 
@@ -1387,16 +1387,6 @@ def space_equivalence(A, B):
     """
 
     return A.mesh() == B.mesh() and A.ufl_element() == B.ufl_element()
-
-
-def unique(iterable):
-    """ Return tuple of unique items in iterable, items must be hashable
-    """
-    # Use dict to preserve order and compare by hash
-    unique_dict = {}
-    for item in iterable:
-        unique_dict[item] = None
-    return tuple(unique_dict.keys())
 
 
 # Establishes levels of precedence for Slate tensors

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -37,6 +37,16 @@ def _init():
         op2.init(**parameters["pyop2_options"])
 
 
+def unique(iterable):
+    """ Return tuple of unique items in iterable, items must be hashable
+    """
+    # Use dict to preserve order and compare by hash
+    unique_dict = {}
+    for item in iterable:
+        unique_dict[item] = None
+    return tuple(unique_dict.keys())
+
+
 def unique_name(name, nameset):
     """Return name if name is not in nameset, or a deterministic
     uniquified name if name is in nameset. The new name is inserted into

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -255,18 +255,15 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 
         # Make sure appcontext is attached to every coefficient DM before we solve.
         problem = self._problem
-        problem_dms = [self.snes.getDM()]
-        seen = {problem.u.function_space()}
         forms = (problem.F, problem.J, problem.Jp)
-        for val in chain.from_iterable(form.coefficients() for form in forms if form is not None):
-            if isinstance(val, (function.Function, cofunction.Cofunction)):
-                V = val.function_space()
-                if V not in seen:
-                    problem_dms.append(V.dm)
-                    seen.add(V)
+        coefficients = utils.unique(chain.from_iterable(form.coefficients() for form in forms if form is not None))
+        # Make sure the solution dm is visited last
+        solution_dm = self.snes.getDM()
+        problem_dms = [V.dm for V in utils.unique(c.function_space() for c in coefficients) if V.dm != solution_dm]
+        problem_dms.append(solution_dm)
 
-        for dbc in self._problem.dirichlet_bcs():
-            dbc.apply(self._problem.u)
+        for dbc in problem.dirichlet_bcs():
+            dbc.apply(problem.u)
 
         if bounds is not None:
             lower, upper = bounds
@@ -280,7 +277,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                 # Ensure options database has full set of options (so monitors
                 # work right)
                 for ctx in chain([self.inserted_options()],
-                                 [dmhooks.add_hooks(dm, self, appctx=self._ctx) for dm in reversed(problem_dms)],
+                                 [dmhooks.add_hooks(dm, self, appctx=self._ctx) for dm in problem_dms],
                                  self._transfer_operators):
                     stack.enter_context(ctx)
                 self.snes.solve(None, work)

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -3,7 +3,7 @@ from itertools import chain
 from contextlib import ExitStack
 
 from firedrake import dmhooks, slate, solving, solving_utils, ufl_expr, utils
-from firedrake import function, cofunction
+from firedrake import function
 from firedrake.petsc import PETSc, OptionsManager, flatten_parameters
 from firedrake.bcs import DirichletBC
 from firedrake.adjoint_utils import NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -257,10 +257,8 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         problem = self._problem
         problem_dms = [self.snes.getDM()]
         seen = {problem.u.function_space()}
-        coefficients = problem.F.coefficients() + problem.J.coefficients()
-        if problem.Jp is not None:
-            coefficients += problem.Jp.coefficients()
-        for val in coefficients:
+        forms = (problem.F, problem.J, problem.Jp)
+        for val in chain.from_iterable(form.coefficients() for form in forms if form is not None):
             if isinstance(val, (function.Function, cofunction.Cofunction)):
                 V = val.function_space()
                 if V not in seen:

--- a/tests/multigrid/test_poisson_gmg.py
+++ b/tests/multigrid/test_poisson_gmg.py
@@ -134,7 +134,7 @@ def test_preconditioner_coarsening(solver_type):
     V = FunctionSpace(mesh, 'CG', 2)
     R = FunctionSpace(mesh, 'R', 0)
     alpha = Function(R)
-    alpha.assign(1)
+    alpha.assign(0.01)
     beta = Function(R)
     beta.assign(100)
 
@@ -145,7 +145,7 @@ def test_preconditioner_coarsening(solver_type):
     # Rescaled a as the preconditioner
     Jp = inner(beta * alpha * grad(u), grad(v))*dx
     bcs = DirichletBC(V, 0.0, (1, 2, 3, 4))
-    L = inner(f, v)*dx
+    L = inner(alpha * f, v)*dx
 
     uh = function.Function(V)
     # If we are providing Jp we need to also specify a python preconditioner

--- a/tests/multigrid/test_poisson_gmg.py
+++ b/tests/multigrid/test_poisson_gmg.py
@@ -156,7 +156,7 @@ def test_preconditioner_coarsening(solver_type):
         "ksp_convergence_test": "skip",
         "ksp_type": "richardson",
         "ksp_max_it": 1,
-        "ksp_richardson_scale": float(beta),  # undo the rescaling
+        "ksp_richardson_scale": float(beta / alpha),  # undo the rescaling
         "pc_type": "python",
         "pc_python_type": "firedrake.AssembledPC",
         "assembled": solver_parameters(solver_type)

--- a/tests/multigrid/test_poisson_gmg.py
+++ b/tests/multigrid/test_poisson_gmg.py
@@ -143,7 +143,7 @@ def test_preconditioner_coarsening(solver_type):
     u = TrialFunction(V)
     a = inner(alpha * grad(u), grad(v))*dx
     # Rescaled a as the preconditioner
-    Jp = inner(beta * grad(u), grad(v))*dx
+    Jp = inner(beta * alpha * grad(u), grad(v))*dx
     bcs = DirichletBC(V, 0.0, (1, 2, 3, 4))
     L = inner(f, v)*dx
 
@@ -156,7 +156,7 @@ def test_preconditioner_coarsening(solver_type):
         "ksp_convergence_test": "skip",
         "ksp_type": "richardson",
         "ksp_max_it": 1,
-        "ksp_richardson_scale": float(beta / alpha),  # undo the rescaling
+        "ksp_richardson_scale": float(beta),  # undo the rescaling
         "pc_type": "python",
         "pc_python_type": "firedrake.AssembledPC",
         "assembled": solver_parameters(solver_type)


### PR DESCRIPTION
# Description
I was mistakenly trying to `extend()` a tuple in the extraction of coefficients inside `inject_on_restrict`. To fix this, we now build an iterable of coefficients using `chain.from_iterable`, which does not rely on the assumption that `form.coefficients()` is a tuple.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
