### PR TITLE
Fix docs build for firedrake.ml

### DIFF
--- a/firedrake/external_operators/point_expr_operator.py
+++ b/firedrake/external_operators/point_expr_operator.py
@@ -117,12 +117,13 @@ def point_expr(point_expr, function_space):
 
     Example
     -------
-    ```
-    # Stage 1: Partially initialise the operator.
-    N = point_expr(lambda x, y: x - y, function_space=V)
-    # Stage 2: Define the operands and use the operator in a UFL expression.
-    F = (inner(grad(u), grad(v)) + inner(N(u, f), v)) * dx
-    ```
+
+    .. code-block:: python
+
+        # Stage 1: Partially initialise the operator.
+        N = point_expr(lambda x, y: x - y, function_space=V)
+        # Stage 2: Define the operands and use the operator in a UFL expression.
+        F = (inner(grad(u), grad(v)) + inner(N(u, f), v)) * dx
 
     Parameters
     ----------

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -104,7 +104,7 @@ def fem_operator(F):
 
     Returns
     -------
-    firedrake.ml.pytorch.FiredrakeTorchOperator
+    firedrake.ml.pytorch.fem_operator.FiredrakeTorchOperator
         A PyTorch custom operator that wraps the reduced functional `F`.
     """
     Citations().register("Bouziani2023")

--- a/firedrake/ml/pytorch/ml_operator.py
+++ b/firedrake/ml/pytorch/ml_operator.py
@@ -178,12 +178,13 @@ def ml_operator(model, function_space, inputs_format=0):
 
     Example
     -------
-    ```
-    # Stage 1: Partially initialise the operator.
-    N = ml_operator(model, function_space=V)
-    # Stage 2: Define the operands and use the operator in a UFL expression.
-    F = (inner(grad(u), grad(v)) + inner(N(u), v) - inner(f, v)) * dx
-    ```
+
+    .. code-block:: python
+
+        # Stage 1: Partially initialise the operator.
+        N = ml_operator(model, function_space=V)
+        # Stage 2: Define the operands and use the operator in a UFL expression.
+        F = (inner(grad(u), grad(v)) + inner(N(u), v) - inner(f, v)) * dx
 
     Parameters
     ----------


### PR DESCRIPTION
The documentation for the `firedrake.ml` subpackage never gets built. This adds an empty init file to fix that and fixes a few other things in the docstrings.