### PR TITLE
Add FASCD as Firedrake app in install script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
             --install icepack \
             --install irksome \
             --install femlium \
+            --install fascd \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -15,6 +15,7 @@ RUN bash -c "source firedrake/bin/activate; \
         --slepc \
         --tinyasm \
         --install femlium \
+        --install fascd \
         --install gusto \
         --install icepack \
         --install irksome \

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -41,6 +41,8 @@ firedrake_apps = {
                 "git+ssh://github.com/firedrakeproject/Irksome.git#egg=Irksome"),
     "femlium": ("""Interactive visualization of finite element simulations on geographic maps with folium. https://femlium.github.io/""",
                 "git+ssh://github.com/FEMlium/FEMlium.git@main#egg=FEMlium"),
+    "fascd": ("""Full approximation scheme constraint decomposition solver for variational inequalities. https://bitbucket.org/pefarrell/fascd""",
+              "git+ssh://bitbucket.org/pefarrell/fascd.git@master#egg=fascd"),
 }
 
 

--- a/tests/regression/test_import_applications.py
+++ b/tests/regression/test_import_applications.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack", "femlium"])
+@pytest.fixture(params=["gusto", "thetis", "irksome", "icepack", "femlium", "fascd"])
 def app(request):
     return request.param
 


### PR DESCRIPTION
FASCD is a solver written by Ed Bueler and myself for solving variational inequalities. It combines full approximation scheme and constraint decompositions to achieve mesh-independent iteration counts (in many cases). For more details, see https://arxiv.org/abs/2308.06888 (accepted in SISC).

This pull request adds FASCD as a Firedrake app.