### PR TITLE
Configure PETSc with --with-strict-petscerrorcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,12 @@ jobs:
           rm -rf firedrake_venv
       - name: Build Firedrake
         run: |
-          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           cd ..
           # Linting should ignore unquoted shell variable $COMPLEX
           # shellcheck disable=SC2086
           ./firedrake/scripts/firedrake-install \
             $COMPLEX \
+            --honour-petsc-dir \
             --mpicc="$MPICH_DIR"/mpicc \
             --mpicxx="$MPICH_DIR"/mpicxx \
             --mpif90="$MPICH_DIR"/mpif90 \
@@ -87,7 +87,6 @@ jobs:
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |
-          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           python "$(which firedrake-clean)"
           python -m pip install \
@@ -95,7 +94,6 @@ jobs:
           python -m pip list
       - name: Test Firedrake
         run: |
-          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           echo OMP_NUM_THREADS is "$OMP_NUM_THREADS"
           echo OPENBLAS_NUM_THREADS is "$OPENBLAS_NUM_THREADS"
@@ -121,7 +119,6 @@ jobs:
       - name: Test pyadjoint
         if: ${{ matrix.scalar-type == 'real' }}
         run: |
-          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           cd ../firedrake_venv/src/pyadjoint
           python -m pytest \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,12 @@ jobs:
           rm -rf firedrake_venv
       - name: Build Firedrake
         run: |
+          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           cd ..
           # Linting should ignore unquoted shell variable $COMPLEX
           # shellcheck disable=SC2086
           ./firedrake/scripts/firedrake-install \
             $COMPLEX \
-            --honour-petsc-dir \
             --mpicc="$MPICH_DIR"/mpicc \
             --mpicxx="$MPICH_DIR"/mpicxx \
             --mpif90="$MPICH_DIR"/mpif90 \
@@ -87,6 +87,7 @@ jobs:
             || (cat firedrake-install.log && /bin/false)
       - name: Install test dependencies
         run: |
+          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           python "$(which firedrake-clean)"
           python -m pip install \
@@ -94,6 +95,7 @@ jobs:
           python -m pip list
       - name: Test Firedrake
         run: |
+          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           echo OMP_NUM_THREADS is "$OMP_NUM_THREADS"
           echo OPENBLAS_NUM_THREADS is "$OPENBLAS_NUM_THREADS"
@@ -119,6 +121,7 @@ jobs:
       - name: Test pyadjoint
         if: ${{ matrix.scalar-type == 'real' }}
         run: |
+          unset PETSC_DIR PETSC_ARCH SLEPC_DIR
           . ../firedrake_venv/bin/activate
           cd ../firedrake_venv/src/pyadjoint
           python -m pytest \

--- a/.github/workflows/pip-mac.yml
+++ b/.github/workflows/pip-mac.yml
@@ -53,6 +53,7 @@ jobs:
             --with-shared-libraries=1 \
             --with-mpi-dir=/opt/homebrew \
             --with-zlib \
+            --with-strict-petscerrorcode \
             --download-bison \
             --download-hdf5 \
             --download-hwloc \

--- a/.github/workflows/pyop2.yml
+++ b/.github/workflows/pyop2.yml
@@ -51,6 +51,7 @@ jobs:
             --with-debugging=1 \
             --with-shared-libraries=1 \
             --with-c2html=0 \
+            --with-strict-petscerrorcode \
             --with-fortran-bindings=0
           make
 

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -66,6 +66,7 @@ RUN bash -c 'cd petsc; \
         --download-scalapack \
         --download-suitesparse \
         --download-superlu_dist \
+        --with-strict-petscerrorcode \
         PETSC_ARCH=packages; \
         mv packages/include/petscconf.h packages/include/old_petscconf.nope; \
         rm -rf /home/firedrake/petsc/**/externalpackages; \
@@ -105,6 +106,7 @@ RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
         --with-scalapack-dir=$PACKAGES \
         --with-suitesparse-dir=$PACKAGES \
         --with-superlu_dist-dir=$PACKAGES \
+        --with-strict-petscerrorcode \
         PETSC_ARCH=default; \
     make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all;'
 
@@ -144,6 +146,7 @@ RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
         --with-scalapack-dir=$PACKAGES \
         --with-suitesparse-dir=$PACKAGES \
         --with-superlu_dist-dir=$PACKAGES \
+        --with-strict-petscerrorcode \
         PETSC_ARCH=complex; \
     make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=complex all;'
 

--- a/scripts/firedrake-install
+++ b/scripts/firedrake-install
@@ -726,6 +726,7 @@ def get_petsc_options(minimal=False):
                      "--with-debugging=0",
                      "--with-shared-libraries=1",
                      "--with-c2html=0",
+                     "--with-strict-petscerrorcode",
                      # Parser generator
                      "--download-bison"}
     for pkg in get_minimal_petsc_packages():

--- a/tinyasm/matinvert.cpp
+++ b/tinyasm/matinvert.cpp
@@ -6,6 +6,6 @@ PetscErrorCode mymatinvert(PetscBLASInt* n, PetscScalar* mat, PetscBLASInt* piv,
     PetscCheck(!(*info), PETSC_COMM_SELF, PETSC_ERR_LIB, "TinyASM error calling ?getrf in mymatinvert");
     PetscCallBLAS("LAPACKgetri", LAPACKgetri_(n, mat, n, piv, work, n, info));
     PetscCheck(!(*info), PETSC_COMM_SELF, PETSC_ERR_LIB, "TinyASM error calling ?getri in mymatinvert");
-    return PETSC_SUCCESS;
+    PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -211,8 +211,8 @@ PetscErrorCode CreateCombinedSF(PC pc, const std::vector<PetscSF>& sf, const std
         }
         /* Offsets are the offsets on the current process of the
          * global dof numbering for the subspaces. */
-        MPI_Type_contiguous(n, MPIU_INT, &contig);
-        MPI_Type_commit(&contig);
+        PetscCallMPI(MPI_Type_contiguous(n, MPIU_INT, &contig));
+        PetscCallMPI(MPI_Type_commit(&contig));
 
 #if MY_PETSC_VERSION_LT(3, 14, 4)
         PetscCall(PetscSFBcastBegin(rankSF, contig, offsets, remoteOffsets));
@@ -221,7 +221,7 @@ PetscErrorCode CreateCombinedSF(PC pc, const std::vector<PetscSF>& sf, const std
         PetscCall(PetscSFBcastBegin(rankSF, contig, offsets, remoteOffsets, MPI_REPLACE));
         PetscCall(PetscSFBcastEnd(rankSF, contig, offsets, remoteOffsets, MPI_REPLACE));
 #endif
-        MPI_Type_free(&contig);
+        PetscCallMPI(MPI_Type_free(&contig));
         PetscCall(PetscFree(offsets));
         PetscCall(PetscSFDestroy(&rankSF));
         /* Now remoteOffsets contains the offsets on the remote

--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -419,6 +419,6 @@ PYBIND11_MODULE(_tinyasm, m) {
               auto blockjacobi = new BlockJacobi(dofsPerBlock, globalDofsPerBlock, localsize, newsf);
               pc->data = (void*)blockjacobi;
               PetscCall(PetscLogEventEnd(PC_tinyasm_SetASMLocalSubdomains, pc, 0, 0, 0));
-              PetscFunctionReturn(PETSC_SUCCESS);
+              return 0;
           });
 }


### PR DESCRIPTION
# Description

Motivation (https://gitlab.com/petsc/petsc/-/blob/main/include/petscsystypes.h?ref_type=heads#L53):

> The user can also configure PETSc with the `--with-strict-petscerrorcode` option to enable
  compiler warnings when the returned error codes are not captured and checked. Users are
  *heavily* encouraged to opt-in to this option, as it will become enabled by default in a
  future release.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
