### PR TITLE
Fix init ordering for PETSc and cache dirs

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -15,10 +15,26 @@ elif not config["options"]["honour_petsc_dir"]:  # Using our own PETSC.
     os.environ["PETSC_ARCH"] = "default"
 del config
 
+# Set up the cache directories before importing PyOP2.
+firedrake_configuration.setup_cache_dirs()
+
 # Ensure petsc is initialised by us before anything else gets in there.
-import firedrake.petsc as petsc
+#
+# When running with pytest-xdist (i.e. pytest -n <#procs>) PETSc finalize will
+# crash (see https://github.com/firedrakeproject/firedrake/issues/3247). This
+# is because PETSc wants to complain about unused options to stderr, but by this
+# point the worker's stderr stream has already been destroyed by xdist, causing
+# a crash. To prevent this we disable unused options checking in PETSc when
+# running with xdist.
+import petsc4py
+if "PYTEST_XDIST_WORKER" in os.environ:
+    petsc4py.init(sys.argv + ["-options_left", "no"])
+else:
+    petsc4py.init(sys.argv)
+del petsc4py
 
 # Initialise PETSc events for both import and entire duration of program
+from firedrake import petsc
 _is_logging = "log_view" in petsc.OptionsManager.commandline_options
 if _is_logging:
     _main_event = petsc.PETSc.Log.Event("firedrake")
@@ -55,8 +71,6 @@ except AttributeError:
 del ufl
 from ufl import *
 from finat.ufl import *
-# Set up the cache directories before importing PyOP2.
-firedrake_configuration.setup_cache_dirs()
 
 # By default we disable pyadjoint annotation.
 # To enable annotation, the user has to call continue_annotation().

--- a/firedrake/petsc.py
+++ b/firedrake/petsc.py
@@ -1,28 +1,15 @@
-# Utility module that imports and initialises petsc4py
 import functools
 import gc
 import itertools
 import os
 import subprocess
-import sys
-
 from contextlib import contextmanager
-from pyop2 import mpi
 from typing import Any
-from mpi4py import MPI
 
-# When running with pytest-xdist (i.e. pytest -n <#procs>) PETSc finalize will
-# crash (see https://github.com/firedrakeproject/firedrake/issues/3247). This
-# is because PETSc wants to complain about unused options to stderr, but by this
-# point the worker's stderr stream has already been destroyed by xdist, causing
-# a crash. To prevent this we disable unused options checking in PETSc when
-# running with xdist.
 import petsc4py
-if "PYTEST_XDIST_WORKER" in os.environ:
-    petsc4py.init(sys.argv + ["-options_left", "no"])
-else:
-    petsc4py.init(sys.argv)
+from mpi4py import MPI
 from petsc4py import PETSc
+from pyop2 import mpi
 
 
 __all__ = ("PETSc", "OptionsManager", "get_petsc_variables")

--- a/tests/test_0init.py
+++ b/tests/test_0init.py
@@ -34,3 +34,11 @@ def test_int_type():
     actual = {4: "int32", 8: "int64"}[IntType.itemsize]
 
     assert expected == actual
+
+
+def test_pyop2_cache_dir_set_correctly():
+    from firedrake_configuration import get_config
+
+    config = get_config()
+    cache_dir = os.path.join(config["options"]["cache_dir"], "pyop2")
+    assert op2.configuration["cache_dir"] == cache_dir


### PR DESCRIPTION
# Description

Fixes #3353 and supersedes #3351.

Note that I have moved the call of `petsc4py.init` into `__init__.py`. I think this is good because I don't like how imports can do "magic". This is more explicit.

@JDBetteridge and @ksagiyam can you verify that this works for you?

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
