### PR TITLE
PC: Housekeeping

### DIFF
--- a/docs/source/_static/firedrake-apps.bib
+++ b/docs/source/_static/firedrake-apps.bib
@@ -198,15 +198,15 @@ firedrake-preprocess-bibtex firedrake-apps.bib
   year          = {2017}
 }
 
-@misc{Brubeck2021,
+@article{Brubeck2022,
   author        = {Brubeck, Pablo D. and Farrell, Patrick E.},
-  eprint        = {2107.14758},
-  eprintclass   = {math.NA},
-  eprinttype    = {arXiv},
-  title         = {A scalable and robust vertex-star relaxation for
-high-order {FEM}},
-  url           = {https://arxiv.org/abs/2107.14758},
-  year          = {2021}
+  doi           = {10.1137/21M1444187},
+  journal       = {SIAM J. Sci. Comput.},
+  number        = {5},
+  pages         = {A2991-A3017},
+  title         = {A scalable and robust vertex-star relaxation for high-order {FEM}},
+  volume        = {44},
+  year          = {2022}
 }
 
 @misc{Brugnoli2020,

--- a/docs/source/preconditioning.rst
+++ b/docs/source/preconditioning.rst
@@ -127,8 +127,8 @@ operator instead.
 :class:`.AuxiliaryOperatorPC`
    Abstract base class for preconditioners built from assembled
    auxiliary operators. One should subclass this preconditioner and
-   implement the :meth:`.AuxiliaryOperatorPC.form` method. This can be
-   used to provided bilinear forms to the solver that were not there
+   override the :meth:`.PCSNESBase.form` method. This can be
+   used to provide bilinear forms to the solver that were not there
    in the original problem, for example, the pressure mass matrix for
    block preconditioners of the Stokes equations.
 :class:`.FDMPC`
@@ -138,7 +138,7 @@ operator instead.
    implemented for quadrilateral and hexahedral cells. The assembled
    matrix becomes as sparse as a low-order refined preconditioner, to
    which one may apply other preconditioners such as :class:`.ASMStarPC` or
-   :class:`.ASMExtrudedStarPC`. See details in :cite:`Brubeck2021`.
+   :class:`.ASMExtrudedStarPC`. See details in :cite:`Brubeck2022`.
 :class:`.MassInvPC`
    Preconditioner for applying an inverse mass matrix.
 :class:`~.PCDPC`

--- a/firedrake/_deprecation.py
+++ b/firedrake/_deprecation.py
@@ -50,8 +50,8 @@ class _fake_module:
 # Deprecate output.File in the global namespace
 output = _fake_module(
     "firedrake.output",
-    ["File",],
-    ["VTKFile",]
+    ["File", ],
+    ["VTKFile", ]
 )
 
 

--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -343,7 +343,7 @@ def create_field_decomposition(dm, *args, **kwargs):
     for d in dms:
         add_hook(parent, setup=partial(push_parent, d, parent), teardown=partial(pop_parent, d, parent),
                  call_setup=True)
-    if ctx is not None:
+    if ctx is not None and len(W) > 1:
         ctxs = ctx.split([(i, ) for i in range(len(W))])
         for d, c in zip(dms, ctxs):
             add_hook(parent, setup=partial(push_appctx, d, c), teardown=partial(pop_appctx, d, c),

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -1160,6 +1160,10 @@ class MixedFunctionSpace(object):
     def _ises(self):
         return self.dof_dset.field_ises
 
+    def collapse(self):
+        from firedrake import MixedFunctionSpace
+        return MixedFunctionSpace([V_ for V_ in self])
+
 
 class ProxyFunctionSpace(FunctionSpace):
     r"""A :class:`FunctionSpace` that one can attach extra properties to.

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -1,5 +1,3 @@
-import abc
-
 from firedrake.preconditioners.base import PCBase
 from firedrake.functionspace import FunctionSpace, MixedFunctionSpace
 from firedrake.petsc import PETSc
@@ -81,15 +79,6 @@ class AssembledPC(PCBase):
     def update(self, pc):
         self._assemble_P(tensor=self.P)
 
-    def form(self, pc, test, trial):
-        _, P = pc.getOperators()
-        if P.getType() == "python":
-            context = P.getPythonContext()
-            return (context.a, context.row_bcs)
-        else:
-            context = dmhooks.get_appctx(pc.getDM())
-            return (context.Jp or context.J, context._problem.bcs)
-
     def set_nullspaces(self, pc):
         # Copy nullspaces over from parent P matrix
         _, P = pc.getOperators()
@@ -123,19 +112,3 @@ class AuxiliaryOperatorPC(AssembledPC):
     """
 
     _prefix = "aux_"
-
-    @abc.abstractmethod
-    def form(self, pc, test, trial):
-        """
-
-        :arg pc: a `PETSc.PC` object. Use `self.get_appctx(pc)` to get the
-             user-supplied application-context, if desired.
-
-        :arg test: a `TestFunction` on this `FunctionSpace`.
-
-        :arg trial: a `TrialFunction` on this `FunctionSpace`.
-
-        :returns `(a, bcs)`, where `a` is a bilinear `Form`
-        and `bcs` is a list of `DirichletBC` boundary conditions (possibly `None`).
-        """
-        raise NotImplementedError

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -20,7 +20,7 @@ class AssembledPC(PCBase):
         from firedrake.assemble import get_assembler
         A, P = pc.getOperators()
 
-        if pc.getType() != "python":
+        if pc.type != "python":
             raise ValueError("Expecting PC type python")
         opc = pc
         appctx = self.get_appctx(pc)
@@ -30,7 +30,7 @@ class AssembledPC(PCBase):
         test = TestFunction(V)
         trial = TrialFunction(V)
 
-        if P.getType() == "python":
+        if P.type == "python":
             context = P.getPythonContext()
             # It only makes sense to preconditioner/invert a diagonal
             # block in general.  That's all we're going to allow.

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -1,5 +1,4 @@
 from firedrake.preconditioners.base import PCBase
-from firedrake.functionspace import FunctionSpace, MixedFunctionSpace
 from firedrake.petsc import PETSc
 from firedrake.ufl_expr import TestFunction, TrialFunction
 import firedrake.dmhooks as dmhooks
@@ -27,15 +26,11 @@ class AssembledPC(PCBase):
         appctx = self.get_appctx(pc)
         fcp = appctx.get("form_compiler_parameters")
 
-        V = get_function_space(pc.getDM())
-        if len(V) == 1:
-            V = FunctionSpace(V.mesh(), V.ufl_element())
-        else:
-            V = MixedFunctionSpace([V_ for V_ in V])
+        V = get_function_space(pc.getDM()).collapse()
         test = TestFunction(V)
         trial = TrialFunction(V)
 
-        if P.type == "python":
+        if P.getType() == "python":
             context = P.getPythonContext()
             # It only makes sense to preconditioner/invert a diagonal
             # block in general.  That's all we're going to allow.

--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -62,18 +62,27 @@ class PCSNESBase(object, metaclass=abc.ABCMeta):
     def form(self, obj, *args):
         """Return the preconditioning bilinear form and boundary conditions.
 
+        Parameters
+        ----------
+        obj : PETSc.PC or PETSc.SNES
+            The PETSc solver object.
+        test : ufl.TestFunction
+            The test function.
+        trial : ufl.TrialFunction
+            The trial function.
+
+        Returns
+        -------
+        a : ufl.Form
+            The preconditioning bilinear form.
+        bcs : DirichletBC[] or None
+            The boundary conditions.
+
+        Notes
+        -----
         Subclasses may override this function to provide an auxiliary bilinear
         form. Use `self.get_appctx(obj)` to get the user-supplied
         application-context, if desired.
-
-        :arg obj: a `PETSc.PC` or `PETSc.SNES` object.
-
-        :arg test: a `TestFunction` on this `FunctionSpace`.
-
-        :arg trial: a `TrialFunction` on this `FunctionSpace`.
-
-        :returns `(a, bcs)`, where `a` is a bilinear `Form`
-        and `bcs` is a list of `DirichletBC` boundary conditions (possibly `None`).
         """
         if isinstance(obj, PETSc.PC):
             pc = obj

--- a/firedrake/preconditioners/base.py
+++ b/firedrake/preconditioners/base.py
@@ -60,7 +60,7 @@ class PCSNESBase(object, metaclass=abc.ABCMeta):
             self.pc.destroy()
 
     def form(self, obj, *args):
-        """Extract the preconditioning bilinear form and boundary conditions.
+        """Return the preconditioning bilinear form and boundary conditions.
 
         Subclasses may override this function to provide an auxiliary bilinear
         form. Use `self.get_appctx(obj)` to get the user-supplied

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -1,6 +1,7 @@
 from functools import partial
 from mpi4py import MPI
 from pyop2 import op2, PermutedMap
+from finat.ufl import RestrictedElement, MixedElement, TensorElement, VectorElement
 from firedrake.petsc import PETSc
 from firedrake.preconditioners.base import PCBase
 import firedrake.dmhooks as dmhooks
@@ -10,7 +11,7 @@ __all__ = ['FacetSplitPC']
 
 
 class FacetSplitPC(PCBase):
-    """ A preconditioner that splits a function into interior and facet DOFs.
+    """A preconditioner that splits a function into interior and facet DOFs.
 
     Internally this creates a PETSc PC object that can be controlled
     by options using the extra options prefix ``facet_``.
@@ -25,94 +26,75 @@ class FacetSplitPC(PCBase):
     needs_python_pmat = False
     _prefix = "facet_"
 
-    _permutation_cache = {}
+    _index_cache = {}
 
-    def get_permutation(self, V, W):
+    def get_indices(self, V, W):
         key = (V, W)
-        if key not in self._permutation_cache:
-            indices = get_permutation_map(V, W)
-            if V._comm.allreduce(numpy.all(indices[:-1] <= indices[1:]), MPI.PROD):
-                self._permutation_cache[key] = None
+        if key not in self._index_cache:
+            indices = get_restriction_indices(V, W)
+            if V._comm.allreduce(len(indices) == V.dof_count and numpy.all(indices[:-1] <= indices[1:]), MPI.PROD):
+                self._index_cache[key] = None
             else:
-                self._permutation_cache[key] = indices
-        return self._permutation_cache[key]
+                self._index_cache[key] = indices
+        return self._index_cache[key]
 
     def initialize(self, pc):
-        from finat.ufl import RestrictedElement, MixedElement, TensorElement, VectorElement
         from firedrake import FunctionSpace, TestFunctions, TrialFunctions
-        from firedrake.assemble import get_assembler
-
-        _, P = pc.getOperators()
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters")
-        self.work_vec_x = P.createVecLeft()
-        self.work_vec_y = P.createVecRight()
 
         prefix = pc.getOptionsPrefix()
         options_prefix = prefix + self._prefix
         options = PETSc.Options(options_prefix)
         mat_type = options.getString("mat_type", "submatrix")
+        domains = options.getString("restriction_domain", "interior,facet")
+        domains = domains.split(",")
 
-        if P.getType() == "python":
-            ctx = P.getPythonContext()
-            a = ctx.a
-            bcs = tuple(ctx.row_bcs)
-        else:
-            ctx = dmhooks.get_appctx(pc.getDM())
-            a = ctx.Jp or ctx.J
-            bcs = tuple(ctx._problem.bcs)
-
+        a, bcs = self.form(pc)
+        appctx = self.get_appctx(pc)
+        fcp = appctx.get("form_compiler_parameters")
         V = a.arguments()[-1].function_space()
-        assert len(V) == 1, "Interior-facet decomposition of mixed elements is not supported"
+        assert len(V) == 1, "Decomposition of mixed elements is not supported"
 
-        def restrict(ele, restriction_domain):
-            if isinstance(ele, VectorElement):
-                return type(ele)(restrict(ele._sub_element, restriction_domain), dim=ele.num_sub_elements)
-            elif isinstance(ele, TensorElement):
-                return type(ele)(restrict(ele._sub_element, restriction_domain), shape=ele._shape, symmetry=ele._symmety)
-            else:
-                return RestrictedElement(ele, restriction_domain)
-
-        # W = V[interior] * V[facet]
-        W = FunctionSpace(V.mesh(), MixedElement([restrict(V.ufl_element(), d) for d in ("interior", "facet")]))
-        assert W.dim() == V.dim(), "Dimensions of the original and decomposed spaces do not match"
+        element = V.ufl_element()
+        elements = [restrict(element, domain) for domain in domains]
+        if len(elements) == 1:
+            W = FunctionSpace(V.mesh(), elements[0])
+            assert W.dim() < V.dim(), "Subspace must be smaller than the original space"
+        else:
+            W = FunctionSpace(V.mesh(), MixedElement(elements))
+            assert W.dim() == V.dim(), "Dimensions of the original and decomposed spaces do not match"
 
         mixed_operator = a(sum(TestFunctions(W)), sum(TrialFunctions(W)))
         mixed_bcs = tuple(bc.reconstruct(V=W[-1], g=0) for bc in bcs)
 
-        self.perm = None
-        self.iperm = None
-        indices = self.get_permutation(V, W)
+        _, P = pc.getOperators()
+
+        self.work_vecs = None
+        indices = self.get_indices(V, W)
+        self.subset = None
         if indices is not None:
-            self.perm = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
-            self.iperm = self.perm.invertPermutation()
+            self.subset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
 
         if mat_type != "submatrix":
-            form_assembler = get_assembler(mixed_operator, bcs=mixed_bcs, form_compiler_parameters=fcp, mat_type=mat_type, options_prefix=options_prefix)
-            self.mixed_op = form_assembler.allocate()
+            from firedrake.assemble import get_assembler
+            form_assembler = get_assembler(mixed_operator, bcs=mixed_bcs,
+                                           form_compiler_parameters=fcp,
+                                           mat_type=mat_type,
+                                           options_prefix=options_prefix)
+            self.P = form_assembler.allocate()
             self._assemble_mixed_op = form_assembler.assemble
-            self._assemble_mixed_op(tensor=self.mixed_op)
-            mixed_opmat = self.mixed_op.petscmat
-
-            def _permute_nullspace(nsp):
-                if not (nsp.handle and self.iperm):
-                    return nsp
-                vecs = [vec.duplicate() for vec in nsp.getVecs()]
-                for vec in vecs:
-                    self.work_vec_x.getArray(readonly=False)[:] = vec.getArray(readonly=True)[:]
-                    self._vec_permute(self.work_vec_x, vec, self.iperm)
-                return PETSc.NullSpace().create(constant=nsp.hasConstant(), vectors=vecs, comm=nsp.getComm())
-
-            mixed_opmat.setNullSpace(_permute_nullspace(P.getNullSpace()))
-            mixed_opmat.setNearNullSpace(_permute_nullspace(P.getNearNullSpace()))
-            mixed_opmat.setTransposeNullSpace(_permute_nullspace(P.getTransposeNullSpace()))
-        elif self.perm:
-            global_indices = V.dof_dset.lgmap.apply(self.iperm.indices)
+            self._assemble_mixed_op(tensor=self.P)
+            self.mixed_opmat = self.P.petscmat
+            self.set_nullspaces(pc)
+            self.work_vecs = self.mixed_opmat.createVecs()
+        elif self.subset:
+            global_indices = V.dof_dset.lgmap.apply(self.subset.indices)
             self._global_iperm = PETSc.IS().createGeneral(global_indices, comm=P.getComm())
             self._permute_op = partial(PETSc.Mat().createSubMatrixVirtual, P, self._global_iperm, self._global_iperm)
-            mixed_opmat = self._permute_op()
+            self.mixed_opmat = self._permute_op()
+            self.set_nullspaces(pc)
+            self.work_vecs = self.mixed_opmat.createVecs()
         else:
-            mixed_opmat = P
+            self.mixed_opmat = P
 
         # Internally, we just set up a PC object that the user can configure
         # however from the PETSc command line.  Since PC allows the user to specify
@@ -135,44 +117,70 @@ class FacetSplitPC(PCBase):
 
         scpc.setDM(mixed_dm)
         scpc.setOptionsPrefix(options_prefix)
-        scpc.setOperators(A=mixed_opmat, P=mixed_opmat)
+        scpc.setOperators(A=self.mixed_opmat, P=self.mixed_opmat)
         with dmhooks.add_hooks(mixed_dm, self, appctx=self._ctx_ref, save=False):
             scpc.setFromOptions()
         self.pc = scpc
 
+    def set_nullspaces(self, pc):
+        _, P = pc.getOperators()
+        Pmat = self.mixed_opmat
+
+        def _restrict_nullspace(nsp):
+            if not (nsp.handle and self.perm):
+                return nsp
+            vecs = []
+            for x in nsp.getVecs():
+                y = Pmat.createVecRight()
+                self.restrict(x, y)
+                vecs.append(y)
+            return PETSc.NullSpace().create(constant=nsp.hasConstant(), vectors=vecs, comm=nsp.getComm())
+
+        Pmat.setNullSpace(_restrict_nullspace(P.getNullSpace()))
+        Pmat.setNearNullSpace(_restrict_nullspace(P.getNearNullSpace()))
+        Pmat.setTransposeNullSpace(_restrict_nullspace(P.getTransposeNullSpace()))
+
     def update(self, pc):
-        if hasattr(self, "mixed_op"):
-            self._assemble_mixed_op(tensor=self.mixed_op)
-        elif hasattr(self, "_permute_op"):
+        if hasattr(self, "_permute_op"):
             for mat in self.pc.getOperators():
                 mat.destroy()
             P = self._permute_op()
             self.pc.setOperators(A=P, P=P)
+            self.mixed_opmat = P
+        elif hasattr(self, "P"):
+            self._assemble_mixed_op(tensor=self.P)
         self.pc.setUp()
 
+    def prolong(self, x, y):
+        y.set(0.0)
+        array_x = x.getArray(readonly=True)
+        array_y = y.getArray(readonly=False)
+        with self.subset as subset_indices:
+            array_y[subset_indices] = array_x[:]
+
+    def restrict(self, x, y):
+        array_x = x.getArray(readonly=True)
+        array_y = y.getArray(readonly=False)
+        with self.subset as subset_indices:
+            array_y[:] = array_x[subset_indices]
+
     def apply(self, pc, x, y):
-        if self.perm:
-            self._vec_permute(x, self.work_vec_x, self.iperm)
-        dm = self._dm
-        with dmhooks.add_hooks(dm, self, appctx=self._ctx_ref):
-            self.pc.apply(self.work_vec_x, self.work_vec_y)
-        if self.perm:
-            self._vec_permute(self.work_vec_y, y, self.perm)
+        xwork, ywork = self.work_vecs or (x, y)
+        if self.subset:
+            self.restrict(x, xwork)
+        with dmhooks.add_hooks(self._dm, self, appctx=self._ctx_ref):
+            self.pc.apply(xwork, ywork)
+        if self.subset:
+            self.prolong(ywork, y)
 
     def applyTranspose(self, pc, x, y):
-        if self.perm:
-            self._vec_permute(x, self.work_vec_y, self.iperm)
-        dm = self._dm
-        with dmhooks.add_hooks(dm, self, appctx=self._ctx_ref):
-            self.pc.applyTranspose(self.work_vec_y, self.work_vec_x)
-        if self.perm:
-            self._vec_permute(self.work_vec_x, y, self.perm)
-
-    def _vec_permute(self, vec_in, vec_out, perm):
-        array_in = vec_in.getArray(readonly=True)
-        array_out = vec_out.getArray(readonly=False)
-        with perm as perm_indices:
-            array_out[:] = array_in[perm_indices]
+        xwork, ywork = self.work_vecs or (x, y)
+        if self.subset:
+            self.restrict(x, xwork)
+        with dmhooks.add_hooks(self._dm, self, appctx=self._ctx_ref):
+            self.pc.applyTranspose(xwork, ywork)
+        if self.subset:
+            self.prolong(ywork, y)
 
     def view(self, pc, viewer=None):
         super(FacetSplitPC, self).view(pc, viewer)
@@ -186,19 +194,28 @@ class FacetSplitPC(PCBase):
                 for mat in self.pc.getOperators():
                     mat.destroy()
             self.pc.destroy()
-        if hasattr(self, "iperm"):
-            if self.iperm:
-                self.iperm.destroy()
-        if hasattr(self, "perm"):
-            if self.perm:
-                self.perm.destroy()
+        if hasattr(self, "subset"):
+            if self.subset:
+                self.subset.destroy()
 
 
-def split_dofs(elem):
+def restrict(ele, restriction_domain):
+    """ Restrict a UFL element, keeping VectorElement and TensorElement as the outermost modifier.
+    """
+    if isinstance(ele, VectorElement):
+        return type(ele)(restrict(ele._sub_element, restriction_domain), dim=ele.num_sub_elements)
+    elif isinstance(ele, TensorElement):
+        return type(ele)(restrict(ele._sub_element, restriction_domain), shape=ele._shape, symmetry=ele._symmety)
+    else:
+        return RestrictedElement(ele, restriction_domain)
+
+
+def split_dofs(elem, dim=None):
     """ Split DOFs into interior and facet DOF, where facets are sorted by entity.
     """
+    if dim is None:
+        dim = elem.cell.get_spatial_dimension()
     entity_dofs = elem.entity_dofs()
-    ndim = elem.cell.get_spatial_dimension()
     edofs = [[], []]
     for key in sorted(entity_dofs.keys()):
         vals = entity_dofs[key]
@@ -208,52 +225,60 @@ def split_dofs(elem):
         except TypeError:
             pass
         for k in sorted(vals.keys()):
-            edofs[edim < ndim].extend(sorted(vals[k]))
+            edofs[edim < dim].extend(sorted(vals[k]))
     return tuple(numpy.array(e, dtype=PETSc.IntType) for e in edofs)
 
 
-def restricted_dofs(celem, felem):
+def restricted_dofs(celem, felem, dim=None):
     """ Find which DOFs from felem are on celem
     :arg celem: the restricted :class:`finat.FiniteElement`
     :arg felem: the unrestricted :class:`finat.FiniteElement`
     :returns: :class:`numpy.array` with indices of felem that correspond to celem
     """
-    csplit = split_dofs(celem)
-    fsplit = split_dofs(felem)
-    if len(csplit[0]) and len(csplit[1]):
-        csplit = [numpy.concatenate(csplit)]
-        fsplit = [numpy.concatenate(fsplit)]
+    indices = []
+    iperm = []
+    cdofs = celem.entity_dofs()
+    fdofs = felem.entity_dofs()
+    for dim in sorted(cdofs):
+        for entity in cdofs[dim]:
+            ndofs = len(cdofs[dim][entity])
+            iperm.extend(cdofs[dim][entity])
+            indices.extend(fdofs[dim][entity][:ndofs])
 
-    k = len(csplit[0]) == 0
-    if len(csplit[k]) != len(fsplit[k]):
-        raise ValueError("Finite elements have different DOFs")
-    perm = numpy.empty_like(csplit[k])
-    perm[csplit[k]] = numpy.arange(len(perm), dtype=perm.dtype)
-    return fsplit[k][perm]
+    indices = numpy.array(indices, dtype=PETSc.IntType)
+    perm = numpy.empty_like(iperm)
+    perm[iperm] = numpy.arange(len(perm))
+    return indices[perm]
 
 
-def get_permutation_map(V, W):
-    perm = numpy.full((V.dof_count,), -1, dtype=PETSc.IntType)
-    vdat = V.make_dat(val=perm)
+def reference_space_dimension(V):
+    return sum(Vsub.finat_element.space_dimension() * Vsub.value_size for Vsub in V)
 
-    offset = 0
-    wdats = []
-    for Wsub in W:
-        val = numpy.arange(offset, offset + Wsub.dof_count, dtype=PETSc.IntType)
-        wdats.append(Wsub.make_dat(val=val))
-        offset += Wsub.dof_dset.layout_vec.sizes[0]
-    wdat = op2.MixedDat(wdats)
-    size = sum(Wsub.finat_element.space_dimension() * Wsub.value_size for Wsub in W)
+
+def get_restriction_indices(V, W):
+    """Return the list of dofs in the space V such that W = V[indices].
+    """
+    vdat = V.make_dat(val=numpy.arange(V.dof_count, dtype=PETSc.IntType))
+    wdats = [Wsub.make_dat(val=numpy.full((Wsub.dof_count,), -1, dtype=PETSc.IntType)) for Wsub in W]
+    wdat = wdats[0] if len(W) == 1 else op2.MixedDat(wdats)
+
+    wsize = reference_space_dimension(W)
+    vsize = reference_space_dimension(V)
     eperm = numpy.concatenate([restricted_dofs(Wsub.finat_element, V.finat_element) for Wsub in W])
+    if wsize < vsize:
+        eperm = numpy.concatenate((eperm, numpy.setdiff1d(numpy.arange(vsize, dtype=PETSc.IntType), eperm)))
     pmap = PermutedMap(V.cell_node_map(), eperm)
 
     kernel_code = f"""
-    void permutation(PetscInt *restrict v, const PetscInt *restrict w) {{
-        for (PetscInt i=0; i<{size}; i++) v[i] = w[i];
+    void copy(PetscInt *restrict w, const PetscInt *restrict v) {{
+        for (PetscInt i=0; i<{wsize}; i++) w[i] = v[i];
     }}"""
-    kernel = op2.Kernel(kernel_code, "permutation", requires_zeroed_output_arguments=False)
+    kernel = op2.Kernel(kernel_code, "copy", requires_zeroed_output_arguments=False)
     op2.par_loop(kernel, V.mesh().cell_set,
-                 vdat(op2.WRITE, pmap), wdat(op2.READ, W.cell_node_map()))
-
-    own = V.dof_dset.layout_vec.sizes[0]
-    return perm[:own]
+                 wdat(op2.WRITE, W.cell_node_map()),
+                 vdat(op2.READ, pmap),
+                 )
+    indices = wdat.data_ro
+    if len(W) > 1:
+        indices = numpy.concatenate(indices)
+    return indices

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -135,6 +135,7 @@ class FacetSplitPC(PCBase):
             for x in nsp.getVecs():
                 y = Pmat.createVecRight()
                 self.restrict(x, y)
+                y.normalize()
                 vecs.append(y)
             return PETSc.NullSpace().create(constant=nsp.hasConstant(), vectors=vecs, comm=nsp.getComm())
 
@@ -237,20 +238,14 @@ def restricted_dofs(celem, felem):
     :arg felem: the unrestricted :class:`finat.FiniteElement`
     :returns: :class:`numpy.array` with indices of felem that correspond to celem
     """
-    indices = []
-    iperm = []
+    indices = numpy.full((celem.space_dimension(),), -1, dtype=PETSc.IntType)
     cdofs = celem.entity_dofs()
     fdofs = felem.entity_dofs()
     for dim in sorted(cdofs):
         for entity in cdofs[dim]:
             ndofs = len(cdofs[dim][entity])
-            iperm.extend(cdofs[dim][entity])
-            indices.extend(fdofs[dim][entity][:ndofs])
-
-    indices = numpy.array(indices, dtype=PETSc.IntType)
-    perm = numpy.empty_like(iperm)
-    perm[iperm] = numpy.arange(len(perm))
-    return indices[perm]
+            indices[cdofs[dim][entity]] = fdofs[dim][entity][:ndofs]
+    return indices
 
 
 def reference_space_dimension(V):

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -52,7 +52,8 @@ class FacetSplitPC(PCBase):
         appctx = self.get_appctx(pc)
         fcp = appctx.get("form_compiler_parameters")
         V = a.arguments()[-1].function_space()
-        assert len(V) == 1, "Decomposition of mixed elements is not supported"
+        if len(V) != 1:
+            raise ValueError("Decomposition of mixed elements is not supported")
 
         element = V.ufl_element()
         elements = [restrict(element, domain) for domain in domains]
@@ -88,7 +89,7 @@ class FacetSplitPC(PCBase):
             self.work_vecs = self.mixed_opmat.createVecs()
         elif self.subset:
             global_indices = V.dof_dset.lgmap.apply(self.subset.indices)
-            self._global_iperm = PETSc.IS().createGeneral(global_indices, comm=P.getComm())
+            self._global_iperm = PETSc.IS().createGeneral(global_indices, comm=pc.comm)
             self._permute_op = partial(PETSc.Mat().createSubMatrixVirtual, P, self._global_iperm, self._global_iperm)
             self.mixed_opmat = self._permute_op()
             self.set_nullspaces(pc)

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -6,7 +6,7 @@ from firedrake.preconditioners.base import PCBase
 from firedrake.preconditioners.patch import bcdofs
 from firedrake.preconditioners.pmg import (prolongation_matrix_matfree,
                                            evaluate_dual,
-                                           get_permutation_to_line_elements,
+                                           get_permutation_to_nodal_elements,
                                            cache_generate_code)
 from firedrake.preconditioners.facet_split import split_dofs, restricted_dofs
 from firedrake.formmanipulation import ExtractSubBlock
@@ -1808,7 +1808,7 @@ class PoissonFDMPC(FDMPC):
 
     def assemble_reference_tensor(self, V):
         try:
-            _, line_elements, shifts = get_permutation_to_line_elements(V)
+            _, line_elements, shifts = get_permutation_to_nodal_elements(V)
         except ValueError:
             raise ValueError("FDMPC does not support the element %s" % V.ufl_element())
 

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -106,15 +106,12 @@ class FDMPC(PCBase):
         self.appctx = appctx
 
         # Get original Jacobian form and bcs
+        J, bcs = self.form(pc)
+
         if Pmat.getType() == "python":
-            ctx = Pmat.getPythonContext()
-            J = ctx.a
-            bcs = tuple(ctx.bcs)
             mat_type = "matfree"
         else:
             ctx = dmhooks.get_appctx(pc.getDM())
-            J = ctx.Jp or ctx.J
-            bcs = tuple(ctx._problem.bcs)
             mat_type = ctx.mat_type
 
         # TODO assemble Schur complements specified by a SLATE Tensor

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -193,6 +193,8 @@ class HiptmairPC(TwoLevelPC):
             diag = numpy.abs(coarse_diagonal.dat.data_ro)
             atol = numpy.max(diag) * 1E-10
             bc_nodes = numpy.flatnonzero(diag <= atol).astype(PETSc.IntType)
+
+            coarse_space.dof_dset.lgmap.apply()
             coarse_space_bcs.append(BCFromNodes(coarse_space, 0, bc_nodes))
 
         cdegree = max(as_tuple(celement.degree()))

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -190,11 +190,9 @@ class HiptmairPC(TwoLevelPC):
             from firedrake.assemble import assemble
             # Remove coarse nodes where beta is zero
             coarse_diagonal = assemble(coarse_operator, diagonal=True)
-            diag = numpy.abs(coarse_diagonal.dat.data_ro)
+            diag = numpy.abs(coarse_diagonal.dat.data_ro_with_halos)
             atol = numpy.max(diag) * 1E-10
             bc_nodes = numpy.flatnonzero(diag <= atol).astype(PETSc.IntType)
-
-            coarse_space.dof_dset.lgmap.apply()
             coarse_space_bcs.append(BCFromNodes(coarse_space, 0, bc_nodes))
 
         cdegree = max(as_tuple(celement.degree()))

--- a/firedrake/preconditioners/hypre_ams.py
+++ b/firedrake/preconditioners/hypre_ams.py
@@ -3,11 +3,11 @@ from firedrake.preconditioners.base import PCBase
 from firedrake.petsc import PETSc
 from firedrake.functionspace import FunctionSpace, VectorFunctionSpace
 from firedrake.ufl_expr import TestFunction
-from firedrake.interpolation import Interpolator, interpolate
 from firedrake.dmhooks import get_function_space
 from firedrake.utils import complex_mode
 from firedrake_citations import Citations
 from firedrake import SpatialCoordinate
+from firedrake.__future__ import interpolate
 from ufl import grad
 from pyop2.utils import as_tuple
 
@@ -50,7 +50,7 @@ class HypreAMS(PCBase):
         P1 = FunctionSpace(mesh, "Lagrange", 1)
         G_callback = appctx.get("get_gradient", None)
         if G_callback is None:
-            G = chop(Interpolator(grad(TestFunction(P1)), V).callable().handle)
+            G = chop(assemble.assemble(interpolate(grad(TestFunction(P1)), V)))
         else:
             G = G_callback(P1, V)
 

--- a/firedrake/preconditioners/hypre_ams.py
+++ b/firedrake/preconditioners/hypre_ams.py
@@ -50,7 +50,7 @@ class HypreAMS(PCBase):
         P1 = FunctionSpace(mesh, "Lagrange", 1)
         G_callback = appctx.get("get_gradient", None)
         if G_callback is None:
-            G = chop(assemble.assemble(interpolate(grad(TestFunction(P1)), V)))
+            G = chop(assemble.assemble(interpolate(grad(TestFunction(P1)), V)).petscmat)
         else:
             G = G_callback(P1, V)
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -454,9 +454,11 @@ class PMGPC(PCBase, PMGBase):
         # the p-MG's coarse problem. So we need to set an option
         # for the user, if they haven't already; I don't know any
         # other way to get PETSc to know this at the right time.
-        opts = PETSc.Options(pc.getOptionsPrefix() + self._prefix)
-        opts["mg_coarse_pc_mg_levels"] = odm.getRefineLevel() + 1
-
+        max_levels = odm.getRefineLevel() + 1
+        if max_levels > 1:
+            opts = PETSc.Options(pc.getOptionsPrefix() + "pmg_")
+            if opts.getString("mg_coarse_pc_type") == "mg":
+                opts["mg_coarse_pc_mg_levels"] = min(opts.getInt("mg_coarse_pc_mg_levels", max_levels), max_levels)
         return ppc
 
     def apply(self, pc, x, y):
@@ -497,10 +499,13 @@ class PMGSNES(SNESBase, PMGBase):
         # the p-MG's coarse problem. So we need to set an option
         # for the user, if they haven't already; I don't know any
         # other way to get PETSc to know this at the right time.
-        opts = PETSc.Options(snes.getOptionsPrefix() + self._prefix)
-        opts["fas_coarse_pc_mg_levels"] = odm.getRefineLevel() + 1
-        opts["fas_coarse_snes_fas_levels"] = odm.getRefineLevel() + 1
-
+        max_levels = odm.getRefineLevel() + 1
+        if max_levels > 1:
+            opts = PETSc.Options(snes.getOptionsPrefix() + "pfas_")
+            if opts.getString("fas_coarse_pc_type") == "mg":
+                opts["fas_coarse_pc_mg_levels"] = min(opts.getInt("fas_coarse_pc_mg_levels", max_levels), max_levels)
+            if opts.getString("fas_coarse_snes_type") == "fas":
+                opts["fas_coarse_snes_fas_levels"] = min(opts.getInt("fas_coarse_snes_fas_levels", max_levels), max_levels)
         return psnes
 
     def step(self, snes, x, f, y):

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -114,10 +114,14 @@ class PMGBase(PCSNESBase):
         ppc = self.configure_pmg(obj, pdm)
         self.is_snes = isinstance(obj, PETSc.SNES)
 
+        default_mat_type = ctx.mat_type
+        if default_mat_type == "submatrix":
+            default_mat_type = "matfree"
+
         # Get the coarse degree from PETSc options
         copts = PETSc.Options(ppc.getOptionsPrefix() + ppc.getType() + "_coarse_")
         self.coarse_degree = copts.getInt("degree", default=1)
-        self.coarse_mat_type = copts.getString("mat_type", default=ctx.mat_type)
+        self.coarse_mat_type = copts.getString("mat_type", default=default_mat_type)
         self.coarse_pmat_type = copts.getString("pmat_type", default=self.coarse_mat_type)
         self.coarse_form_compiler_mode = copts.getString("form_compiler_mode", default=mode)
 

--- a/tests/multigrid/test_hiptmair.py
+++ b/tests/multigrid/test_hiptmair.py
@@ -81,11 +81,8 @@ def run_riesz_map(V, mat_type, max_it):
     L = inner(f, v) * dx(degree=2)
 
     bcs = [DirichletBC(V, u_exact, "on_boundary")]
-    if V.mesh().ufl_cell().is_simplex():
-        appctx = dict()
-    else:
-        appctx = {"get_gradient": tabulate_exterior_derivative,
-                  "get_curl": tabulate_exterior_derivative}
+    appctx = {"get_gradient": tabulate_exterior_derivative,
+              "get_curl": tabulate_exterior_derivative}
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs, form_compiler_parameters={"mode": "vanilla"})
     solver = LinearVariationalSolver(problem, solver_parameters=parameters, appctx=appctx)
     solver.solve()

--- a/tests/multigrid/test_p_multigrid.py
+++ b/tests/multigrid/test_p_multigrid.py
@@ -489,6 +489,7 @@ def test_p_fas_nonlinear_scalar():
     relax = {
         "ksp_type": "chebyshev",
         "ksp_norm_type": "unpreconditioned",
+        "ksp_chebyshev_esteig": "0.75,0.25,0,1",
         "ksp_max_it": 3,
         "pc_type": "jacobi"}
 


### PR DESCRIPTION
# Description

`PCSNESBase` implements `form()` to remove code duplication.

`FacetSplitPC` now supports a split onto any number of restricted elements (this allows proper subspaces).

`HiptmairPC` now supports restricted potential spaces.

`tabulate_exterior_derivative` works for simplices.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
