### PR TITLE
Remove old install tricks

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1765,17 +1765,6 @@ run_pip(["install", "-U", "nanobind"])
 run_pip(["install", "-U", "make"])
 run_pip(["install", "-U", "pcpp"])
 
-# See build failure caused by pybind11==2.10.0 at https://github.com/firedrakeproject/firedrake/runs/7370283417?check_suite_focus=true.
-log.info("We use pybind11==2.9.2 until the issue with pybind11==2.10.0 is resolved.\n")
-run_pip(["install", "pybind11==2.9.2"])
-# Tarball of islpy==2023.2 appears to be broken
-run_pip([
-    "install",
-    "--no-build-isolation",
-    "--no-binary", ",".join(wheel_blacklist),
-    "islpy!=2023.2"
-])
-
 petsc_dir, petsc_arch = get_petsc_dir()
 if options["slepc"]:
     slepc_dir, _ = get_slepc_dir()


### PR DESCRIPTION
# Description

I believe that the following lines can be deleted from the install script. pybind11 have now [released 2.11](https://pypi.org/project/pybind11/), so hopefully this problem with version 2.10 has gone away. Also, the dodgy islpy version has been [yanked from PyPI](https://pypi.org/project/islpy/#history) and several versions have subsequently been released.

I'll run this through CI to see if it throws any issues.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
