### PR TITLE
JDBetteridge/pytest fixup

### DIFF
--- a/tests/demos/test_demos_run.py
+++ b/tests/demos/test_demos_run.py
@@ -71,12 +71,12 @@ def test_demo_runs(py_file, env):
         try:
             from slepc4py import SLEPc  # noqa: F401
         except ImportError:
-            pytest.skip(msg="SLEPc unavailable, skipping qgbasinmodes.py")
+            pytest.skip(reason="SLEPc unavailable, skipping qgbasinmodes.py")
 
     if basename(py_file) in ("DG_advection.py", "qgbasinmodes.py"):
         try:
             import matplotlib  # noqa: F401
         except ImportError:
-            pytest.skip(msg=f"Matplotlib unavailable, skipping {basename(py_file)}")
+            pytest.skip(reason=f"Matplotlib unavailable, skipping {basename(py_file)}")
 
     subprocess.check_call([sys.executable, py_file], env=env)

--- a/tests/multigrid/test_opencascade_poisson.py
+++ b/tests/multigrid/test_opencascade_poisson.py
@@ -21,7 +21,7 @@ def test_opencascade_poisson(stepdata, order):
     try:
         mh = OpenCascadeMeshHierarchy(stepfile, element_size=h, levels=2, order=order, cache=False, verbose=True)
     except ImportError:
-        pytest.skip(msg="OpenCascade unavailable, skipping test")
+        pytest.skip(reason="OpenCascade unavailable, skipping test")
 
     # Solve Poisson
     mesh = mh[-1]

--- a/tests/multigrid/test_opencascade_volume.py
+++ b/tests/multigrid/test_opencascade_volume.py
@@ -49,7 +49,7 @@ def test_volume(stepdata):
         mh = OpenCascadeMeshHierarchy(stepfile, element_size=h, levels=3, cache=False, verbose=False)
         v_true = get_volume(stepfile)
     except ImportError:
-        pytest.skip(msg="OpenCascade unavailable, skipping test")
+        pytest.skip(reason="OpenCascade unavailable, skipping test")
 
     print("True volume for %s: %s" % (os.path.basename(stepfile), v_true))
     err = compute_err(mh, v_true)
@@ -67,7 +67,7 @@ def test_area(order):
     try:
         mh = OpenCascadeMeshHierarchy(stepfile, element_size=h, levels=3, cache=False, verbose=False, order=order)
     except ImportError:
-        pytest.skip(msg="OpenCascade unavailable, skipping test")
+        pytest.skip(reason="OpenCascade unavailable, skipping test")
     from math import pi
     a_true = pi/4
     print("True ara for %s: %s" % (os.path.basename(stepfile), a_true))

--- a/tests/regression/test_moore_spence.py
+++ b/tests/regression/test_moore_spence.py
@@ -8,7 +8,7 @@ def test_moore_spence():
     try:
         from slepc4py import SLEPc
     except ImportError:
-        pytest.skip(msg="SLEPc unavailable, skipping eigenvalue test")
+        pytest.skip(reason="SLEPc unavailable, skipping eigenvalue test")
 
     msh = IntervalMesh(1000, 1)
     V = FunctionSpace(msh, "CG", 1)

--- a/tests/regression/test_slepc.py
+++ b/tests/regression/test_slepc.py
@@ -12,7 +12,7 @@ def test_laplace_physical_ev(parallel=False):
     try:
         from slepc4py import SLEPc
     except ImportError:
-        pytest.skip(msg="SLEPc unavailable, skipping eigenvalue test")
+        pytest.skip(reason="SLEPc unavailable, skipping eigenvalue test")
 
     mesh = UnitSquareMesh(64, 64)
     V = FunctionSpace(mesh, 'CG', 1)


### PR DESCRIPTION
# Description
`pytest` finally deprecated `msg=` in favour of `reason=`. The former now causes a hard error.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
