### PR TITLE
Add `__call__` method docstrings to the API documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,11 @@ mathjax3_config = {
 # inserted into the class definition
 autoclass_content = 'both'
 
+# Document __call__ methods
+autodoc_default_options = {
+    'special-members': '__call__'
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/firedrake/adjoint/ensemble_reduced_functional.py
+++ b/firedrake/adjoint/ensemble_reduced_functional.py
@@ -79,6 +79,22 @@ class EnsembleReducedFunctional(ReducedFunctional):
         return vals
 
     def __call__(self, values):
+        """Computes the reduced functional with supplied control value.
+
+        Parameters
+        ----------
+        values : pyadjoint.OverloadedType
+            If you have multiple controls this should be a list of
+            new values for each control in the order you listed the controls to the constructor.
+            If you have a single control it can either be a list or a single object.
+            Each new value should have the same type as the corresponding control.
+
+        Returns
+        -------
+        pyadjoint.OverloadedType
+            The computed value. Typically of instance of :class:`pyadjoint.AdjFloat`.
+
+        """
         local_functional = super(EnsembleReducedFunctional, self).__call__(values)
         ensemble_comm = self.ensemble.ensemble_comm
         if self.gather_functional:

--- a/firedrake/slate/slac/kernel_builder.py
+++ b/firedrake/slate/slac/kernel_builder.py
@@ -480,11 +480,19 @@ class IndexCreator:
     def __call__(self, extents):
         """Create new indices with specified extents.
 
-        :arg extents. :class:`tuple` containting :class:`tuple` for extents of mixed tensors
-            and :class:`int` for extents non-mixed tensor
-        :returns: tuple of pymbolic Variable objects representing indices, contains tuples
-            of Variables for mixed tensors
-            and Variables for non-mixed tensors, where each Variable represents one extent."""
+        Parameters
+        ----------
+        extents : tuple
+            :class:`tuple` containing :class:`tuple` for extents of mixed tensors
+            and :class:`int` for extents non-mixed tensor.
+
+        Returns
+        -------
+        tuple
+            :class:`tuple` of pymbolic Variable objects representing indices, contains tuples
+            of Variables for mixed tensors and Variables for non-mixed tensors,
+            where each Variable represents one extent.
+        """
 
         # Indices for scalar tensors
         extents += (1, ) if len(extents) == 0 else ()


### PR DESCRIPTION
# Description
By default sphinx doesn't document special (dunder) methods. This PR adds a line to the documentation configuration to include `__call__` method docstrings in the API.

It also updates a couple of `__call__` docstrings so they build successfully.