### PR TITLE
Fix coarsening for R space

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -268,20 +268,23 @@ def coarsen_snescontext(context, self, coefficient_mapping=None):
     coarse._fine = context
     context._coarse = coarse
 
-    # Now that we have the coarse snescontext, push it to the coarsened DMs
-    # Otherwise they won't have the right transfer manager when they are
-    # coarsened in turn
-    for val in chain(coefficient_mapping.values(), (bc.function_arg for bc in problem.bcs)):
-        if isinstance(val, (firedrake.Function, firedrake.Cofunction)):
-            V = val.function_space()
-            coarseneddm = V.dm
-            parentdm = get_parent(context._problem.u.function_space().dm)
+    solution = context._problem.u
+    solutiondm = solution.function_space().dm
+    parentdm = get_parent(solutiondm)
+    if parentdm != solutiondm:
+        # Now that we have the coarse snescontext, push it to the coarsened DMs
+        # Otherwise they won't have the right transfer manager when they are
+        # coarsened in turn
+        for val in chain(coefficient_mapping.values(), (bc.function_arg for bc in problem.bcs)):
+            if isinstance(val, (firedrake.Function, firedrake.Cofunction)):
+                V = val.function_space()
+                coarseneddm = V.dm
 
-            # Now attach the hook to the parent DM
-            if get_appctx(coarseneddm) is None:
-                push_appctx(coarseneddm, coarse)
-                teardown = partial(pop_appctx, coarseneddm, coarse)
-                add_hook(parentdm, teardown=teardown)
+                # Now attach the hook to the parent DM
+                if get_appctx(coarseneddm) is None:
+                    push_appctx(coarseneddm, coarse)
+                    teardown = partial(pop_appctx, coarseneddm, coarse)
+                    add_hook(parentdm, teardown=teardown)
 
     ises = problem.J.arguments()[0].function_space()._ises
     coarse._nullspace = self(context._nullspace, self, coefficient_mapping=coefficient_mapping)
@@ -384,7 +387,8 @@ def create_interpolation(dmc, dmf):
     mat.setType(mat.Type.PYTHON)
     mat.setPythonContext(ctx)
     mat.setUp()
-    return mat, None
+    rscale = mat.createVecLeft() if row_size == col_size else None
+    return mat, rscale
 
 
 def create_injection(dmc, dmf):

--- a/tests/multigrid/test_transfer_manager.py
+++ b/tests/multigrid/test_transfer_manager.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy
+import warnings
 from firedrake import *
 from firedrake.mg.ufl_utils import coarsen
 from firedrake.utils import complex_mode
@@ -131,3 +132,25 @@ def test_transfer_manager_dat_version_cache(action, transfer_op, spaces):
 
     else:
         raise ValueError(f"Unrecognized action {action}")
+
+
+@pytest.mark.parametrize("family", ("DG", "R"))
+def test_cached_transfer(family):
+    # Test that we can properly reuse transfers within solve
+    sp = {"mat_type": "matfree",
+          "pc_type": "mg",
+          "mg_coarse_pc_type": "none",
+          "mg_levels_pc_type": "none"}
+
+    base = UnitSquareMesh(1, 1)
+    hierarchy = MeshHierarchy(base, 3)
+    mesh = hierarchy[-1]
+
+    V = FunctionSpace(mesh, family, 0)
+    u = Function(V)
+    F = inner(u - 1, TestFunction(V)) * dx
+
+    # This test will fail if we raise this warning
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", "Creating new TransferManager", RuntimeWarning)
+        solve(F == 0, u, solver_parameters=sp)


### PR DESCRIPTION
# Description
This PR fixes two separate issues for multigrid with `Functions` in R.

1. The restriction operator for the R space is square. For these cases PETSc complains if we do not pass a vector to rescale the restriction operator to construct the "cheap" injection, even though it is not necessary, as we already pass the proper injection operator. To fix this we just pass a vector of the appropiate size.

2. The `parentdm` of an R space function sometimes might have a null `__setup_hooks__`, which makes it impossible to call `add_hook` on it. As a workaround, we just skip that call.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
