### PR TITLE
ASMPC: do not setUnfactored for TinyASM

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -114,8 +114,9 @@ class ASMPatchPC(PCBase):
 
     def update(self, pc):
         # This is required to update an inplace ILU factorization
-        for sub in self.asmpc.getASMSubKSP():
-            sub.getOperators()[0].setUnfactored()
+        if self.asmpc.getType() == "asm":
+            for sub in self.asmpc.getASMSubKSP():
+                sub.getOperators()[0].setUnfactored()
 
     def apply(self, pc, x, y):
         self.asmpc.apply(x, y)


### PR DESCRIPTION
# Description
TinyASM does not implement getASMSubKSP(), hence it was breaking on update. This PR skips the resetting of the sub-KSPs if they are not there.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
