### PR TITLE
Dham/periodic meshes

### DIFF
--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -3,17 +3,13 @@ import numpy as np
 import ufl
 
 from pyop2.mpi import COMM_WORLD
-from firedrake.utils import IntType, RealType, ScalarType
+from firedrake.utils import IntType, ScalarType
 
 from firedrake import (
     VectorFunctionSpace,
     FunctionSpace,
     Function,
     Constant,
-    par_loop,
-    dx,
-    WRITE,
-    READ,
     assemble,
     Interpolate,
     FiniteElement,

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -989,7 +989,7 @@ def PeriodicRectangleMesh(
     x, y, z = SpatialCoordinate(m)
     eps = 1.e-14
     indicator_y = Function(FunctionSpace(m, coord_family, 0))
-    indicator_y.interpolate(conditional(real(y), 0), 0., 1.))
+    indicator_y.interpolate(conditional(gt(real(y), 0), 0., 1.))
     x_coord = Function(FunctionSpace(m, coord_family, 1, variant="equispaced"))
     x_coord.interpolate(
         # Periodic break.
@@ -1000,7 +1000,7 @@ def PeriodicRectangleMesh(
     phi_coord = as_vector([cos(2*pi*x_coord), sin(2*pi*x_coord)])
     dr = dot(as_vector((x, y))-phi_coord, phi_coord)
     indicator_z = Function(FunctionSpace(m, coord_family, 0))
-    indicator_z.interpolate(conditional(real(z), 0), 0., 1.))
+    indicator_z.interpolate(conditional(gt(real(z), 0), 0., 1.))
     new_coordinates.interpolate(as_vector((
         x_coord * Lx,
         # Periodic break.

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -25,7 +25,8 @@ from firedrake import (
     dot,
     And,
     sin,
-    cos
+    cos,
+    real
 )
 from firedrake.cython import dmcommon
 from firedrake import mesh
@@ -278,9 +279,11 @@ cells are not currently supported"
     eps = 1.e-14
     indicator.interpolate(conditional(gt(y, 0), 0., 1.))
     new_coordinates.interpolate(
-        as_vector((conditional(gt(x, 1. - eps), indicator,  # Periodic break.
-                               # Unwrap rest of circle.
-                               atan2(-y, -x)/(2 * pi) + 0.5) * length,))
+        as_vector((conditional(
+            gt(x, 1. - eps), indicator,  # Periodic break.
+            # Unwrap rest of circle.
+            atan2(real(-y), real(-x))/(2 * pi) + 0.5
+        ) * length,))
     )
 
     return _postprocess_periodic_mesh(new_coordinates,
@@ -992,7 +995,7 @@ def PeriodicRectangleMesh(
         # Periodic break.
         conditional(And(gt(eps, abs(y)), gt(x, 0.)), indicator_y,
                     # Unwrap rest of circle.
-                    atan2(-y, -x)/(2*pi)+0.5)
+                    atan2(real(-y), real(-x))/(2*pi)+0.5)
     )
     phi_coord = as_vector([cos(2*pi*x_coord), sin(2*pi*x_coord)])
     dr = dot(as_vector((x, y))-phi_coord, phi_coord)
@@ -1003,7 +1006,7 @@ def PeriodicRectangleMesh(
         # Periodic break.
         conditional(And(gt(eps, abs(z)), gt(dr, 0.)), indicator_z,
                     # Unwrap rest of circle.
-                    atan2(-z, -dr)/(2*pi)+0.5) * Ly
+                    atan2(real(-z), real(-dr))/(2*pi)+0.5) * Ly
     )))
 
     return _postprocess_periodic_mesh(new_coordinates,
@@ -3041,7 +3044,7 @@ def PartiallyPeriodicRectangleMesh(
         as_vector((
             conditional(gt(x, 1. - eps), indicator,  # Periodic break.
                         # Unwrap rest of circle.
-                        atan2(-y, -x)/(2 * pi) + 0.5),
+                        atan2(real(-y), real(-x))/(2 * pi) + 0.5),
             z
         ))
     ))

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -277,10 +277,10 @@ cells are not currently supported"
     )
     x, y = SpatialCoordinate(m)
     eps = 1.e-14
-    indicator.interpolate(conditional(gt(y, 0), 0., 1.))
+    indicator.interpolate(conditional(gt(real(y), 0), 0., 1.))
     new_coordinates.interpolate(
         as_vector((conditional(
-            gt(x, 1. - eps), indicator,  # Periodic break.
+            gt(real(x), real(1. - eps)), indicator,  # Periodic break.
             # Unwrap rest of circle.
             atan2(real(-y), real(-x))/(2 * pi) + 0.5
         ) * length,))
@@ -989,22 +989,22 @@ def PeriodicRectangleMesh(
     x, y, z = SpatialCoordinate(m)
     eps = 1.e-14
     indicator_y = Function(FunctionSpace(m, coord_family, 0))
-    indicator_y.interpolate(conditional(gt(y, 0), 0., 1.))
+    indicator_y.interpolate(conditional(real(y), 0), 0., 1.))
     x_coord = Function(FunctionSpace(m, coord_family, 1, variant="equispaced"))
     x_coord.interpolate(
         # Periodic break.
-        conditional(And(gt(eps, abs(y)), gt(x, 0.)), indicator_y,
+        conditional(And(gt(real(eps), real(abs(y))), gt(real(x), 0.)), indicator_y,
                     # Unwrap rest of circle.
                     atan2(real(-y), real(-x))/(2*pi)+0.5)
     )
     phi_coord = as_vector([cos(2*pi*x_coord), sin(2*pi*x_coord)])
     dr = dot(as_vector((x, y))-phi_coord, phi_coord)
     indicator_z = Function(FunctionSpace(m, coord_family, 0))
-    indicator_z.interpolate(conditional(gt(z, 0), 0., 1.))
+    indicator_z.interpolate(conditional(real(z), 0), 0., 1.))
     new_coordinates.interpolate(as_vector((
         x_coord * Lx,
         # Periodic break.
-        conditional(And(gt(eps, abs(z)), gt(dr, 0.)), indicator_z,
+        conditional(And(gt(real(eps), real(abs(z))), gt(real(dr), 0.)), indicator_z,
                     # Unwrap rest of circle.
                     atan2(real(-z), real(-dr))/(2*pi)+0.5) * Ly
     )))
@@ -2274,10 +2274,10 @@ def OctahedralSphereMesh(
     s = ufl.real(abs(z) - z0) / (1 - z0)
     exp = ufl.exp
     taper = ufl.conditional(
-        ufl.gt(s, 1.0 - tol),
+        ufl.gt(real(s), real(1.0 - tol)),
         1.0,
         ufl.conditional(
-            ufl.gt(s, tol), exp(-1.0 / s) / (exp(-1.0 / s) + exp(-1.0 / (1.0 - s))), 0.0
+            ufl.gt(real(s), real(tol)), exp(-1.0 / s) / (exp(-1.0 / s) + exp(-1.0 / (1.0 - s))), 0.0
         ),
     )
     m.coordinates.interpolate(taper * Xradial + (1 - taper) * Xlatitudinal)
@@ -3034,7 +3034,7 @@ def PartiallyPeriodicRectangleMesh(
     )
     x, y, z = SpatialCoordinate(m)
     eps = 1.e-14
-    indicator.interpolate(conditional(gt(y, 0), 0., 1.))
+    indicator.interpolate(conditional(gt(real(y), 0), 0., 1.))
     if direction == "x":
         transform = as_tensor([[Lx, 0.], [0., Ly]])
     else:
@@ -3042,7 +3042,7 @@ def PartiallyPeriodicRectangleMesh(
     new_coordinates.interpolate(dot(
         transform,
         as_vector((
-            conditional(gt(x, 1. - eps), indicator,  # Periodic break.
+            conditional(gt(real(x), real(1. - eps)), indicator,  # Periodic break.
                         # Unwrap rest of circle.
                         atan2(real(-y), real(-x))/(2 * pi) + 0.5),
             z

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -3,7 +3,6 @@ import numpy as np
 import ufl
 
 from pyop2.mpi import COMM_WORLD
-from firedrake.__future__ import interpolate
 from firedrake.utils import IntType, RealType, ScalarType
 
 from firedrake import (

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -413,7 +413,7 @@ def test_interpolate_periodic_coords_max():
     continuous = assemble(interpolate(SpatialCoordinate(mesh), V, access=MAX))
 
     # All nodes on the "seam" end up being 1, not 0.
-    assert np.allclose(np.unique(continuous.dat.data_ro),
+    assert np.allclose(np.unique(continuous.dat.data_ro.round(decimals=16)),
                        [0.25, 0.5, 0.75, 1])
 
 


### PR DESCRIPTION
The periodic interval and rectangle meshes are created by unrolling circle, cylinder and torus meshes respectively. This PR changes the previous hand-coded parloops to instead use interpolation.