### PR TITLE
Using numpy.prod instead of numpy.product

### DIFF
--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -1276,10 +1276,10 @@ class CheckpointFile(object):
         nodes_per_entity = tuple(mesh.make_dofs_per_plex_entity(entity_dofs))
         if isinstance(ufl_element, finat.ufl.TensorElement):
             shape = ufl_element.reference_value_shape
-            block_size = np.product(shape)
+            block_size = np.prod(shape)
         elif isinstance(ufl_element, finat.ufl.VectorElement):
             shape = ufl_element.value_shape[:1]
-            block_size = np.product(shape)
+            block_size = np.prod(shape)
         else:
             block_size = 1
         return (nodes_per_entity, real_tensorproduct, block_size)

--- a/firedrake/paraview_reordering.py
+++ b/firedrake/paraview_reordering.py
@@ -100,7 +100,7 @@ def vtk_hex_local_to_cart(orders):
     """
 
     sizes = tuple([o + 1 for o in orders])
-    size = np.product(sizes)
+    size = np.prod(sizes)
     loc_to_cart = np.empty(size, dtype="object")
     hexa = vtkLagrangeHexahedron()
     for loc in np.ndindex(sizes):
@@ -132,7 +132,7 @@ def vtk_quad_local_to_cart(orders):
     :return a list of arrays of floats.
     """
     sizes = tuple([o + 1 for o in orders])
-    size = np.product(sizes)
+    size = np.prod(sizes)
     loc_to_cart = np.empty(size, dtype="object")
     quad = vtkLagrangeQuadrilateral()
     for loc in np.ndindex(sizes):
@@ -169,7 +169,7 @@ def vtk_hex8_to_hex9(orders):
     :return a list of integers
     """
     sizes = tuple([o + 1 for o in orders])
-    size = np.product(sizes)
+    size = np.prod(sizes)
     nodeNums = range(size)
     hexa = vtkLagrangeHexahedron()
     return [hexa.NodeNumberingMappingFromVTK8To9(orders, x)


### PR DESCRIPTION

# Description
Used mainly in checkpointing.py, numpy.product is used for multiplying an array of numbers, but is deprecated as of Numpy 1.25.0 and will be removed  from Numpy 2.0. This PR simply replaces numpy.product by the equivalent numpy.prod to avoid the annoying warnings when checkpointing (especially for adjoint. )
