### PR TITLE
ASMVankaPC: fix tests

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -227,18 +227,20 @@ class ASMVankaPC(ASMPatchPC):
 
             # Create point list from mesh DM
             star, _ = mesh_dm.getTransitiveClosure(seed, useCone=False)
-            pt_array = set()
-            for pt in star.tolist():
+            star = order_points(mesh_dm, star, ordering, self.prefix)
+            pt_array = []
+            for pt in reversed(star):
                 closure, _ = mesh_dm.getTransitiveClosure(pt, useCone=True)
-                pt_array.update(closure.tolist())
+                pt_array.extend(closure)
+            # Grab unique points with stable ordering
+            pt_array = list(reversed(dict.fromkeys(pt_array)))
 
-            pt_array = order_points(mesh_dm, list(pt_array), ordering, self.prefix)
             # Get DoF indices for patch
             indices = []
             for (i, W) in enumerate(V):
                 section = W.dm.getDefaultSection()
                 if i in exclude_subspaces:
-                    loop_list = [seed]
+                    loop_list = star
                 else:
                     loop_list = pt_array
                 for p in loop_list:

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -58,12 +58,12 @@ class ASMPatchPC(PCBase):
             asmpc.setType(asmpc.Type.ASM)
             # Set default solver parameters
             asmpc.setASMType(PETSc.PC.ASMType.BASIC)
-            opts = PETSc.Options(asmpc.getOptionsPrefix())
-            if "sub_pc_type" not in opts:
-                opts["sub_pc_type"] = "lu"
-            if "sub_pc_factor_mat_ordering_type" not in opts:
+            sub_opts = PETSc.Options(asmpc.getOptionsPrefix())
+            if "sub_pc_type" not in sub_opts:
+                sub_opts["sub_pc_type"] = "lu"
+            if "sub_pc_factor_mat_ordering_type" not in sub_opts:
                 # Preserve the natural ordering to avoid zero pivots in saddle-point problems
-                opts["sub_pc_factor_mat_ordering_type"] = "natural"
+                sub_opts["sub_pc_factor_mat_ordering_type"] = "natural"
 
             # If an ordering type is provided, PCASM should not sort patch indices, otherwise it can.
             mat_type = P.getType()

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -61,6 +61,9 @@ class ASMPatchPC(PCBase):
             opts = PETSc.Options(asmpc.getOptionsPrefix())
             if "sub_pc_type" not in opts:
                 opts["sub_pc_type"] = "lu"
+            if "sub_pc_factor_mat_ordering_type" not in opts:
+                # Preserve the natural ordering to avoid zero pivots in saddle-point problems
+                opts["sub_pc_factor_mat_ordering_type"] = "natural"
 
             # If an ordering type is provided, PCASM should not sort patch indices, otherwise it can.
             mat_type = P.getType()

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -61,8 +61,6 @@ class ASMPatchPC(PCBase):
             opts = PETSc.Options(asmpc.getOptionsPrefix())
             if "sub_pc_type" not in opts:
                 opts["sub_pc_type"] = "lu"
-            if "sub_pc_factor_shift_type" not in opts:
-                opts["sub_pc_factor_shift_type"] = "NONE"
 
             # If an ordering type is provided, PCASM should not sort patch indices, otherwise it can.
             mat_type = P.getType()

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -79,23 +79,23 @@ def test_star_equivalence(problem_type, backend):
                        "snes_type": "ksponly",
                        "ksp_type": "cg",
                        "pc_type": "mg",
-                       "pc_mg_type": "full",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "richardson",
                        "mg_levels_ksp_richardson_scale": 1/4,
                        "mg_levels_ksp_max_it": 1,
                        "mg_levels_pc_type": "python",
                        "mg_levels_pc_python_type": "firedrake.ASMStarPC",
                        "mg_levels_pc_star_construct_dim": 1,
-                       "mg_coarse_pc_type": "python",
-                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                       "mg_coarse_assembled_pc_type": "lu",
-                       "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+                       "mg_coarse_pc_type": "lu",
+                       "mg_coarse_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
                        "ksp_type": "cg",
                        "pc_type": "mg",
-                       "pc_mg_type": "full",
+                       "pc_mg_type": "multiplicative",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "richardson",
                        "mg_levels_ksp_richardson_scale": 1/4,
                        "mg_levels_ksp_max_it": 1,
@@ -134,23 +134,21 @@ def test_star_equivalence(problem_type, backend):
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",
-                       "pc_mg_cycles": "v",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "chebyshev",
                        "mg_levels_ksp_max_it": 2,
                        "mg_levels_ksp_convergence_test": "skip",
                        "mg_levels_pc_type": "python",
                        "mg_levels_pc_python_type": "firedrake.ASMStarPC",
                        "mg_levels_pc_star_construct_dim": 0,
-                       "mg_coarse_pc_type": "python",
-                       "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                       "mg_coarse_assembled_pc_type": "lu"}
+                       "mg_coarse_pc_type": "lu"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",
-                       "pc_mg_cycles": "v",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "chebyshev",
                        "mg_levels_ksp_max_it": 2,
                        "mg_levels_ksp_convergence_test": "skip",
@@ -167,6 +165,8 @@ def test_star_equivalence(problem_type, backend):
                        "mg_coarse_assembled_pc_type": "lu"}
 
     star_params["mg_levels_pc_star_backend"] = backend
+    star_params["mg_levels_pc_star_mat_ordering_type"] = "rcm"
+    star_params["mg_levels_pc_star_sub_sub_pc_factor_mat_ordering_type"] = "natural"
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=star_params, nullspace=nsp)
     star_solver.solve()
@@ -202,24 +202,22 @@ def test_vanka_equivalence(problem_type):
                         "ksp_type": "richardson",
                         "pc_type": "mg",
                         "pc_mg_type": "multiplicative",
-                        "pc_mg_cycles": "v",
+                        "pc_mg_cycle_type": "v",
                         "mg_levels_ksp_type": "richardson",
                         "mg_levels_ksp_richardson_scale": 1/10,
                         "mg_levels_ksp_max_it": 1,
                         "mg_levels_pc_type": "python",
                         "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
                         "mg_levels_pc_vanka_construct_codim": 0,
-                        "mg_coarse_pc_type": "python",
-                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                        "mg_coarse_assembled_pc_type": "lu",
-                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+                        "mg_coarse_pc_type": "lu",
+                        "mg_coarse_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",
-                       "pc_mg_cycles": "v",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "richardson",
                        "mg_levels_ksp_richardson_scale": 1/10,
                        "mg_levels_ksp_max_it": 1,
@@ -262,10 +260,8 @@ def test_vanka_equivalence(problem_type):
                         "mg_levels_pc_type": "python",
                         "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
                         "mg_levels_pc_vanka_construct_codim": 0,
-                        "mg_coarse_pc_type": "python",
-                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                        "mg_coarse_assembled_pc_type": "lu",
-                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+                        "mg_coarse_pc_type": "lu",
+                        "mg_coarse_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
@@ -310,7 +306,7 @@ def test_vanka_equivalence(problem_type):
                         "ksp_type": "richardson",
                         "pc_type": "mg",
                         "pc_mg_type": "multiplicative",
-                        "pc_mg_cycles": "v",
+                        "pc_mg_cycle_type": "v",
                         "mg_levels_ksp_type": "chebyshev",
                         "mg_levels_ksp_max_it": 2,
                         "mg_levels_ksp_convergence_test": "skip",
@@ -319,18 +315,15 @@ def test_vanka_equivalence(problem_type):
                         "mg_levels_pc_vanka_construct_dim": 0,
                         "mg_levels_pc_vanka_exclude_subspaces": "1",
                         "mg_levels_pc_vanka_sub_sub_pc_type": "cholesky",
-                        "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
-                        "mg_coarse_pc_type": "python",
-                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                        "mg_coarse_assembled_pc_type": "cholesky",
-                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
+                        "mg_coarse_pc_type": "cholesky",
+                        "mg_coarse_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",
                        "snes_type": "ksponly",
                        "ksp_type": "richardson",
                        "pc_type": "mg",
                        "pc_mg_type": "multiplicative",
-                       "pc_mg_cycles": "v",
+                       "pc_mg_cycle_type": "v",
                        "mg_levels_ksp_type": "chebyshev",
                        "mg_levels_ksp_max_it": 2,
                        "mg_levels_ksp_convergence_test": "skip",
@@ -348,6 +341,8 @@ def test_vanka_equivalence(problem_type):
                        "mg_coarse_assembled_pc_type": "lu",
                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
+    vanka_params["mg_levels_pc_vanka_mat_ordering_type"] = "rcm"
+    vanka_params["mg_levels_pc_vanka_sub_sub_pc_factor_mat_ordering_type"] = "natural"  # avoids zero pivots in saddle-point problems
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=vanka_params, nullspace=nsp)
     star_solver.solve()

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -166,7 +166,6 @@ def test_star_equivalence(problem_type, backend):
 
     star_params["mg_levels_pc_star_backend"] = backend
     star_params["mg_levels_pc_star_mat_ordering_type"] = "rcm"
-    star_params["mg_levels_pc_star_sub_sub_pc_factor_mat_ordering_type"] = "natural"
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=star_params, nullspace=nsp)
     star_solver.solve()
@@ -342,7 +341,6 @@ def test_vanka_equivalence(problem_type):
                        "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
     vanka_params["mg_levels_pc_vanka_mat_ordering_type"] = "rcm"
-    vanka_params["mg_levels_pc_vanka_sub_sub_pc_factor_mat_ordering_type"] = "natural"  # avoids zero pivots in saddle-point problems
     nvproblem = NonlinearVariationalProblem(a, u, bcs=bcs)
     star_solver = NonlinearVariationalSolver(nvproblem, solver_parameters=vanka_params, nullspace=nsp)
     star_solver.solve()

--- a/tests/regression/test_star_pc.py
+++ b/tests/regression/test_star_pc.py
@@ -141,7 +141,6 @@ def test_star_equivalence(problem_type, backend):
                        "mg_levels_pc_type": "python",
                        "mg_levels_pc_python_type": "firedrake.ASMStarPC",
                        "mg_levels_pc_star_construct_dim": 0,
-                       "mg_levels_pc_star_sub_sub_pc_factor_shift_type": "nonzero",
                        "mg_coarse_pc_type": "python",
                        "mg_coarse_pc_python_type": "firedrake.AssembledPC",
                        "mg_coarse_assembled_pc_type": "lu"}
@@ -181,7 +180,6 @@ def test_star_equivalence(problem_type, backend):
     assert star_its == comp_its
 
 
-@pytest.mark.skipif(True, reason="This test seems to randomly fail CI")
 def test_vanka_equivalence(problem_type):
     distribution_parameters = {"partition": True,
                                "overlap_type": (DistributedMeshOverlapType.VERTEX, 2)}
@@ -302,7 +300,7 @@ def test_vanka_equivalence(problem_type):
         (z, p) = split(u)
         (v, q) = split(TestFunction(V))
 
-        a = inner(grad(z), grad(v))*dx - inner(p, div(v))*dx - inner(q, div(z))*dx
+        a = inner(grad(z), grad(v))*dx - inner(p, div(v))*dx - inner(div(z), q)*dx
 
         bcs = DirichletBC(V.sub(0), Constant((1., 0.)), "on_boundary")
         nsp = MixedVectorSpaceBasis(V, [V.sub(0), VectorSpaceBasis(constant=True)])
@@ -320,11 +318,11 @@ def test_vanka_equivalence(problem_type):
                         "mg_levels_pc_python_type": "firedrake.ASMVankaPC",
                         "mg_levels_pc_vanka_construct_dim": 0,
                         "mg_levels_pc_vanka_exclude_subspaces": "1",
+                        "mg_levels_pc_vanka_sub_sub_pc_type": "cholesky",
                         "mg_levels_pc_vanka_sub_sub_pc_factor_shift_type": "nonzero",
-                        "mg_levels_pc_vanka_sub_sub_pc_factor_mat_solver_type": "mumps",
                         "mg_coarse_pc_type": "python",
                         "mg_coarse_pc_python_type": "firedrake.AssembledPC",
-                        "mg_coarse_assembled_pc_type": "lu",
+                        "mg_coarse_assembled_pc_type": "cholesky",
                         "mg_coarse_assembled_pc_factor_mat_solver_type": "mumps"}
 
         comp_params = {"mat_type": "aij",


### PR DESCRIPTION
# Description

Restore/fix ASMVankaPC tests, fixes #3430

Test `-pc_star_mat_ordering_type`, fixes #3431

We should expect unpivoted LU to work on a 2×2 block matrix with the natural saddle-point ordering (velocity followed by pressure). This is because (block) Gaussian elimination in the natural ordering should form the (LU factors of the) pressure Schur complement (which should be invertible). Nevertheless, we've been having plenty of issues with singular pivots throughout the years.

By default, petsc imposes a nested dissection reordering which messes up the block structure of the Vanka patches. Traditionally, this has been fixed by forcing a nonzero pivot or relying on sophisticated direct solver packages (using mumps on many small matrices was causing some issues here). The proposed fix is to keep the natural ordering of the fields and to use PETSc's own LU/Cholesky implementation.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
