### PR TITLE
remove deprecated method.

### DIFF
--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -10,8 +10,13 @@ class AssembleBlock(Block):
     def __init__(self, form, ad_block_tag=None):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
         self.form = form
-        mesh = self.form.ufl_domain() if hasattr(self.form, 'ufl_domain') \
-            else None
+        if hasattr(self.form, 'ufl_domain'):
+            if isinstance(self.form, ufl.Interpolate):
+                mesh = ufl.domain.extract_unique_domain(self.form)
+            else:
+                mesh = self.form.ufl_domain()
+        else:
+            mesh = None
 
         if mesh and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -10,14 +10,11 @@ class AssembleBlock(Block):
     def __init__(self, form, ad_block_tag=None):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
         self.form = form
-        if hasattr(self.form, 'ufl_domain'):
-            if isinstance(self.form, ufl.Interpolate):
-                mesh = ufl.domain.extract_unique_domain(self.form)
-            else:
-                mesh = self.form.ufl_domain()
-        else:
+        try:
+            mesh = ufl.domain.as_domain(form)
+        except AttributeError:
             mesh = None
-
+    
         if mesh and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
             self.add_dependency(mesh)

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -14,7 +14,7 @@ class AssembleBlock(Block):
             mesh = ufl.domain.as_domain(form)
         except AttributeError:
             mesh = None
-    
+
         if mesh and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
             self.add_dependency(mesh)

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -1,5 +1,6 @@
 import ufl
 import firedrake
+from ufl.domain import as_domain
 from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, AdjFloat, create_overloaded_object
 from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
@@ -11,7 +12,7 @@ class AssembleBlock(Block):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
         self.form = form
         try:
-            mesh = ufl.domain.as_domain(form)
+            mesh = as_domain(form)
         except AttributeError:
             mesh = None
 
@@ -104,7 +105,7 @@ class AssembleBlock(Block):
         arity_form = len(extract_arguments(form))
 
         if isconstant(c):
-            mesh = self.form.ufl_domain()
+            mesh = as_domain(self.form)
             space = c._ad_function_space(mesh)
         elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             space = c.function_space()
@@ -163,7 +164,7 @@ class AssembleBlock(Block):
         c1_rep = block_variable.saved_output
 
         if isconstant(c1):
-            mesh = form.ufl_domain()
+            mesh = as_domain(form)
             space = c1._ad_function_space(mesh)
         elif isinstance(c1, (firedrake.Function, firedrake.Cofunction)):
             space = c1.function_space()


### PR DESCRIPTION
# Description

For `ufl.interpolate` object, we need to use ` ufl.domain.extract_unique_domain(self.form)` instead of `self.form.ufl_domain()`.  This fix warnings of deprecated `self.form.ufl_domain()` for `ufl.interpolate`.
