### PR TITLE
MG: Fix issue with multiple refinements per level

### DIFF
--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -210,7 +210,7 @@ def compile_element(expression, dual_space=None, parameters=None,
 def prolong_kernel(expression):
     meshc = extract_unique_domain(expression)
     hierarchy, level = utils.get_level(extract_unique_domain(expression))
-    levelf = level + Fraction(1 / hierarchy.refinements_per_level)
+    levelf = level + Fraction(1, hierarchy.refinements_per_level)
     cache = hierarchy._shared_data_cache["transfer_kernels"]
     coordinates = extract_unique_domain(expression).coordinates
     if meshc.cell_set._extruded:
@@ -293,7 +293,7 @@ def prolong_kernel(expression):
 
 def restrict_kernel(Vf, Vc):
     hierarchy, level = utils.get_level(Vc.ufl_domain())
-    levelf = level + Fraction(1 / hierarchy.refinements_per_level)
+    levelf = level + Fraction(1, hierarchy.refinements_per_level)
     cache = hierarchy._shared_data_cache["transfer_kernels"]
     coordinates = Vc.ufl_domain().coordinates
     if Vf.extruded:


### PR DESCRIPTION
# Description
We were labelling MG levels with a Fraction created from a float, and we were losing precision except when the denominator was a power of 2. This is fixed by creating a Fraction from two ints.
fixes #3233

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
