### PR TITLE
Cut down Docker image sizes

### DIFF
--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -67,9 +67,14 @@ RUN bash -c 'cd petsc; \
         --download-suitesparse \
         --download-superlu_dist \
         PETSC_ARCH=packages; \
-        mv packages/include/petscconf.h packages/include/old_petscconf.nope;'
+        mv packages/include/petscconf.h packages/include/old_petscconf.nope; \
+        rm -rf /home/firedrake/petsc/**/externalpackages; \
+        rm -rf /home/firedrake/petsc/src/docs; \
+        rm -f /home/firedrake/petsc/src/**/tutorials/output/*; \
+        rm -f /home/firedrake/petsc/src/**/tests/output/*'
 # Don't run make here, we only want MPICH and HWLOC
 # It is also necessary to move `petscconf.h` so packages isn't treated like a working PETSc
+# Cleaned up unnecessary files
 
 # Build default Firedrake PETSc
 RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
@@ -148,12 +153,6 @@ RUN bash -c 'export PETSC_DIR=/home/firedrake/petsc; \
     cd slepc; \
     ./configure; \
     make SLEPC_DIR=/home/firedrake/slepc PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=complex;'
-
-# Clean up unnecessary files
-RUN rm -rf /home/firedrake/petsc/**/externalpackages \
-    && rm -rf /home/firedrake/petsc/src/docs \
-    && rm -f /home/firedrake/petsc/src/**/tutorials/output/* \
-    && rm -f /home/firedrake/petsc/src/**/tests/output/*
 
 # Set some useful environment variables
 ENV PETSC_DIR /home/firedrake/petsc


### PR DESCRIPTION
# Description

Currently unnecessary files are removed in a separate layer in `Dockerfile.firedrake-env`, which doesn't reduce the final image size. In this PR I removed them inside the build layer, so the image size is reduced by 3GB (from 6.58GB to 3.57GB).
