### PR TITLE
If VTK is installed, have `from firedrake import *` import VTKFile

### DIFF
--- a/demos/benney_luke/benney_luke.py.rst
+++ b/demos/benney_luke/benney_luke.py.rst
@@ -88,7 +88,6 @@ Finally, before implementing the problem in Firedrake, we calculate the total en
 The implementation of this problem in Firedrake requires solving two nonlinear variational problems and one linear problem. The Benney-Luke equations are solved in a rectangular domain :math:`\Omega=[0,10]\times[0,1]`, with :math:`\mu=\epsilon=0.01`, time step :math:`dt=0.005` and up to the final time :math:`T=2.0`. Additionally, the domain is split into 50 cells in the x-direction using a quadrilateral mesh. In the y-direction only 1 cell is enough since there are no variations in y::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
 Now we move on to defining parameters::
 

--- a/demos/burgers/burgers.py.rst
+++ b/demos/burgers/burgers.py.rst
@@ -34,7 +34,6 @@ stability we elect to use a backward Euler discretisation:
 We can now proceed to set up the problem. We choose a resolution and set up a square mesh::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   n = 30
   mesh = UnitSquareMesh(n, n)
 

--- a/demos/camassa-holm/camassaholm.py.rst
+++ b/demos/camassa-holm/camassaholm.py.rst
@@ -62,7 +62,6 @@ As usual, to implement this problem, we start by importing the
 Firedrake namespace. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
 To visualise the output, we also need to import matplotlib.pyplot to display
 the visual output ::

--- a/demos/extruded_shallow_water/test_extrusion_lsw.py
+++ b/demos/extruded_shallow_water/test_extrusion_lsw.py
@@ -3,7 +3,6 @@
 a sin(x)*sin(y) solution that doesn't care about the silly BCs"""
 
 from firedrake import *
-from firedrake.output import VTKFile
 
 
 power = 5

--- a/demos/helmholtz/helmholtz.py.rst
+++ b/demos/helmholtz/helmholtz.py.rst
@@ -49,7 +49,6 @@ method, so lets go ahead and produce a numerical solution.
 First, we always need a mesh. Let's have a :math:`10\times10` element unit square::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   mesh = UnitSquareMesh(10, 10)
 
 We need to decide on the function space in which we'd like to solve the

--- a/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
+++ b/demos/higher_order_mass_lumping/higher_order_mass_lumping.py.rst
@@ -49,7 +49,6 @@ In the work of :cite:`Chin:1999` and later :cite:`Geevers:2018`, several triangu
 In addition to importing firedrake as usual, we will need to construct the correct quadrature rules for the mass-lumping by hand. FInAT is responsible for providing these quadrature rules, so we import it here too.::
 
     from firedrake import *
-    from firedrake.output import VTKFile
     import finat
 
     import math

--- a/demos/linear-wave-equation/linear_wave_equation.py.rst
+++ b/demos/linear-wave-equation/linear_wave_equation.py.rst
@@ -50,7 +50,6 @@ This time we created the mesh with `Gmsh <http://gmsh.info/>`_:
 We can then start our Python script and load this mesh::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   mesh = Mesh("wave_tank.msh")
 
 We choose a degree 1 continuous function space, and set up the

--- a/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
+++ b/demos/linear_fluid_structure_interaction/linear_fluid_structure_interaction.py.rst
@@ -64,7 +64,6 @@ The underlined terms are the coupling terms. Note that the first equation for :m
 Now we present the code used to solve the system of equations above. We start with appropriate imports::
 
     from firedrake import *
-    from firedrake.output import VTKFile
     import math
     import numpy as np
 

--- a/demos/ma-demo/ma-demo.py.rst
+++ b/demos/ma-demo/ma-demo.py.rst
@@ -75,7 +75,6 @@ We now proceed to set up the problem in Firedrake using a square
 mesh of quadrilaterals. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   n = 100
   mesh = UnitSquareMesh(n, n, quadrilateral=True)
 

--- a/demos/matrix_free/navier_stokes.py.rst
+++ b/demos/matrix_free/navier_stokes.py.rst
@@ -5,7 +5,6 @@ We solve the Navier-Stokes equations using Taylor-Hood elements.  The
 example is that of a lid-driven cavity. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
   N = 64
 

--- a/demos/matrix_free/rayleigh-benard.py.rst
+++ b/demos/matrix_free/rayleigh-benard.py.rst
@@ -11,7 +11,6 @@ the Navier-Stokes part, and piecewise linear elements for the
 temperature. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
   N = 128
 

--- a/demos/matrix_free/stokes.py.rst
+++ b/demos/matrix_free/stokes.py.rst
@@ -9,7 +9,6 @@ cavity.
 As ever, we import firedrake and define a mesh.::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
   N = 64
 

--- a/demos/multigrid/geometric_multigrid.py.rst
+++ b/demos/multigrid/geometric_multigrid.py.rst
@@ -20,7 +20,6 @@ hierarchies are constructed using regular bisection refinement, so we
 must create a coarse mesh. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
   mesh = UnitSquareMesh(8, 8)
 

--- a/demos/netgen/netgen_mesh.py.rst
+++ b/demos/netgen/netgen_mesh.py.rst
@@ -14,7 +14,6 @@ Installing Netgen
 This demo requires the NGSolve/Netgen suite to be installed. This is most easily achieved by providing the optional `--netgen` flag to either `firedrake-install` (for a new installation), or `firedrake-update` (to add the NGSolve/Netgen suite to an existing installation). ::
 
    from firedrake import *
-   from firedrake.output import VTKFile
    try:
        import netgen
    except ImportError:

--- a/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
+++ b/demos/nonlinear_QG_winddrivengyre/qg_winddrivengyre.py.rst
@@ -138,7 +138,6 @@ Now that we know the weak form we are now ready to solve this using Firedrake!
 First, we import the Firedrake, PETSc, NumPy and UFL packages, ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   from firedrake.petsc import PETSc
   import numpy as np
   import ufl

--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -85,7 +85,6 @@ follows:
 The mesh is chosen as a :math:`32\times32` element unit square. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
   mesh = UnitSquareMesh(32, 32)
 
 As argued above, a stable choice of function spaces for our problem is the

--- a/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
+++ b/demos/quasigeostrophy_1layer/qg_1layer_wave.py.rst
@@ -106,7 +106,6 @@ freely propagating Rossby wave.  As ever, we begin by importing the
 Firedrake library. ::
 
   from firedrake import *
-  from firedrake.output import VTKFile
 
 Next we define the domain we will solve the equations on, square
 domain with 50 cells in each direction that is periodic along the

--- a/docs/source/visualisation.rst
+++ b/docs/source/visualisation.rst
@@ -22,8 +22,6 @@ PVD_ and therefore the requested file name must end in ``.pvd``.
 
 .. code-block:: python3
 
-   from firedrake.output import VTKFile
-
    outfile = VTKFile("output.pvd")
    # The following raises an error
    badfile = VTKFile("output.vtu")

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -131,7 +131,7 @@ from firedrake._deprecation import plot, File  # noqa: F401
 # Once `File` is deprecated update the above line removing `File` and add
 #   from firedrake._deprecation import output
 #   sys.modules["firedrake.output"] = output
-#   from firedrake.output import *
+from firedrake.output import *
 sys.modules["firedrake.plot"] = plot
 from firedrake.plot import *
 

--- a/firedrake/output/__init__.py
+++ b/firedrake/output/__init__.py
@@ -1,1 +1,5 @@
-from .vtk_output import VTKFile  # noqa: F401
+try:
+    import vtkmodules.vtkCommonDataModel  # noqa: F401
+    from .vtk_output import VTKFile  # noqa: F401
+except ModuleNotFoundError:
+    from .vtk_unavailable import VTKFile  # noqa: F401

--- a/firedrake/output/vtk_unavailable.py
+++ b/firedrake/output/vtk_unavailable.py
@@ -1,0 +1,7 @@
+class VTKFile(object):
+    def __init__(self, *args, **kwargs):
+        raise ModuleNotFoundError(
+            "Error importing vtkmodules. Firedrake does not install VTK by default, "
+            "you may need to install VTK by running\n\t"
+            "pip install vtk"
+        )

--- a/tests/extrusion/test_rhs_bcs.py
+++ b/tests/extrusion/test_rhs_bcs.py
@@ -27,7 +27,6 @@ def run_test(x, degree, quadrilateral, parameters={}, test_mode=False):
               - (boundary * 1.0 / layers))
 
     if not test_mode:
-        from firedrake.output import VTKFile
         print("The error is ", res)
         file = VTKFile("bt-bcs.pvd")
         file.write(u)

--- a/tests/extrusion/test_rhs_side_bcs.py
+++ b/tests/extrusion/test_rhs_side_bcs.py
@@ -39,7 +39,6 @@ def run_test(x, degree, quadrilateral, parameters={}, test_mode=False):
     res1 = abs(sqrt(assemble(inner(u1 - v1, u1 - v1) * dx)))
 
     if not test_mode:
-        from firedrake.output import VTKFile
         print("The error is ", res1)
         file = VTKFile("side-bcs.pvd")
         file.write(u1, v1)

--- a/tests/extrusion/test_side_strong_bcs.py
+++ b/tests/extrusion/test_side_strong_bcs.py
@@ -41,7 +41,6 @@ def run_test_3D(size, quadrilateral, parameters={}, test_mode=False):
     res = sqrt(assemble(inner(out - exact, out - exact) * dx))
 
     if not test_mode:
-        from firedrake.output import VTKFile
         print("The error is ", res)
         file = VTKFile("side-bcs.pvd")
         file.write(out, exact)
@@ -82,7 +81,6 @@ def run_test_2D(intervals, parameters={}, test_mode=False):
     res = sqrt(assemble(inner(out - exact, out - exact) * dx))
 
     if not test_mode:
-        from firedrake.output import VTKFile
         print("The error is ", res)
         file = VTKFile("side-bcs.pvd")
         file.write(out, exact)


### PR DESCRIPTION
# Description

This PR ensures that, if VTK is installed in the user's venv, `from firedrake import *` makes `VTKFile` available. This restores consistency of the Firedrake interface (other objects do not need to be imported from their respective subpackages).
