### PR TITLE
Fix log_view by ensuring PETSc initialised before PyOP2 import

### DIFF
--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -5,10 +5,9 @@ import itertools
 import os
 import subprocess
 import sys
-
 from contextlib import contextmanager
-from pyop2 import mpi
 from typing import Any
+
 from mpi4py import MPI
 
 # When running with pytest-xdist (i.e. pytest -n <#procs>) PETSc finalize will
@@ -17,12 +16,16 @@ from mpi4py import MPI
 # point the worker's stderr stream has already been destroyed by xdist, causing
 # a crash. To prevent this we disable unused options checking in PETSc when
 # running with xdist.
+# NOTE: petsc4py.init must be called before importing PyOP2 since PyOP2 would
+# initialise PETSc incorrectly.
 import petsc4py
 if "PYTEST_XDIST_WORKER" in os.environ:
     petsc4py.init(sys.argv + ["-options_left", "no"])
 else:
     petsc4py.init(sys.argv)
 from petsc4py import PETSc
+
+from pyop2 import mpi
 
 
 __all__ = ("PETSc", "OptionsManager", "get_petsc_variables")


### PR DESCRIPTION
# Description

`-log_view` was not working because we imported PyOP2 too early.

Note: make sure to check that we don't hit the "no options left" error in CI.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
