### PR TITLE
DO NOT MERGE - upstream update test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
             --install fascd \
             --install defcon \
             --install gadopt \
+            --package-branch loopy JHopeCollins/upstream-update \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |


### PR DESCRIPTION
Test updated loopy with deprecated numpy bool type removed.
Should prevent deprecation warnings being raised.

Associated loopy PR:
https://github.com/firedrakeproject/loopy/pull/22