### PR TITLE
pyop3: Block matrix

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -1409,7 +1409,8 @@ class ExplicitMatrixAssembler(ParloopFormAssembler):
         sparsity = op3.Sparsity(
             test.function_space().axes,
             trial.function_space().axes,
-            mat_type=mat_type
+            mat_type=mat_type,
+            block_shape=test.function_space().value_size
         )
 
         # Pretend that we are doing assembly by looping over the right

--- a/tests/regression/test_nested_fieldsplit_solves.py
+++ b/tests/regression/test_nested_fieldsplit_solves.py
@@ -184,12 +184,13 @@ def test_matrix_types(W):
 
 
 def test_block_matrix_type():
-    mesh = UnitSquareMesh(1, 1)
-    V = VectorFunctionSpace(mesh, "DG", 0)
+    mesh = UnitSquareMesh(2, 2)
+    V = VectorFunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     v = TestFunction(V)
     a = inner(u, v)*dx
-
-    A = assemble(a, mat_type="aij")
-    B = assemble(a, mat_type="baij")
-    assert A.M.mat.view() == B.M.mat.view()
+    f = Function(V)
+    f.interpolate(Constant((1, 2)))
+    result = Function(V)
+    solve(a == inner(f, v)*dx, result, solver_parameters={'mat_type':'baij'})
+    assert errornorm(f, result) < 1e-10

--- a/tests/regression/test_nested_fieldsplit_solves.py
+++ b/tests/regression/test_nested_fieldsplit_solves.py
@@ -181,3 +181,15 @@ def test_matrix_types(W):
     A = assemble(a, mat_type="nest", sub_mat_type="baij")
 
     assert A.M[1, 1].handle.getType() == "seqbaij"
+
+
+def test_block_matrix_type():
+    mesh = UnitSquareMesh(1, 1)
+    V = VectorFunctionSpace(mesh, "DG", 0)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = inner(u, v)*dx
+
+    A = assemble(a, mat_type="aij")
+    B = assemble(a, mat_type="baij")
+    assert A.M.mat.view() == B.M.mat.view()


### PR DESCRIPTION
Add `block_shape` at `pyop3.Sparsity` and testing for the block matrix type.
