### PR TITLE
Fix the `FormSum` memory leak

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -5,7 +5,6 @@ import functools
 import itertools
 from itertools import product
 import numbers
-import numpy as np
 
 import cachetools
 import finat
@@ -472,11 +471,7 @@ class BaseFormAssembler(AbstractFormAssembler):
                 V, = set(a.function_space() for a in args)
                 result = firedrake.Cofunction(V)
                 for op, w in zip(args, expr.weights()):
-                    for dat_result, dat_op in zip(result.dat.split, op.dat.split):
-                        np.add(
-                            dat_result.data_ro_with_halos,
-                            w * dat_op.data_ro_with_halos,
-                            out=dat_result.data_wo_with_halos)
+                    result.dat.axpy(w, op.dat)
                 return result
             elif all(isinstance(op, ufl.Matrix) for op in args):
                 res = tensor.petscmat if tensor else PETSc.Mat()

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -470,8 +470,7 @@ class BaseFormAssembler(AbstractFormAssembler):
             elif all(isinstance(op, firedrake.Cofunction) for op in args):
                 V, = set(a.function_space() for a in args)
                 result = firedrake.Cofunction(V)
-                for op, w in zip(args, expr.weights()):
-                    result.dat.axpy(w, op.dat)
+                result.dat.maxpy(expr.weights(), [a.dat for a in args])
                 return result
             elif all(isinstance(op, ufl.Matrix) for op in args):
                 res = tensor.petscmat if tensor else PETSc.Mat()

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -378,8 +378,7 @@ class BaseFormAssembler(AbstractFormAssembler):
             return self.base_form_assembly_visitor(e, t, *operands)
 
         # DAG assembly: traverse the DAG in a post-order fashion and evaluate the node on the fly.
-        visited = {}
-        result = BaseFormAssembler.base_form_postorder_traversal(self._form, visitor, visited)
+        result = BaseFormAssembler.base_form_postorder_traversal(self._form, visitor)
 
         if tensor:
             BaseFormAssembler.update_tensor(result, tensor)

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -583,7 +583,8 @@ class BaseFormAssembler(AbstractFormAssembler):
             raise NotImplementedError("Cannot update tensor of type %s" % type(tensor))
 
     @staticmethod
-    def base_form_postorder_traversal(expr, visitor, visited={}):
+    def base_form_postorder_traversal(expr, visitor, visited=None):
+        visited = visited if visited is not None else {}
         if expr in visited:
             return visited[expr]
 
@@ -605,7 +606,8 @@ class BaseFormAssembler(AbstractFormAssembler):
         return visited[expr]
 
     @staticmethod
-    def base_form_preorder_traversal(expr, visitor, visited={}):
+    def base_form_preorder_traversal(expr, visitor, visited=None):
+        visited = visited if visited is not None else {}
         if expr in visited:
             return visited[expr]
 

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -492,16 +492,18 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
         from math import sqrt
         return sqrt(self.inner(self).real)
 
-    def maxpy(self, scalar: list, x: list) -> None:
+    def maxpy(self, scalar: Sequence, x: Sequence) -> None:
         """Compute a sequence of axpy operations.
 
         This is equivalent to calling :meth:`axpy` for each pair of
         scalars and :class:`Dat` in the input sequences.
 
-        :arg scalar: A sequence of scalars.
-        :arg x: A sequence of :class:`Dat`.
-
-        See also :meth:`axpy`.
+        Parameters
+        ----------
+        scalar :
+            A sequence of scalars.
+        x :
+            A sequence of :class:`Dat`.
 
         """
         if len(scalar) != len(x):
@@ -512,7 +514,7 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
     def axpy(self, alpha: float, other: 'Dat') -> None:
         """Compute the operation :math:`y = \\alpha x + y`.
 
-        On this case, `self` is `y` and `other` is `x`.
+        In this case, ``self`` is ``y`` and ``other`` is ``x``.
 
         """
         self._check_shape(other)

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -1035,7 +1035,7 @@ class MixedDat(AbstractDat, VecAccessMixin):
         for s, o in zip(self, other):
             ret += s.inner(o)
         return ret
-    
+
     def axpy(self, alpha: float, other: 'MixedDat') -> None:
         """Compute the operation :math:`y = \\alpha x + y`.
 

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -3,6 +3,7 @@ import contextlib
 import ctypes
 import itertools
 import operator
+from collections.abc import Sequence
 
 import loopy as lp
 import numpy as np

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -1061,7 +1061,7 @@ class MixedDat(AbstractDat, VecAccessMixin):
     def axpy(self, alpha: float, other: 'MixedDat') -> None:
         """Compute the operation :math:`y = \\alpha x + y`.
 
-        On this case, `self` is `y` and `other` is `x`.
+        In this case, ``self`` is ``y`` and ``other`` is ``x``.
 
         """
         self._check_shape(other)

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -499,13 +499,12 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
         :arg other: the :class:`Dat` to add to this one
 
         """
-        for dat_result, dat_other in zip(self.split, other.split):
-            if isinstance(dat_result._data, np.ndarray):
-                np.add(
-                    alpha * dat_other.data_ro, dat_result.data_ro,
-                    out=dat_result.data_wo)
-            else:
-                raise NotImplementedError("Not implemented for GPU")
+        if isinstance(other._data, np.ndarray):
+            np.add(
+                alpha * other.data_ro, self.data_ro,
+                out=self.data_wo)
+        else:
+            raise NotImplementedError("Not implemented for GPU")
 
     def __pos__(self):
         pos = Dat(self)
@@ -1036,6 +1035,21 @@ class MixedDat(AbstractDat, VecAccessMixin):
         for s, o in zip(self, other):
             ret += s.inner(o)
         return ret
+    
+    def axpy(self, alpha: float, other: 'MixedDat') -> None:
+        """Compute the operation :math:`y = \\alpha x + y`.
+
+        :arg alpha: a scalar
+        :arg other: the :class:`Dat` to add to this one
+
+        """
+        for dat_result, dat_other in zip(self, other):
+            if isinstance(dat_result._data, np.ndarray):
+                np.add(
+                    alpha * dat_other.data_ro, dat_result.data_ro,
+                    out=dat_result.data_wo)
+            else:
+                raise NotImplementedError("Not implemented for GPU")
 
     def _op(self, other, op):
         ret = []

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -492,6 +492,21 @@ class AbstractDat(DataCarrier, EmptyDataMixin, abc.ABC):
         from math import sqrt
         return sqrt(self.inner(self).real)
 
+    def axpy(self, alpha: float, other: 'Dat') -> None:
+        """Compute the operation :math:`y = \\alpha x + y`.
+
+        :arg alpha: a scalar
+        :arg other: the :class:`Dat` to add to this one
+
+        """
+        for dat_result, dat_other in zip(self.split, other.split):
+            if isinstance(dat_result._data, np.ndarray):
+                np.add(
+                    alpha * dat_other.data_ro, dat_result.data_ro,
+                    out=dat_result.data_wo)
+            else:
+                raise NotImplementedError("Not implemented for GPU")
+
     def __pos__(self):
         pos = Dat(self)
         return pos

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -203,6 +203,15 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         assert issubclass(type(other), type(self))
         return np.dot(self.data_ro, np.conj(other.data_ro))
 
+    def axpy(self, alpha, other):
+        """Compute the operation :math:`y = \\alpha x + y`.
+        """
+        if isinstance(self._data, np.ndarray):
+            np.add(alpha * other.data_ro, self.data_ro,
+                out=self.data_wo)
+        else:
+            raise NotImplementedError("Not implemented for GPU")
+
 
 # must have comm, can be modified in parloop (implies a reduction)
 class Global(SetFreeDataCarrier, VecAccessMixin):

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -203,16 +203,18 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         assert issubclass(type(other), type(self))
         return np.dot(self.data_ro, np.conj(other.data_ro))
 
-    def maxpy(self, scalar: list, x: list) -> None:
+    def maxpy(self, scalar: Sequence, x: Sequence) -> None:
         """Compute a sequence of axpy operations.
 
         This is equivalent to calling :meth:`axpy` for each pair of
         scalars and :class:`Dat` in the input sequences.
 
-        :arg scalar: A sequence of scalars.
-        :arg x: A sequence of :class:`Dat`.
-
-        See also :meth:`axpy`.
+        Parameters
+        ----------
+        scalar :
+            A sequence of scalars.
+        x :
+            A sequence of `Global`.
 
         """
         if len(scalar) != len(x):
@@ -223,7 +225,7 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
     def axpy(self, alpha: float, other: 'Global') -> None:
         """Compute the operation :math:`y = \\alpha x + y`.
 
-        On this case, `self` is `y` and `other` is `x`.
+        In this case, ``self`` is ``y`` and ``other`` is ``x``.
 
         """
         if isinstance(self._data, np.ndarray):

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -207,8 +207,7 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         """Compute the operation :math:`y = \\alpha x + y`.
         """
         if isinstance(self._data, np.ndarray):
-            np.add(alpha * other.data_ro, self.data_ro,
-                out=self.data_wo)
+            np.add(alpha * other.data_ro, self.data_ro, out=self.data_wo)
         else:
             raise NotImplementedError("Not implemented for GPU")
 

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -2,6 +2,7 @@ import contextlib
 import ctypes
 import operator
 import warnings
+from collections.abc import Sequence
 
 import numpy as np
 from petsc4py import PETSc

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -203,10 +203,32 @@ class SetFreeDataCarrier(DataCarrier, EmptyDataMixin):
         assert issubclass(type(other), type(self))
         return np.dot(self.data_ro, np.conj(other.data_ro))
 
-    def axpy(self, alpha, other):
+    def maxpy(self, scalar: list, x: list) -> None:
+        """Compute a sequence of axpy operations.
+
+        This is equivalent to calling :meth:`axpy` for each pair of
+        scalars and :class:`Dat` in the input sequences.
+
+        :arg scalar: A sequence of scalars.
+        :arg x: A sequence of :class:`Dat`.
+
+        See also :meth:`axpy`.
+
+        """
+        if len(scalar) != len(x):
+            raise ValueError("scalar and x must have the same length")
+        for alpha_i, x_i in zip(scalar, x):
+            self.axpy(alpha_i, x_i)
+
+    def axpy(self, alpha: float, other: 'Global') -> None:
         """Compute the operation :math:`y = \\alpha x + y`.
+
+        On this case, `self` is `y` and `other` is `x`.
+
         """
         if isinstance(self._data, np.ndarray):
+            if not np.isscalar(alpha):
+                raise ValueError("alpha must be a scalar")
             np.add(alpha * other.data_ro, self.data_ro, out=self.data_wo)
         else:
             raise NotImplementedError("Not implemented for GPU")

--- a/tests/pyop2/test_dats.py
+++ b/tests/pyop2/test_dats.py
@@ -263,6 +263,22 @@ static void write(unsigned int* v) {
         d1.data_with_halos
         assert d1.dat_version == 1
 
+    def test_axpy(self, d1):
+        d2 = op2.Dat(d1.dataset)
+        d1.data[:] = 0
+        d2.data[:] = 2
+        d1.axpy(3, d2)
+        assert (d1.data_ro == 3 * 2).all()
+
+    def test_maxpy(self, d1):
+        d2 = op2.Dat(d1.dataset)
+        d3 = op2.Dat(d1.dataset)
+        d1.data[:] = 0
+        d2.data[:] = 2
+        d3.data[:] = 3
+        d1.maxpy((2, 3), (d2, d3))
+        assert (d1.data_ro == 2 * 2 + 3 * 3).all()
+
 
 class TestDatView():
 


### PR DESCRIPTION
# Description

We are having memory leaks and more expensive computation of solvers involving `FormSum` (See more details on this [discussion](https://github.com/firedrakeproject/firedrake/discussions/3887)). That is caused by the [sum operation](https://github.com/firedrakeproject/firedrake/blob/master/firedrake/assemble.py#L472) involving `dat`. My solution here is to make a sum operation through the numpy arrays. Below is a comparison (using the example added at the [discussion](https://github.com/firedrakeproject/firedrake/discussions/3887)) of time and memory computation differences between the master branch and the current PR.

![result](https://github.com/user-attachments/assets/316e73a2-c436-4686-bee0-4a37b1c1e0c9)


