### PR TITLE
Redesign periodic meshes

### DIFF
--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2960,7 +2960,7 @@ def exchange_cell_orientations(
         raise ValueError("Don't know how to create datatype for %r", PETSc.IntType)
     # Halo exchange of cell orientations, i.e. receive orientations
     # from the owners in the halo region.
-    if plex.comm.size > 1:
+    if plex.comm.size > 1 and plex.isDistributed():
         sf = plex.getPointSF()
         CHKERR(PetscSFGetGraph(sf.sf, &nroots, &nleaves, &ilocal, &iremote))
 

--- a/firedrake/cython/petschdr.pxi
+++ b/firedrake/cython/petschdr.pxi
@@ -30,6 +30,8 @@ cdef extern from "petscsys.h" nogil:
 cdef extern from "petscdmplex.h" nogil:
     int DMPlexGetHeightStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
     int DMPlexGetDepthStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
+    int DMPlexGetPointHeight(PETSc.PetscDM,PetscInt,PetscInt*)
+    int DMPlexGetPointDepth(PETSc.PetscDM,PetscInt,PetscInt*)
 
     int DMPlexGetChart(PETSc.PetscDM,PetscInt*,PetscInt*)
     int DMPlexGetConeSize(PETSc.PetscDM,PetscInt,PetscInt*)
@@ -68,11 +70,15 @@ cdef extern from "petscdmswarm.h" nogil:
 cdef extern from "petscvec.h" nogil:
     int VecGetArray(PETSc.PetscVec,PetscScalar**)
     int VecRestoreArray(PETSc.PetscVec,PetscScalar**)
+    int VecGetArrayRead(PETSc.PetscVec,const PetscScalar**)
+    int VecRestoreArrayRead(PETSc.PetscVec,const PetscScalar**)
 
 cdef extern from "petscis.h" nogil:
     int PetscSectionGetOffset(PETSc.PetscSection,PetscInt,PetscInt*)
     int PetscSectionGetDof(PETSc.PetscSection,PetscInt,PetscInt*)
     int PetscSectionSetDof(PETSc.PetscSection,PetscInt,PetscInt)
+    int PetscSectionSetFieldDof(PETSc.PetscSection,PetscInt,PetscInt,PetscInt)
+    int PetscSectionGetFieldDof(PETSc.PetscSection,PetscInt,PetscInt,PetscInt*)
     int PetscSectionGetMaxDof(PETSc.PetscSection,PetscInt*)
     int PetscSectionSetPermutation(PETSc.PetscSection,PETSc.PetscIS)
     int ISGetIndices(PETSc.PetscIS,PetscInt*[])

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2400,13 +2400,16 @@ def make_mesh_from_coordinates(coordinates, name):
     return mesh
 
 
-def make_mesh_from_mesh_topology(topology, name, comm=COMM_WORLD):
+def make_mesh_from_mesh_topology(topology, name):
     # Construct coordinate element
     # TODO: meshfile might indicates higher-order coordinate element
     cell = topology.ufl_cell()
     geometric_dim = topology.topology_dm.getCoordinateDim()
     cell = cell.reconstruct(geometric_dimension=geometric_dim)
-    element = finat.ufl.VectorElement("Lagrange", cell, 1)
+    if not topology.topology_dm.getCoordinatesLocalized():
+        element = finat.ufl.VectorElement("Lagrange", cell, 1)
+    else:
+        element = finat.ufl.VectorElement("DQ" if cell in [ufl.quadrilateral, ufl.hexahedron] else "DG", cell, 1, variant="equispaced")
     # Create mesh object
     mesh = MeshGeometry.__new__(MeshGeometry, element)
     mesh._init_topology(topology)

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -63,12 +63,41 @@ __all__ = [
 ]
 
 
+distribution_parameters_noop = {"partition": False,
+                                "overlap_type": (mesh.DistributedMeshOverlapType.NONE, 0)}
+reorder_noop = False
+
+
+def _postprocess_periodic_mesh(coords, comm, distribution_parameters, reorder, name, distribution_name, permutation_name):
+    dm = coords.function_space().mesh().topology.topology_dm
+    dm.removeLabel("pyop2_core")
+    dm.removeLabel("pyop2_owned")
+    dm.removeLabel("pyop2_ghost")
+    dm.removeLabel("exterior_facets")
+    dm.removeLabel("interior_facets")
+    V = coords.function_space()
+    dmcommon._set_dg_coordinates(dm,
+                                 V.finat_element,
+                                 V.dm.getLocalSection(),
+                                 coords.dat._vec)
+    return mesh.Mesh(
+        dm,
+        comm=comm,
+        distribution_parameters=distribution_parameters,
+        reorder=reorder,
+        name=name,
+        distribution_name=distribution_name,
+        permutation_name=permutation_name,
+    )
+
+
 @PETSc.Log.EventDecorator()
 def IntervalMesh(
     ncells,
     length_or_left,
     right=None,
     distribution_parameters=None,
+    reorder=False,
     comm=COMM_WORLD,
     name=mesh.DEFAULT_MESH_NAME,
     distribution_name=None,
@@ -85,6 +114,7 @@ def IntervalMesh(
          be the left boundary point).
     :kwarg distribution_parameters: options controlling mesh
            distribution, see :func:`.Mesh` for details.
+    :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on.
     :kwarg name: Optional name of the mesh.
     :kwarg distribution_name: the name of parallel distribution used
@@ -134,7 +164,7 @@ def IntervalMesh(
 
     m = mesh.Mesh(
         plex,
-        reorder=False,
+        reorder=reorder,
         distribution_parameters=distribution_parameters,
         name=name,
         distribution_name=distribution_name,
@@ -148,6 +178,7 @@ def IntervalMesh(
 def UnitIntervalMesh(
     ncells,
     distribution_parameters=None,
+    reorder=False,
     comm=COMM_WORLD,
     name=mesh.DEFAULT_MESH_NAME,
     distribution_name=None,
@@ -159,6 +190,7 @@ def UnitIntervalMesh(
     :arg ncells: The number of the cells over the interval.
     :kwarg distribution_parameters: options controlling mesh
            distribution, see :func:`.Mesh` for details.
+    :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on.
     :kwarg name: Optional name of the mesh.
     :kwarg distribution_name: the name of parallel distribution used
@@ -176,6 +208,7 @@ def UnitIntervalMesh(
         ncells,
         length_or_left=1.0,
         distribution_parameters=distribution_parameters,
+        reorder=reorder,
         comm=comm,
         name=name,
         distribution_name=distribution_name,
@@ -188,6 +221,7 @@ def PeriodicIntervalMesh(
     ncells,
     length,
     distribution_parameters=None,
+    reorder=False,
     comm=COMM_WORLD,
     name=mesh.DEFAULT_MESH_NAME,
     distribution_name=None,
@@ -199,6 +233,7 @@ def PeriodicIntervalMesh(
     :arg length: The length the interval.
     :kwarg distribution_parameters: options controlling mesh
            distribution, see :func:`.Mesh` for details.
+    :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on.
     :kwarg name: Optional name of the mesh.
     :kwarg distribution_name: the name of parallel distribution used
@@ -214,10 +249,10 @@ def PeriodicIntervalMesh(
             "1D periodic meshes with fewer than 3 \
 cells are not currently supported"
         )
-
     m = CircleManifoldMesh(
         ncells,
-        distribution_parameters=distribution_parameters,
+        distribution_parameters=distribution_parameters_noop,
+        reorder=reorder_noop,
         comm=comm,
         name=name,
         distribution_name=distribution_name,
@@ -263,19 +298,20 @@ cells are not currently supported"
         },
     )
 
-    return mesh.Mesh(
-        new_coordinates,
-        name=name,
-        distribution_name=distribution_name,
-        permutation_name=permutation_name,
-        comm=comm,
-    )
+    return _postprocess_periodic_mesh(new_coordinates,
+                                      comm,
+                                      distribution_parameters,
+                                      reorder,
+                                      name,
+                                      distribution_name,
+                                      permutation_name)
 
 
 @PETSc.Log.EventDecorator()
 def PeriodicUnitIntervalMesh(
     ncells,
     distribution_parameters=None,
+    reorder=False,
     comm=COMM_WORLD,
     name=mesh.DEFAULT_MESH_NAME,
     distribution_name=None,
@@ -286,6 +322,7 @@ def PeriodicUnitIntervalMesh(
     :arg ncells: The number of cells in the interval.
     :kwarg distribution_parameters: options controlling mesh
            distribution, see :func:`.Mesh` for details.
+    :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on.
     :kwarg name: Optional name of the mesh.
     :kwarg distribution_name: the name of parallel distribution used
@@ -299,6 +336,7 @@ def PeriodicUnitIntervalMesh(
         ncells,
         length=1.0,
         distribution_parameters=distribution_parameters,
+        reorder=reorder,
         comm=comm,
         name=name,
         distribution_name=distribution_name,
@@ -944,8 +982,8 @@ def PeriodicRectangleMesh(
         1.0,
         0.5,
         quadrilateral=quadrilateral,
-        reorder=reorder,
-        distribution_parameters=distribution_parameters,
+        reorder=reorder_noop,
+        distribution_parameters=distribution_parameters_noop,
         comm=comm,
         name=name,
         distribution_name=distribution_name,
@@ -1007,13 +1045,13 @@ def PeriodicRectangleMesh(
         },
     )
 
-    return mesh.Mesh(
-        new_coordinates,
-        name=name,
-        distribution_name=distribution_name,
-        permutation_name=permutation_name,
-        comm=comm,
-    )
+    return _postprocess_periodic_mesh(new_coordinates,
+                                      comm,
+                                      distribution_parameters,
+                                      reorder,
+                                      name,
+                                      distribution_name,
+                                      permutation_name)
 
 
 @PETSc.Log.EventDecorator()
@@ -1147,6 +1185,7 @@ def CircleManifoldMesh(
     radius=1,
     degree=1,
     distribution_parameters=None,
+    reorder=False,
     comm=COMM_WORLD,
     name=mesh.DEFAULT_MESH_NAME,
     distribution_name=None,
@@ -1161,6 +1200,7 @@ def CircleManifoldMesh(
            cells are straight line segments if degree=1).
     :kwarg distribution_parameters: options controlling mesh
            distribution, see :func:`.Mesh` for details.
+    :kwarg reorder: (optional), should the mesh be reordered?
     :kwarg comm: Optional communicator to build the mesh on.
     :kwarg name: Optional name of the mesh.
     :kwarg distribution_name: the name of parallel distribution used
@@ -1193,7 +1233,7 @@ def CircleManifoldMesh(
     m = mesh.Mesh(
         plex,
         dim=2,
-        reorder=False,
+        reorder=reorder,
         distribution_parameters=distribution_parameters,
         name=name,
         distribution_name=distribution_name,
@@ -1863,8 +1903,8 @@ def PeriodicBoxMesh(
     )
     m = mesh.Mesh(
         plex,
-        reorder=reorder,
-        distribution_parameters=distribution_parameters,
+        reorder=reorder_noop,
+        distribution_parameters=distribution_parameters_noop,
         name=name,
         distribution_name=distribution_name,
         permutation_name=permutation_name,
@@ -1928,14 +1968,13 @@ def PeriodicBoxMesh(
             "hz": (hz, READ),
         },
     )
-    m1 = mesh.Mesh(
-        new_coordinates,
-        name=name,
-        distribution_name=distribution_name,
-        permutation_name=permutation_name,
-        comm=comm,
-    )
-    return m1
+    return _postprocess_periodic_mesh(new_coordinates,
+                                      comm,
+                                      distribution_parameters,
+                                      reorder,
+                                      name,
+                                      distribution_name,
+                                      permutation_name)
 
 
 @PETSc.Log.EventDecorator()
@@ -3043,8 +3082,8 @@ def PartiallyPeriodicRectangleMesh(
         1.0,
         longitudinal_direction="z",
         quadrilateral=quadrilateral,
-        reorder=reorder,
-        distribution_parameters=distribution_parameters,
+        reorder=reorder_noop,
+        distribution_parameters=distribution_parameters_noop,
         diagonal=diagonal,
         comm=comm,
         name=name,
@@ -3100,10 +3139,10 @@ def PartiallyPeriodicRectangleMesh(
         operator = np.asarray([[0, 1], [1, 0]])
         new_coordinates.dat.data[:] = np.dot(new_coordinates.dat.data, operator.T)
 
-    return mesh.Mesh(
-        new_coordinates,
-        name=name,
-        distribution_name=distribution_name,
-        permutation_name=permutation_name,
-        comm=comm,
-    )
+    return _postprocess_periodic_mesh(new_coordinates,
+                                      comm,
+                                      distribution_parameters,
+                                      reorder,
+                                      name,
+                                      distribution_name,
+                                      permutation_name)

--- a/tests/multigrid/test_grid_transfer.py
+++ b/tests/multigrid/test_grid_transfer.py
@@ -96,36 +96,36 @@ def exact_primal(mesh, vector, degree):
     return expr
 
 
-def run_injection(hierarchy, vector, space, degrees):
+def run_injection(hierarchy, vector, space, degrees, exact=exact_primal):
     for degree in degrees:
         Ve = element(space, hierarchy[0].ufl_cell(), degree, vector)
 
         mesh = hierarchy[-1]
         V = FunctionSpace(mesh, Ve)
 
-        actual = interpolate(exact_primal(mesh, vector, degree), V)
+        actual = interpolate(exact(mesh, vector, degree), V)
 
         for mesh in reversed(hierarchy[:-1]):
             V = FunctionSpace(mesh, Ve)
-            expect = interpolate(exact_primal(mesh, vector, degree), V)
+            expect = interpolate(exact(mesh, vector, degree), V)
             tmp = Function(V)
             inject(actual, tmp)
             actual = tmp
             assert numpy.allclose(expect.dat.data_ro, actual.dat.data_ro)
 
 
-def run_prolongation(hierarchy, vector, space, degrees):
+def run_prolongation(hierarchy, vector, space, degrees, exact=exact_primal):
     for degree in degrees:
         Ve = element(space, hierarchy[0].ufl_cell(), degree, vector)
 
         mesh = hierarchy[0]
         V = FunctionSpace(mesh, Ve)
 
-        actual = interpolate(exact_primal(mesh, vector, degree), V)
+        actual = interpolate(exact(mesh, vector, degree), V)
 
         for mesh in hierarchy[1:]:
             V = FunctionSpace(mesh, Ve)
-            expect = interpolate(exact_primal(mesh, vector, degree), V)
+            expect = interpolate(exact(mesh, vector, degree), V)
             tmp = Function(V)
             prolong(actual, tmp)
             actual = tmp
@@ -266,3 +266,60 @@ def test_grid_transfer_deformed(deformed_hierarchy, deformed_transfer_type):
         run_restriction(deformed_hierarchy, vector, space, degrees)
     elif deformed_transfer_type == "prolongation":
         run_prolongation(deformed_hierarchy, vector, space, degrees)
+
+
+@pytest.fixture(params=["interval", "triangle", "quadrilateral", "tetrahedron"], scope="module")
+def periodic_cell(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def periodic_hierarchy(periodic_cell):
+    if periodic_cell == "interval":
+        mesh = PeriodicUnitIntervalMesh(17)
+    elif periodic_cell == "triangle":
+        mesh = PeriodicUnitSquareMesh(13, 11, quadrilateral=False)
+    elif periodic_cell == "quadrilateral":
+        mesh = PeriodicUnitSquareMesh(11, 13, quadrilateral=True)
+    elif periodic_cell == "tetrahedron":
+        mesh = PeriodicUnitCubeMesh(3, 5, 7)
+    else:
+        raise NotImplementedError(f"NotImplemented: periodic_cell = {periodic_cell}")
+    return MeshHierarchy(mesh, 2)
+
+
+@pytest.fixture(params=["CG", "DG"])
+def periodic_space(request, periodic_cell):
+    if periodic_cell == "quadrilateral" and request.param == "DG":
+        return "DQ"
+    else:
+        return request.param
+
+
+def exact_primal_periodic(mesh, vector, degree):
+    x = SpatialCoordinate(mesh)
+    if len(x) == 1:
+        expr = (1 - x[0]) * x[0]
+    elif len(x) == 2:
+        expr = (1 - x[0]) * x[0] + \
+               (1 - x[1]) * x[1] * x[1]
+    elif len(x) == 3:
+        expr = (1 - x[0]) * x[0] + \
+               (1 - x[1]) * x[1] * x[1] + \
+               (1 - x[2]) * x[2] * x[2] * x[2]
+    if vector:
+        expr = as_vector([(-1)**i * expr for i in range(len(x))])
+    return expr
+
+
+@pytest.mark.parallel(nprocs=3)
+def test_grid_transfer_periodic(periodic_hierarchy, periodic_space):
+    degrees = [4]
+    vector = False
+    if periodic_space in {"DG", "DQ"} and complex_mode:
+        with pytest.raises(NotImplementedError):
+            run_injection(periodic_hierarchy, vector, periodic_space, degrees, exact=exact_primal_periodic)
+    else:
+        run_injection(periodic_hierarchy, vector, periodic_space, degrees, exact=exact_primal_periodic)
+    run_prolongation(periodic_hierarchy, vector, periodic_space, degrees, exact=exact_primal_periodic)
+    run_restriction(periodic_hierarchy, vector, periodic_space, degrees)

--- a/tests/output/test_io_function.py
+++ b/tests/output/test_io_function.py
@@ -27,8 +27,8 @@ def _get_mesh(cell_type, comm):
     if cell_type == "triangle":
         mesh = Mesh("./docs/notebooks/stokes-control.msh", name=mesh_name, comm=comm)
     elif cell_type == "tetrahedra":
-        mesh = Mesh(join(os.environ.get("PETSC_DIR"), "share/petsc/datafiles/meshes/mesh-3d-box-innersphere.msh"),
-                    name=mesh_name, comm=comm)
+        # TODO: Prepare more interesting mesh.
+        mesh = UnitCubeMesh(16, 16, 16, name=mesh_name, comm=comm)
     elif cell_type == "tetrahedra_large":
         mesh = Mesh(join(os.environ.get("PETSC_DIR"), "share/petsc/datafiles/meshes/mesh-3d-box-innersphere.msh"),
                     name=mesh_name, comm=comm)


### PR DESCRIPTION
~Depends on https://gitlab.com/petsc/petsc/-/merge_requests/7035~ (merged and forks updated).

Make periodic meshes work just like regular meshes.

We construct a periodic mesh as in the following:
- make a mesh with a periodic topology (with no partition overlap),
- make the Firedrake DG coordinates,
- convert the Firedrake DG coordinates to the DMPlex DG coordinates,
- set the DMPlex DG coordinates in the underlying plex,
- distribute, add overlap, refine, as needed,
- convert the DMPlex DG coordinates to the Firedrake DG coordinates.