### PR TITLE
Function has fs.block_size components not fs.value_size

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -331,7 +331,7 @@ class Function(ufl.Coefficient, FunctionMixin):
             return (self, )
         else:
             return tuple(type(self)(self.function_space().sub(i), self.topological.sub(i))
-                         for i in range(self.function_space().value_size))
+                         for i in range(self.function_space().block_size))
 
     @PETSc.Log.EventDecorator()
     def sub(self, i):


### PR DESCRIPTION
In #3862 `FunctionSpace.block_size` took on the old behaviour of `FunctionSpace.value_size`.
Defining the components for a `FunctionSpace` was updated to use `block_size`, but the components definition for `Function` wasn't.