### PR TITLE
Fix a deadlock with VertexOnlyMesh'es created not on COMM_WORLD

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2325,7 +2325,8 @@ values from f.)"""
                     str(libspatialindex_so),
                     f"-Wl,-rpath,{sys.prefix}/lib",
                     lsi_runpath
-                ]
+                ],
+                comm=self.comm
             )
 
             locator.argtypes = [ctypes.POINTER(function._CFunction),

--- a/tests/vertexonly/test_different_comms.py
+++ b/tests/vertexonly/test_different_comms.py
@@ -1,0 +1,13 @@
+from firedrake import *
+import pytest
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_different_comms():
+
+    rank = COMM_WORLD.rank
+
+    if rank == 0:
+        mesh = UnitIntervalMesh(1, comm=COMM_SELF)
+        vom = VertexOnlyMesh(mesh, [[0.5]])
+        assert vom is not None


### PR DESCRIPTION
@UZerbinati wrote some defcon code that used a VertexOnlyMesh. The code was deadlocking. Upon inspection, VertexOnlyMesh was compiling some code but not passing the relevant communicator.