### PR TITLE
Get value_shape from FunctionSpace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
             --install defcon \
             --install gadopt \
             --install asQ \
+            --package-branch tsfc mscroggs/gdim \
+            --package-branch finat mscroggs/gdim \
+            --package-branch ufl ksagiyam/merge_upstream \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,6 @@ jobs:
             --install defcon \
             --install gadopt \
             --install asQ \
-            --package-branch tsfc mscroggs/gdim \
-            --package-branch finat mscroggs/gdim \
-            --package-branch ufl ksagiyam/merge_upstream \
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |

--- a/demos/full_waveform_inversion/full_waveform_inversion.py.rst
+++ b/demos/full_waveform_inversion/full_waveform_inversion.py.rst
@@ -261,6 +261,7 @@ To have the step 4, we need first to tape the forward problem. That is done by c
 
     from firedrake.adjoint import *
     continue_annotation()
+    get_working_tape().progress_bar = ProgressBar
 
 **Steps 2-3**: Solve the wave equation and compute the functional::
 

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -1628,7 +1628,7 @@ class _GlobalKernelBuilder:
 
     @cached_property
     def _mesh(self):
-        return tuple(self._form.ufl_domains())[self._kinfo.domain_number]
+        return self._form.ufl_domains()[self._kinfo.domain_number]
 
     @cached_property
     def _needs_subset(self):
@@ -1970,7 +1970,7 @@ class ParloopBuilder:
 
     @cached_property
     def _mesh(self):
-        return tuple(self._form.ufl_domains())[self._kinfo.domain_number]
+        return self._form.ufl_domains()[self._kinfo.domain_number]
 
     @cached_property
     def _iterset(self):

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -1610,7 +1610,7 @@ class _GlobalKernelBuilder:
 
     @cached_property
     def _mesh(self):
-        return self._form.ufl_domains()[self._kinfo.domain_number]
+        return tuple(self._form.ufl_domains())[self._kinfo.domain_number]
 
     @cached_property
     def _needs_subset(self):
@@ -1731,7 +1731,7 @@ def _as_global_kernel_arg_coefficient(_, self):
 
     ufl_element = V.ufl_element()
     if ufl_element.family() == "Real":
-        return op2.GlobalKernelArg((ufl_element.value_size,))
+        return op2.GlobalKernelArg((V.value_size,))
     else:
         return self._make_dat_global_kernel_arg(V, index=index)
 
@@ -1945,7 +1945,7 @@ class ParloopBuilder:
 
     @cached_property
     def _mesh(self):
-        return self._form.ufl_domains()[self._kinfo.domain_number]
+        return tuple(self._form.ufl_domains())[self._kinfo.domain_number]
 
     @cached_property
     def _iterset(self):

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -348,12 +348,12 @@ class DirichletBC(BCBase, DirichletBCMixin):
                 raise RuntimeError("%r is defined on incompatible FunctionSpace!" % g)
             self._function_arg = g
         elif isinstance(g, ufl.classes.Zero):
-            if g.ufl_shape and g.ufl_shape != V.ufl_element().value_shape(V.mesh()):
+            if g.ufl_shape and g.ufl_shape != V.value_shape:
                 raise ValueError(f"Provided boundary value {g} does not match shape of space")
             # Special case. Scalar zero for direct Function.assign.
             self._function_arg = g
         elif isinstance(g, ufl.classes.Expr):
-            if g.ufl_shape != V.ufl_element().value_shape(V.mesh()):
+            if g.ufl_shape != V.value_shape:
                 raise RuntimeError(f"Provided boundary value {g} does not match shape of space")
             try:
                 self._function_arg = firedrake.Function(V)

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -935,7 +935,7 @@ class CheckpointFile(object):
             self._update_function_name_function_space_name_map(tmesh.name, mesh.name, {f.name(): V_name})
             # Embed if necessary
             element = V.ufl_element()
-            _element = get_embedding_element_for_checkpointing(element)
+            _element = get_embedding_element_for_checkpointing(element, element.value_shape(mesh))
             if _element != element:
                 path = self._path_to_function_embedded(tmesh.name, mesh.name, V_name, f.name())
                 self.require_group(path)
@@ -1337,7 +1337,7 @@ class CheckpointFile(object):
                 _name = self.get_attr(path, PREFIX_EMBEDDED + "_function")
                 _f = self.load_function(mesh, _name, idx=idx)
                 element = V.ufl_element()
-                _element = get_embedding_element_for_checkpointing(element)
+                _element = get_embedding_element_for_checkpointing(element, element.value_shape(mesh))
                 method = get_embedding_method_for_checkpointing(element)
                 assert _element == _f.function_space().ufl_element()
                 f = Function(V, name=name)
@@ -1436,8 +1436,7 @@ class CheckpointFile(object):
             shape = ufl_element.reference_value_shape
             block_size = np.prod(shape)
         elif isinstance(ufl_element, finat.ufl.VectorElement):
-            shape = ufl_element.value_shape[:1]
-            block_size = np.prod(shape)
+            block_size = ufl_element.reference_value_shape[0]
         else:
             block_size = 1
         return (nodes_per_entity, real_tensorproduct, block_size)

--- a/firedrake/checkpointing.py
+++ b/firedrake/checkpointing.py
@@ -935,7 +935,7 @@ class CheckpointFile(object):
             self._update_function_name_function_space_name_map(tmesh.name, mesh.name, {f.name(): V_name})
             # Embed if necessary
             element = V.ufl_element()
-            _element = get_embedding_element_for_checkpointing(element, element.value_shape(mesh))
+            _element = get_embedding_element_for_checkpointing(element, V.value_shape)
             if _element != element:
                 path = self._path_to_function_embedded(tmesh.name, mesh.name, V_name, f.name())
                 self.require_group(path)
@@ -1337,7 +1337,7 @@ class CheckpointFile(object):
                 _name = self.get_attr(path, PREFIX_EMBEDDED + "_function")
                 _f = self.load_function(mesh, _name, idx=idx)
                 element = V.ufl_element()
-                _element = get_embedding_element_for_checkpointing(element, element.value_shape(mesh))
+                _element = get_embedding_element_for_checkpointing(element, V.value_shape)
                 method = get_embedding_method_for_checkpointing(element)
                 assert _element == _f.function_space().ufl_element()
                 f = Function(V, name=name)

--- a/firedrake/constant.py
+++ b/firedrake/constant.py
@@ -79,7 +79,7 @@ class Constant(ufl.constantvalue.ConstantValue, ConstantMixin, TSFCConstantMixin
 
             if not isinstance(domain, ufl.AbstractDomain):
                 cell = ufl.as_cell(domain)
-                coordinate_element = finat.ufl.VectorElement("Lagrange", cell, 1, gdim=cell.geometric_dimension)
+                coordinate_element = finat.ufl.VectorElement("Lagrange", cell, 1, dim=cell.topological_dimension())
                 domain = ufl.Mesh(coordinate_element)
 
             cell = domain.ufl_cell()

--- a/firedrake/embedding.py
+++ b/firedrake/embedding.py
@@ -4,7 +4,7 @@ import finat.ufl
 import ufl
 
 
-def get_embedding_dg_element(element, broken_cg=False):
+def get_embedding_dg_element(element, value_shape, broken_cg=False):
     cell = element.cell
     family = lambda c: "DG" if c.is_simplex() else "DQ"
     if isinstance(cell, ufl.TensorProductCell):
@@ -19,7 +19,7 @@ def get_embedding_dg_element(element, broken_cg=False):
         scalar_element = finat.ufl.FiniteElement(family(cell), cell=cell, degree=degree)
     if broken_cg:
         scalar_element = finat.ufl.BrokenElement(scalar_element.reconstruct(family="Lagrange"))
-    shape = element.value_shape
+    shape = value_shape
     if len(shape) == 0:
         DG = scalar_element
     elif len(shape) == 1:
@@ -37,12 +37,12 @@ def get_embedding_dg_element(element, broken_cg=False):
 native_elements_for_checkpointing = {"Lagrange", "Discontinuous Lagrange", "Q", "DQ", "Real"}
 
 
-def get_embedding_element_for_checkpointing(element):
+def get_embedding_element_for_checkpointing(element, value_shape):
     """Convert the given UFL element to an element that :class:`~.CheckpointFile` can handle."""
     if element.family() in native_elements_for_checkpointing:
         return element
     else:
-        return get_embedding_dg_element(element)
+        return get_embedding_dg_element(element, value_shape)
 
 
 def get_embedding_method_for_checkpointing(element):

--- a/firedrake/external_operators/point_expr_operator.py
+++ b/firedrake/external_operators/point_expr_operator.py
@@ -44,7 +44,7 @@ class PointexprOperator(AbstractExternalOperator):
         if not isinstance(operator_data["func"], types.FunctionType):
             raise TypeError("Expecting a FunctionType pointwise expression")
         expr_shape = operator_data["func"](*operands).ufl_shape
-        if expr_shape != function_space.ufl_element().value_shape(function_space.mesh()):
+        if expr_shape != function_space.value_shape:
             raise ValueError("The dimension does not match with the dimension of the function space %s" % function_space)
 
     @property

--- a/firedrake/external_operators/point_expr_operator.py
+++ b/firedrake/external_operators/point_expr_operator.py
@@ -44,7 +44,7 @@ class PointexprOperator(AbstractExternalOperator):
         if not isinstance(operator_data["func"], types.FunctionType):
             raise TypeError("Expecting a FunctionType pointwise expression")
         expr_shape = operator_data["func"](*operands).ufl_shape
-        if expr_shape != function_space.ufl_element().value_shape:
+        if expr_shape != function_space.ufl_element().value_shape(function_space.mesh()):
             raise ValueError("The dimension does not match with the dimension of the function space %s" % function_space)
 
     @property

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -124,7 +124,7 @@ class ExtractSubBlock(MultiFunction):
                     args += [a_[j] for j in numpy.ndindex(a_.ufl_shape)]
             else:
                 args += [Zero()
-                         for j in numpy.ndindex(V_is[i].block_size)]
+                         for j in numpy.ndindex(V_is[i].value_shape)]
         return self._arg_cache.setdefault(o, as_vector(args))
 
 

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -124,8 +124,7 @@ class ExtractSubBlock(MultiFunction):
                     args += [a_[j] for j in numpy.ndindex(a_.ufl_shape)]
             else:
                 args += [Zero()
-                         for j in numpy.ndindex(
-                         V_is[i].ufl_element().value_shape(V_is[i].mesh()))]
+                         for j in numpy.ndindex(V_is[i].value_shape)]
         return self._arg_cache.setdefault(o, as_vector(args))
 
 

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -124,7 +124,7 @@ class ExtractSubBlock(MultiFunction):
                     args += [a_[j] for j in numpy.ndindex(a_.ufl_shape)]
             else:
                 args += [Zero()
-                         for j in numpy.ndindex(V_is[i].value_shape)]
+                         for j in numpy.ndindex(V_is[i].block_size)]
         return self._arg_cache.setdefault(o, as_vector(args))
 
 

--- a/firedrake/formmanipulation.py
+++ b/firedrake/formmanipulation.py
@@ -125,7 +125,7 @@ class ExtractSubBlock(MultiFunction):
             else:
                 args += [Zero()
                          for j in numpy.ndindex(
-                         V_is[i].ufl_element().value_shape)]
+                         V_is[i].ufl_element().value_shape(V_is[i].mesh()))]
         return self._arg_cache.setdefault(o, as_vector(args))
 
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -633,7 +633,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             raise NotImplementedError("Point evaluation not implemented for variable layers")
 
         # Validate geometric dimension
-        gdim = mesh.ufl_cell().geometric_dimension()
+        gdim = mesh.geometric_dimension()
         if arg.shape[-1] == gdim:
             pass
         elif len(arg.shape) == 1 and gdim == 1:

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -184,7 +184,7 @@ def VectorFunctionSpace(mesh, family, degree=None, dim=None,
     """
     sub_element = make_scalar_element(mesh, family, degree, vfamily, vdegree, variant)
     if dim is None:
-        dim = mesh.ufl_cell().geometric_dimension()
+        dim = mesh.geometric_dimension()
     if not isinstance(dim, numbers.Integral) and dim > 0:
         raise ValueError(f"Can't make VectorFunctionSpace with dim={dim}")
     element = finat.ufl.VectorElement(sub_element, dim=dim)
@@ -237,7 +237,7 @@ def TensorFunctionSpace(mesh, family, degree=None, shape=None,
 
     """
     sub_element = make_scalar_element(mesh, family, degree, vfamily, vdegree, variant)
-    shape = shape or (mesh.ufl_cell().geometric_dimension(),) * 2
+    shape = shape or (mesh.geometric_dimension(),) * 2
     element = finat.ufl.TensorElement(sub_element, shape=shape, symmetry=symmetry)
     return FunctionSpace(mesh, element, name=name)
 

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -176,16 +176,13 @@ class WithGeometryBase(object):
     def _components(self):
         if len(self) == 1:
             return tuple(type(self).create(self.topological.sub(i), self.mesh())
-                         for i in range(self.value_size))
+                         for i in range(numpy.prod(self.shape)))
         else:
             return self.subfunctions
 
     @PETSc.Log.EventDecorator()
     def sub(self, i):
-        if len(self) == 1:
-            bound = self.value_size
-        else:
-            bound = len(self)
+        bound = len(self._components)
         if i < 0 or i >= bound:
             raise IndexError("Invalid component %d, not in [0, %d)" % (i, bound))
         return self._components[i]
@@ -654,7 +651,7 @@ class FunctionSpace(object):
 
     @utils.cached_property
     def _components(self):
-        return tuple(ComponentFunctionSpace(self, i) for i in range(self.value_size))
+        return tuple(ComponentFunctionSpace(self, i) for i in range(numpy.prod(self.shape)))
 
     def sub(self, i):
         r"""Return a view into the ith component."""

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -176,7 +176,7 @@ class WithGeometryBase(object):
     def _components(self):
         if len(self) == 1:
             return tuple(type(self).create(self.topological.sub(i), self.mesh())
-                         for i in range(numpy.prod(self.shape)))
+                         for i in range(self.block_size))
         else:
             return self.subfunctions
 
@@ -494,6 +494,9 @@ class FunctionSpace(object):
         self._ufl_function_space = ufl.FunctionSpace(mesh.ufl_mesh(), element, label=self._label)
         self._mesh = mesh
 
+        self.value_size = self._ufl_function_space.value_size
+        r"""The number of scalar components of this :class:`FunctionSpace`."""
+
         self.rank = len(self.shape)
         r"""The rank of this :class:`FunctionSpace`.  Spaces where the
         element is scalar-valued (or intrinsically vector-valued) have
@@ -502,7 +505,7 @@ class FunctionSpace(object):
         the number of components of their
         :attr:`finat.ufl.finiteelementbase.FiniteElementBase.value_shape`."""
 
-        self.value_size = int(numpy.prod(self.shape, dtype=int))
+        self.block_size = int(numpy.prod(self.shape, dtype=int))
         r"""The total number of degrees of freedom at each function
         space node."""
         self.name = name
@@ -651,7 +654,7 @@ class FunctionSpace(object):
 
     @utils.cached_property
     def _components(self):
-        return tuple(ComponentFunctionSpace(self, i) for i in range(numpy.prod(self.shape)))
+        return tuple(ComponentFunctionSpace(self, i) for i in range(self.block_size))
 
     def sub(self, i):
         r"""Return a view into the ith component."""
@@ -681,7 +684,7 @@ class FunctionSpace(object):
     def dof_count(self):
         r"""The number of degrees of freedom (includes halo dofs) of this
         function space on this process. Cf. :attr:`FunctionSpace.node_count` ."""
-        return self.node_count*self.value_size
+        return self.node_count*self.block_size
 
     def dim(self):
         r"""The global number of degrees of freedom for this function space.
@@ -818,7 +821,7 @@ class FunctionSpace(object):
             else:
                 indices = lgmap.block_indices.copy()
                 bsize = lgmap.getBlockSize()
-                assert bsize == self.value_size
+                assert bsize == self.block_size
         else:
             # MatBlock case, LGMap is already unrolled.
             indices = lgmap.block_indices.copy()
@@ -827,11 +830,11 @@ class FunctionSpace(object):
         nodes = []
         for bc in bcs:
             if bc.function_space().component is not None:
-                nodes.append(bc.nodes * self.value_size
+                nodes.append(bc.nodes * self.block_size
                              + bc.function_space().component)
             elif unblocked:
-                tmp = bc.nodes * self.value_size
-                for i in range(self.value_size):
+                tmp = bc.nodes * self.block_size
+                for i in range(self.block_size):
                     nodes.append(tmp + i)
             else:
                 nodes.append(bc.nodes)
@@ -1299,9 +1302,9 @@ def ComponentFunctionSpace(parent, component):
     """
     element = parent.ufl_element()
     assert type(element) in frozenset([finat.ufl.VectorElement, finat.ufl.TensorElement])
-    if not (0 <= component < parent.value_size):
+    if not (0 <= component < parent.block_size):
         raise IndexError("Invalid component %d. not in [0, %d)" %
-                         (component, parent.value_size))
+                         (component, parent.block_size))
     new = ProxyFunctionSpace(parent.mesh(), element.sub_elements[0], name=parent.name)
     new.identifier = "component"
     new.component = component
@@ -1345,7 +1348,7 @@ class RealFunctionSpace(FunctionSpace):
     def make_dat(self, val=None, valuetype=None, name=None):
         r"""Return a newly allocated :class:`pyop2.types.glob.Global` representing the
         data for a :class:`.Function` on this space."""
-        return op2.Global(self.value_size, val, valuetype, name, self._comm)
+        return op2.Global(self.block_size, val, valuetype, name, self._comm)
 
     def entity_node_map(self, source_mesh, source_integral_type, source_subdomain_id, source_all_integer_subdomain_ids):
         return None

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -489,7 +489,7 @@ class FunctionSpace(object):
             shape_element = element
             if isinstance(element, finat.ufl.WithMapping):
                 shape_element = element.wrapee
-            sub = shape_element.sub_elements[0].value_shape
+            sub = shape_element.sub_elements[0].reference_value_shape
             self.shape = rvs[:len(rvs) - len(sub)]
         else:
             self.shape = ()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -546,8 +546,7 @@ class CrossMeshInterpolator(Interpolator):
                 # For a VectorElement or TensorElement the correct
                 # VectorFunctionSpace equivalent is built from the scalar
                 # sub-element.
-                ufl_scalar_element = ufl_scalar_element.sub_elements[0]
-                if ufl_scalar_element.value_shape(V_dest.mesh()) != ():
+                if V_dest.sub(0).value_shape != ():
                     raise NotImplementedError(
                         "Can't yet cross-mesh interpolate onto function spaces made from VectorElements or TensorElements made from sub elements with value shape other than ()."
                     )
@@ -614,7 +613,7 @@ class CrossMeshInterpolator(Interpolator):
         # I first point evaluate my expression at these locations, giving a
         # P0DG function on the VOM. As described in the manual, this is an
         # interpolation operation.
-        shape = V_dest.ufl_element().value_shape(V_dest.mesh())
+        shape = V_dest.value_shape
         if len(shape) == 0:
             fs_type = firedrake.FunctionSpace
         elif len(shape) == 1:
@@ -988,7 +987,7 @@ def make_interpolator(expr, V, subset, access, bcs=None):
     else:
         # Make sure we have an expression of the right length i.e. a value for
         # each component in the value shape of each function space
-        dims = [numpy.prod(fs.ufl_element().value_shape(fs.mesh()), dtype=int)
+        dims = [numpy.prod(fs.value_shape, dtype=int)
                 for fs in V]
         loops = []
         if numpy.prod(expr.ufl_shape, dtype=int) != sum(dims):
@@ -1024,13 +1023,13 @@ def _interpolator(V, tensor, expr, subset, arguments, access, bcs=None):
     if access is op2.READ:
         raise ValueError("Can't have READ access for output function")
 
-    if len(expr.ufl_shape) != len(V.ufl_element().value_shape(V.mesh())):
+    if len(expr.ufl_shape) != len(V.value_shape):
         raise RuntimeError('Rank mismatch: Expression rank %d, FunctionSpace rank %d'
-                           % (len(expr.ufl_shape), len(V.ufl_element().value_shape(V.mesh()))))
+                           % (len(expr.ufl_shape), len(V.value_shape)))
 
-    if expr.ufl_shape != V.ufl_element().value_shape(V.mesh()):
+    if expr.ufl_shape != V.value_shape:
         raise RuntimeError('Shape mismatch: Expression shape %r, FunctionSpace shape %r'
-                           % (expr.ufl_shape, V.ufl_element().value_shape(V.mesh())))
+                           % (expr.ufl_shape, V.value_shape))
 
     # NOTE: The par_loop is always over the target mesh cells.
     target_mesh = as_domain(V)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -988,18 +988,16 @@ def make_interpolator(expr, V, subset, access, bcs=None):
     else:
         # Make sure we have an expression of the right length i.e. a value for
         # each component in the value shape of each function space
-        dims = [numpy.prod(fs.value_shape, dtype=int)
-                for fs in V]
         loops = []
-        if numpy.prod(expr.ufl_shape, dtype=int) != sum(dims):
+        if numpy.prod(expr.ufl_shape, dtype=int) != V.value_size:
             raise RuntimeError('Expression of length %d required, got length %d'
-                               % (sum(dims), numpy.prod(expr.ufl_shape, dtype=int)))
+                               % (V.value_size, numpy.prod(expr.ufl_shape, dtype=int)))
         if len(V) > 1:
             raise NotImplementedError(
                 "UFL expressions for mixed functions are not yet supported.")
         loops.extend(_interpolator(V, tensor, expr, subset, arguments, access, bcs=bcs))
         if bcs and len(arguments) == 0:
-            loops.extend([partial(bc.apply, f) for bc in bcs])
+            loops.extend(partial(bc.apply, f) for bc in bcs)
 
         def callable(loops, f):
             for l in loops:

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -547,7 +547,7 @@ class CrossMeshInterpolator(Interpolator):
                 # VectorFunctionSpace equivalent is built from the scalar
                 # sub-element.
                 ufl_scalar_element = ufl_scalar_element.sub_elements[0]
-                if ufl_scalar_element.value_shape != ():
+                if ufl_scalar_element.value_shape(V_dest.mesh()) != ():
                     raise NotImplementedError(
                         "Can't yet cross-mesh interpolate onto function spaces made from VectorElements or TensorElements made from sub elements with value shape other than ()."
                     )
@@ -614,7 +614,7 @@ class CrossMeshInterpolator(Interpolator):
         # I first point evaluate my expression at these locations, giving a
         # P0DG function on the VOM. As described in the manual, this is an
         # interpolation operation.
-        shape = V_dest.ufl_element().value_shape
+        shape = V_dest.ufl_element().value_shape(V_dest.mesh())
         if len(shape) == 0:
             fs_type = firedrake.FunctionSpace
         elif len(shape) == 1:
@@ -988,7 +988,7 @@ def make_interpolator(expr, V, subset, access, bcs=None):
     else:
         # Make sure we have an expression of the right length i.e. a value for
         # each component in the value shape of each function space
-        dims = [numpy.prod(fs.ufl_element().value_shape, dtype=int)
+        dims = [numpy.prod(fs.ufl_element().value_shape(fs.mesh()), dtype=int)
                 for fs in V]
         loops = []
         if numpy.prod(expr.ufl_shape, dtype=int) != sum(dims):
@@ -1024,13 +1024,13 @@ def _interpolator(V, tensor, expr, subset, arguments, access, bcs=None):
     if access is op2.READ:
         raise ValueError("Can't have READ access for output function")
 
-    if len(expr.ufl_shape) != len(V.ufl_element().value_shape):
+    if len(expr.ufl_shape) != len(V.ufl_element().value_shape(V.mesh())):
         raise RuntimeError('Rank mismatch: Expression rank %d, FunctionSpace rank %d'
-                           % (len(expr.ufl_shape), len(V.ufl_element().value_shape)))
+                           % (len(expr.ufl_shape), len(V.ufl_element().value_shape(V.mesh()))))
 
-    if expr.ufl_shape != V.ufl_element().value_shape:
+    if expr.ufl_shape != V.ufl_element().value_shape(V.mesh()):
         raise RuntimeError('Shape mismatch: Expression shape %r, FunctionSpace shape %r'
-                           % (expr.ufl_shape, V.ufl_element().value_shape))
+                           % (expr.ufl_shape, V.ufl_element().value_shape(V.mesh())))
 
     # NOTE: The par_loop is always over the target mesh cells.
     target_mesh = as_domain(V)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2920,7 +2920,7 @@ def make_vom_from_vom_topology(topology, name, tolerance=0.5):
     gdim = topology.topology_dm.getCoordinateDim()
     cell = topology.ufl_cell()
     element = finat.ufl.VectorElement("DG", cell, 0, dim=gdim)
-    vmesh = MeshGeometry.__new__(MeshGeometry, element)
+    vmesh = MeshGeometry.__new__(MeshGeometry, element, topology.comm)
     vmesh._init_topology(topology)
     # Save vertex reference coordinate (within reference cell) in function
     parent_tdim = topology._parent_mesh.ufl_cell().topological_dimension()

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -111,7 +111,7 @@ class TransferManager(object):
             # global Vector counting the number of cells that see each
             # dof.
             f = firedrake.Function(V)
-            firedrake.par_loop(("{[i, j]: 0 <= i < A.dofs and 0 <= j < %d}" % V.value_size,
+            firedrake.par_loop(("{[i, j]: 0 <= i < A.dofs and 0 <= j < %d}" % V.block_size,
                                "A[i, j] = A[i, j] + 1"),
                                firedrake.dx,
                                {"A": (f, firedrake.INC)})

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -91,7 +91,7 @@ class TransferManager(object):
 
     def get_cache_key(self, V):
         elem = V.ufl_element()
-        value_shape = elem.value_shape(V.mesh())
+        value_shape = V.value_shape
         return elem, value_shape
 
     def V_dof_weights(self, V):

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -152,7 +152,7 @@ class TransferManager(object):
         :arg DG: the DG space
         :returns: A PETSc Mat mapping from V -> DG.
         """
-        cache = self.cache(DG)
+        cache = self.cache(V)
         key = V.dim()
         try:
             return cache._V_approx_inv_mass[key]

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -46,11 +46,11 @@ def to_reference_coordinates(ufl_coordinate_element, parameters=None):
 
     # Create FInAT element
     element = tsfc.finatinterface.create_element(ufl_coordinate_element)
-
+    gdim, = ufl_coordinate_element.reference_value_shape
     cell = ufl_coordinate_element.cell
 
     code = {
-        "geometric_dimension": cell.geometric_dimension(),
+        "geometric_dimension": gdim,
         "topological_dimension": cell.topological_dimension(),
         "to_reference_coords_newton_step": to_reference_coords_newton_step_body(ufl_coordinate_element, parameters, x0_dtype=ScalarType, dX_dtype="double"),
         "init_X": init_X(element.cell, parameters),
@@ -220,7 +220,7 @@ def prolong_kernel(expression):
         assert hierarchy._meshes[int(idx)].cell_set._extruded
     V = expression.function_space()
     key = (("prolong",)
-           + expression.ufl_element().value_shape
+           + expression.ufl_element().value_shape(meshc)
            + entity_dofs_key(V.finat_element.complex.get_topology())
            + entity_dofs_key(V.finat_element.entity_dofs())
            + entity_dofs_key(coordinates.function_space().finat_element.entity_dofs()))
@@ -302,7 +302,7 @@ def restrict_kernel(Vf, Vc):
     if Vf.extruded:
         assert Vc.extruded
     key = (("restrict",)
-           + Vf.ufl_element().value_shape
+           + Vf.ufl_element().value_shape(Vf.mesh())
            + entity_dofs_key(Vf.finat_element.complex.get_topology())
            + entity_dofs_key(Vc.finat_element.complex.get_topology())
            + entity_dofs_key(Vf.finat_element.entity_dofs())
@@ -390,7 +390,7 @@ def inject_kernel(Vf, Vc):
     else:
         level_ratio = 1
     key = (("inject", level_ratio)
-           + Vf.ufl_element().value_shape
+           + Vf.ufl_element().value_shape(Vf.mesh())
            + entity_dofs_key(Vc.finat_element.complex.get_topology())
            + entity_dofs_key(Vf.finat_element.complex.get_topology())
            + entity_dofs_key(Vc.finat_element.entity_dofs())

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -283,7 +283,7 @@ def prolong_kernel(expression):
                "evaluate": eval_code,
                "spacedim": element.cell.get_spatial_dimension(),
                "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
-               "Rdim": numpy.prod(V.value_shape),
+               "Rdim": V.value_size,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
                "Xc_cell_inc": coords_element.space_dimension(),

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -177,11 +177,10 @@ def compile_element(expression, dual_space=None, parameters=None,
         return_variable = gem.Indexed(gem.Variable('R', finat_elem.index_shape), argument_multiindex)
         result = gem.Indexed(result, tensor_indices)
         if dual_space:
-            elem = create_element(dual_space.ufl_element())
-            if elem.value_shape:
-                var = gem.Indexed(gem.Variable("b", elem.value_shape),
-                                  tensor_indices)
-                b_arg = [lp.GlobalArg("b", dtype=ScalarType, shape=elem.value_shape)]
+            value_shape = dual_space.value_shape
+            if value_shape:
+                var = gem.Indexed(gem.Variable("b", value_shape), tensor_indices)
+                b_arg = [lp.GlobalArg("b", dtype=ScalarType, shape=value_shape)]
             else:
                 var = gem.Indexed(gem.Variable("b", (1, )), (0, ))
                 b_arg = [lp.GlobalArg("b", dtype=ScalarType, shape=(1,))]
@@ -220,7 +219,7 @@ def prolong_kernel(expression):
         assert hierarchy._meshes[int(idx)].cell_set._extruded
     V = expression.function_space()
     key = (("prolong",)
-           + expression.ufl_element().value_shape(meshc)
+           + V.value_shape
            + entity_dofs_key(V.finat_element.complex.get_topology())
            + entity_dofs_key(V.finat_element.entity_dofs())
            + entity_dofs_key(coordinates.function_space().finat_element.entity_dofs()))
@@ -284,7 +283,7 @@ def prolong_kernel(expression):
                "evaluate": eval_code,
                "spacedim": element.cell.get_spatial_dimension(),
                "ncandidate": hierarchy.fine_to_coarse_cells[levelf].shape[1],
-               "Rdim": numpy.prod(element.value_shape),
+               "Rdim": numpy.prod(V.value_shape),
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
                "Xc_cell_inc": coords_element.space_dimension(),
@@ -302,7 +301,7 @@ def restrict_kernel(Vf, Vc):
     if Vf.extruded:
         assert Vc.extruded
     key = (("restrict",)
-           + Vf.ufl_element().value_shape(Vf.mesh())
+           + Vf.value_shape
            + entity_dofs_key(Vf.finat_element.complex.get_topology())
            + entity_dofs_key(Vc.finat_element.complex.get_topology())
            + entity_dofs_key(Vf.finat_element.entity_dofs())
@@ -390,7 +389,7 @@ def inject_kernel(Vf, Vc):
     else:
         level_ratio = 1
     key = (("inject", level_ratio)
-           + Vf.ufl_element().value_shape(Vf.mesh())
+           + Vf.value_shape
            + entity_dofs_key(Vc.finat_element.complex.get_topology())
            + entity_dofs_key(Vf.finat_element.complex.get_topology())
            + entity_dofs_key(Vc.finat_element.entity_dofs())
@@ -465,7 +464,7 @@ def inject_kernel(Vf, Vc):
             "celldist_l1_c_expr": celldist_l1_c_expr(Vc.finat_element.cell, X="Xref"),
             "tdim": Vc.mesh().topological_dimension(),
             "ncandidate": ncandidate,
-            "Rdim": numpy.prod(Vf_element.value_shape),
+            "Rdim": numpy.prod(Vf.value_shape),
             "Xf_cell_inc": coords_element.space_dimension(),
             "f_cell_inc": Vf_element.space_dimension()
         }

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -173,7 +173,7 @@ def MeshHierarchy(mesh, refinement_levels,
             scale = mesh._radius / np.linalg.norm(coords, axis=1).reshape(-1, 1)
             coords *= scale
 
-    meshes = [mesh] + [mesh_builder(dm, dim=mesh.ufl_cell().geometric_dimension(),
+    meshes = [mesh] + [mesh_builder(dm, dim=mesh.geometric_dimension(),
                                     distribution_parameters=distribution_parameters,
                                     reorder=reorder, comm=mesh.comm)
                        for dm in dms]

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -135,7 +135,7 @@ def coarse_cell_to_fine_node_map(Vc, Vf):
 
 def physical_node_locations(V):
     element = V.ufl_element()
-    if element.value_shape:
+    if element.value_shape(V.mesh()):
         assert isinstance(element, (finat.ufl.VectorElement, finat.ufl.TensorElement))
         element = element.sub_elements[0]
     mesh = V.mesh()

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -135,7 +135,7 @@ def coarse_cell_to_fine_node_map(Vc, Vf):
 
 def physical_node_locations(V):
     element = V.ufl_element()
-    if element.value_shape(V.mesh()):
+    if V.value_shape:
         assert isinstance(element, (finat.ufl.VectorElement, finat.ufl.TensorElement))
         element = element.sub_elements[0]
     mesh = V.mesh()

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -146,7 +146,7 @@ def physical_node_locations(V):
     try:
         return cache[key]
     except KeyError:
-        Vc = firedrake.FunctionSpace(mesh, finat.ufl.VectorElement(element))
+        Vc = firedrake.VectorFunctionSpace(mesh, element)
         # FIXME: This is unsafe for DG coordinates and CG target spaces.
         locations = firedrake.assemble(firedrake.Interpolate(firedrake.SpatialCoordinate(mesh), Vc))
         return cache.setdefault(key, locations)

--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -116,7 +116,7 @@ def compile_element(expression, coordinates, parameters=None):
     extruded = isinstance(cell, TensorProductCell)
 
     code = {
-        "geometric_dimension": cell.geometric_dimension(),
+        "geometric_dimension": domain.geometric_dimension(),
         "layers_arg": ", int const *__restrict__ layers" if extruded else "",
         "layers": ", layers" if extruded else "",
         "extruded_define": "1" if extruded else "0",

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -7,6 +7,7 @@ import loopy as lp
 from pyop2 import op2
 from pyop2.parloop import generate_single_cell_wrapper
 
+from firedrake.mesh import MeshGeometry
 from firedrake.petsc import PETSc
 from firedrake.utils import IntType, as_cstr, ScalarType, ScalarType_c, complex_mode, RealType_c
 
@@ -193,16 +194,18 @@ def to_reference_coords_newton_step(ufl_coordinate_element, parameters, x0_dtype
 
 
 @PETSc.Log.EventDecorator()
-def compile_coordinate_element(mesh, contains_eps, parameters=None):
+def compile_coordinate_element(mesh: MeshGeometry, contains_eps: float, parameters: dict | None = None):
     """Generates C code for changing to reference coordinates.
 
     Parameters
     ----------
-    mesh : MeshTopology
+    mesh :
         The mesh.
 
-    contains_eps : float
+    contains_eps :
         The tolerance used to verify that a point is contained by a cell.
+    parameters :
+        Form compiler parameters, defaults to whatever TSFC defaults to.
 
     Returns
     -------

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -206,12 +206,12 @@ def compile_coordinate_element(ufl_coordinate_element, contains_eps, parameters=
         parameters = _
     # Create FInAT element
     element = tsfc.finatinterface.create_element(ufl_coordinate_element)
-
+    gdim, = ufl_coordinate_element.reference_value_shape
     cell = ufl_coordinate_element.cell
     extruded = isinstance(cell, ufl.TensorProductCell)
 
     code = {
-        "geometric_dimension": cell.geometric_dimension(),
+        "geometric_dimension": gdim,
         "topological_dimension": cell.topological_dimension(),
         "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, "X"),
         "to_reference_coords_newton_step": to_reference_coords_newton_step(ufl_coordinate_element, parameters),

--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -81,8 +81,8 @@ class ASMPatchPC(PCBase):
             tinyasm.SetASMLocalSubdomains(
                 asmpc, ises,
                 [W.dm.getDefaultSF() for W in V],
-                [W.value_size for W in V],
-                sum(W.value_size * W.dof_dset.total_size for W in V))
+                [W.block_size for W in V],
+                sum(W.block_size * W.dof_dset.total_size for W in V))
             asmpc.setUp()
         else:
             raise ValueError(f"Unknown backend type {backend}")
@@ -168,7 +168,7 @@ class ASMStarPC(ASMPatchPC):
                         continue
                     off = section.getOffset(p)
                     # Local indices within W
-                    W_indices = slice(off*W.value_size, W.value_size * (off + dof))
+                    W_indices = slice(off*W.block_size, W.block_size * (off + dof))
                     indices.extend(V_local_ises_indices[i][W_indices])
             iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
             ises.append(iset)
@@ -247,7 +247,7 @@ class ASMVankaPC(ASMPatchPC):
                         continue
                     off = section.getOffset(p)
                     # Local indices within W
-                    W_indices = slice(off*W.value_size, W.value_size * (off + dof))
+                    W_indices = slice(off*W.block_size, W.block_size * (off + dof))
                     indices.extend(V_local_ises_indices[i][W_indices])
             iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
             ises.append(iset)
@@ -296,7 +296,7 @@ class ASMLinesmoothPC(ASMPatchPC):
                 if dof <= 0:
                     continue
                 off = section.getOffset(p)
-                indices = numpy.arange(off*V.value_size, V.value_size * (off + dof), dtype=IntType)
+                indices = numpy.arange(off*V.block_size, V.block_size * (off + dof), dtype=IntType)
                 iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)
                 ises.append(iset)
 
@@ -471,7 +471,7 @@ class ASMExtrudedStarPC(ASMStarPC):
                                 else:
                                     begin = off + min(k, k+plane) * blayer_offset + dof
                                     end = off + max(k, k+plane) * blayer_offset
-                                zlice = slice(W.value_size * begin, W.value_size * end)
+                                zlice = slice(W.block_size * begin, W.block_size * end)
                                 indices.extend(iset[zlice])
 
                     iset = PETSc.IS().createGeneral(indices, comm=PETSc.COMM_SELF)

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -258,7 +258,7 @@ def get_restriction_indices(V, W):
         eperm = numpy.concatenate((eperm, numpy.setdiff1d(numpy.arange(vsize, dtype=PETSc.IntType), eperm)))
     pmap = PermutedMap(V.cell_node_map(), eperm)
 
-    wsize = sum(Vsub.finat_element.space_dimension() * Vsub.value_size for Vsub in W)
+    wsize = sum(Vsub.finat_element.space_dimension() * Vsub.block_size for Vsub in W)
     kernel_code = f"""
     void copy(PetscInt *restrict w, const PetscInt *restrict v) {{
         for (PetscInt i=0; i<{wsize}; i++) w[i] = v[i];

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -150,9 +150,9 @@ class HiptmairPC(TwoLevelPC):
         element = V.ufl_element()
         formdegree = V.finat_element.formdegree
         if formdegree == 1:
-            celement = curl_to_grad(element)
+            celement = curl_to_grad(element, mesh)
         elif formdegree == 2:
-            celement = div_to_curl(element)
+            celement = div_to_curl(element, mesh)
         else:
             raise ValueError("Hiptmair decomposition not available for", element)
 
@@ -211,15 +211,15 @@ class HiptmairPC(TwoLevelPC):
         return coarse_operator, coarse_space_bcs, interp_petscmat
 
 
-def curl_to_grad(ele):
+def curl_to_grad(ele, mesh):
     if isinstance(ele, finat.ufl.VectorElement):
-        return type(ele)(curl_to_grad(ele._sub_element), dim=ele.num_sub_elements)
+        return type(ele)(curl_to_grad(ele._sub_element, mesh), dim=ele.num_sub_elements)
     elif isinstance(ele, finat.ufl.TensorElement):
-        return type(ele)(curl_to_grad(ele._sub_element), shape=ele.value_shape, symmetry=ele.symmetry())
+        return type(ele)(curl_to_grad(ele._sub_element, mesh), shape=ele.value_shape(mesh), symmetry=ele.symmetry())
     elif isinstance(ele, finat.ufl.MixedElement):
-        return type(ele)(*(curl_to_grad(e) for e in ele.sub_elements))
+        return type(ele)(*(curl_to_grad(e, mesh) for e in ele.sub_elements))
     elif isinstance(ele, finat.ufl.RestrictedElement):
-        return finat.ufl.RestrictedElement(curl_to_grad(ele._element), ele.restriction_domain())
+        return finat.ufl.RestrictedElement(curl_to_grad(ele._element, mesh), ele.restriction_domain())
     else:
         cell = ele.cell
         family = ele.family()
@@ -238,25 +238,25 @@ def curl_to_grad(ele):
         return finat.ufl.FiniteElement(family, cell=cell, degree=degree, variant=variant)
 
 
-def div_to_curl(ele):
+def div_to_curl(ele, mesh):
     if isinstance(ele, finat.ufl.VectorElement):
-        return type(ele)(div_to_curl(ele._sub_element), dim=ele.num_sub_elements)
+        return type(ele)(div_to_curl(ele._sub_element, mesh), dim=ele.num_sub_elements)
     elif isinstance(ele, finat.ufl.TensorElement):
-        return type(ele)(div_to_curl(ele._sub_element), shape=ele.value_shape, symmetry=ele.symmetry())
+        return type(ele)(div_to_curl(ele._sub_element, mesh), shape=ele.value_shape(mesh), symmetry=ele.symmetry())
     elif isinstance(ele, finat.ufl.MixedElement):
-        return type(ele)(*(div_to_curl(e) for e in ele.sub_elements))
+        return type(ele)(*(div_to_curl(e, mesh) for e in ele.sub_elements))
     elif isinstance(ele, finat.ufl.RestrictedElement):
-        return finat.ufl.RestrictedElement(div_to_curl(ele._element), ele.restriction_domain())
+        return finat.ufl.RestrictedElement(div_to_curl(ele._element, mesh), ele.restriction_domain())
     elif isinstance(ele, finat.ufl.EnrichedElement):
-        return type(ele)(*(div_to_curl(e) for e in reversed(ele._elements)))
+        return type(ele)(*(div_to_curl(e, mesh) for e in reversed(ele._elements)))
     elif isinstance(ele, finat.ufl.TensorProductElement):
-        return type(ele)(*(div_to_curl(e) for e in ele.sub_elements), cell=ele.cell)
+        return type(ele)(*(div_to_curl(e, mesh) for e in ele.sub_elements), cell=ele.cell)
     elif isinstance(ele, finat.ufl.WithMapping):
-        return type(ele)(div_to_curl(ele.wrapee), ele.mapping())
+        return type(ele)(div_to_curl(ele.wrapee, mesh), ele.mapping())
     elif isinstance(ele, finat.ufl.BrokenElement):
-        return type(ele)(div_to_curl(ele._element))
+        return type(ele)(div_to_curl(ele._element, mesh))
     elif isinstance(ele, finat.ufl.HDivElement):
-        return finat.ufl.HCurlElement(div_to_curl(ele._element))
+        return finat.ufl.HCurlElement(div_to_curl(ele._element, mesh))
     elif isinstance(ele, finat.ufl.HCurlElement):
         raise ValueError("Expecting an H(div) element")
     else:

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -150,9 +150,9 @@ class HiptmairPC(TwoLevelPC):
         element = V.ufl_element()
         formdegree = V.finat_element.formdegree
         if formdegree == 1:
-            celement = curl_to_grad(element, mesh)
+            celement = curl_to_grad(element)
         elif formdegree == 2:
-            celement = div_to_curl(element, mesh)
+            celement = div_to_curl(element)
         else:
             raise ValueError("Hiptmair decomposition not available for", element)
 
@@ -211,15 +211,15 @@ class HiptmairPC(TwoLevelPC):
         return coarse_operator, coarse_space_bcs, interp_petscmat
 
 
-def curl_to_grad(ele, mesh):
+def curl_to_grad(ele):
     if isinstance(ele, finat.ufl.VectorElement):
-        return type(ele)(curl_to_grad(ele._sub_element, mesh), dim=ele.num_sub_elements)
+        return type(ele)(curl_to_grad(ele._sub_element), dim=ele.num_sub_elements)
     elif isinstance(ele, finat.ufl.TensorElement):
-        return type(ele)(curl_to_grad(ele._sub_element, mesh), shape=ele.value_shape(mesh), symmetry=ele.symmetry())
+        return type(ele)(curl_to_grad(ele._sub_element), shape=ele._shape, symmetry=ele.symmetry())
     elif isinstance(ele, finat.ufl.MixedElement):
-        return type(ele)(*(curl_to_grad(e, mesh) for e in ele.sub_elements))
+        return type(ele)(*(curl_to_grad(e) for e in ele.sub_elements))
     elif isinstance(ele, finat.ufl.RestrictedElement):
-        return finat.ufl.RestrictedElement(curl_to_grad(ele._element, mesh), ele.restriction_domain())
+        return finat.ufl.RestrictedElement(curl_to_grad(ele._element), ele.restriction_domain())
     else:
         cell = ele.cell
         family = ele.family()
@@ -238,25 +238,25 @@ def curl_to_grad(ele, mesh):
         return finat.ufl.FiniteElement(family, cell=cell, degree=degree, variant=variant)
 
 
-def div_to_curl(ele, mesh):
+def div_to_curl(ele):
     if isinstance(ele, finat.ufl.VectorElement):
-        return type(ele)(div_to_curl(ele._sub_element, mesh), dim=ele.num_sub_elements)
+        return type(ele)(div_to_curl(ele._sub_element), dim=ele.num_sub_elements)
     elif isinstance(ele, finat.ufl.TensorElement):
-        return type(ele)(div_to_curl(ele._sub_element, mesh), shape=ele.value_shape(mesh), symmetry=ele.symmetry())
+        return type(ele)(div_to_curl(ele._sub_element), shape=ele._shape, symmetry=ele.symmetry())
     elif isinstance(ele, finat.ufl.MixedElement):
-        return type(ele)(*(div_to_curl(e, mesh) for e in ele.sub_elements))
+        return type(ele)(*(div_to_curl(e) for e in ele.sub_elements))
     elif isinstance(ele, finat.ufl.RestrictedElement):
-        return finat.ufl.RestrictedElement(div_to_curl(ele._element, mesh), ele.restriction_domain())
+        return finat.ufl.RestrictedElement(div_to_curl(ele._element), ele.restriction_domain())
     elif isinstance(ele, finat.ufl.EnrichedElement):
-        return type(ele)(*(div_to_curl(e, mesh) for e in reversed(ele._elements)))
+        return type(ele)(*(div_to_curl(e) for e in reversed(ele._elements)))
     elif isinstance(ele, finat.ufl.TensorProductElement):
-        return type(ele)(*(div_to_curl(e, mesh) for e in ele.sub_elements), cell=ele.cell)
+        return type(ele)(*(div_to_curl(e) for e in ele.sub_elements), cell=ele.cell)
     elif isinstance(ele, finat.ufl.WithMapping):
-        return type(ele)(div_to_curl(ele.wrapee, mesh), ele.mapping())
+        return type(ele)(div_to_curl(ele.wrapee), ele.mapping())
     elif isinstance(ele, finat.ufl.BrokenElement):
-        return type(ele)(div_to_curl(ele._element, mesh))
+        return type(ele)(div_to_curl(ele._element))
     elif isinstance(ele, finat.ufl.HDivElement):
-        return finat.ufl.HCurlElement(div_to_curl(ele._element, mesh))
+        return finat.ufl.HCurlElement(div_to_curl(ele._element))
     elif isinstance(ele, finat.ufl.HCurlElement):
         raise ValueError("Expecting an H(div) element")
     else:

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -585,18 +585,18 @@ def bcdofs(bc, ghost=True):
             if ghost:
                 offset += sum(Z.sub(j).dof_count for j in range(idx))
             else:
-                offset += sum(Z.sub(j).dof_dset.size * Z.sub(j).value_size for j in range(idx))
+                offset += sum(Z.sub(j).dof_dset.size * Z.sub(j).block_size for j in range(idx))
         else:
             raise NotImplementedError("How are you taking a .sub?")
 
         Z = Z.sub(idx)
 
     if Z.parent is not None and isinstance(Z.parent.ufl_element(), VectorElement):
-        bs = Z.parent.value_size
+        bs = Z.parent.block_size
         start = 0
         stop = 1
     else:
-        bs = Z.value_size
+        bs = Z.block_size
         start = 0
         stop = bs
     nodes = bc.nodes
@@ -868,7 +868,7 @@ class PatchBase(PCSNESBase):
         offsets = numpy.append([0], numpy.cumsum([W.dof_count
                                                   for W in V])).astype(PETSc.IntType)
         patch.setPatchDiscretisationInfo([W.dm for W in V],
-                                         numpy.array([W.value_size for
+                                         numpy.array([W.block_size for
                                                       W in V], dtype=PETSc.IntType),
                                          [W.cell_node_list for W in V],
                                          offsets,

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -580,7 +580,7 @@ def bcdofs(bc, ghost=True):
         if isinstance(Z.ufl_element(), VectorElement):
             offset += idx
             assert i == len(indices)-1  # assert we're at the end of the chain
-            assert Z.sub(idx).value_size == 1
+            assert Z.sub(idx).block_size == 1
         elif isinstance(Z.ufl_element(), MixedElement):
             if ghost:
                 offset += sum(Z.sub(j).dof_count for j in range(idx))

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -132,7 +132,7 @@ class PMGBase(PCSNESBase):
         while True:
             try:
                 ele_ = self.coarsen_element(ele)
-                assert ele_.value_shape == ele.value_shape
+                assert ele_.value_shape(V.mesh()) == ele.value_shape(V.mesh())
                 ele = ele_
             except ValueError:
                 break
@@ -1098,7 +1098,7 @@ def make_mapping_code(Q, cmapping, fmapping, t_in, t_out):
     if B:
         tensor = ufl.dot(B, tensor) if tensor else B
     if tensor is None:
-        tensor = ufl.Identity(Q.ufl_element().value_shape[0])
+        tensor = ufl.Identity(Q.ufl_element().value_shape(Q.mesh())[0])
 
     u = ufl.Coefficient(Q)
     expr = ufl.dot(tensor, u)
@@ -1347,8 +1347,8 @@ class StandaloneInterpolationMatrix(object):
                 in_place_mapping = True
             except Exception:
                 qelem = finat.ufl.FiniteElement("DQ", cell=felem.cell, degree=PMGBase.max_degree(felem))
-                if felem.value_shape:
-                    qelem = finat.ufl.TensorElement(qelem, shape=felem.value_shape, symmetry=felem.symmetry())
+                if felem.value_shape(Vf.mesh()):
+                    qelem = finat.ufl.TensorElement(qelem, shape=felem.value_shape(Vf.mesh()), symmetry=felem.symmetry())
                 Qf = firedrake.FunctionSpace(Vf.mesh(), qelem)
                 mapping_output = make_mapping_code(Qf, cmapping, fmapping, "t0", "t1")
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -904,19 +904,19 @@ def make_kron_code(Vc, Vf, t_in, t_out, mat_name, scratch):
     shifts = fshifts
     in_place = False
     if len(felems) == len(celems):
-        in_place = all((len(fs)*Vf.value_size == len(cs)*Vc.value_size) for fs, cs in zip(fshifts, cshifts))
-        psize = Vf.value_size
+        in_place = all((len(fs)*Vf.block_size == len(cs)*Vc.block_size) for fs, cs in zip(fshifts, cshifts))
+        psize = Vf.block_size
 
     if not in_place:
         if len(celems) == 1:
-            psize = Vc.value_size
+            psize = Vc.block_size
             pelem = celems[0]
             perm_name = "perm_%s" % t_in
             celems = celems*len(felems)
 
         elif len(felems) == 1:
             shifts = cshifts
-            psize = Vf.value_size
+            psize = Vf.block_size
             pelem = felems[0]
             perm_name = "perm_%s" % t_out
             felems = felems*len(celems)
@@ -924,7 +924,7 @@ def make_kron_code(Vc, Vf, t_in, t_out, mat_name, scratch):
             raise ValueError("Cannot assign fine to coarse DOFs")
 
         if set(cshifts) == set(fshifts):
-            csize = Vc.value_size * Vc.finat_element.space_dimension()
+            csize = Vc.block_size * Vc.finat_element.space_dimension()
             prolong_code.append(f"""
             for({IntType_c} j=1; j<{len(fshifts)}; j++)
                 for({IntType_c} i=0; i<{csize}; i++)
@@ -938,8 +938,8 @@ def make_kron_code(Vc, Vf, t_in, t_out, mat_name, scratch):
 
         elif pelem == celems[0]:
             for k in range(len(shifts)):
-                if Vc.value_size*len(shifts[k]) < Vf.value_size:
-                    shifts[k] = shifts[k]*(Vf.value_size//Vc.value_size)
+                if Vc.block_size*len(shifts[k]) < Vf.block_size:
+                    shifts[k] = shifts[k]*(Vf.block_size//Vc.block_size)
 
             pshape = [e.space_dimension() for e in pelem]
             pargs = ", ".join(map(str, pshape+[1]*(3-len(pshape))))
@@ -1115,7 +1115,7 @@ def make_mapping_code(Q, cmapping, fmapping, t_in, t_out):
 
     coef_args = "".join([", c%d" % i for i in range(len(coefficients))])
     coef_decl = "".join([", PetscScalar const *restrict c%d" % i for i in range(len(coefficients))])
-    qlen = Q.value_size * Q.finat_element.space_dimension()
+    qlen = Q.block_size * Q.finat_element.space_dimension()
     prolong_code = f"""
             for({IntType_c} i=0; i<{qlen}; i++) {t_out}[i] = 0.0E0;
 
@@ -1221,7 +1221,7 @@ class StandaloneInterpolationMatrix(object):
     @cached_property
     def _weight(self):
         weight = firedrake.Function(self.Vf)
-        size = self.Vf.finat_element.space_dimension() * self.Vf.value_size
+        size = self.Vf.finat_element.space_dimension() * self.Vf.block_size
         kernel_code = f"""
         void weight(PetscScalar *restrict w){{
             for(PetscInt i=0; i<{size}; i++) w[i] += 1.0;
@@ -1350,7 +1350,7 @@ class StandaloneInterpolationMatrix(object):
                 Qf = firedrake.FunctionSpace(Vf.mesh(), qelem)
                 mapping_output = make_mapping_code(Qf, cmapping, fmapping, "t0", "t1")
 
-            qshape = (Qf.value_size, Qf.finat_element.space_dimension())
+            qshape = (Qf.block_size, Qf.finat_element.space_dimension())
             # interpolate to embedding fine space
             decl[0], prolong[0], restrict[0], shapes = make_kron_code(Vc, Qf, "t0", "t1", "J0", "t2")
 
@@ -1375,8 +1375,8 @@ class StandaloneInterpolationMatrix(object):
         # We could benefit from loop tiling for the transpose, but that makes the code
         # more complicated.
 
-        fshape = (Vf.value_size, Vf.finat_element.space_dimension())
-        cshape = (Vc.value_size, Vc.finat_element.space_dimension())
+        fshape = (numpy.prod(Vf.shape), Vf.finat_element.space_dimension())
+        cshape = (numpy.prod(Vc.shape), Vc.finat_element.space_dimension())
 
         lwork = numpy.prod([max(*dims) for dims in zip(*shapes)])
         lwork = max(lwork, max(numpy.prod(fshape), numpy.prod(cshape)))
@@ -1468,8 +1468,8 @@ class StandaloneInterpolationMatrix(object):
         element_kernel = element_kernel.replace("void expression_kernel", "static void expression_kernel")
         coef_args = "".join([", c%d" % i for i in range(len(coefficients))])
         coef_decl = "".join([", const %s *restrict c%d" % (ScalarType_c, i) for i in range(len(coefficients))])
-        dimc = Vc.finat_element.space_dimension() * Vc.value_size
-        dimf = Vf.finat_element.space_dimension() * Vf.value_size
+        dimc = Vc.finat_element.space_dimension() * Vc.block_size
+        dimf = Vf.finat_element.space_dimension() * Vf.block_size
         restrict_code = f"""
         {element_kernel}
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1375,8 +1375,8 @@ class StandaloneInterpolationMatrix(object):
         # We could benefit from loop tiling for the transpose, but that makes the code
         # more complicated.
 
-        fshape = (numpy.prod(Vf.shape), Vf.finat_element.space_dimension())
-        cshape = (numpy.prod(Vc.shape), Vc.finat_element.space_dimension())
+        fshape = (Vf.block_size, Vf.finat_element.space_dimension())
+        cshape = (Vc.block_size, Vc.finat_element.space_dimension())
 
         lwork = numpy.prod([max(*dims) for dims in zip(*shapes)])
         lwork = max(lwork, max(numpy.prod(fshape), numpy.prod(cshape)))

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -131,9 +131,7 @@ class PMGBase(PCSNESBase):
         elements = [ele]
         while True:
             try:
-                ele_ = self.coarsen_element(ele)
-                assert ele_.value_shape(V.mesh()) == ele.value_shape(V.mesh())
-                ele = ele_
+                ele = self.coarsen_element(ele)
             except ValueError:
                 break
             elements.append(ele)
@@ -1098,7 +1096,7 @@ def make_mapping_code(Q, cmapping, fmapping, t_in, t_out):
     if B:
         tensor = ufl.dot(B, tensor) if tensor else B
     if tensor is None:
-        tensor = ufl.Identity(Q.ufl_element().value_shape(Q.mesh())[0])
+        tensor = ufl.Identity(Q.value_shape[0])
 
     u = ufl.Coefficient(Q)
     expr = ufl.dot(tensor, u)
@@ -1347,8 +1345,8 @@ class StandaloneInterpolationMatrix(object):
                 in_place_mapping = True
             except Exception:
                 qelem = finat.ufl.FiniteElement("DQ", cell=felem.cell, degree=PMGBase.max_degree(felem))
-                if felem.value_shape(Vf.mesh()):
-                    qelem = finat.ufl.TensorElement(qelem, shape=felem.value_shape(Vf.mesh()), symmetry=felem.symmetry())
+                if Vf.value_shape:
+                    qelem = finat.ufl.TensorElement(qelem, shape=Vf.value_shape, symmetry=felem.symmetry())
                 Qf = firedrake.FunctionSpace(Vf.mesh(), qelem)
                 mapping_output = make_mapping_code(Qf, cmapping, fmapping, "t0", "t1")
 

--- a/firedrake/progress_bar.py
+++ b/firedrake/progress_bar.py
@@ -11,7 +11,7 @@ class _NullProgressBar:
     def __enter__(self):
         pass
 
-    def __exit__(self):
+    def __exit__(self, *args, **kwargs):
         pass
 
     def iter(self, iterator):

--- a/firedrake/pyplot/pgf.py
+++ b/firedrake/pyplot/pgf.py
@@ -217,12 +217,12 @@ def pgfplot(f, filename, degree=1, complex_component='real', print_latex_example
         raise NotImplementedError(f"Not yet implemented for functions in spatial dimension {dim}")
     if mesh.extruded:
         raise NotImplementedError("Not yet implemented for functions on extruded meshes")
-    if elem.value_shape():
+    if elem.value_shape(mesh):
         raise NotImplementedError("Currently only implemeted for scalar functions")
-    coordelem = get_embedding_dg_element(mesh.coordinates.function_space().ufl_element()).reconstruct(degree=degree, variant="equispaced")
+    coordelem = get_embedding_dg_element(mesh.coordinates.function_space().ufl_element(), (dim, )).reconstruct(degree=degree, variant="equispaced")
     coordV = FunctionSpace(mesh, coordelem)
     coords = Function(coordV).interpolate(SpatialCoordinate(mesh))
-    elemdg = get_embedding_dg_element(elem).reconstruct(degree=degree, variant="equispaced")
+    elemdg = get_embedding_dg_element(elem, elem.value_shape(mesh)).reconstruct(degree=degree, variant="equispaced")
     Vdg = FunctionSpace(mesh, elemdg)
     fdg = Function(Vdg)
     method = get_embedding_method_for_checkpointing(elem)

--- a/firedrake/pyplot/pgf.py
+++ b/firedrake/pyplot/pgf.py
@@ -217,12 +217,12 @@ def pgfplot(f, filename, degree=1, complex_component='real', print_latex_example
         raise NotImplementedError(f"Not yet implemented for functions in spatial dimension {dim}")
     if mesh.extruded:
         raise NotImplementedError("Not yet implemented for functions on extruded meshes")
-    if elem.value_shape(mesh):
+    if V.value_shape:
         raise NotImplementedError("Currently only implemeted for scalar functions")
     coordelem = get_embedding_dg_element(mesh.coordinates.function_space().ufl_element(), (dim, )).reconstruct(degree=degree, variant="equispaced")
     coordV = FunctionSpace(mesh, coordelem)
     coords = Function(coordV).interpolate(SpatialCoordinate(mesh))
-    elemdg = get_embedding_dg_element(elem, elem.value_shape(mesh)).reconstruct(degree=degree, variant="equispaced")
+    elemdg = get_embedding_dg_element(elem, V.value_shape).reconstruct(degree=degree, variant="equispaced")
     Vdg = FunctionSpace(mesh, elemdg)
     fdg = Function(Vdg)
     method = get_embedding_method_for_checkpointing(elem)

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -82,7 +82,8 @@ def _compile_expression_hashkey(slate_expr, compiler_parameters=None):
 
 def _compile_expression_comm(*args, **kwargs):
     # args[0] is a slate_expr
-    return args[0].ufl_domains()[0].comm
+    domain, = args[0].ufl_domains()
+    return domain.comm
 
 
 @memory_and_disk_cache(

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -247,11 +247,11 @@ class TensorBase(object, metaclass=ABCMeta):
 
         The function will fail if multiple domains are found.
         """
-        domains = self.ufl_domains()
-        assert all(domain == domains[0] for domain in domains), (
-            "All integrals must share the same domain of integration."
-        )
-        return domains[0]
+        try:
+            domain, = self.ufl_domains()
+        except ValueError:
+            raise ValueError("All integrals must share the same domain of integration.")
+        return domain
 
     @abstractmethod
     def ufl_domains(self):

--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -31,7 +31,7 @@ from pyop2.utils import as_tuple
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.corealg.multifunction import MultiFunction
 from ufl.classes import Zero
-from ufl.domain import join_domains
+from ufl.domain import join_domains, sort_domains
 from ufl.form import Form
 import hashlib
 
@@ -983,7 +983,7 @@ class TensorOp(TensorBase):
         the tensor.
         """
         collected_domains = [op.ufl_domains() for op in self.operands]
-        return join_domains(chain(*collected_domains))
+        return sort_domains(join_domains(chain(*collected_domains)))
 
     def subdomain_data(self):
         """Returns a mapping on the tensor:

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -61,7 +61,7 @@ class HybridizationPC(SCBase):
         if len(V) != 2:
             raise ValueError("Expecting two function spaces.")
 
-        if all(Vi.ufl_element().value_shape(Vi.mesh()) for Vi in V):
+        if all(Vi.value_shape for Vi in V):
             raise ValueError("Expecting an H(div) x L2 pair of spaces.")
 
         # Automagically determine which spaces are vector and scalar

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -61,7 +61,7 @@ class HybridizationPC(SCBase):
         if len(V) != 2:
             raise ValueError("Expecting two function spaces.")
 
-        if all(Vi.ufl_element().value_shape for Vi in V):
+        if all(Vi.ufl_element().value_shape(Vi.mesh()) for Vi in V):
             raise ValueError("Expecting an H(div) x L2 pair of spaces.")
 
         # Automagically determine which spaces are vector and scalar

--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -76,7 +76,8 @@ class Argument(ufl.argument.Argument):
             return self
         if not isinstance(number, int):
             raise TypeError(f"Expecting an int, not {number}")
-        if function_space.ufl_element().value_shape != self.ufl_element().value_shape:
+        mesh = self.function_space().mesh()
+        if function_space.ufl_element().value_shape(mesh) != self.ufl_element().value_shape(mesh):
             raise ValueError("Cannot reconstruct an Argument with a different value shape.")
         return Argument(function_space, number, part=part)
 
@@ -140,7 +141,8 @@ class Coargument(ufl.argument.Coargument):
             return self
         if not isinstance(number, int):
             raise TypeError(f"Expecting an int, not {number}")
-        if function_space.ufl_element().value_shape != self.ufl_element().value_shape:
+        mesh = self.function_space().mesh()
+        if function_space.ufl_element().value_shape(mesh) != self.ufl_element().value_shape(mesh):
             raise ValueError("Cannot reconstruct an Coargument with a different value shape.")
         return Coargument(function_space, number, part=part)
 

--- a/firedrake/ufl_expr.py
+++ b/firedrake/ufl_expr.py
@@ -76,8 +76,7 @@ class Argument(ufl.argument.Argument):
             return self
         if not isinstance(number, int):
             raise TypeError(f"Expecting an int, not {number}")
-        mesh = self.function_space().mesh()
-        if function_space.ufl_element().value_shape(mesh) != self.ufl_element().value_shape(mesh):
+        if function_space.value_shape != self.function_space().value_shape:
             raise ValueError("Cannot reconstruct an Argument with a different value shape.")
         return Argument(function_space, number, part=part)
 
@@ -141,8 +140,7 @@ class Coargument(ufl.argument.Coargument):
             return self
         if not isinstance(number, int):
             raise TypeError(f"Expecting an int, not {number}")
-        mesh = self.function_space().mesh()
-        if function_space.ufl_element().value_shape(mesh) != self.ufl_element().value_shape(mesh):
+        if function_space.value_shape != self.function_space().value_shape:
             raise ValueError("Cannot reconstruct an Coargument with a different value shape.")
         return Coargument(function_space, number, part=part)
 

--- a/tests/macro/test_macro_multigrid.py
+++ b/tests/macro/test_macro_multigrid.py
@@ -136,6 +136,7 @@ mg_params = {
     "mg_levels_pc_type": "jacobi",
     "mg_coarse_pc_type": "python",
     "mg_coarse_pc_python_type": "firedrake.AssembledPC",
+    "mg_coarse_assembled_pc_type": "cholesky",
 }
 
 

--- a/tests/multigrid/test_non_nested.py
+++ b/tests/multigrid/test_non_nested.py
@@ -59,7 +59,7 @@ def test_sphere_mg():
     u = TrialFunction(V)
     v = TestFunction(V)
 
-    a = (inner(u, v) + inner(u, v))*dx
+    a = (inner(grad(u), grad(v)) + inner(u, v))*dx
 
     f1 = exp((x+y+z)/R)*x*y*z/R**3
     F = inner(f1, v)*dx
@@ -91,4 +91,4 @@ def test_sphere_mg():
     prob = LinearVariationalProblem(a, F, w)
     solver = LinearVariationalSolver(prob, solver_parameters=mg_params)
     solver.solve()
-    assert solver.snes.ksp.getIterationNumber() < 5
+    assert solver.snes.ksp.getIterationNumber() < 7

--- a/tests/output/test_io_backward_compat.py
+++ b/tests/output/test_io_backward_compat.py
@@ -150,7 +150,7 @@ def _get_mesh_and_V(params):
 def _get_expr(V):
     mesh = V.mesh()
     dim = mesh.geometric_dimension()
-    shape = V.ufl_element().value_shape
+    shape = V.value_shape
     if dim == 2:
         x, y = SpatialCoordinate(mesh)
         z = x + y
@@ -240,9 +240,8 @@ def test_io_backward_compat_base_load(version, params):
 
 def _get_expr_timestepping(V, i):
     mesh = V.mesh()
-    element = V.ufl_element()
     x, y = SpatialCoordinate(mesh)
-    shape = element.value_shape
+    shape = V.value_shape
     if shape == (4, ):
         return as_vector([x + i, y + i, x * y + i, i * i])
     else:

--- a/tests/output/test_io_function.py
+++ b/tests/output/test_io_function.py
@@ -67,7 +67,7 @@ def _get_mesh(cell_type, comm):
 def _get_expr(V):
     mesh = V.mesh()
     dim = mesh.geometric_dimension()
-    shape = V.ufl_element().value_shape
+    shape = V.ufl_element().value_shape(mesh)
     if dim == 2:
         x, y = SpatialCoordinate(mesh)
         z = x * y

--- a/tests/output/test_io_function.py
+++ b/tests/output/test_io_function.py
@@ -67,7 +67,7 @@ def _get_mesh(cell_type, comm):
 def _get_expr(V):
     mesh = V.mesh()
     dim = mesh.geometric_dimension()
-    shape = V.ufl_element().value_shape(mesh)
+    shape = V.value_shape
     if dim == 2:
         x, y = SpatialCoordinate(mesh)
         z = x * y

--- a/tests/output/test_io_timestepping.py
+++ b/tests/output/test_io_timestepping.py
@@ -16,7 +16,7 @@ def _get_expr(V, i):
     mesh = V.mesh()
     element = V.ufl_element()
     x, y = SpatialCoordinate(mesh)
-    shape = element.value_shape
+    shape = element.value_shape(mesh)
     if element.family() == "Real":
         return 7. + i * i
     elif shape == ():

--- a/tests/output/test_io_timestepping.py
+++ b/tests/output/test_io_timestepping.py
@@ -16,7 +16,7 @@ def _get_expr(V, i):
     mesh = V.mesh()
     element = V.ufl_element()
     x, y = SpatialCoordinate(mesh)
-    shape = element.value_shape(mesh)
+    shape = V.value_shape
     if element.family() == "Real":
         return 7. + i * i
     elif shape == ():

--- a/tests/regression/test_2dcohomology.py
+++ b/tests/regression/test_2dcohomology.py
@@ -51,7 +51,7 @@ def test_betti0(space, mesh):
 
     L = assemble(inner(nabla_grad(u), nabla_grad(v))*dx)
 
-    bc0 = DirichletBC(V0, Constant(0.0), 9)
+    bc0 = DirichletBC(V0, 0, 9)
     L0 = assemble(inner(nabla_grad(u), nabla_grad(v))*dx, bcs=[bc0])
 
     u, s, v = linalg.svd(L.M.values)
@@ -94,8 +94,8 @@ def test_betti1(space, mesh):
     L = assemble((inner(sigma, tau) - inner(u, rot(tau)) + inner(rot(sigma), v)
                   + inner(div(u), div(v))) * dx)
 
-    bc0 = DirichletBC(W.sub(0), Constant(0.0), 9)
-    bc1 = DirichletBC(W.sub(1), Constant((0.0, 0.0)), 9)
+    bc0 = DirichletBC(W.sub(0), 0, 9)
+    bc1 = DirichletBC(W.sub(1), 0, 9)
     L0 = assemble((inner(sigma, tau) - inner(u, rot(tau)) + inner(rot(sigma), v)
                    + inner(div(u), div(v))) * dx, bcs=[bc0, bc1])
 
@@ -155,7 +155,7 @@ def test_betti2(space, mesh):
 
     L = assemble((inner(sigma, tau) - inner(u, div(tau)) + inner(div(sigma), v))*dx)
 
-    bc1 = DirichletBC(W.sub(0), Constant((0.0, 0.0)), 9)
+    bc1 = DirichletBC(W.sub(0), 0, 9)
     L0 = assemble((inner(sigma, tau) - inner(u, div(tau)) + inner(div(sigma), v))*dx, bcs=[bc1])
 
     dV1 = V1.dof_count

--- a/tests/regression/test_change_coordinates.py
+++ b/tests/regression/test_change_coordinates.py
@@ -13,7 +13,7 @@ def test_immerse_1d(dim):
 
     m = Mesh(new_coords)
 
-    assert m.ufl_cell().geometric_dimension() == dim
+    assert m.geometric_dimension() == dim
 
 
 def test_immerse_2d():
@@ -23,7 +23,7 @@ def test_immerse_2d():
 
     m = Mesh(new_coords)
 
-    assert m.ufl_cell().geometric_dimension() == 3
+    assert m.geometric_dimension() == 3
 
 
 def test_project_2d():
@@ -33,7 +33,7 @@ def test_project_2d():
 
     m = Mesh(new_coords)
 
-    assert m.ufl_cell().geometric_dimension() == 1
+    assert m.geometric_dimension() == 1
 
 
 def test_immerse_extruded():
@@ -44,4 +44,4 @@ def test_immerse_extruded():
 
     m = Mesh(new_coords)
 
-    assert m.ufl_cell().geometric_dimension() == 3
+    assert m.geometric_dimension() == 3

--- a/tests/regression/test_ensembleparallelism.py
+++ b/tests/regression/test_ensembleparallelism.py
@@ -205,13 +205,13 @@ def test_ensemble_reduce(ensemble, mesh, W, urank, urank_sum, root, blocking):
     parallel_assert(
         lambda: error < 1e-12,
         subset=root_ranks,
-        msg=f"{error = :.5f}"
+        msg=f"{error=:.5f}"
     )
     error = errornorm(Function(W).assign(10), u_reduce)
     parallel_assert(
         lambda: error < 1e-12,
         subset={range(COMM_WORLD.size)} - root_ranks,
-        msg=f"{error = :.5f}"
+        msg=f"{error=:.5f}"
     )
 
     # check that u_reduce dat vector is still synchronised
@@ -347,7 +347,7 @@ def test_send_and_recv(ensemble, mesh, W, blocking):
     parallel_assert(
         lambda: error < 1e-12,
         subset=root_ranks,
-        msg=f"{error = :.5f}"
+        msg=f"{error=:.5f}"
     )
 
 

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -295,7 +295,7 @@ def test_assign_with_different_meshes_fails():
 def test_assign_vector_const_to_vfs(vcg1):
     f = Function(vcg1)
 
-    c = Constant(range(1, f.ufl_element().value_shape[0]+1))
+    c = Constant(range(1, f.ufl_element().value_shape(vcg1.mesh())[0]+1))
 
     f.assign(c)
     assert np.allclose(f.dat.data_ro, c.dat.data_ro)

--- a/tests/regression/test_expressions.py
+++ b/tests/regression/test_expressions.py
@@ -295,7 +295,7 @@ def test_assign_with_different_meshes_fails():
 def test_assign_vector_const_to_vfs(vcg1):
     f = Function(vcg1)
 
-    c = Constant(range(1, f.ufl_element().value_shape(vcg1.mesh())[0]+1))
+    c = Constant(range(1, f.function_space().value_shape[0]+1))
 
     f.assign(c)
     assert np.allclose(f.dat.data_ro, c.dat.data_ro)

--- a/tests/regression/test_fas_snespatch.py
+++ b/tests/regression/test_fas_snespatch.py
@@ -170,8 +170,7 @@ def test_snespatch(mesh, CG1, solver_params):
     f = Constant(1, domain=mesh)
     F = inner(grad(u), grad(v))*dx - inner(f, v)*dx + inner(u**3 - u, v)*dx
 
-    z = zero(CG1.ufl_element().value_shape(mesh))
-    bcs = DirichletBC(CG1, z, "on_boundary")
+    bcs = DirichletBC(CG1, 0, "on_boundary")
 
     nvproblem = NonlinearVariationalProblem(F, u, bcs=bcs)
     solver = NonlinearVariationalSolver(nvproblem, solver_parameters=solver_params)

--- a/tests/regression/test_fas_snespatch.py
+++ b/tests/regression/test_fas_snespatch.py
@@ -170,7 +170,7 @@ def test_snespatch(mesh, CG1, solver_params):
     f = Constant(1, domain=mesh)
     F = inner(grad(u), grad(v))*dx - inner(f, v)*dx + inner(u**3 - u, v)*dx
 
-    z = zero(CG1.ufl_element().value_shape)
+    z = zero(CG1.ufl_element().value_shape(mesh))
     bcs = DirichletBC(CG1, z, "on_boundary")
 
     nvproblem = NonlinearVariationalProblem(F, u, bcs=bcs)

--- a/tests/regression/test_fdm.py
+++ b/tests/regression/test_fdm.py
@@ -90,7 +90,7 @@ def build_riesz_map(V, d):
 
     x = SpatialCoordinate(V.mesh())
     x -= Constant([0.5]*len(x))
-    if V.ufl_element().value_shape(V.mesh()) == ():
+    if V.value_shape == ():
         u_exact = exp(-10*dot(x, x))
         u_bc = u_exact
     else:
@@ -195,7 +195,7 @@ def test_variable_coefficient(mesh):
     subs = ("on_boundary",)
     if mesh.cell_set._extruded:
         subs += ("top", "bottom")
-    bcs = [DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), sub) for sub in subs]
+    bcs = [DirichletBC(V, 0, sub) for sub in subs]
 
     uh = Function(V)
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_fdm.py
+++ b/tests/regression/test_fdm.py
@@ -90,7 +90,7 @@ def build_riesz_map(V, d):
 
     x = SpatialCoordinate(V.mesh())
     x -= Constant([0.5]*len(x))
-    if V.ufl_element().value_shape == ():
+    if V.ufl_element().value_shape(V.mesh()) == ():
         u_exact = exp(-10*dot(x, x))
         u_bc = u_exact
     else:
@@ -195,7 +195,7 @@ def test_variable_coefficient(mesh):
     subs = ("on_boundary",)
     if mesh.cell_set._extruded:
         subs += ("top", "bottom")
-    bcs = [DirichletBC(V, zero(V.ufl_element().value_shape), sub) for sub in subs]
+    bcs = [DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), sub) for sub in subs]
 
     uh = Function(V)
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_function.py
+++ b/tests/regression/test_function.py
@@ -97,7 +97,7 @@ def test_mismatching_shape_interpolation(V):
     VV = VectorFunctionSpace(V.mesh(), 'CG', 1)
     f = Function(VV)
     with pytest.raises(RuntimeError):
-        f.interpolate(Constant([1] * (VV.ufl_element().value_shape[0] + 1)))
+        f.interpolate(Constant([1] * (VV.ufl_element().value_shape(VV.mesh())[0] + 1)))
 
 
 def test_function_val(V):

--- a/tests/regression/test_function.py
+++ b/tests/regression/test_function.py
@@ -97,7 +97,7 @@ def test_mismatching_shape_interpolation(V):
     VV = VectorFunctionSpace(V.mesh(), 'CG', 1)
     f = Function(VV)
     with pytest.raises(RuntimeError):
-        f.interpolate(Constant([1] * (VV.ufl_element().value_shape(VV.mesh())[0] + 1)))
+        f.interpolate(Constant([1] * (VV.value_shape[0] + 1)))
 
 
 def test_function_val(V):

--- a/tests/regression/test_function_spaces.py
+++ b/tests/regression/test_function_spaces.py
@@ -276,7 +276,7 @@ def test_reconstruct_component(space, dg0, rt1, mesh, mesh2, dual):
     Z = {"dg0": dg0, "rt1": rt1}[space]
     if dual:
         Z = Z.dual()
-    for component in range(Z.value_size):
+    for component in range(len(Z)):
         V1 = Z.sub(component)
         V2 = V1.reconstruct(mesh=mesh2)
         assert is_dual(V1) == is_dual(V2) == dual
@@ -293,7 +293,7 @@ def test_reconstruct_sub_component(dg0, rt1, mesh, mesh2, dual):
     if dual:
         Z = Z.dual()
     for index, Vsub in enumerate(Z):
-        for component in range(Vsub.value_size):
+        for component in range(len(Vsub._components)):
             V1 = Z.sub(index).sub(component)
             V2 = V1.reconstruct(mesh=mesh2)
             assert is_dual(V1) == is_dual(V2) == dual

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -471,7 +471,7 @@ def test_interpolation_tensor_convergence():
         V = TensorFunctionSpace(mesh, "RT", 1)
         x, y = SpatialCoordinate(mesh)
 
-        vs = V.ufl_element().value_shape
+        vs = V.ufl_element().value_shape(mesh)
         expr = as_tensor(np.asarray([
             sin(2*pi*x*(i+1))*cos(4*pi*y*i)
             for i in range(np.prod(vs, dtype=int))

--- a/tests/regression/test_interpolate.py
+++ b/tests/regression/test_interpolate.py
@@ -471,7 +471,7 @@ def test_interpolation_tensor_convergence():
         V = TensorFunctionSpace(mesh, "RT", 1)
         x, y = SpatialCoordinate(mesh)
 
-        vs = V.ufl_element().value_shape(mesh)
+        vs = V.value_shape
         expr = as_tensor(np.asarray([
             sin(2*pi*x*(i+1))*cos(4*pi*y*i)
             for i in range(np.prod(vs, dtype=int))

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -361,7 +361,7 @@ def test_interpolate_unitsquare_mixed():
 
     # Can't go from non-mixed to mixed
     V_src_2 = VectorFunctionSpace(m_src, "CG", 1)
-    assert V_src_2.ufl_element().value_shape == V_src.ufl_element().value_shape
+    assert V_src_2.ufl_element().value_shape == V_src.ufl_element().value_shape(m_src)
     f_src_2 = Function(V_src_2)
     with pytest.raises(NotImplementedError):
         assemble(interpolate(f_src_2, V_dest))

--- a/tests/regression/test_interpolate_cross_mesh.py
+++ b/tests/regression/test_interpolate_cross_mesh.py
@@ -361,7 +361,7 @@ def test_interpolate_unitsquare_mixed():
 
     # Can't go from non-mixed to mixed
     V_src_2 = VectorFunctionSpace(m_src, "CG", 1)
-    assert V_src_2.ufl_element().value_shape == V_src.ufl_element().value_shape(m_src)
+    assert V_src_2.value_shape == V_src.value_shape
     f_src_2 = Function(V_src_2)
     with pytest.raises(NotImplementedError):
         assemble(interpolate(f_src_2, V_dest))

--- a/tests/regression/test_interpolate_vs_project.py
+++ b/tests/regression/test_interpolate_vs_project.py
@@ -37,7 +37,7 @@ def test_interpolate_vs_project(V):
     elif dim == 3:
         x, y, z = SpatialCoordinate(mesh)
 
-    shape = V.ufl_element().value_shape(mesh)
+    shape = V.value_shape
     if dim == 2:
         if len(shape) == 0:
             expression = x + y

--- a/tests/regression/test_interpolate_vs_project.py
+++ b/tests/regression/test_interpolate_vs_project.py
@@ -37,7 +37,7 @@ def test_interpolate_vs_project(V):
     elif dim == 3:
         x, y, z = SpatialCoordinate(mesh)
 
-    shape = V.ufl_element().value_shape
+    shape = V.ufl_element().value_shape(mesh)
     if dim == 2:
         if len(shape) == 0:
             expression = x + y

--- a/tests/regression/test_p1pc.py
+++ b/tests/regression/test_p1pc.py
@@ -36,7 +36,7 @@ def test_p_independence(mesh, expected):
 
         L = inner(Constant(1), v)*dx
 
-        bcs = DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), "on_boundary")
+        bcs = DirichletBC(V, 0, "on_boundary")
 
         uh = Function(V)
         problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_p1pc.py
+++ b/tests/regression/test_p1pc.py
@@ -36,7 +36,7 @@ def test_p_independence(mesh, expected):
 
         L = inner(Constant(1), v)*dx
 
-        bcs = DirichletBC(V, zero(V.ufl_element().value_shape), "on_boundary")
+        bcs = DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), "on_boundary")
 
         uh = Function(V)
         problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -38,7 +38,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         R = TensorFunctionSpace(mesh, "CG", 1)
         V = P*Q*R
 
-    shape = V.ufl_element().value_shape(mesh)
+    shape = V.value_shape
     rhs = numpy.full(shape, 1, dtype=float)
 
     u = TrialFunction(V)
@@ -48,16 +48,16 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         # We also test patch pc with kernel argument compression.
         i = 1  # only active index
         f = Function(V)
-        fval = numpy.full(V.sub(i).ufl_element().value_shape(mesh), 1.0, dtype=float)
+        fval = numpy.full(V.sub(i).value_shape, 1.0, dtype=float)
         f.sub(i).interpolate(Constant(fval))
         a = (inner(f[i], f[i]) * inner(grad(u), grad(v)))*dx
         L = inner(Constant(rhs), v)*dx
-        bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape(mesh)), "on_boundary")
+        bcs = [DirichletBC(Q, 0, "on_boundary")
                for Q in V.subfunctions]
     else:
         a = inner(grad(u), grad(v))*dx
         L = inner(Constant(rhs), v)*dx
-        bcs = DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), "on_boundary")
+        bcs = DirichletBC(V, 0, "on_boundary")
 
     uh = Function(V)
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_patch_pc.py
+++ b/tests/regression/test_patch_pc.py
@@ -38,7 +38,7 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         R = TensorFunctionSpace(mesh, "CG", 1)
         V = P*Q*R
 
-    shape = V.ufl_element().value_shape
+    shape = V.ufl_element().value_shape(mesh)
     rhs = numpy.full(shape, 1, dtype=float)
 
     u = TrialFunction(V)
@@ -48,16 +48,16 @@ def test_jacobi_sor_equivalence(mesh, problem_type, multiplicative):
         # We also test patch pc with kernel argument compression.
         i = 1  # only active index
         f = Function(V)
-        fval = numpy.full(V.sub(i).ufl_element().value_shape, 1.0, dtype=float)
+        fval = numpy.full(V.sub(i).ufl_element().value_shape(mesh), 1.0, dtype=float)
         f.sub(i).interpolate(Constant(fval))
         a = (inner(f[i], f[i]) * inner(grad(u), grad(v)))*dx
         L = inner(Constant(rhs), v)*dx
-        bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape), "on_boundary")
+        bcs = [DirichletBC(Q, zero(Q.ufl_element().value_shape(mesh)), "on_boundary")
                for Q in V.subfunctions]
     else:
         a = inner(grad(u), grad(v))*dx
         L = inner(Constant(rhs), v)*dx
-        bcs = DirichletBC(V, zero(V.ufl_element().value_shape), "on_boundary")
+        bcs = DirichletBC(V, zero(V.ufl_element().value_shape(mesh)), "on_boundary")
 
     uh = Function(V)
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)

--- a/tests/regression/test_patch_precompute_element_tensors.py
+++ b/tests/regression/test_patch_precompute_element_tensors.py
@@ -27,7 +27,7 @@ def test_patch_precompute_element_tensors(mesh, V):
     f = Constant((1, 1))
     F = inner(grad(u), grad(v))*dx + gamma*inner(div(u), div(v))*dx - inner(f, v)*dx + avg(inner(u, v))*dS
 
-    z = zero(V.ufl_element().value_shape)
+    z = zero(V.ufl_element().value_shape(mesh))
     bcs = DirichletBC(V, z, "on_boundary")
 
     sp = {

--- a/tests/regression/test_patch_precompute_element_tensors.py
+++ b/tests/regression/test_patch_precompute_element_tensors.py
@@ -27,8 +27,7 @@ def test_patch_precompute_element_tensors(mesh, V):
     f = Constant((1, 1))
     F = inner(grad(u), grad(v))*dx + gamma*inner(div(u), div(v))*dx - inner(f, v)*dx + avg(inner(u, v))*dS
 
-    z = zero(V.ufl_element().value_shape(mesh))
-    bcs = DirichletBC(V, z, "on_boundary")
+    bcs = DirichletBC(V, 0, "on_boundary")
 
     sp = {
         "mat_type": "matfree",

--- a/tests/regression/test_tensor_algebra.py
+++ b/tests/regression/test_tensor_algebra.py
@@ -34,7 +34,7 @@ def mesh(request):
                          "-2*mu_s*inner(grad(u), outer(conj(v), n)) * ds")],
                 ids=lambda x: x[0])
 def form_expect(request, mesh):
-    dim = mesh.ufl_cell().geometric_dimension()
+    dim = mesh.geometric_dimension()
     if mesh.ufl_cell().cellname() == "quadrilateral":
         V = FunctionSpace(mesh, "RTCF", 1)
     else:

--- a/tests/submesh/test_submesh_interpolate.py
+++ b/tests/submesh/test_submesh_interpolate.py
@@ -21,9 +21,9 @@ def _get_expr(V):
         x, y, z = SpatialCoordinate(m)
     else:
         raise NotImplementedError("Not implemented")
-    if V.ufl_element().value_shape == ():
+    if V.value_shape == ():
         return cos(x) + x * exp(y) + sin(z)
-    elif V.ufl_element().value_shape == (2, ):
+    elif V.value_shape == (2, ):
         return as_vector([cos(x), sin(y)])
 
 
@@ -50,7 +50,7 @@ def _test_submesh_interpolate_cell_cell(mesh, subdomain_cond, fe_fesub):
     # if there is no ambiguity on the subdomain boundary.
     # For testing, the following suffices.
     g.interpolate(f)
-    temp = Constant(999.) if V.ufl_element().value_shape == () else as_vector([Constant(999.)] * np.prod(V.ufl_element().value_shape, dtype=int))
+    temp = Constant(999.*np.ones(V.value_shape))
     g.interpolate(temp, subset=mesh.topology.cell_subset(label_value))  # pollute the data
     g.interpolate(gsub, subset=mesh.topology.cell_subset(label_value))
     assert assemble(inner(g - f, g - f) * dx(label_value)).real < 1e-14

--- a/tests/vertexonly/test_swarm.py
+++ b/tests/vertexonly/test_swarm.py
@@ -27,11 +27,11 @@ def cell_midpoints(m):
     num_cells_local = len(f.dat.data_ro)
     num_cells = MPI.COMM_WORLD.allreduce(num_cells_local, op=MPI.SUM)
     # reshape is for 1D case where f.dat.data_ro has shape (num_cells_local,)
-    local_midpoints = f.dat.data_ro.reshape(num_cells_local, m.ufl_cell().geometric_dimension())
+    local_midpoints = f.dat.data_ro.reshape(num_cells_local, m.geometric_dimension())
     local_midpoints_size = np.array(local_midpoints.size)
     local_midpoints_sizes = np.empty(MPI.COMM_WORLD.size, dtype=int)
     MPI.COMM_WORLD.Allgatherv(local_midpoints_size, local_midpoints_sizes)
-    midpoints = np.empty((num_cells, m.ufl_cell().geometric_dimension()), dtype=local_midpoints.dtype)
+    midpoints = np.empty((num_cells, m.geometric_dimension()), dtype=local_midpoints.dtype)
     MPI.COMM_WORLD.Allgatherv(local_midpoints, (midpoints, local_midpoints_sizes))
     assert len(np.unique(midpoints, axis=0)) == len(midpoints)
     return midpoints, local_midpoints

--- a/tests/vertexonly/test_vertex_only_mesh_generation.py
+++ b/tests/vertexonly/test_vertex_only_mesh_generation.py
@@ -26,11 +26,11 @@ def cell_midpoints(m):
     num_cells_local = len(f.dat.data_ro)
     num_cells = MPI.COMM_WORLD.allreduce(num_cells_local, op=MPI.SUM)
     # reshape is for 1D case where f.dat.data_ro has shape (num_cells_local,)
-    local_midpoints = f.dat.data_ro.reshape(num_cells_local, m.ufl_cell().geometric_dimension())
+    local_midpoints = f.dat.data_ro.reshape(num_cells_local, m.geometric_dimension())
     local_midpoints_size = np.array(local_midpoints.size)
     local_midpoints_sizes = np.empty(MPI.COMM_WORLD.size, dtype=int)
     MPI.COMM_WORLD.Allgatherv(local_midpoints_size, local_midpoints_sizes)
-    midpoints = np.empty((num_cells, m.ufl_cell().geometric_dimension()), dtype=local_midpoints.dtype)
+    midpoints = np.empty((num_cells, m.geometric_dimension()), dtype=local_midpoints.dtype)
     MPI.COMM_WORLD.Allgatherv(local_midpoints, (midpoints, local_midpoints_sizes))
     assert len(np.unique(midpoints, axis=0)) == len(midpoints)
     return midpoints, local_midpoints


### PR DESCRIPTION
# Description

1. Replace `V.ufl_element().value_shape` by `V.value_shape`,
2. `firedrake.FunctionSpace.value_size` has been redefined to agree with `ufl.FunctionSpace.value_size = numpy.prod(value_shape, int)`, so the old behaviour gets renamed as `firedrake.FunctionSpace.block_size`

Depends on:
https://github.com/firedrakeproject/ufl/pull/52
https://github.com/FInAT/FInAT/pull/118
https://github.com/firedrakeproject/tsfc/pull/307



<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
