### PR TITLE
AssembledPC: Keep original operator

### DIFF
--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -21,7 +21,7 @@ class AssembledPC(PCBase):
 
     def initialize(self, pc):
         from firedrake.assemble import allocate_matrix, TwoFormAssembler
-        _, P = pc.getOperators()
+        A, P = pc.getOperators()
 
         if pc.getType() != "python":
             raise ValueError("Expecting PC type python")
@@ -81,7 +81,7 @@ class AssembledPC(PCBase):
 
         pc.setDM(dm)
         pc.setOptionsPrefix(options_prefix)
-        pc.setOperators(Pmat, Pmat)
+        pc.setOperators(A, Pmat)
         self.pc = pc
         with dmhooks.add_hooks(dm, self, appctx=self._ctx_ref, save=False):
             pc.setFromOptions()

--- a/tests/multigrid/test_poisson_gmg.py
+++ b/tests/multigrid/test_poisson_gmg.py
@@ -159,7 +159,8 @@ def test_preconditioner_coarsening(solver_type):
         "ksp_richardson_scale": float(beta),  # undo the rescaling
         "pc_type": "python",
         "pc_python_type": "firedrake.AssembledPC",
-        "assembled": solver_parameters(solver_type)
+        "assembled": solver_parameters(solver_type),
+        "assembled_pc_use_amat": False
     }
     solve(a == L, uh, bcs=bcs, J=a, Jp=Jp, solver_parameters=parameters)
 


### PR DESCRIPTION
# Description
AssembledPC is built from the preconditioner bilinear form `Jp` if supplied in the SNES context. For this cases, the original operator `J` was removed from the new SNES context. This is problematic if one wants to apply multigrid or a Schur complement fieldsplit on the original operator `J` using `Jp` to only build the relaxation / Schur complement approximation, while being able to update residuals correctly with `J`. This PR attaches the original operator to the new SNES context by default.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
