### PR TITLE
Fix memory leak for Solver Block recomputation

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -6,8 +6,7 @@ from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, stop_annotating
 from pyadjoint.enlisting import Enlist
 import firedrake
-from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint, \
-    CheckpointFunction
+from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
 from .block_utils import isconstant
 
 

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -6,7 +6,8 @@ from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, stop_annotating
 from pyadjoint.enlisting import Enlist
 import firedrake
-from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
+from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint, \
+    CheckpointFunction
 from .block_utils import isconstant
 
 
@@ -525,6 +526,8 @@ class GenericSolveBlock(Block):
         func = prepared[2]
         bcs = prepared[3]
         result = self._forward_solve(lhs, rhs, func, bcs)
+        if isinstance(block_variable.checkpoint, firedrake.Function):
+            result = block_variable.checkpoint.assign(result)
         return maybe_disk_checkpoint(result)
 
 


### PR DESCRIPTION
# Description

This PR addresses a memory leak issue encountered during the recomputation of a functional. The leak appears to be related to the `NonlinearVariationalProblem` / `LinearVariationalProblem` Block recomputation process.

### Problem

When recomputing the functional, we update the Block with the following [line of code](https://github.com/dolfin-adjoint/pyadjoint/blob/master/pyadjoint/block.py#L355)

Output refers to `GenericSolveBlock.func`, which looks like it is leading to a memory leak.

### Solution

To fix this issue, this PR removes the reference to `GenericSolveBlock.func` during recomputation.

### Testing

I tested this fix using a Burger's equation `NonlinearVariationalProblem` solver available on this [test](https://github.com/dolfin-adjoint/pyadjoint/blob/master/tests/firedrake_adjoint/test_burgers_newton.py#L27).  See the memory graph:
![mem](https://github.com/firedrakeproject/firedrake/assets/63597005/77b95b45-1aaa-476a-81cc-82c98fd43165)
