### PR TITLE
Add g-adopt as Firedrake app in install script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
             --install femlium \
             --install fascd \
             --install defcon \
+            --install gadopt \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -17,6 +17,7 @@ RUN bash -c "source firedrake/bin/activate; \
         --install femlium \
         --install defcon \
         --install fascd \
+        --install gadopt \
         --install gusto \
         --install icepack \
         --install irksome \

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -45,6 +45,8 @@ firedrake_apps = {
               "git+ssh://bitbucket.org/pefarrell/fascd.git@master#egg=fascd"),
     "defcon": ("""Deflated continuation algorithm for bifurcation analysis. https://bitbucket.org/pefarrell/defcon""",
                "git+ssh://bitbucket.org/pefarrell/defcon.git@master#egg=defcon"),
+    "gadopt": ("""Geodynamic Adjoint Optimization Platform. http://g-adopt.github.io""",
+               "git+ssh://github.com/g-adopt/g-adopt.git@master#egg=gadopt"),
 }
 
 

--- a/tests/regression/test_import_applications.py
+++ b/tests/regression/test_import_applications.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack", "femlium", "fascd", "defcon"])
+@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack", "femlium", "fascd", "defcon", "gadopt"])
 def app(request):
     return request.param
 


### PR DESCRIPTION
G-adopt is a firedrake-based platform for geodynamic, and more broadly geoscientific, adjoint-based inversion - see https://g-adopt.github.io/ This PR adds it as a firedrake app to the install script, like similar firedrake-based models such as Gusto, Thetis and Icepack.