### PR TITLE
Purge old easychair links

### DIFF
--- a/docs/source/firedrake_17.rst
+++ b/docs/source/firedrake_17.rst
@@ -31,7 +31,7 @@ Key Dates
 ---------
 
 * Early registration deadline: 10 February 2017
-* `Abstract <https://easychair.org/conferences/?conf=firedrake17>`_ deadline: 10 February 2017
+* Abstract deadline: 10 February 2017
 * Workshop: 27-28 March 2017
 
 

--- a/docs/source/firedrake_18.rst
+++ b/docs/source/firedrake_18.rst
@@ -33,7 +33,7 @@ Key Dates
 
 * Early registration deadline: 20 April 2018
 * Registration deadline: 25 May 2018
-* `Abstract <https://easychair.org/conferences/?conf=firedrake18>`_ deadline: 20 April 2018
+* Abstract deadline: 20 April 2018
 * Workshop: 7-8 June 2018
 
 

--- a/docs/source/firedrake_19.rst
+++ b/docs/source/firedrake_19.rst
@@ -35,18 +35,8 @@ Key Dates
 * Early registration deadline: 17 August 2019
 * Registration deadline: 6 September 2019 (via Durham event
   registration).
-* Abstract submission deadline: 17 August 2019 (`via Easychair
-  <https://easychair.org/conferences/?conf=firedrake19>`_).
+* Abstract submission deadline: 17 August 2019.
 * Workshop: 26-27 September 2019
-
-
-Abstract submission
--------------------
-
-Submission for talks is now closed. If you would still like to bring a
-poster, please submit an abstract `on Easychair
-<https://easychair.org/conferences/?conf=firedrake19>`_ (so it appears
-in the programme, and we know how many poster boards we'll need).
 
 Programme
 ---------

--- a/docs/source/firedrake_usa_20.rst
+++ b/docs/source/firedrake_usa_20.rst
@@ -45,38 +45,12 @@ Key Dates
 * Abstract submission deadline: 15 January 2020
 * Workshop: 10-11 February 2020
 
-
-Abstract submission
--------------------
-
-If you are using or developing Firedrake, we'd absolutely love to see
-a presentation on your work at the workshop. Please submit a short abstract `on Easychair
-<https://easychair.org/conferences/?conf=firedrakeusa20>`_.
-
-
-Workshop dinner
-~~~~~~~~~~~~~~~
-
-There will be a workshop dinner in the evening of 10 February. More
-details will follow soon.
-
 Location
 ~~~~~~~~
 
-The workshop will be held in the `Data Science Studio
+The workshop was held in the `Data Science Studio
 <https://escience.washington.edu/wrf-data-science-studio/>`_ on the
 6th floor of the UW Physics and Astronomy Building.
-
-
-Registration
-------------
-
-Early registration is now open. Registration will rise to $40 for students and $100 for others after 15 January. Registration for the tutorial only is free.
-
-.. raw:: html
-
-   <div style="width:100%; text-align:left;"><iframe src="https://eventbrite.com/tickets-external?eid=85712932689&ref=etckt" frameborder="0" height="400" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="padding:10px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/">Powered by Eventbrite</a></div></div>
-
 
 
 Organising Committee


### PR DESCRIPTION
Old abstract submission links that are no longer current and sometimes cause the docs build to fail.