### PR TITLE
Allow for interpolation adjoint block tags

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -378,7 +378,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         expression,
         subset=None,
         allow_missing_dofs=False,
-        default_missing_val=None
+        default_missing_val=None,
+        ad_block_tag=None
     ):
         r"""Interpolate an expression onto this :class:`Function`.
 
@@ -400,6 +401,8 @@ class Function(ufl.Coefficient, FunctionMixin):
             value to assign to DoFs in the target mesh that are outside the source
             mesh. If this is not set then zero is used. Ignored if interpolating
             within the same mesh or onto a :func:`.VertexOnlyMesh`.
+        :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on
+            the Pyadjoint tape.
         :returns: this :class:`Function` object"""
         from firedrake import interpolation, assemble
         V = self.function_space()
@@ -407,7 +410,7 @@ class Function(ufl.Coefficient, FunctionMixin):
                                            subset=subset,
                                            allow_missing_dofs=allow_missing_dofs,
                                            default_missing_val=default_missing_val)
-        return assemble(interp, tensor=self)
+        return assemble(interp, tensor=self, ad_block_tag=ad_block_tag)
 
     def zero(self, subset=None):
         """Set all values to zero.

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -153,6 +153,7 @@ def interpolate(
     access=op2.WRITE,
     allow_missing_dofs=False,
     default_missing_val=None,
+    ad_block_tag=None
 ):
     """Interpolate an expression onto a new function in V.
 
@@ -184,6 +185,7 @@ def interpolate(
         some ``output`` is given to the :meth:`interpolate` method or (b) set
         to zero. Ignored if interpolating within the same mesh or onto a
         :func:`.VertexOnlyMesh`.
+    :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on the Pyadjoint tape.
     :returns: a new :class:`.Function` in the space ``V`` (or ``V`` if
         it was a Function).
 
@@ -208,7 +210,7 @@ def interpolate(
     """
     return Interpolator(
         expr, V, subset=subset, access=access, allow_missing_dofs=allow_missing_dofs
-    ).interpolate(default_missing_val=default_missing_val)
+    ).interpolate(default_missing_val=default_missing_val, ad_block_tag=ad_block_tag)
 
 
 class Interpolator(abc.ABC):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -347,7 +347,8 @@ class Interpolator(abc.ABC):
         return interp
 
     @PETSc.Log.EventDecorator()
-    def interpolate(self, *function, output=None, transpose=False, default_missing_val=None):
+    def interpolate(self, *function, output=None, transpose=False, default_missing_val=None,
+                    ad_block_tag=None):
         """Compute the interpolation by assembling the appropriate :class:`Interpolate` object.
 
         Parameters
@@ -368,6 +369,8 @@ class Interpolator(abc.ABC):
                              :meth:`interpolate` method or (b) set to zero. This does not affect
                              transpose interpolation. Ignored if interpolating within the same
                              mesh or onto a :func:`.VertexOnlyMesh`.
+        ad_block_tag: str
+                      An optional string for tagging the resulting assemble block on the Pyadjoint tape.
 
         Returns
         -------
@@ -410,7 +413,7 @@ the derivative, and then assemble the resulting form.
         # to perform the interpolation. Having this structure ensures consistency between
         # `Interpolator` and `Interp`. This mechanism handles annotation since performing interpolation will drop an
         # `AssembleBlock` on the tape.
-        return assemble(interp, tensor=output)
+        return assemble(interp, tensor=output, ad_block_tag=ad_block_tag)
 
     @abc.abstractmethod
     def _interpolate(self, *args, **kwargs):


### PR DESCRIPTION
This adds support to specify adjoint block tags to interpolation, which can then be transmitted to the resulting assemble block on the tape. This adds support for tags on interpolation of the form:

-  `Function(...).interpolate(..., ad_block_tag=...)`
- `interpolate(..., ad_block_tag=...)` when `firedrake.__future__` is not imported (deprecated behaviour). This bit will be removed as soon as we get rid of the deprecated interpolation behaviour.

Tests can be found at https://github.com/dolfin-adjoint/pyadjoint/pull/136