### PR TITLE
Fix ASMExtrudedStarPC: include vertical edge and face patches

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -112,13 +112,9 @@ class ASMPatchPC(PCBase):
         self.asmpc.view(viewer=viewer)
 
     def update(self, pc):
-        # This is required to update an inplace ILU/ICC factorization
-        try:
-            for sub in self.asmpc.getASMSubKSP():
-                sub.getOperators()[0].setUnfactored()
-        except PETSc.Error:
-            pass
-        self.asmpc.setUp()
+        # This is required to update an inplace ILU factorization
+        for sub in self.asmpc.getASMSubKSP():
+            sub.getOperators()[0].setUnfactored()
 
     def apply(self, pc, x, y):
         self.asmpc.apply(x, y)

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -65,9 +65,11 @@ class ASMPatchPC(PCBase):
                 opts["sub_pc_factor_shift_type"] = "NONE"
 
             # If an ordering type is provided, PCASM should not sort patch indices, otherwise it can.
-            sentinel = object()
-            ordering = PETSc.Options().getString(self.prefix + "mat_ordering_type", default=sentinel)
-            asmpc.setASMSortIndices(ordering is sentinel)
+            mat_type = P.getType()
+            if not mat_type.endswith("sbaij"):
+                sentinel = object()
+                ordering = PETSc.Options().getString(self.prefix + "mat_ordering_type", default=sentinel)
+                asmpc.setASMSortIndices(ordering is sentinel)
 
             lgmap = V.dof_dset.lgmap
             # Translate to global numbers
@@ -90,14 +92,14 @@ class ASMPatchPC(PCBase):
                 sum(W.value_size * W.dof_dset.total_size for W in V))
             asmpc.setUp()
         else:
-            raise ValueError(f"Unknown backend type f{backend}")
+            raise ValueError(f"Unknown backend type {backend}")
 
         asmpc.setFromOptions()
         self.asmpc = asmpc
 
     @abc.abstractmethod
     def get_patches(self, V):
-        ''' Get the patches used for PETSc PSASM
+        ''' Get the patches used for PETSc PCASM
 
         :param  V: the :class:`~.FunctionSpace`.
 
@@ -110,6 +112,12 @@ class ASMPatchPC(PCBase):
         self.asmpc.view(viewer=viewer)
 
     def update(self, pc):
+        # This is required to update an inplace ILU/ICC factorization
+        try:
+            for sub in self.asmpc.getASMSubKSP():
+                sub.getOperators()[0].setUnfactored()
+        except PETSc.Error:
+            pass
         self.asmpc.setUp()
 
     def apply(self, pc, x, y):
@@ -302,7 +310,7 @@ class ASMLinesmoothPC(ASMPatchPC):
 
 
 def order_points(mesh_dm, points, ordering_type, prefix):
-    '''Order a the points (topological entities) of a patch based
+    '''Order the points (topological entities) of a patch based
     on the adjacency graph of the mesh.
 
     :arg mesh_dm: the `mesh.topology_dm`
@@ -312,6 +320,8 @@ def order_points(mesh_dm, points, ordering_type, prefix):
 
     :returns: the permuted array of points
     '''
+    # Order points by decreasing topological dimension (interiors, faces, edges, vertices)
+    points = points[::-1]
     if ordering_type == "natural":
         return points
     subgraph = [numpy.intersect1d(points, mesh_dm.getAdjacency(p), return_indices=True)[1] for p in points]
@@ -319,9 +329,12 @@ def order_points(mesh_dm, points, ordering_type, prefix):
     ja = numpy.concatenate(subgraph).astype(PETSc.IntType)
     A = PETSc.Mat().createAIJ((len(points), )*2, csr=(ia, ja, numpy.ones(ja.shape, PETSc.RealType)), comm=PETSc.COMM_SELF)
     A.setOptionsPrefix(prefix)
-    rperm, _ = A.getOrdering(ordering_type)
+    rperm, cperm = A.getOrdering(ordering_type)
+    indices = points[rperm.getIndices()]
     A.destroy()
-    return points[rperm.getIndices()]
+    rperm.destroy()
+    cperm.destroy()
+    return indices
 
 
 def get_basemesh_nodes(W):
@@ -395,54 +408,79 @@ class ASMExtrudedStarPC(ASMStarPC):
 
         # Build index sets for the patches
         ises = []
-        start, end = mesh_dm.getDepthStratum(depth)
-        pstart, _ = mesh_dm.getChart()
-        for seed in range(start, end):
-            # Only build patches over owned DoFs
-            if mesh_dm.getLabelValue("pyop2_ghost", seed) != -1:
+        # Build a base_depth-star on the base mesh and extrude it by an
+        # interval_depth-star on the interval mesh such that the depths sum to depth
+        # and 0 <= base_depth <= dim, 0 <= interval_depth <= 1.
+        #
+        # Vertex-stars: depth = 0 = 0 + 0.
+        # 0 + 0 -> vertex-star = (2D vertex-star) x (1D vertex-star)
+        #
+        # Edge-stars: depth = 1 = 1 + 0 = 0 + 1.
+        # 1 + 0 -> horizontal edge-star = (2D edge-star) x (1D vertex-star)
+        # 0 + 1 -> vertical edge-star = (2D vertex-star) x (1D interior)
+        #
+        # Face-stars: depth = 2 = 2 + 0 = 1 + 1.
+        # 2 + 0 -> horizontal face-star = (2D interior) x (1D vertex-star)
+        # 1 + 1 -> vertical face-star = (2D edge-star) x (1D interior)
+        for base_depth in range(depth+1):
+            interval_depth = depth - base_depth
+            if interval_depth > 1:
                 continue
 
-            # Create point list from mesh DM
-            points, _ = mesh_dm.getTransitiveClosure(seed, useCone=False)
-            points = order_points(mesh_dm, points, ordering, self.prefix)
-            points -= pstart  # offset by chart start
-            for k in range(nlayers):
-                if k == 0:
-                    planes = [1, 0]
-                elif k == nlayers - 1:
-                    planes = [-1, 0]
-                else:
-                    planes = [-1, 1, 0]
+            start, end = mesh_dm.getDepthStratum(base_depth)
+            pstart, _ = mesh_dm.getChart()
+            for seed in range(start, end):
+                # Only build patches over owned DoFs
+                if mesh_dm.getLabelValue("pyop2_ghost", seed) != -1:
+                    continue
 
-                indices = []
-                # Get DoF indices for patch
-                for i, W in enumerate(V):
-                    iset = V_ises[i]
-                    for plane in planes:
-                        for p in points:
-                            # How to walk up one layer
-                            blayer_offset = basemeshlayeroffsets[i][p]
-                            if blayer_offset <= 0:
-                                # In this case we don't have any dofs on
-                                # this entity.
-                                continue
-                            # Offset in the global array for the bottom of
-                            # the column
-                            off = basemeshoff[i][p]
-                            # Number of dofs in the interior of the
-                            # vertical interval cell on top of this base
-                            # entity
-                            dof = basemeshdof[i][p]
-                            # Hard-code taking the star
-                            if plane == 0:
-                                begin = off + k * blayer_offset
-                                end = off + k * blayer_offset + dof
-                            else:
-                                begin = off + min(k, k+plane) * blayer_offset + dof
-                                end = off + max(k, k+plane) * blayer_offset
-                            zlice = slice(W.value_size * begin, W.value_size * end)
-                            indices.extend(iset[zlice])
+                # Create point list from mesh DM
+                points, _ = mesh_dm.getTransitiveClosure(seed, useCone=False)
+                points = order_points(mesh_dm, points, ordering, self.prefix)
+                points -= pstart  # offset by chart start
+                for k in range(nlayers-interval_depth):
+                    if interval_depth == 1:
+                        # extrude by 1D interior
+                        planes = [1]
+                    elif k == 0:
+                        # extrude by 1D vertex-star on the bottom
+                        planes = [1, 0]
+                    elif k == nlayers - 1:
+                        # extrude by 1D vertex-star on the top
+                        planes = [-1, 0]
+                    else:
+                        # extrude by 1D vertex-star
+                        planes = [-1, 1, 0]
 
-                iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
-                ises.append(iset)
+                    indices = []
+                    # Get DoF indices for patch
+                    for i, W in enumerate(V):
+                        iset = V_ises[i]
+                        for plane in planes:
+                            for p in points:
+                                # How to walk up one layer
+                                blayer_offset = basemeshlayeroffsets[i][p]
+                                if blayer_offset <= 0:
+                                    # In this case we don't have any dofs on
+                                    # this entity.
+                                    continue
+                                # Offset in the global array for the bottom of
+                                # the column
+                                off = basemeshoff[i][p]
+                                # Number of dofs in the interior of the
+                                # vertical interval cell on top of this base
+                                # entity
+                                dof = basemeshdof[i][p]
+                                # Hard-code taking the star
+                                if plane == 0:
+                                    begin = off + k * blayer_offset
+                                    end = off + k * blayer_offset + dof
+                                else:
+                                    begin = off + min(k, k+plane) * blayer_offset + dof
+                                    end = off + max(k, k+plane) * blayer_offset
+                                zlice = slice(W.value_size * begin, W.value_size * end)
+                                indices.extend(iset[zlice])
+
+                    iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
+                    ises.append(iset)
         return ises

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -238,8 +238,7 @@ def restricted_dofs(celem, felem):
 
 
 def get_permutation_map(V, W):
-    perm = numpy.empty((V.dof_count, ), dtype=PETSc.IntType)
-    perm.fill(-1)
+    perm = numpy.full((V.dof_count,), -1, dtype=PETSc.IntType)
     vdat = V.make_dat(val=perm)
 
     offset = 0

--- a/tests/multigrid/test_hiptmair.py
+++ b/tests/multigrid/test_hiptmair.py
@@ -3,9 +3,11 @@ from firedrake.preconditioners.fdm import tabulate_exterior_derivative
 import pytest
 
 
-def mesh_hierarchy(cell):
+@pytest.fixture(params=["tetrahedron", "hexahedron"])
+def mesh_hierarchy(request):
     nx = 5
     nlevels = 2
+    cell = request.param
     if cell == "tetrahedron":
         base = UnitCubeMesh(nx, nx, nx)
         return MeshHierarchy(base, nlevels)
@@ -15,12 +17,27 @@ def mesh_hierarchy(cell):
         return ExtrudedMeshHierarchy(basemh, height=1, base_layer=nx)
 
 
-def run_riesz_map(V, mat_type):
-    relax = {
+def run_riesz_map(V, mat_type, max_it):
+    jacobi = {
         "mat_type": mat_type,
         "ksp_type": "preonly",
         "pc_type": "jacobi",
     }
+    potential = jacobi
+    if V.mesh().extruded and mat_type == "aij":
+        # Test equivalence of Jacobi and ASM on edge/face-stars
+        formdegree = V.finat_element.formdegree
+        relax = {
+            "ksp_type": "preonly",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.ASMExtrudedStarPC",
+            "pc_star_construct_dim": formdegree,
+            "pc_star_sub_sub_ksp_type": "preonly",
+            "pc_star_sub_sub_pc_type": "jacobi",
+        }
+    else:
+        relax = jacobi
+
     coarse = {
         "ksp_type": "preonly",
         "pc_type": "cholesky",
@@ -34,9 +51,11 @@ def run_riesz_map(V, mat_type):
         }
     parameters = {
         "mat_type": mat_type,
-        "snes_type": "ksponly",
+        "ksp_max_it": max_it,
         "ksp_type": "cg",
         "ksp_norm_type": "natural",
+        "ksp_monitor": None,
+        "ksp_convergence_test": "skip",
         "pc_type": "mg",
         "mg_coarse": coarse,
         "mg_levels": {
@@ -45,7 +64,7 @@ def run_riesz_map(V, mat_type):
             "pc_type": "python",
             "pc_python_type": "firedrake.HiptmairPC",
             "hiptmair_mg_levels": relax,
-            "hiptmair_mg_coarse": relax,
+            "hiptmair_mg_coarse": potential,
         },
     }
 
@@ -70,24 +89,32 @@ def run_riesz_map(V, mat_type):
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs, form_compiler_parameters={"mode": "vanilla"})
     solver = LinearVariationalSolver(problem, solver_parameters=parameters, appctx=appctx)
     solver.solve()
-    return solver.snes.ksp.getIterationNumber()
+    return errornorm(u_exact, uh)
 
 
 @pytest.mark.skipcomplexnoslate
-@pytest.mark.parametrize(["family", "cell"],
-                         [("N1curl", "tetrahedron"), ("NCE", "hexahedron")])
-def test_hiptmair_hcurl(family, cell):
-    mesh = mesh_hierarchy(cell)[-1]
+@pytest.mark.parametrize("mat_type", ["aij", "matfree"])
+def test_hiptmair_hcurl(mesh_hierarchy, mat_type):
+    mesh = mesh_hierarchy[-1]
+    if mesh.ufl_cell().is_simplex():
+        family = "N1curl"
+        max_it = 14
+    else:
+        family = "NCE"
+        max_it = 5
     V = FunctionSpace(mesh, family, degree=1)
-    assert run_riesz_map(V, "aij") <= 15
-    assert run_riesz_map(V, "matfree") <= 15
+    assert run_riesz_map(V, mat_type, max_it) < 1E-6
 
 
 @pytest.mark.skipcomplexnoslate
-@pytest.mark.parametrize(["family", "cell"],
-                         [("RT", "tetrahedron"), ("NCF", "hexahedron")])
-def test_hiptmair_hdiv(family, cell):
-    mesh = mesh_hierarchy(cell)[-1]
+@pytest.mark.parametrize("mat_type", ["aij", "matfree"])
+def test_hiptmair_hdiv(mesh_hierarchy, mat_type):
+    mesh = mesh_hierarchy[-1]
+    if mesh.ufl_cell().is_simplex():
+        family = "N1div"
+        max_it = 14
+    else:
+        family = "NCF"
+        max_it = 7
     V = FunctionSpace(mesh, family, degree=1)
-    assert run_riesz_map(V, "aij") <= 12
-    assert run_riesz_map(V, "matfree") <= 12
+    assert run_riesz_map(V, mat_type, max_it) < 1E-6


### PR DESCRIPTION
# Description

Adding vertical edge/face patches to `ASMExtrudedStarPC`, which were missing when `pc_star_construct_dim` is equal to 1 or 2. Also include `ASMExtrudedStarPC` solver parameters on an exisisting test to verify that such a space decomposition is equivalent to Jacobi relaxation.

The tests were updated to terminate after a fixed number of KSP iterations, only checking for convergence outside PETSc.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
