### PR TITLE
Remove old `_function_arg_update` attribute when setting `DirichletBC` value

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -325,6 +325,11 @@ class DirichletBC(BCBase, DirichletBCMixin):
     @function_arg.setter
     def function_arg(self, g):
         '''Set the value of this boundary condition.'''
+        try:
+            # Clear any previously set update function
+            del self._function_arg_update
+        except AttributeError:
+            pass
         if isinstance(g, firedrake.Function) and g.ufl_element().family() != "Real":
             if g.function_space() != self.function_space():
                 raise RuntimeError("%r is defined on incompatible FunctionSpace!" % g)

--- a/tests/regression/test_bcs.py
+++ b/tests/regression/test_bcs.py
@@ -149,6 +149,32 @@ def test_set_bc_value(a, u, V, f):
     assert np.allclose(u.vector().array(), 7.0)
 
 
+def test_homogenize_old_function_arg_unchanged(a, u, V, f):
+    bc = DirichletBC(V, 2 * f, 1)
+    g_old = bc.function_arg
+    g_old_ref = g_old.copy(deepcopy=True)
+
+    bc.homogenize()
+    f.assign(-f)
+    g_new = bc.function_arg
+
+    assert g_new == 0
+    assert (g_old.dat.data_ro == g_old_ref.dat.data_ro).all()
+
+
+def test_set_bc_value_old_function_arg_unchanged(a, u, V, f):
+    bc = DirichletBC(V, 2 * f, 1)
+    g_old = bc.function_arg
+    g_old_ref = g_old.copy(deepcopy=True)
+
+    bc.set_value(2)
+    f.assign(-f)
+    g_new = bc.function_arg
+
+    assert g_new == 2
+    assert (g_old.dat.data_ro == g_old_ref.dat.data_ro).all()
+
+
 def test_update_bc_constant(a, u, V, f):
     if V.rank == 1:
         # Don't bother with the VFS case


### PR DESCRIPTION
# Description

Fixes the following behaviour:

```
bc = DirichletBC(V, expression_depending_on_u_to_be_interpolated, sub_domain)
old_value = bc.function_arg
bc.homogenize()
u.assign(new_u_value)
new_value = bc.function_arg  # Modifies old_value
```

The second access to `bc.function_arg` modifies the value obtained in the first access, which seems inefficient/unintended.

Caused by an old update function, `bc._function_arg_update`, being retained after the `bc.homogenize` call.