### PR TITLE
Dham/fix cofunction interpolate

### DIFF
--- a/firedrake/__future__.py
+++ b/firedrake/__future__.py
@@ -1,4 +1,5 @@
 from ufl.domain import as_domain, extract_unique_domain
+from ufl.algorithms import extract_arguments
 from firedrake.mesh import VertexOnlyMeshTopology
 from firedrake.interpolation import (interpolate as interpolate_old,
                                      Interpolator as InterpolatorOld,
@@ -38,7 +39,8 @@ class CrossMeshInterpolator(Interpolator, CrossMeshInterpolatorOld):
 def interpolate(expr, V, *args, **kwargs):
     default_missing_val = kwargs.pop("default_missing_val", None)
     if isinstance(V, Cofunction):
+        transpose = bool(extract_arguments(expr))
         return Interpolator(
             expr, V.function_space().dual(), *args, **kwargs
-        ).interpolate(V, transpose=True, default_missing_val=default_missing_val)
+        ).interpolate(V, transpose=transpose, default_missing_val=default_missing_val)
     return Interpolator(expr, V, *args, **kwargs).interpolate(default_missing_val=default_missing_val)

--- a/firedrake/__future__.py
+++ b/firedrake/__future__.py
@@ -4,6 +4,8 @@ from firedrake.interpolation import (interpolate as interpolate_old,
                                      Interpolator as InterpolatorOld,
                                      SameMeshInterpolator as SameMeshInterpolatorOld,
                                      CrossMeshInterpolator as CrossMeshInterpolatorOld)
+from firedrake.cofunction import Cofunction
+from functools import wraps
 
 
 __all__ = ("interpolate", "Interpolator")
@@ -32,9 +34,11 @@ class CrossMeshInterpolator(Interpolator, CrossMeshInterpolatorOld):
     pass
 
 
-def interpolate(*args, **kwargs):
+@wraps(interpolate_old)
+def interpolate(expr, V, *args, **kwargs):
     default_missing_val = kwargs.pop("default_missing_val", None)
-    return Interpolator(*args, **kwargs).interpolate(default_missing_val=default_missing_val)
-
-
-interpolate.__doc__ = interpolate_old.__doc__
+    if isinstance(V, Cofunction):
+        return Interpolator(
+            expr, V.function_space().dual(), *args, **kwargs
+        ).interpolate(V, transpose=True, default_missing_val=default_missing_val)
+    return Interpolator(expr, V, *args, **kwargs).interpolate(default_missing_val=default_missing_val)

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -359,8 +359,7 @@ def test_adjoint_Pk(degree):
 
     v = conj(TestFunction(Pkp1))
     u_Pk = assemble(conj(TestFunction(Pk)) * dx)
-    interpolator = Interpolator(TestFunction(Pk), Pkp1)
-    v_adj = assemble(interpolator.interpolate(assemble(v * dx), transpose=True))
+    v_adj = assemble(interpolate(TestFunction(Pk), assemble(v * dx)))
 
     assert np.allclose(u_Pk.dat.data, v_adj.dat.data)
 

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -388,6 +388,23 @@ def test_adjoint_dg():
     assert np.allclose(u_cg.dat.data, v_adj.dat.data)
 
 
+@pytest.mark.parametrize("degree", range(1, 4))
+def test_function_cofunction(degree):
+    mesh = UnitSquareMesh(10, 10)
+    Pkp1 = FunctionSpace(mesh, "CG", degree+1)
+    Pk = FunctionSpace(mesh, "CG", degree)
+
+    v1 = conj(TestFunction(Pkp1))
+    x = SpatialCoordinate(mesh)
+    f = assemble(interpolate(sin(2*pi*x[0])*sin(2*pi*x[1])), Pk)
+
+    fhat = assemble(f*v1*dx)
+    norm_i = assemble(interpolate(f, fhat))
+    norm = assemble(f*f*dx)
+
+    assert np.allclose(norm_i, norm)
+
+
 @pytest.mark.skipcomplex  # complex numbers are not orderable
 def test_interpolate_periodic_coords_max():
     mesh = PeriodicUnitSquareMesh(4, 4)

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -396,7 +396,7 @@ def test_function_cofunction(degree):
 
     v1 = conj(TestFunction(Pkp1))
     x = SpatialCoordinate(mesh)
-    f = assemble(interpolate(sin(2*pi*x[0])*sin(2*pi*x[1])), Pk)
+    f = assemble(interpolate(sin(2*pi*x[0])*sin(2*pi*x[1]), Pk))
 
     fhat = assemble(f*v1*dx)
     norm_i = assemble(interpolate(f, fhat))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -372,8 +372,7 @@ def test_adjoint_quads():
 
     v = conj(TestFunction(P2))
     u_P1 = assemble(conj(TestFunction(P1)) * dx)
-    interpolator = Interpolator(TestFunction(P1), P2)
-    v_adj = assemble(interpolator.interpolate(assemble(v * dx), transpose=True))
+    v_adj = assemble(interpolate(TestFunction(P1), assemble(v * dx)))
 
     assert np.allclose(u_P1.dat.data, v_adj.dat.data)
 
@@ -385,8 +384,7 @@ def test_adjoint_dg():
 
     v = conj(TestFunction(dg1))
     u_cg = assemble(conj(TestFunction(cg1)) * dx)
-    interpolator = Interpolator(TestFunction(cg1), dg1)
-    v_adj = assemble(interpolator.interpolate(assemble(v * dx), transpose=True))
+    v_adj = assemble(interpolate(TestFunction(cg1), assemble(v * dx)))
 
     assert np.allclose(u_cg.dat.data, v_adj.dat.data)
 


### PR DESCRIPTION
# Description

The existing implementation of interpolate didn't work if passed a Cofunction in the second argument slot (as opposed to a function space or a coargument). This meant that the most natural syntax for point forcing functions didn't work and users had to explicitly construct an Interpolator instead. This PR fixes this. Existing tests that used the Interpolator workaround have been updated, and a new test has been added for the case where there are no arguments on either side of the interpolate, and the result is hence a scalar.