### PR TITLE
Replace PETSc.DMPlex.createGmsh by PETSc.DMPlex.createFromFile

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -305,24 +305,7 @@ def _from_gmsh(filename, comm=None):
         COMM_WORLD).
     """
     comm = comm or COMM_WORLD
-    # check the filetype of the gmsh file
-    filetype = None
-    if comm.rank == 0:
-        with open(filename, 'rb') as fid:
-            header = fid.readline().rstrip(b'\n\r')
-            version = fid.readline().rstrip(b'\n\r')
-        assert header == b'$MeshFormat'
-        if version.split(b' ')[1] == b'1':
-            filetype = "binary"
-        else:
-            filetype = "ascii"
-    filetype = comm.bcast(filetype, root=0)
-    # Create a read-only PETSc.Viewer
-    gmsh_viewer = PETSc.Viewer().create(comm=comm)
-    gmsh_viewer.setType(filetype)
-    gmsh_viewer.setFileMode("r")
-    gmsh_viewer.setFileName(filename)
-    gmsh_plex = PETSc.DMPlex().createGmsh(gmsh_viewer, comm=comm)
+    gmsh_plex = PETSc.DMPlex().createFromFile(filename, comm=comm)
 
     return gmsh_plex
 


### PR DESCRIPTION
The previous code creates a viewer from a file and then constructs the Plex from the viewer. The viewer should be destroyed using `gmsh_viewer.destroy` after the Plex is created, otherwise, this may result in `OSError: open too many files` in parallel.

Since PETSc provides PETSc.DMPlex.createFromFile, we can utilize it directly.
<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
