### PR TITLE
Fix progress bar error for parallel executions

### DIFF
--- a/demos/full_waveform_inversion/full_waveform_inversion.py.rst
+++ b/demos/full_waveform_inversion/full_waveform_inversion.py.rst
@@ -251,6 +251,7 @@ To have the step 4, we need first to tape the forward problem. That is done by c
 
     from firedrake.adjoint import *
     continue_annotation()
+    get_working_tape().progress_bar = ProgressBar
 
 **Steps 2-3**: Solve the wave equation and compute the functional::
 

--- a/firedrake/progress_bar.py
+++ b/firedrake/progress_bar.py
@@ -11,7 +11,7 @@ class _NullProgressBar:
     def __enter__(self):
         pass
 
-    def __exit__(self):
+    def __exit__(self, *args, **kwargs):
         pass
 
     def iter(self, iterator):


### PR DESCRIPTION
# Description

`ProgressBar` is now being tested by adding it in parallel execution.

See the error: 
```

Evaluating Adjoint ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 401/401 [0:00:41]Traceback (most recent call last):
  File "/Users/ddolci/work/firedrake/simulations_worflows_did/fwi/circle_fwi.py", line 118, in <module>
Traceback (most recent call last):
  File "/Users/ddolci/work/firedrake/simulations_worflows_did/fwi/circle_fwi.py", line 118, in <module>
    J_hat.derivative()
    J_hat.derivative()
  File "/Users/ddolci/work/firedrake/src/firedrake/firedrake/adjoint/ensemble_reduced_functional.py", line 139, in derivative
  File "/Users/ddolci/work/firedrake/src/firedrake/firedrake/adjoint/ensemble_reduced_functional.py", line 139, in derivative
    dJdm_local = super(EnsembleReducedFunctional, self).derivative(adj_input=adj_input, options=options)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/reduced_functional.py", line 130, in derivative
    dJdm_local = super(EnsembleReducedFunctional, self).derivative(adj_input=adj_input, options=options)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/reduced_functional.py", line 130, in derivative
    derivatives = compute_gradient(self.functional,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/drivers.py", line 30, in compute_gradient
    derivatives = compute_gradient(self.functional,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/drivers.py", line 30, in compute_gradient
    tape.evaluate_adj(markings=True)
    tape.evaluate_adj(markings=True)
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/tape.py", line 339, in evaluate_adj
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/tape.py", line 339, in evaluate_adj
    self._checkpoint_manager.evaluate_adj(last_block, markings)
    self._checkpoint_manager.evaluate_adj(last_block, markings)
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/checkpointing.py", line 220, in evaluate_adj
  File "/Users/ddolci/work/firedrake/src/pyadjoint/pyadjoint/checkpointing.py", line 220, in evaluate_adj
    with self.tape.progress_bar("Evaluating Adjoint", max=self.total_timesteps) as progress_bar:
    with self.tape.progress_bar("Evaluating Adjoint", max=self.total_timesteps) as progress_bar:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _NullProgressBar.__exit__() takes 1 positional argument but 4 were given
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _NullProgressBar.__exit__() takes 1 positional argument but 4 were given
```