### PR TITLE
Make DualSpace return a FiredrakeDualSpace when given a MixedElement

### DIFF
--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -161,7 +161,8 @@ def DualSpace(mesh, family, degree=None, name=None, vfamily=None,
 
     # Support FunctionSpace(mesh, MixedElement)
     if type(element) is ufl.MixedElement:
-        return MixedFunctionSpace(element, mesh=mesh, name=name)
+        new = MixedFunctionSpace(element, mesh=mesh, name=name)
+        return impl.FiredrakeDualSpace.create(new, mesh)
 
     # Check that any Vector/Tensor/Mixed modifiers are outermost.
     check_element(element)

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -184,7 +184,7 @@ def coarsen_function(expr, self, coefficient_mapping=None):
     if new is None:
         Vf = expr.function_space()
         Vc = self(Vf, self)
-        new = firedrake.Function(Vc, name=f"coarse_{expr.name()}")
+        new = type(expr)(Vc, name=f"coarse_{expr.name()}")
         expr._child = weakref.proxy(new)
         manager = get_transfer_manager(Vf.dm)
         if is_dual(expr):


### PR DESCRIPTION
# Description
This PR tries to address #3234.

`firedrake.DualSpace` has a special case for `MixedElements` which looks like it was taken from `firedrake.FunctionSpace`. The special case explicitly creates a `MixedFunctionSpace` and exits early. This is wrong for `DualSpace` because I think it should return a `FiredrakeDualSpace`.

Instead, I've followed the pattern for the other return statements, and returned a `FiredrakeDualSpace` created from the `MixedFunctionSpace`.
