### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET to 12.0 in firedrake-install

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1161,8 +1161,8 @@ def build_and_install_petsc():
         petsc_options = get_petsc_options()
         # Set MACOSX_DEPLOYMENT_TARGET to the current macos version
         # to workaround issues configuring PETSc on macos.
-        # Choosing 11.0 as the oldest MacOS version supported as at 2023-03-22
-        macosx_deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "11.0")
+        # Choosing 12.0 as the oldest MacOS version supported as of 2024-02-08
+        macosx_deployment_target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "12.0")
         with environment(MACOSX_DEPLOYMENT_TARGET=macosx_deployment_target):
             check_call([python, "./configure", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch)] + petsc_options)
             check_call(["make", "PETSC_DIR={}".format(petsc_dir), "PETSC_ARCH={}".format(petsc_arch), "all"])


### PR DESCRIPTION
# Description

macOS 11 is [no longer receiving security updates](https://endoflife.date/macos), and users have reported issues building. I'm updating `firedrake-install` to reflect this in line with [this policy](https://github.com/firedrakeproject/firedrake/wiki/macOS-version-support).
<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
