### PR TITLE
Fix interpolation behaviour when default_missing_val=0 and clarify documentation

### DIFF
--- a/docs/source/interpolation.rst
+++ b/docs/source/interpolation.rst
@@ -180,13 +180,16 @@ argument:
    :dedent:
    :lines: 72-73, 80
 
-By default the missing degrees of freedom (DoFs, the global basis function
-coefficients which could not be set) are zero:
+In this case, the missing degrees of freedom (DoFs, the global basis function
+coefficients which could not be set) are, by default, set to zero:
 
 .. literalinclude:: ../../tests/regression/test_interpolation_manual.py
    :language: python3
    :dedent:
    :lines: 85
+
+If we specify an output :py:class:`~.Function` then the missing DoFs are
+unmodified.
 
 We can optionally specify a value to use for our missing DoFs. Here
 we set them to be ``nan`` ('not a number') for easy identification:
@@ -195,6 +198,9 @@ we set them to be ``nan`` ('not a number') for easy identification:
    :language: python3
    :dedent:
    :lines: 90-93
+
+If we specify an output :py:class:`~.Function`, this overwrites the missing
+DoFs.
 
 When using :py:class:`~.Interpolator`\s, the ``allow_missing_dofs`` keyword
 argument is set at construction:

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -103,15 +103,19 @@ def interpolate(
         defined on the source mesh. For example, where nodes are point
         evaluations, points in the target mesh that are not in the source mesh.
         When ``False`` this raises a ``ValueError`` should this occur. When
-        ``True`` the corresponding values are set to zero or to the value
-        ``default_missing_val`` if given. Ignored if interpolating within the
-        same mesh or onto a :func:`.VertexOnlyMesh` (the behaviour of a
-        :func:`.VertexOnlyMesh` in this scenario is, at present, set when
-        it is created).
+        ``True`` the corresponding values are either (a) unchanged if
+        some ``output`` is given to the :meth:`interpolate` method or (b) set
+        to zero. In either case, if ``default_missing_val`` is specified, that
+        value is used. This does not affect transpose interpolation. Ignored if
+        interpolating within the same mesh or onto a :func:`.VertexOnlyMesh`
+        (the behaviour of a :func:`.VertexOnlyMesh` in this scenario is, at
+        present, set when it is created).
     :kwarg default_missing_val: For interpolation across meshes: the optional
         value to assign to DoFs in the target mesh that are outside the source
-        mesh. If this is not set then zero is used. Ignored if interpolating
-        within the same mesh or onto a :func:`.VertexOnlyMesh`.
+        mesh. If this is not set then the values are either (a) unchanged if
+        some ``output`` is given to the :meth:`interpolate` method or (b) set
+        to zero. Ignored if interpolating within the same mesh or onto a
+        :func:`.VertexOnlyMesh`.
     :kwarg ad_block_tag: An optional string for tagging the resulting block on
         the Pyadjoint tape.
     :returns: a new :class:`.Function` in the space ``V`` (or ``V`` if
@@ -167,13 +171,13 @@ class Interpolator(abc.ABC):
         defined on the source mesh. For example, where nodes are point
         evaluations, points in the target mesh that are not in the source mesh.
         When ``False`` this raises a ``ValueError`` should this occur. When
-        ``True`` the corresponding values are either left unchanged in the
-        :class:`.Function` produced by the interpolation, or are set to a
-        default value if one is provided. See the ``default_missing_val`` kwarg
-        of :meth:`interpolate` for more. Ignored if interpolating within the
-        same mesh or onto a :func:`.VertexOnlyMesh` (the behaviour of a
-        :func:`.VertexOnlyMesh` in this scenario is, at present, set when it is
-        created).
+        ``True`` the corresponding values are either (a) unchanged if
+        some ``output`` is given to the :meth:`interpolate` method or (b) set
+        to zero. Can be overwritten with the ``default_missing_val`` kwarg
+        of :meth:`interpolate`. This does not affect transpose interpolation.
+        Ignored if interpolating within the same mesh or onto a
+        :func:`.VertexOnlyMesh` (the behaviour of a :func:`.VertexOnlyMesh` in
+        this scenario is, at present, set when it is created).
 
     This object can be used to carry out the same interpolation
     multiple times (for example in a timestepping loop).
@@ -229,10 +233,9 @@ class Interpolator(abc.ABC):
               interpolation operator.
         :kwarg default_missing_val: For interpolation across meshes: the
             optional value to assign to DoFs in the target mesh that are
-            outside the source mesh. If this is not set and an ``output``
-            :class:`.Function` is specified, then such DoF values are left
-            unchanged. If this is not set and no ``output`` :class:`.Function`
-            is specified, then the default value is zero. This does not affect
+            outside the source mesh. If this is not set then the values are
+            either (a) unchanged if some ``output`` is specified to the
+            :meth:`interpolate` method or (b) set to zero. This does not affect
             transpose interpolation. Ignored if interpolating within the same
             mesh or onto a :func:`.VertexOnlyMesh`.
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -548,7 +548,7 @@ class CrossMeshInterpolator(Interpolator):
             )
             # We have to create the Function before interpolating so we can
             # set default missing values (if requested).
-            if default_missing_val:
+            if default_missing_val is not None:
                 f_src_at_dest_node_coords_dest_mesh_decomp.dat.data_wo[
                     :
                 ] = default_missing_val

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -661,6 +661,11 @@ def test_missing_dofs():
     assert np.allclose(f_dest.at(coords), np.array([1.0, 1.0]))
     interpolator.interpolate(f_src, default_missing_val=2.0, output=f_dest)
     assert np.allclose(f_dest.at(coords), np.array([0.25, 2.0]))
+    f_dest = Function(V_dest).assign(Constant(1.0))
+    # make sure we have actually changed f_dest before checking interpolation
+    assert np.allclose(f_dest.at(coords), np.array([1.0, 1.0]))
+    interpolator.interpolate(f_src, default_missing_val=0.0, output=f_dest)
+    assert np.allclose(f_dest.at(coords), np.array([0.25, 0.0]))
 
     # Try the other way around so we can check transpose is unaffected
     m_src = UnitSquareMesh(4, 5)


### PR DESCRIPTION
In cross-mesh interpolation, where we had `default_missing_val=0.0` it would not be used due to an incorrect if statement. This fixes that and clarifies some documentation. Supersedes #3237