### PR TITLE
Hot-fix for broken Stokes test

### DIFF
--- a/tests/firedrake/macro/test_macro_solve.py
+++ b/tests/firedrake/macro/test_macro_solve.py
@@ -148,16 +148,10 @@ def test_stokes(mh, variant, mixed_element, convergence_test):
         a, L = stokes_mms(Z, as_vector(zexact))
         bcs = DirichletBC(Z[0], as_vector(zexact[:dim]), "on_boundary")
 
+        zh = Function(Z)
         pconst = VectorSpaceBasis(constant=True, comm=Z.comm)
         nullspace = MixedVectorSpaceBasis(Z, [Z.sub(0), pconst])
-        zh = Function(Z)
-        solve(a == L, zh, bcs=bcs,
-              nullspace=nullspace,
-              solver_parameters={
-                  "mat_type": "nest",
-                  "ksp_type": "gmres",
-                  "ksp_pc_side": "right",
-                  "pc_type": "lu"})
+        solve(a == L, zh, bcs=bcs, nullspace=nullspace)
 
         uh, ph = zh.subfunctions
         u_err.append(errornorm(as_vector(zexact[:dim]), uh))

--- a/tests/firedrake/regression/test_stokes_hdiv_parallel.py
+++ b/tests/firedrake/regression/test_stokes_hdiv_parallel.py
@@ -1,4 +1,5 @@
 from firedrake import *
+from firedrake.petsc import DEFAULT_DIRECT_SOLVER
 import pytest
 import numpy
 
@@ -103,6 +104,7 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
                 # Avoid MUMPS segfaults
                 "assembled_pc_type": "redundant",
                 "assembled_redundant_pc_type": "cholesky",
+                "assembled_redundant_pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
             },
             "fieldsplit_1": {
                 "ksp_type": "preonly",
@@ -132,6 +134,6 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
     err_p = numpy.asarray(err_p)
     err_div = numpy.asarray(err_div)
 
-    assert numpy.allclose(err_div, 0, atol=2e-7, rtol=1e-5)
+    assert numpy.allclose(err_div, 0, atol=1e-7, rtol=1e-5)
     assert (numpy.log2(err_u[:-1] / err_u[1:]) > 2.8).all()
     assert (numpy.log2(err_p[:-1] / err_p[1:]) > 1.8).all()

--- a/tests/firedrake/regression/test_stokes_hdiv_parallel.py
+++ b/tests/firedrake/regression/test_stokes_hdiv_parallel.py
@@ -101,10 +101,8 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
                 "ksp_type": "preonly",
                 "pc_type": "python",
                 "pc_python_type": "firedrake.AssembledPC",
-                # Avoid MUMPS segfaults
-                "assembled_pc_type": "redundant",
-                "assembled_redundant_pc_type": "cholesky",
-                "assembled_redundant_pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
+                "assembled_pc_type": "lu",
+                "assembled_pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
             },
             "fieldsplit_1": {
                 "ksp_type": "preonly",

--- a/tests/firedrake/regression/test_stokes_hdiv_parallel.py
+++ b/tests/firedrake/regression/test_stokes_hdiv_parallel.py
@@ -132,6 +132,6 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
     err_p = numpy.asarray(err_p)
     err_div = numpy.asarray(err_div)
 
-    assert numpy.allclose(err_div, 0, atol=1e-7, rtol=1e-5)
+    assert numpy.allclose(err_div, 0, atol=2e-7, rtol=1e-5)
     assert (numpy.log2(err_u[:-1] / err_u[1:]) > 2.8).all()
     assert (numpy.log2(err_p[:-1] / err_p[1:]) > 1.8).all()


### PR DESCRIPTION
# Description
Two PETSc issues have arised after a recent hardware update. These should be further investigated and reported if necessary.

1. The macro Stokes tests broke as the combination of a **nullspace** and the solver parameters (GMRES + MUMPS LU) obtained an incorrect solution (without raising a solver error) on new hardware. This PR is to ensure that these tests work with the default solver parameters (preonly + MUMPS LU). The convergence of the solution test and div-free test have been now merged into a single test.

2. Another non-macro Stokes (IPDG H(div)) test was not meeting an absolute tolerance. Here we make it pass by using more sensible solver parameters (parallel direct solver as opposed to redundant). The old solver parameters alluded to segfaults with (MUMPS Cholesky) in complex mode, and for this reason a (redundant + PETSc Cholesky) solver was used instead. This PR changes the solver to a parallel one using (MUMPS + LU).

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
