### PR TITLE
Localise pytools cache to each runner

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -26,6 +26,7 @@ jobs:
       FIREDRAKE_CI_TESTS: 1  # needed to symlink the checked out branch into the venv
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Add homebrew to PATH
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
@@ -35,7 +36,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cd ..
-          rm -rf firedrake_venv
+          rm -rf firedrake_venv "$XDG_CACHE_HOME"
       - name: Install Python
         run: brew install python python-setuptools
       - name: Build Firedrake
@@ -58,4 +59,4 @@ jobs:
         if: ${{ always() }}
         run: |
           cd ..
-          rm -rf firedrake_venv
+          rm -rf firedrake_venv "$XDG_CACHE_HOME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,14 @@ jobs:
       OPENBLAS_NUM_THREADS: 1
       COMPLEX: ${{ matrix.complex }}
       RDMAV_FORK_SAFE: 1
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@v4
       - name: Cleanup
         if: ${{ always() }}
         run: |
           cd ..
-          rm -rf firedrake_venv
+          rm -rf firedrake_venv "$XDG_CACHE_HOME"
       - name: Build Firedrake
         run: |
           cd ..
@@ -134,7 +135,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cd ..
-          rm -rf firedrake_venv
+          rm -rf firedrake_venv "$XDG_CACHE_HOME"
   docker_tag:
     name: "Set the Docker release tag"
     runs-on: [self-hosted, Linux]

--- a/.github/workflows/pip-mac.yml
+++ b/.github/workflows/pip-mac.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Add homebrew to PATH
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
@@ -36,7 +37,7 @@ jobs:
       - name: Cleanup (pre)
         if: ${{ always() }}
         run: |
-          rm -rf pip_venv
+          rm -rf pip_venv "$XDG_CACHE_HOME"
           "$(brew --prefix)/bin/python3" -m pip cache purge
 
       - name: Create a virtual environment
@@ -108,5 +109,5 @@ jobs:
       - name: Cleanup (post)
         if: ${{ always() }}
         run: |
-          rm -rf pip_venv
+          rm -rf pip_venv "$XDG_CACHE_HOME"
           "$(brew --prefix)/bin/python3" -m pip cache purge

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -42,10 +42,11 @@ jobs:
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
       RDMAV_FORK_SAFE: 1
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Cleanup
         if: ${{ always() }}
-        run: rm -rf pip_venv
+        run: rm -rf pip_venv "$XDG_CACHE_HOME"
 
       - name: Create a venv
         run: |
@@ -107,4 +108,4 @@ jobs:
       - name: Cleanup
         # Belt and braces: clean up before and after the run.
         if: ${{ always() }}
-        run: rm -rf pip_venv
+        run: rm -rf pip_venv "$XDG_CACHE_HOME"

--- a/.github/workflows/pyop2.yml
+++ b/.github/workflows/pyop2.yml
@@ -20,9 +20,14 @@ jobs:
       PETSC_ARCH: default
       RDMAV_FORK_SAFE: 1
       PYOP2_CI_TESTS: 1
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     timeout-minutes: 60
 
     steps:
+      - name: Pre-run cleanup
+        if: ${{ always() }}
+        run: rm -rf firedrake "$XDG_CACHE_HOME"
+
       - name: Install system dependencies
         shell: bash
         run: |
@@ -91,3 +96,7 @@ jobs:
           mpiexec -n 2 --oversubscribe pytest -m "parallel[2]" --tb=native --timeout=480 --timeout-method=thread -o faulthandler_timeout=540 -v tests/pyop2
           mpiexec -n 3 --oversubscribe pytest -m "parallel[3]" --tb=native --timeout=480 --timeout-method=thread -o faulthandler_timeout=540 -v tests/pyop2
         timeout-minutes: 10
+
+      - name: Post-run cleanup
+        if: ${{ always() }}
+        run: rm -rf firedrake "$XDG_CACHE_HOME"


### PR DESCRIPTION
My theory:

Previously we were sharing the pytools cache between runners ($XDG_CACHE_HOME is in the home directory) and so different runners would be clearing it at different times. This may well be the reason for CI times to get so bad when the runners are oversubscribed.

Potentially relevant for https://github.com/thetisproject/thetis/issues/383


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
