### PR TITLE
fix the interface of sort comparison function

### DIFF
--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2438,7 +2438,7 @@ cdef struct CommFacet:
     PetscInt global_u, global_v
     PetscInt local_facet
 
-cdef int CommFacet_cmp(void *x_, void *y_) nogil:
+cdef int CommFacet_cmp(const void *x_, const void *y_) nogil:
     """Three-way comparison C function for CommFacet structs."""
     cdef:
         CommFacet *x = <CommFacet *>x_


### PR DESCRIPTION
My compiler just failed while building Firedrake's cython modules, complaining about the interface of the comparison function we pass to qsort not matching. On closer inspection, it appears that the compiler is right. Here is the interface definition: https://github.com/cython/cython/blob/368bbde62565f8798e061754caf60c94107f2d8c/Cython/Includes/libc/stdlib.pxd#L47

