### PR TITLE
address of old fenics docs changed

### DIFF
--- a/demos/poisson/poisson_mixed.py.rst
+++ b/demos/poisson/poisson_mixed.py.rst
@@ -171,5 +171,5 @@ Don't forget to show the image::
     warning("Cannot show figure. Error msg '%s'" % e)
 
 This demo is based on the corresponding `DOLFIN mixed Poisson demo
-<http://fenicsproject.org/olddocs/dolfin/1.3.0/python/demo/documented/mixed-poisson/python/documentation.html>`__
+<https://olddocs.fenicsproject.org/dolfin/1.3.0/python/demo/documented/mixed-poisson/python/documentation.html>`__
 and can be found as a script in :demo:`poisson_mixed.py <poisson_mixed.py>`.


### PR DESCRIPTION
The link to the Poisson demo on the old FENICS docs will redirect to a slightly different address if you open in a browser, but the doc build doesn't pick this up so it breaks.
This updates the address in the demo file to match the real one.