### PR TITLE
Preserve  default mesh name after Netgen mesh creation

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3092,7 +3092,7 @@ def Mesh(meshfile, **kwargs):
                             permutation_name=kwargs.get("permutation_name"),
                             comm=user_comm)
     if netgen and isinstance(meshfile, netgen.libngpy._meshing.Mesh):
-        netgen_firedrake_mesh.createFromTopology(topology, name=name, comm=user_comm)
+        netgen_firedrake_mesh.createFromTopology(topology, name=plex.getName(), comm=user_comm)
         mesh = netgen_firedrake_mesh.firedrakeMesh
     else:
         mesh = make_mesh_from_mesh_topology(topology, name)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3064,6 +3064,7 @@ def Mesh(meshfile, **kwargs):
         netgen_flags = kwargs.get("netgen_flags", {"quad": False, "transform": None, "purify_to_tets": False})
         netgen_firedrake_mesh = FiredrakeMesh(meshfile, netgen_flags, user_comm)
         plex = netgen_firedrake_mesh.meshMap.petscPlex
+        plex.setName(name)
     else:
         basename, ext = os.path.splitext(meshfile)
         if ext.lower() in ['.e', '.exo']:
@@ -3090,11 +3091,11 @@ def Mesh(meshfile, **kwargs):
                             distribution_name=kwargs.get("distribution_name"),
                             permutation_name=kwargs.get("permutation_name"),
                             comm=user_comm)
-    mesh = make_mesh_from_mesh_topology(topology, name)
     if netgen and isinstance(meshfile, netgen.libngpy._meshing.Mesh):
-        netgen_firedrake_mesh.createFromTopology(topology, name=plex.getName(), comm=user_comm)
+        netgen_firedrake_mesh.createFromTopology(topology, name=name, comm=user_comm)
         mesh = netgen_firedrake_mesh.firedrakeMesh
-        mesh.name = name
+    else:
+        mesh = make_mesh_from_mesh_topology(topology, name)
     mesh._tolerance = tolerance
     return mesh
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3064,7 +3064,7 @@ def Mesh(meshfile, **kwargs):
         netgen_flags = kwargs.get("netgen_flags", {"quad": False, "transform": None, "purify_to_tets": False})
         netgen_firedrake_mesh = FiredrakeMesh(meshfile, netgen_flags, user_comm)
         plex = netgen_firedrake_mesh.meshMap.petscPlex
-        plex.setName(name)
+        plex.setName(_generate_default_mesh_topology_name(name))
     else:
         basename, ext = os.path.splitext(meshfile)
         if ext.lower() in ['.e', '.exo']:
@@ -3092,7 +3092,7 @@ def Mesh(meshfile, **kwargs):
                             permutation_name=kwargs.get("permutation_name"),
                             comm=user_comm)
     if netgen and isinstance(meshfile, netgen.libngpy._meshing.Mesh):
-        netgen_firedrake_mesh.createFromTopology(topology, name=plex.getName(), comm=user_comm)
+        netgen_firedrake_mesh.createFromTopology(topology, name=name, comm=user_comm)
         mesh = netgen_firedrake_mesh.firedrakeMesh
     else:
         mesh = make_mesh_from_mesh_topology(topology, name)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3094,6 +3094,7 @@ def Mesh(meshfile, **kwargs):
     if netgen and isinstance(meshfile, netgen.libngpy._meshing.Mesh):
         netgen_firedrake_mesh.createFromTopology(topology, name=plex.getName(), comm=user_comm)
         mesh = netgen_firedrake_mesh.firedrakeMesh
+        mesh.name = name
     mesh._tolerance = tolerance
     return mesh
 


### PR DESCRIPTION
…pointing errors

# Description
Root Cause:
The function createFromTopology in ngsPETSc.FiredrakeMesh sets the mesh's name to "Default" regardless of the provided custom or default name. This overwrites the expected mesh.name set during the Firedrake Mesh creation.
Fix Summary:
To preserve the expected mesh.name:
    After createFromTopology is called, explicitly reset mesh.name to the desired value (name) to ensure the consistency of the naming conventions.
    This ensures that the custom or default name (DEFAULT_MESH_NAME, i.e., "firedrake_default") is maintained after the Netgen mesh is created.
