### PR TITLE
Fix pytest-xdist + PETSc finalize crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
             --install icepack \
             --install irksome \
             --install femlium \
+            --package-branch pyadjoint connorjward/petsc-finalize-fix \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,3 +55,27 @@ def check_empty_tape(request):
             assert len(tape.get_blocks()) == 0
 
     request.addfinalizer(fin)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Eagerly call PETSc finalize.
+
+    This is required because of a diabolical ordering issue between petsc2py and
+    pytest-xdist setup and teardown operations (see
+    https://github.com/firedrakeproject/firedrake/issues/3245). Without this
+    modification the ordering is:
+
+        pytest init -> PETSc init -> pytest finalize -> PETSc finalize
+
+    This is problematic because pytest finalize cleans up some state that causes
+    PETSc finalize to crash. To get around this we call PETSc finalize earlier
+    in the process resulting in:
+
+        pytest init -> PETSc init -> PETSc finalize -> pytest finalize
+
+    """
+    # import must be inside the function to avoid calling petsc2py initialize here
+    from petsc2py import PETSc
+
+    PETSc._finalize()


### PR DESCRIPTION
This works locally. Note that I have also contributed code to pyadjoint (which seems a bit ick given `firedrake_adjoint` is no longer inside pyadjoint).

Fixes #3247 