### PR TITLE
Do not copy nullspaces for MassInvPC

### DIFF
--- a/firedrake/preconditioners/massinv.py
+++ b/firedrake/preconditioners/massinv.py
@@ -26,3 +26,7 @@ class MassInvPC(AssembledPC):
         mu = appctx.get("mu", 1.0)
         a = inner((1/mu) * trial, test) * dx
         return a, bcs
+
+    def set_nullspaces(self, pc):
+        # the mass matrix does not have a nullspace
+        pass

--- a/tests/regression/test_nullspace.py
+++ b/tests/regression/test_nullspace.py
@@ -289,10 +289,12 @@ def test_nullspace_mixed_multiple_components():
     assert schur_ksp.getIterationNumber() < 6
 
 
+@pytest.mark.parallel(nprocs=2)
 @pytest.mark.parametrize("aux_pc", [False, True], ids=["PC(mu)", "PC(DG0-mu)"])
 def test_near_nullspace_mixed(aux_pc):
     # test nullspace and nearnullspace for a mixed Stokes system
     # this is tested on the SINKER case of May and Moresi https://doi.org/10.1016/j.pepi.2008.07.036
+    # fails in parallel if nullspace is copied to fieldsplit_1_Mp_ksp solve (see PR #3488)
     PETSc.Sys.popErrorHandler()
     n = 64
     mesh = UnitSquareMesh(n, n)
@@ -385,5 +387,5 @@ def test_near_nullspace_mixed(aux_pc):
     assert ksp_inner.getConvergedReason() > 0
     A, P = ksp_inner.getOperators()
     assert A.getNearNullSpace().handle
-    # currently ~22 vs. >45-ish for with/without near nullspace
-    assert ksp_inner.getIterationNumber() < 25
+    # currently ~22 (25 on 2 cores) vs. >45-ish for with/without near nullspace
+    assert ksp_inner.getIterationNumber() < 27


### PR DESCRIPTION
The mass matrix itself does not have a nullspace.

As an example, solving Stokes in a closed box which has a pressure nullspace. The implicit Schur complement matrix of fieldsplit_1 has that constant nullspace attached. At the level of fieldsplit_1_Mp however we have the explicit mass matrix approximation. If we copy the nullspace from the parent implicit matrix, we get into trouble when we specify a solve, "fieldsplit_1_Mp_pc_type": "ksp", with that mass matrix as the nullspace will now be applied within the iterations of the mass matrix solve, where it does not have one. This leads to hard to detect convergence failures. If we don't copy the nullspace over (as per this PR), the nullspace is still removed (as we want) immediately _after_ the MassInvPc as a whole has been applied, in the outer loop of the Schur complement solve.