### PR TITLE
Riesz representative changed from l2 to L2

### DIFF
--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -225,7 +225,7 @@ class FunctionMixin(FloatingType):
         from firedrake import Function, Cofunction
 
         options = {} if options is None else options
-        riesz_representation = options.get("riesz_representation", "l2")
+        riesz_representation = options.get("riesz_representation", "L2")
         solver_options = options.get("solver_options", {})
         V = options.get("function_space", self.function_space())
 


### PR DESCRIPTION
# Description
Ensure that default Riesz representative is L2 and not l2 by changing line 228 of firedrake/adjoint_utils/function.py from 

`
riesz_representation = options.get("riesz_representation", "l2")
`
to

`
riesz_representation = options.get("riesz_representation", "L2")
`
This fixes #3575 

