### PR TITLE
tinyasm - use PetscMPIInt not PetscInt for PetscSFGetRootRanks

### DIFF
--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -178,7 +178,7 @@ PetscErrorCode CreateCombinedSF(PC pc, const std::vector<PetscSF>& sf, const std
         ierr = PetscHSetICreate(&ranksUniq);CHKERRQ(ierr);
         for (i = 0; i < n; ++i) {
             const PetscMPIInt *ranks = NULL;
-            PetscInt           nranks, j;
+            PetscMPIInt        nranks, j;
 
             ierr = PetscSFSetUp(sf[i]);CHKERRQ(ierr);
             ierr = PetscSFGetRootRanks(sf[i], &nranks, &ranks, NULL, NULL, NULL);CHKERRQ(ierr);


### PR DESCRIPTION
# Description

If building with 64 bit integers, compiling tinyasm results in the following error:

```
    tinyasm/tinyasm.cpp:184:47: error: cannot convert ‘PetscInt*’ {aka ‘long int*’} to ‘PetscMPIInt*’ {aka ‘int*’}
      184 |             ierr = PetscSFGetRootRanks(sf[i], &nranks, &ranks, NULL, NULL, NULL);CHKERRQ(ierr);
          |                                               ^~~~~~~
          |                                               |
          |                                               PetscInt* {aka long int*}
```

`PetscSFGetRootRanks` has the following signature (https://petsc.org/release/manualpages/PetscSF/PetscSFGetRootRanks/):
```
PetscSFGetRootRanks(PetscSF sf, PetscMPIInt *nranks, const PetscMPIInt **ranks, ...)
```
but `nranks` is declared as `PetscInt`.

This PR changes the declaration of `nranks` to `PetscMPIInt`. The `j` variable is also changed to `PetscMPIInt` - this is fine because the only thing `j` is used for is a loop index with maximum extent `nranks`.
