### PR TITLE
Fix test interpolation nodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
             --install icepack \
             --install irksome \
             --install femlium \
+            --package-branch fiat pbrubeck/fix/gauss-jacobi-quadrature \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/tests/regression/test_interpolation_nodes.py
+++ b/tests/regression/test_interpolation_nodes.py
@@ -34,19 +34,13 @@ def degree(request):
                 ids=lambda x: "%s" % x)
 def V(request, mesh, degree):
     space = request.param
-    V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant=f"integral({5*degree})")
+    V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant="integral(10)")
     return FunctionSpace(mesh, V_el)
 
 
 def test_div_curl_preserving(V):
     mesh = V.ufl_domain()
     dim = mesh.geometric_dimension()
-    if dim == 3 and V.ufl_element().degree() == 3 and "Nedelec" not in V.ufl_element().family():
-        pytest.skip("N2div interpolation kernel with exact quadrature creates tensors which risk stack overflow")
-    if dim == 3 and V.ufl_element().degree() == 2 and "Nedelec" not in V.ufl_element().family():
-        # This issue is probably down to gcc attempting to constant-propagate
-        # every entry in the array.
-        pytest.skip("N2div interpolation kernel with exact quadrature takes 40 minutes!")
     if dim == 2:
         x, y = SpatialCoordinate(mesh)
     elif dim == 3:
@@ -84,8 +78,7 @@ def compute_interpolation_error(baseMesh, nref, space, degree):
             expression = as_vector([sin(x)*cos(y), exp(x)*y])
         elif dim == 3:
             expression = as_vector([sin(y)*z*cos(x), cos(x)*z*x, exp(x)*y])
-        variant = f"integral({degree+1})"
-        V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant=variant)
+        V_el = FiniteElement(space, mesh.ufl_cell(), degree, variant="integral")
         V = FunctionSpace(mesh, V_el)
         f = interpolate(expression, V)
         error_l2 = errornorm(expression, f, 'L2')


### PR DESCRIPTION
# Description
After optimizing dual evaluation of integral variants, we can now run tests that were previously disabled because they involved a large number of quadrature points. These tests only went upto degree = 3, but the way FIAT was coded before involved quadrature rules with an unresonably high degree to define certain DOFs (twice as big as it meant to be).

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
