### PR TITLE
MG: embedded transfer support for non-point variants

### DIFF
--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -13,7 +13,7 @@ __all__ = ("TransferManager", )
 
 
 native_families = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
-integral_variants = frozenset(["integral", "fdm"])
+non_native_integral_variants = frozenset(["integral", "fdm"])
 
 
 class Op(IntEnum):
@@ -59,7 +59,7 @@ class TransferManager(object):
             return True
         if isinstance(element.cell, ufl.TensorProductCell) and len(element.sub_elements) > 0:
             return reduce(and_, map(self.is_native, element.sub_elements))
-        return element.family() in native_families and not element.variant() in integral_variants
+        return element.family() in native_families and not element.variant() in non_native_integral_variants
 
     def _native_transfer(self, element, op):
         try:

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -12,7 +12,8 @@ from firedrake.embedding import get_embedding_dg_element
 __all__ = ("TransferManager", )
 
 
-native = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
+native_families = frozenset(["Lagrange", "Discontinuous Lagrange", "Real", "Q", "DQ"])
+integral_variants = frozenset(["integral", "fdm"])
 
 
 class Op(IntEnum):
@@ -58,7 +59,7 @@ class TransferManager(object):
             return True
         if isinstance(element.cell, ufl.TensorProductCell) and len(element.sub_elements) > 0:
             return reduce(and_, map(self.is_native, element.sub_elements))
-        return element.family() in native
+        return element.family() in native_families and not element.variant() in integral_variants
 
     def _native_transfer(self, element, op):
         try:

--- a/tests/multigrid/test_embedded_transfer.py
+++ b/tests/multigrid/test_embedded_transfer.py
@@ -25,14 +25,14 @@ def degree(request):
     return request.param
 
 
-@pytest.fixture(params=["RT", "N1curl"])
+@pytest.fixture(params=["RT", "N1curl", "CG"])
 def space(request):
     return request.param
 
 
 @pytest.fixture
 def V(mesh, degree, space):
-    return FunctionSpace(mesh, space, degree)
+    return FunctionSpace(mesh, space, degree, variant="integral")
 
 
 @pytest.fixture(params=["Default", "Exact", "Averaging"])
@@ -93,6 +93,8 @@ def solver(V, space, solver_parameters):
         F = a*inner(u, v)*dx + b*inner(div(u), div(v))*dx - inner(f, v)*dx
     elif space == "N1curl":
         F = a*inner(u, v)*dx + b*inner(curl(u), curl(v))*dx - inner(f, v)*dx
+    elif space == "CG":
+        F = a*inner(u, v)*dx + b*inner(grad(u), grad(v))*dx - inner(1, v)*dx
     problem = NonlinearVariationalProblem(F, u)
     solver = NonlinearVariationalSolver(problem, solver_parameters=solver_parameters,
                                         options_prefix="")


### PR DESCRIPTION
# Description
The MG transfer kernels assume Lagrange elements with point evaluation, and they produce an error when the element we want to transfer does not have point evaluation DOFs. 

We have CG/DG element variants that are not Lagrange, for instance the "fdm" and "integral" (a.k.a. hierarchical) variants. To transfer functions with these elements we must use an embedding space with a point variant.

Note that CG1 and DG0 would always have point evaluation DOFs regardless of the variant, and we can easily detect this from the FInAT element instance. UFL elements can only tell us about the family, variant, and degree. So in order to ensure that the element at hand is Lagrange, it'd be better to cache the MG tranfers with a key derived from the FInAT element. 

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
