### PR TITLE
Temporarily pin mpi4py to 3.1.6

### DIFF
--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -1836,7 +1836,7 @@ if mode == "install":
 
     # Install mpi4py
     with environment(**compiler_env, **link_env):
-        run_pip_install(["--no-cache-dir", "mpi4py"])
+        run_pip_install(["--no-cache-dir", "mpi4py==3.1.6"])
 
     for p in packages:
         pip_requirements(p, compiler_env)
@@ -1981,7 +1981,7 @@ else:
 
     # Install mpi4py
     with environment(**compiler_env, **link_env):
-        run_pip_install(["--no-cache-dir", "mpi4py"])
+        run_pip_install(["--no-cache-dir", "mpi4py==3.1.6"])
 
     # update dependencies.
     for p in packages:


### PR DESCRIPTION
# Description
mpi4py 4.0 has been released, which is not compatible with petsc4py. A linked issue to follow

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
