### PR TITLE
Ksagiyam/hex interior facet

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -1759,6 +1759,16 @@ def _as_global_kernel_arg_interior_facet(_, self):
     return op2.DatKernelArg((2,))
 
 
+@_as_global_kernel_arg.register(kernel_args.ExteriorFacetOrientationKernelArg)
+def _as_global_kernel_arg_exterior_facet_orientation(_, self):
+    return op2.DatKernelArg((1,))
+
+
+@_as_global_kernel_arg.register(kernel_args.InteriorFacetOrientationKernelArg)
+def _as_global_kernel_arg_interior_facet_orientation(_, self):
+    return op2.DatKernelArg((2,))
+
+
 @_as_global_kernel_arg.register(CellFacetKernelArg)
 def _as_global_kernel_arg_cell_facet(_, self):
     if self._mesh.extruded:
@@ -2051,6 +2061,16 @@ def _as_parloop_arg_exterior_facet(_, self):
 @_as_parloop_arg.register(kernel_args.InteriorFacetKernelArg)
 def _as_parloop_arg_interior_facet(_, self):
     return op2.DatParloopArg(self._mesh.interior_facets.local_facet_dat)
+
+
+@_as_parloop_arg.register(kernel_args.ExteriorFacetOrientationKernelArg)
+def _as_parloop_arg_exterior_facet_orientation(_, self):
+    return op2.DatParloopArg(self._mesh.exterior_facets.local_facet_orientation_dat)
+
+
+@_as_parloop_arg.register(kernel_args.InteriorFacetOrientationKernelArg)
+def _as_parloop_arg_interior_facet_orientation(_, self):
+    return op2.DatParloopArg(self._mesh.interior_facets.local_facet_orientation_dat)
 
 
 @_as_parloop_arg.register(CellFacetKernelArg)

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -143,6 +143,7 @@ def compile_element(expression, dual_space=None, parameters=None,
 
     config = dict(interface=builder,
                   ufl_cell=cell,
+                  integral_type="cell",
                   point_indices=(),
                   point_expr=point,
                   argument_multiindices=argument_multiindices,
@@ -537,6 +538,7 @@ def dg_injection_kernel(Vf, Vc, ncell):
     integration_dim, entity_ids = lower_integral_type(Vfe.cell, "cell")
     macro_cfg = dict(interface=macro_builder,
                      ufl_cell=Vf.ufl_cell(),
+                     integral_type="cell",
                      integration_dim=integration_dim,
                      entity_ids=entity_ids,
                      index_cache=index_cache,
@@ -573,6 +575,7 @@ def dg_injection_kernel(Vf, Vc, ncell):
 
     coarse_cfg = dict(interface=coarse_builder,
                       ufl_cell=Vc.ufl_cell(),
+                      integral_type="cell",
                       integration_dim=integration_dim,
                       entity_ids=entity_ids,
                       index_cache=index_cache,

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -71,6 +71,7 @@ def compile_element(expression, coordinates, parameters=None):
 
     config = dict(interface=builder,
                   ufl_cell=extract_unique_domain(coordinates).ufl_cell(),
+                  integral_type="cell",
                   point_indices=(),
                   point_expr=point,
                   scalar_type=utils.ScalarType)

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -160,6 +160,7 @@ def to_reference_coords_newton_step(ufl_coordinate_element, parameters, x0_dtype
     context = tsfc.fem.GemPointContext(
         interface=builder,
         ufl_cell=cell,
+        integral_type="cell",
         point_indices=(),
         point_expr=point,
         scalar_type=parameters["scalar_type"]

--- a/tests/regression/test_integral_hex.py
+++ b/tests/regression/test_integral_hex.py
@@ -18,3 +18,38 @@ def test_integral_hex_exterior_facet(mesh_from_file, family):
     x, y, z = SpatialCoordinate(mesh)
     f = Function(V).interpolate(2 * x + 3 * y * y + 4 * z * z * z)
     assert abs(assemble(f * ds) - (2 + 4 + 2 + 5 + 2 + 6)) < 1.e-10
+
+
+@pytest.mark.parallel(nprocs=2)
+@pytest.mark.parametrize('mesh_from_file', [False, True])
+@pytest.mark.parametrize('family', ["Q", "DQ"])
+def test_integral_hex_interior_facet(mesh_from_file, family):
+    if mesh_from_file:
+        mesh = Mesh(join(cwd, "..", "meshes", "cube_hex.msh"))
+    else:
+        mesh = UnitCubeMesh(2, 3, 5, hexahedral=True)
+    V = FunctionSpace(mesh, family, 3)
+    x, y, z = SpatialCoordinate(mesh)
+    f = Function(V).interpolate(2 * x + 3 * y * y + 4 * z * z * z)
+    assert assemble((f('+') - f('-'))**2 * dS)**0.5 < 1.e-14
+
+
+@pytest.mark.parallel(nprocs=2)
+@pytest.mark.parametrize('mesh_from_file', [False, True])
+def test_integral_hex_interior_facet_solve(mesh_from_file):
+    if mesh_from_file:
+        mesh = Mesh(join(cwd, "..", "meshes", "cube_hex.msh"))
+    else:
+        mesh = UnitCubeMesh(2, 3, 5, hexahedral=True)
+    V = FunctionSpace(mesh, "Q", 1)
+    x, y, z = SpatialCoordinate(mesh)
+    f = Function(V).interpolate(2 * x + 3 * y + 5 * z)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    a = inner(u('+'), v('+')) * dS(degree=3)
+    L = inner(f('+'), v('-')) * dS(degree=3)
+    bc = DirichletBC(V, f, "on_boundary")
+    sol = Function(V)
+    solve(a == L, sol, bcs=[bc])
+    err = assemble((sol - f)**2 * dx)**0.5
+    assert err < 1.e-14


### PR DESCRIPTION
Enable interior facet integration on hex by applying correct permutation to the quadrature points on each side (`+` and `-`).

Note:
Another way of handling interior facet integration on hex would be to choose reference cell - physical cell mapping on each side so that permutation would not be needed.

Depend on:
https://github.com/firedrakeproject/tsfc/pull/317
https://github.com/FInAT/FInAT/pull/138
https://github.com/firedrakeproject/fiat/pull/83