### PR TITLE
Interpolate -> interpolate in CrossMeshInterpolator

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -592,7 +592,7 @@ class CrossMeshInterpolator(Interpolator):
 
         from firedrake.assemble import assemble
         V_dest_vec = firedrake.VectorFunctionSpace(dest_mesh, ufl_scalar_element)
-        f_dest_node_coords = interpolate(dest_mesh.coordinates, V_dest_vec)
+        f_dest_node_coords = Interpolate(dest_mesh.coordinates, V_dest_vec)
         f_dest_node_coords = assemble(f_dest_node_coords)
         dest_node_coords = f_dest_node_coords.dat.data_ro.reshape(-1, dest_mesh_gdim)
         try:


### PR DESCRIPTION
Fix #3383. The `CrossMeshInterpolator` is currently using `interpolate` to get the symbolic interpolation object that then get assembled. However, at the level of `interpolation.py`, `interpolate` doesn't correspond to the `__future__` implementation, thereby leading to a warning. This replaces `interpolate` by `Interpolate`, which is the symbolic object.
