### PR TITLE
Override equals for firedrake.Cofunction

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -142,6 +142,14 @@ class Cofunction(ufl.Cofunction, FunctionMixin):
         """
         return self._function_space
 
+    def equals(self, other):
+        """Check equality."""
+        if type(other) is not Cofunction:
+            return False
+        if self is other:
+            return True
+        return self._count == other._count and self._function_space == other._function_space
+
     @FunctionMixin._ad_not_implemented
     @utils.known_pyop2_safe
     def assign(self, expr, subset=None):


### PR DESCRIPTION
This fixes https://github.com/firedrakeproject/firedrake/issues/3272. The equality check for cofunctions is currently faulty because `equals` wasn't overriden for `firedrake.Cofunction`s. Consequently, the same object will compare `False` to itself because of type checking, see [here](https://github.com/firedrakeproject/ufl/blob/3f337c833653a1b9fba9328c795b3f3006daf5dd/ufl/coefficient.py#L138).