### PR TITLE
Scaled zero form assembly bugfix

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence  # noqa: F401
 import functools
 import itertools
 from itertools import product
+import numbers
 
 import cachetools
 import finat
@@ -463,8 +464,8 @@ class BaseFormAssembler(AbstractFormAssembler):
                 raise TypeError("Mismatching weights and operands in FormSum")
             if len(args) == 0:
                 raise TypeError("Empty FormSum")
-            if all(isinstance(op, float) for op in args):
-                return sum(args)
+            if all(isinstance(op, numbers.Complex) for op in args):
+                return sum(weight * arg for weight, arg in zip(expr.weights(), args))
             elif all(isinstance(op, firedrake.Cofunction) for op in args):
                 V, = set(a.function_space() for a in args)
                 res = sum([w*op.dat for (op, w) in zip(args, expr.weights())])

--- a/tests/regression/test_assemble_baseform.py
+++ b/tests/regression/test_assemble_baseform.py
@@ -214,6 +214,20 @@ def test_cofunction_assign(a, M, f):
         assert np.allclose(a.dat.data, 0.5 * b.dat.data)
 
 
+def test_cofunction_action(a, f):
+    zero_form_ref = assemble(ufl.action(a, f))
+    v = assemble(a)
+
+    zero_form = assemble(action(v, f))
+    assert np.allclose(zero_form, zero_form_ref, rtol=1.0e-14)
+
+    zero_form = assemble(0.5 * action(v, f))
+    assert np.allclose(zero_form, 0.5 * zero_form_ref, rtol=1.0e-14)
+
+    zero_form = assemble(0.5 * action(v, f) - 0.25  * action(v, f))
+    assert np.allclose(zero_form, 0.25 * zero_form_ref, rtol=1.0e-14)
+
+
 def test_cofunction_riesz_representation(a):
     # Get a Cofunction
     c = assemble(a)

--- a/tests/regression/test_assemble_baseform.py
+++ b/tests/regression/test_assemble_baseform.py
@@ -224,7 +224,7 @@ def test_cofunction_action(a, f):
     zero_form = assemble(0.5 * action(v, f))
     assert np.allclose(zero_form, 0.5 * zero_form_ref, rtol=1.0e-14)
 
-    zero_form = assemble(0.5 * action(v, f) - 0.25  * action(v, f))
+    zero_form = assemble(0.5 * action(v, f) - 0.25 * action(v, f))
     assert np.allclose(zero_form, 0.25 * zero_form_ref, rtol=1.0e-14)
 
 


### PR DESCRIPTION
Scale by weights in `BaseFormAssembler.base_form_assembly_visitor` for the case of an arity 0 `FormSum`.

I have not attempted to ensure that the result is a `ScalarType.type`.

Fixes #3597