### PR TITLE
annotate `FunctionMixin` methods  `_ad_mul` and `_ad_add`

### DIFF
--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -300,7 +300,6 @@ class FunctionMixin(FloatingType):
         with checkpoint_init_data():
             super()._ad_will_add_as_dependency()
 
-    @no_annotations
     def _ad_mul(self, other):
         from firedrake import Function
 
@@ -309,7 +308,6 @@ class FunctionMixin(FloatingType):
         r.assign(other * self)
         return r
 
-    @no_annotations
     def _ad_add(self, other):
         from firedrake import Function
 

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -361,16 +361,12 @@ class FunctionMixin(FloatingType):
         return self.function_space().dim()
 
     def _ad_imul(self, other):
-        vec = self.vector()
-        vec *= other
+        self *= other
+        return self
 
     def _ad_iadd(self, other):
-        vec = self.vector()
-        ovec = other.vector()
-        if ovec.dat == vec.dat:
-            vec *= 2
-        else:
-            vec += ovec
+        self += other
+        return self
 
     def _ad_function_space(self, mesh):
         return self.ufl_function_space()


### PR DESCRIPTION
These are not marked `no_annotate` in the `pyadjoint.OverloadedType` abstract methods.