### PR TITLE
Fixing errors related to default L2 grad in adjoints

### DIFF
--- a/firedrake/adjoint_utils/blocks/function.py
+++ b/firedrake/adjoint_utils/blocks/function.py
@@ -60,7 +60,8 @@ class FunctionAssignBlock(Block):
                 R = block_variable.output._ad_function_space(
                     prepared.function_space().mesh()
                 )
-                return self._adj_assign_constant(prepared, R)
+                adj_output = self._adj_assign_constant(prepared, R)
+                return adj_output.riesz_representation(riesz_map="l2")
             else:
                 adj_output = firedrake.Function(
                     block_variable.output.function_space())
@@ -86,7 +87,7 @@ class FunctionAssignBlock(Block):
                     ufl.derivative(
                         expr,
                         block_variable.saved_output,
-                        firedrake.Constant(1., domain=mesh)
+                        firedrake.Function(firedrake.FunctionSpace(mesh, "R", 0), val=1.0)
                     )
                 )
                 adj_output.assign(diff_expr)

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -240,10 +240,10 @@ class FunctionMixin(FloatingType):
         if riesz_representation == "l2":
             return Function(V, val=value.dat)
 
-        if not isinstance(value, Cofunction):
-            raise TypeError("Expected a Cofunction")
-
         elif riesz_representation in ("L2", "H1"):
+            if not isinstance(value, Cofunction):
+                raise TypeError("Expected a Cofunction")
+
             ret = Function(V)
             a = self._define_riesz_map_form(riesz_representation, V)
             firedrake.solve(a == value, ret, **solver_options)
@@ -253,7 +253,7 @@ class FunctionMixin(FloatingType):
             return riesz_representation(value)
 
         else:
-            raise NotImplementedError(
+            raise ValueError(
                 "Unknown Riesz representation %s" % riesz_representation)
 
     def _define_riesz_map_form(self, riesz_representation, V):

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -285,9 +285,9 @@ class FunctionMixin(FloatingType):
     @no_annotations
     def _ad_convert_type(self, value, options=None):
         # `_ad_convert_type` is not annotated, unlike `_ad_convert_riesz`
-        options = {} if options is None else options
-        riesz_representation = options.get("riesz_representation", "L2")
-        if riesz_representation is None:
+        options = {} if options is None else options.copy()
+        options.setdefault("riesz_representation", "L2")
+        if options["riesz_representation"] is None:
             return value
         else:
             return self._ad_convert_riesz(value, options=options)

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -232,21 +232,15 @@ class FunctionMixin(FloatingType):
         if not isinstance(value, (Number, Cofunction, Function)):
             raise TypeError("Expected a Cofunction, Function or a float")
 
-        if value == 0.:
+        if isinstance(value, Number):
             # Default of a function datatype is zero
-            return Function(V)
-
-        if riesz_representation != "l2" and not isinstance(value, Cofunction):
-            raise TypeError("Expected a Cofunction")
+            # Only works for l2 riesz representation
+            f = Function(V)
+            f.assign(value)
+            return f
 
         if riesz_representation == "l2":
-            if isinstance(value, (Cofunction, Function)):
-                return Function(V, val=value.dat)
-            else:
-                f = Function(V)
-                with stop_annotating():
-                    f.assign(value)
-                return f
+            return Function(V, val=value.dat)
         elif riesz_representation in ("L2", "H1"):
             ret = Function(V)
             a = self._define_riesz_map_form(riesz_representation, V)

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -225,8 +225,10 @@ class FunctionMixin(FloatingType):
 
         V = options.get("function_space", self.function_space())
         if value == 0.:
-            # This is seen in adjoint-based derivative when the functional
-            # is independent of the control variable.
+            # In adjoint-based differentiation, value == 0. arises only when
+            # the functional is independent on the control variable.
+            # In this case, we do not apply the Riesz map and return a zero
+            # Cofunction.
             return Cofunction(V.dual())
 
         options = {} if options is None else options
@@ -238,7 +240,7 @@ class FunctionMixin(FloatingType):
         if riesz_representation == "l2":
             return Function(V, val=value.dat)
 
-        if riesz_representation != "l2" and not isinstance(value, Cofunction):
+        if not isinstance(value, Cofunction):
             raise TypeError("Expected a Cofunction")
 
         elif riesz_representation in ("L2", "H1"):

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -225,7 +225,7 @@ class FunctionMixin(FloatingType):
         from firedrake import Function, Cofunction
 
         options = {} if options is None else options
-        riesz_representation = options.get("riesz_representation", "l2")
+        riesz_representation = options.get("riesz_representation", "L2")
         solver_options = options.get("solver_options", {})
         V = options.get("function_space", self.function_space())
 

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -232,6 +232,13 @@ class FunctionMixin(FloatingType):
         if not isinstance(value, (Number, Cofunction, Function)):
             raise TypeError("Expected a Cofunction, Function or a float")
 
+        if value == 0.:
+            # Default of a function datatype is zero
+            return Function(V)
+
+        if riesz_representation != "l2" and not isinstance(value, Cofunction):
+            raise TypeError("Expected a Cofunction")
+
         if riesz_representation == "l2":
             if isinstance(value, (Cofunction, Function)):
                 return Function(V, val=value.dat)
@@ -241,14 +248,9 @@ class FunctionMixin(FloatingType):
                     f.assign(value)
                 return f
         elif riesz_representation in ("L2", "H1"):
-            if isinstance(value, Number):
-                b = Cofunction(V.dual())
-                b.assign(value)
-            else:
-                b = value
             ret = Function(V)
             a = self._define_riesz_map_form(riesz_representation, V)
-            firedrake.solve(a == b, ret, **solver_options)
+            firedrake.solve(a == value, ret, **solver_options)
             return ret
 
         elif callable(riesz_representation):

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -321,7 +321,7 @@ class FunctionMixin(FloatingType):
         from firedrake import assemble
 
         options = {} if options is None else options
-        riesz_representation = options.get("riesz_representation", "l2")
+        riesz_representation = options.get("riesz_representation", "L2")
         if riesz_representation == "l2":
             return self.dat.inner(other.dat)
         elif riesz_representation == "L2":

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -233,14 +233,17 @@ class FunctionMixin(FloatingType):
             raise TypeError("Expected a Cofunction, Function or a float")
 
         if isinstance(value, Number):
-            # Default of a function datatype is zero
-            # Only works for l2 riesz representation
+            # It is applied l2 representation for this case.
             f = Function(V)
             f.assign(value)
             return f
 
         if riesz_representation == "l2":
             return Function(V, val=value.dat)
+
+        if riesz_representation != "l2" and not isinstance(value, Cofunction):
+            raise TypeError("Expected a Cofunction")
+
         elif riesz_representation in ("L2", "H1"):
             ret = Function(V)
             a = self._define_riesz_map_form(riesz_representation, V)
@@ -275,8 +278,6 @@ class FunctionMixin(FloatingType):
     def _ad_convert_type(self, value, options=None):
         # `_ad_convert_type` is not annotated, unlike `_ad_convert_riesz`
         options = {} if options is None else options
-        if "riesz_representation" not in options:
-            options = {"riesz_representation": "L2"}
         riesz_representation = options.get("riesz_representation", "L2")
         if riesz_representation is None:
             return value

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -7,7 +7,6 @@ from firedrake.adjoint_utils.blocks import FunctionAssignBlock, ProjectBlock, Su
 import firedrake
 from .checkpointing import disk_checkpointing, CheckpointFunction, \
     CheckpointBase, checkpoint_init_data, DelegatedFunctionCheckpoint
-from numbers import Number
 
 
 class FunctionMixin(FloatingType):
@@ -224,27 +223,17 @@ class FunctionMixin(FloatingType):
     def _ad_convert_riesz(self, value, options=None):
         from firedrake import Function, Cofunction
 
+        V = options.get("function_space", self.function_space())
+        if value == 0.:
+            # This is seen in adjoint-based derivative when the functional
+            # is independent of the control variable.
+            return Cofunction(V.dual())
+
         options = {} if options is None else options
         riesz_representation = options.get("riesz_representation", "L2")
         solver_options = options.get("solver_options", {})
-        V = options.get("function_space", self.function_space())
-
-        if not isinstance(value, (Number, Cofunction, Function, Number)):
-            raise TypeError("Expected a Cofunction, Function or a float")
-
-        if isinstance(value, Number):
-            if value == 0.:
-                # l2 Riesz map is directly applied when the value is a real number 0..
-                # This is seen in adjoint-based derivative when the functional
-                # is independent of the control variable.
-                return Function(V)
-            elif self.ufl_element().family() == "Real":
-                # Apply the l2 Riesz map for the case where self is a function in Real space.
-                f = Function(V)
-                f.assign(value)
-                return f
-            else:
-                raise TypeError("Riesz map of a non-zero scalar is not supported for non-Real function spaces.")
+        if not isinstance(value, (Cofunction, Function)):
+            raise TypeError("Expected a Cofunction or a Function")
 
         if riesz_representation == "l2":
             return Function(V, val=value.dat)

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -83,7 +83,7 @@ class FiredrakeTorchOperator(torch.autograd.Function):
             adj_input = float(adj_input)
 
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
-        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": "L2"})
+        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": "l2"})
 
         # Tuplify adjoint output
         adj_output = (adj_output,) if not isinstance(adj_output, collections.abc.Sequence) else adj_output

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -82,7 +82,7 @@ class FiredrakeTorchOperator(torch.autograd.Function):
             # This will later on result in an `AdjFloat` adjoint input instead of a Constant
             adj_input = float(adj_input)
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
-        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": None})
+        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": 'l2'})
 
         # Tuplify adjoint output
         adj_output = (adj_output,) if not isinstance(adj_output, collections.abc.Sequence) else adj_output

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -81,9 +81,8 @@ class FiredrakeTorchOperator(torch.autograd.Function):
         if isinstance(adj_input, Constant) and adj_input.ufl_shape == ():
             # This will later on result in an `AdjFloat` adjoint input instead of a Constant
             adj_input = float(adj_input)
-
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
-        adj_output = F.derivative(adj_input=adj_input)
+        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": None})
 
         # Tuplify adjoint output
         adj_output = (adj_output,) if not isinstance(adj_output, collections.abc.Sequence) else adj_output

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -81,6 +81,7 @@ class FiredrakeTorchOperator(torch.autograd.Function):
         if isinstance(adj_input, Constant) and adj_input.ufl_shape == ():
             # This will later on result in an `AdjFloat` adjoint input instead of a Constant
             adj_input = float(adj_input)
+
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
         adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": 'l2'})
 

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -83,7 +83,7 @@ class FiredrakeTorchOperator(torch.autograd.Function):
             adj_input = float(adj_input)
 
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
-        adj_output = F.derivative(adj_input=adj_input)
+        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": "L2"})
 
         # Tuplify adjoint output
         adj_output = (adj_output,) if not isinstance(adj_output, collections.abc.Sequence) else adj_output

--- a/firedrake/ml/pytorch/fem_operator.py
+++ b/firedrake/ml/pytorch/fem_operator.py
@@ -83,7 +83,7 @@ class FiredrakeTorchOperator(torch.autograd.Function):
             adj_input = float(adj_input)
 
         # Compute adjoint model of `F`: delegated to pyadjoint.ReducedFunctional
-        adj_output = F.derivative(adj_input=adj_input, options={"riesz_representation": 'l2'})
+        adj_output = F.derivative(adj_input=adj_input)
 
         # Tuplify adjoint output
         adj_output = (adj_output,) if not isinstance(adj_output, collections.abc.Sequence) else adj_output

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -899,31 +899,33 @@ def test_riesz_representation_for_adjoints():
     with stop_annotating():
         v = TestFunction(space)
         u = TrialFunction(space)
-        dJdu_cofunction = assemble(2 * inner(f, v) * dx)
+        dJdu_cofunction = assemble(derivative((f ** 2) * dx, f, v))
 
         # Riesz representation with l2
         dJdu_function_l2 = Function(space, val=dJdu_cofunction.dat)
 
         # Riesz representation with H1
-        a = firedrake.inner(u, v)*firedrake.dx \
-            + firedrake.inner(firedrake.grad(u), firedrake.grad(v))*firedrake.dx
+        a = u * v * dx + inner(grad(u), grad(v)) * dx
         dJdu_function_H1 = Function(space)
         solve(a == dJdu_cofunction, dJdu_function_H1)
 
         # Riesz representation with L2
-        a = firedrake.inner(u, v)*firedrake.dx
+        a = u*v*dx
         dJdu_function_L2 = Function(space)
         solve(a == dJdu_cofunction, dJdu_function_L2)
 
     dJdu_none = rf.derivative(options={"riesz_representation": None})
     dJdu_l2 = rf.derivative(options={"riesz_representation": "l2"})
     dJdu_H1 = rf.derivative(options={"riesz_representation": "H1"})
+    dJdu_L2 = rf.derivative(options={"riesz_representation": "L2"})
     dJdu_default_L2 = rf.derivative()
     assert (
         isinstance(dJdu_none, Cofunction) and isinstance(dJdu_function_l2, Function)
         and isinstance(dJdu_H1, Function) and isinstance(dJdu_default_L2, Function)
+        and isinstance(dJdu_L2, Function)
         and np.allclose(dJdu_none.dat.data, dJdu_cofunction.dat.data)
         and np.allclose(dJdu_l2.dat.data, dJdu_function_l2.dat.data)
         and np.allclose(dJdu_H1.dat.data, dJdu_function_H1.dat.data)
         and np.allclose(dJdu_default_L2.dat.data, dJdu_function_L2.dat.data)
+        and np.allclose(dJdu_L2.dat.data, dJdu_function_L2.dat.data)
     )

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -744,8 +744,7 @@ def test_copy_function():
 def test_consecutive_nonlinear_solves():
     mesh = UnitSquareMesh(1, 1)
     V = FunctionSpace(mesh, "CG", 1)
-    uic = Function(V)
-    uic.assign(2.0)
+    uic = Constant(2.0, domain=mesh)
     u1 = Function(V).assign(uic)
     u0 = Function(u1)
     v = TestFunction(V)
@@ -757,7 +756,8 @@ def test_consecutive_nonlinear_solves():
         solver.solve()
     J = assemble(u1**16*dx)
     rf = ReducedFunctional(J, Control(uic))
-    assert taylor_test(rf, uic, Function(V).assign(0.1)) > 1.9
+    h = Constant(0.01, domain=mesh)
+    assert taylor_test(rf, uic, h) > 1.9
 
 
 @pytest.mark.skipcomplex

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -889,7 +889,8 @@ def test_cofunction_subfunctions_with_adjoint():
 
 
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
-def test_none_riesz_representation_to_derivative():
+def test_riesz_representation_for_adjoints():
+    # Test is the riesz representation norms for adjoints are working as expected.
     mesh = UnitIntervalMesh(1)
     space = FunctionSpace(mesh, "Lagrange", 1)
     f = Function(space).interpolate(SpatialCoordinate(mesh)[0])

--- a/tests/regression/test_adjoint_operators.py
+++ b/tests/regression/test_adjoint_operators.py
@@ -890,7 +890,7 @@ def test_cofunction_subfunctions_with_adjoint():
 
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
 def test_riesz_representation_for_adjoints():
-    # Test is the riesz representation norms for adjoints are working as expected.
+    # Check if the Riesz representation norms for adjoints are working as expected.
     mesh = UnitIntervalMesh(1)
     space = FunctionSpace(mesh, "Lagrange", 1)
     f = Function(space).interpolate(SpatialCoordinate(mesh)[0])


### PR DESCRIPTION
# Description

This PR seeks the application of Riesz maps using the L2 norm as the default in Firedrake for adjoint gradients. Implementing this change requires some coding modifications.  

Some pyadjoint tests will fail because they were designed with Riesz maps using the l2 norm. To address these test failures, refer to [Pyadjoint PR 149](https://github.com/dolfin-adjoint/pyadjoint/pull/149), which has the necessary fixes.
