### PR TITLE
Add more tests for dS(hex_mesh)

### DIFF
--- a/tsfc/fem.py
+++ b/tsfc/fem.py
@@ -47,15 +47,18 @@ from pyop2.caching import serial_cache
 class ContextBase(ProxyKernelInterface):
     """Common UFL -> GEM translation context."""
 
-    keywords = ('ufl_cell',
-                'fiat_cell',
-                'integral_type',
-                'integration_dim',
-                'entity_ids',
-                'argument_multiindices',
-                'facetarea',
-                'index_cache',
-                'scalar_type')
+    keywords = (
+        'ufl_cell',
+        'fiat_cell',
+        'integral_type',
+        'integration_dim',
+        'entity_ids',
+        'argument_multiindices',
+        'facetarea',
+        'index_cache',
+        'scalar_type',
+        'use_canonical_quadrature_point_ordering',
+    )
 
     def __init__(self, interface, **kwargs):
         ProxyKernelInterface.__init__(self, interface)
@@ -113,6 +116,9 @@ class ContextBase(ProxyKernelInterface):
 
     @cached_property
     def use_canonical_quadrature_point_ordering(self):
+        # Directly set use_canonical_quadrature_point_ordering = False in context
+        # for translation of special nodes, e.g., CellVolume, FacetArea, CellOrigin, and CellVertices,
+        # as quadrature point ordering is not relevant for those node types.
         return isinstance(self.fiat_cell, UFCHexahedron) and self.integral_type in ['exterior_facet', 'interior_facet']
 
 
@@ -162,6 +168,7 @@ class CoordinateMapping(PhysicalGeometry):
             expr = NegativeRestricted(expr)
         config = {"point_set": PointSingleton(point)}
         config.update(self.config)
+        config.update(use_canonical_quadrature_point_ordering=False)  # quad point ordering not relevant.
         context = PointSetContext(**config)
         expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
@@ -174,6 +181,7 @@ class CoordinateMapping(PhysicalGeometry):
             expr = NegativeRestricted(expr)
         config = {"point_set": PointSingleton(point)}
         config.update(self.config)
+        config.update(use_canonical_quadrature_point_ordering=False)  # quad point ordering not relevant.
         context = PointSetContext(**config)
         expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
@@ -222,6 +230,7 @@ class CoordinateMapping(PhysicalGeometry):
         expr = ufl.as_vector([ufl.sqrt(ufl.dot(expr[i, :], expr[i, :])) for i in range(num_edges)])
         config = {"point_set": PointSingleton(cell.make_points(sd, 0, sd+1)[0])}
         config.update(self.config)
+        config.update(use_canonical_quadrature_point_ordering=False)  # quad point ordering not relevant.
         context = PointSetContext(**config)
         expr = self.preprocess(expr, context)
         return map_expr_dag(context.translator, expr)
@@ -244,6 +253,7 @@ class CoordinateMapping(PhysicalGeometry):
         if entity is not None:
             config.update({name: getattr(self.interface, name)
                            for name in ["integration_dim", "entity_ids"]})
+        config.update(use_canonical_quadrature_point_ordering=False)  # quad point ordering not relevant.
         context = PointSetContext(**config)
         expr = self.preprocess(expr, context)
         mapped = map_expr_dag(context.translator, expr)
@@ -539,7 +549,7 @@ def translate_cellvolume(terminal, mt, ctx):
 
     config = {name: getattr(ctx, name)
               for name in ["ufl_cell", "index_cache", "scalar_type"]}
-    config.update(interface=interface, quadrature_degree=degree)
+    config.update(interface=interface, quadrature_degree=degree, use_canonical_quadrature_point_ordering=False)
     expr, = compile_ufl(integrand, PointSetContext(**config), point_sum=True)
     return expr
 
@@ -553,7 +563,7 @@ def translate_facetarea(terminal, mt, ctx):
     config = {name: getattr(ctx, name)
               for name in ["ufl_cell", "integration_dim", "scalar_type",
                            "entity_ids", "index_cache"]}
-    config.update(interface=ctx, quadrature_degree=degree)
+    config.update(interface=ctx, quadrature_degree=degree, use_canonical_quadrature_point_ordering=False)
     expr, = compile_ufl(integrand, PointSetContext(**config), point_sum=True)
     return expr
 
@@ -567,7 +577,7 @@ def translate_cellorigin(terminal, mt, ctx):
 
     config = {name: getattr(ctx, name)
               for name in ["ufl_cell", "index_cache", "scalar_type"]}
-    config.update(interface=ctx, point_set=point_set)
+    config.update(interface=ctx, point_set=point_set, use_canonical_quadrature_point_ordering=False)
     context = PointSetContext(**config)
     return context.translator(expression)
 
@@ -580,7 +590,7 @@ def translate_cell_vertices(terminal, mt, ctx):
 
     config = {name: getattr(ctx, name)
               for name in ["ufl_cell", "index_cache", "scalar_type"]}
-    config.update(interface=ctx, point_set=ps)
+    config.update(interface=ctx, point_set=ps, use_canonical_quadrature_point_ordering=False)
     context = PointSetContext(**config)
     expr = context.translator(ufl_expr)
 


### PR DESCRIPTION
Fix https://github.com/firedrakeproject/firedrake/issues/3874

Follow up [PR for interior facet integration of hex] (https://github.com/firedrakeproject/tsfc/pull/317)

TSFC:

Some ufl-gem translation contexts for interior facet integration (such as the ones for `CellVolume` and `FacetArea`) do not even need to check if quadrature point ordering on the '+' and '-' sides agree or not. This PR explicitly set `PointSetcontext.use_canonical_quadrature_point_ordering=False` for those translation contexts.

Firedrake:

Add more tests for interior facet integration of hex.