### PR TITLE
Constant: raise NotImplementedError for __itruediv__

### DIFF
--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -196,11 +196,11 @@ class FunctionMixin(FloatingType):
         return wrapper
 
     @staticmethod
-    def _ad_annotate_idiv(__idiv__):
-        @wraps(__idiv__)
+    def _ad_annotate_itruediv(__itruediv__):
+        @wraps(__itruediv__)
         def wrapper(self, other, **kwargs):
             with stop_annotating():
-                func = __idiv__(self, other, **kwargs)
+                func = __itruediv__(self, other, **kwargs)
 
             ad_block_tag = kwargs.pop("ad_block_tag", None)
             annotate = annotate_tape(kwargs)

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -199,7 +199,7 @@ class Constant(ufl.constantvalue.ConstantValue, ConstantMixin, TSFCConstantMixin
     def __imul__(self, o):
         raise NotImplementedError("Augmented assignment to Constant not implemented")
 
-    def __idiv__(self, o):
+    def __itruediv__(self, o):
         raise NotImplementedError("Augmented assignment to Constant not implemented")
 
     def __str__(self):

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -521,7 +521,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         IMulAssigner(self, expr).assign()
         return self
 
-    @FunctionMixin._ad_annotate_idiv
+    @FunctionMixin._ad_annotate_itruediv
     def __itruediv__(self, expr):
         from firedrake.assign import IDivAssigner
         IDivAssigner(self, expr).assign()


### PR DESCRIPTION
# Description

Python3 has `__itruediv__` as the method for in-place division, `Constant` implemented the old `__idiv__`, which is only used in python 2.
https://docs.python.org/3/library/operator.html

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
