### PR TITLE
bc: postpone raising exception for zany elements

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -40,10 +40,6 @@ class BCBase(object):
     @PETSc.Log.EventDecorator()
     def __init__(self, V, sub_domain):
 
-        # First, we bail out on zany elements.  We don't know how to do BC's for them.
-        if isinstance(V.finat_element, (finat.Argyris, finat.Morley, finat.Bell)) or \
-           (isinstance(V.finat_element, finat.Hermite) and V.mesh().topological_dimension() > 1):
-            raise NotImplementedError("Strong BCs not implemented for element %r, use Nitsche-type methods until we figure this out" % V.finat_element)
         self._function_space = V
         self.sub_domain = sub_domain
         # If this BC is defined on a subspace (IndexedFunctionSpace or
@@ -130,6 +126,12 @@ class BCBase(object):
     @utils.cached_property
     def nodes(self):
         '''The list of nodes at which this boundary condition applies.'''
+
+        # First, we bail out on zany elements.  We don't know how to do BC's for them.
+        V = self._function_space
+        if isinstance(V.finat_element, (finat.Argyris, finat.Morley, finat.Bell)) or \
+           (isinstance(V.finat_element, finat.Hermite) and V.mesh().topological_dimension() > 1):
+            raise NotImplementedError("Strong BCs not implemented for element %r, use Nitsche-type methods until we figure this out" % V.finat_element)
 
         def hermite_stride(bcnodes):
             if isinstance(self._function_space.finat_element, finat.Hermite) and \


### PR DESCRIPTION
Postpone raising exception for zany elements in BC class so that one can subclass BC on zany space and define one's own `bc.nodes`.