### PR TITLE
fixing pytest petsc messages errors 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,6 @@ jobs:
           cd ../firedrake_venv/src/pyadjoint
           python -m pytest \
             --durations=200 \
-            --cov firedrake \
             --timeout=600 \
             --timeout-method=thread \
             -o faulthandler_timeout=660 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
           cd ../firedrake_venv/src/pyadjoint
           python -m pytest \
             --durations=200 \
+            --cov firedrake \
             --timeout=600 \
             --timeout-method=thread \
             -o faulthandler_timeout=660 \

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import petsc4py
 import sys
-from pyop2.mpi import COMM_WORLD
+from mpi4py.MPI import COMM_WORLD
 petsc4py.init(args=sys.argv, comm=COMM_WORLD)
 from petsc4py import PETSc
 import itertools

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -3,7 +3,8 @@ import os
 import subprocess
 import petsc4py
 import sys
-petsc4py.init(sys.argv)
+from pyop2.mpi import COMM_WORLD
+petsc4py.init(args=sys.argv, comm=COMM_WORLD)
 from petsc4py import PETSc
 import itertools
 import functools


### PR DESCRIPTION
I am not sure what `--cov firedrake` is, but the fails with `firedrake_adjoint` tests are sorted locally when I add it. 