### PR TITLE
Fix ASMVankaPC ordering

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -234,7 +234,7 @@ class ASMVankaPC(ASMPatchPC):
                 closure, _ = mesh_dm.getTransitiveClosure(pt, useCone=True)
                 pt_array.update(closure.tolist())
 
-            pt_array = order_points(mesh_dm, pt_array, ordering, self.prefix)
+            pt_array = order_points(mesh_dm, list(pt_array), ordering, self.prefix)
             # Get DoF indices for patch
             indices = []
             for (i, W) in enumerate(V):


### PR DESCRIPTION
# Description

#3422 breaks `ASMVankaPC` by assuming inputs to `order_points` are lists, when they are sets in `ASMVankaPC`.  This casts the set to a list in that call.

Two separate issues should be addressed (but not here, since this fix is needed or master breaks a lot of things).  First, we need a test for values of `mat_ordering_type` that aren't `natural` for both `ASMStarPC` and `ASMVankaPC`.  Secondly, we need to remove the `xfail` on `test_vanka_equivalence` in `tests/regression/test_star_pc.py`.

