### PR TITLE
Remove reference cycle in VecAccessMixin

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -84,7 +84,7 @@ class CoordinatelessFunction(ufl.Coefficient):
         else:
             self.dat = function_space.make_dat(val, dtype, self.name())
 
-    @utils.cached_property
+    @property
     def topological(self):
         r"""The underlying coordinateless function."""
         return self

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -127,6 +127,9 @@ class LocalDat(pyop2.types.AbstractDat):
     def __call__(self, access, map_=None):
         return LocalDatLegacyArg(self, map_, access)
 
+    def increment_dat_version(self):
+        pass
+
 
 register_petsc_function("MatSetValues")
 

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -726,7 +726,7 @@ class DatView(AbstractDat):
                                       name="view[%s](%s)" % (index, dat.name))
 
     def increment_dat_version(self):
-        pass
+        self._parent.increment_dat_version()
 
     @utils.cached_property
     def _kernel_args_(self):

--- a/pyop2/types/dat.py
+++ b/pyop2/types/dat.py
@@ -725,6 +725,9 @@ class DatView(AbstractDat):
                                       dtype=dat.dtype,
                                       name="view[%s](%s)" % (index, dat.name))
 
+    def increment_dat_version(self):
+        pass
+
     @utils.cached_property
     def _kernel_args_(self):
         return self._parent._kernel_args_
@@ -840,6 +843,9 @@ class Dat(AbstractDat, VecAccessMixin):
             self._data[:size][self._data_filter] = self._data_filtered[:]
         if access is not Access.READ:
             self.halo_valid = False
+
+    def increment_dat_version(self):
+        VecAccessMixin.increment_dat_version(self)
 
 
 class MixedDat(AbstractDat, VecAccessMixin):

--- a/pyop2/types/data_carrier.py
+++ b/pyop2/types/data_carrier.py
@@ -80,24 +80,21 @@ class EmptyDataMixin(abc.ABC):
 class VecAccessMixin(abc.ABC):
 
     def __init__(self, petsc_counter=None):
-        if petsc_counter:
-            # Use lambda since `_vec` allocates the data buffer
-            # -> Dat/Global should not allocate storage until accessed
-            self._dat_version = lambda: self._vec.stateGet()
-            self.increment_dat_version = lambda: self._vec.stateIncrease()
-        else:
-            # No associated PETSc Vec if incompatible type:
-            # -> Equip Dat/Global with their own counter.
-            self._version = 0
-            self._dat_version = lambda: self._version
-
-            def _inc():
-                self._version += 1
-            self.increment_dat_version = _inc
+        self._petsc_counter = petsc_counter
+        self._version = 0
 
     @property
     def dat_version(self):
-        return self._dat_version()
+        if self._petsc_counter:
+            return self._vec.stateGet()
+
+        return self._version
+
+    def increment_dat_version(self):
+        if self._petsc_counter:
+            self._vec.stateIncrease()
+        else:
+            self._version += 1
 
     @abc.abstractmethod
     def vec_context(self, access):

--- a/pyop2/types/data_carrier.py
+++ b/pyop2/types/data_carrier.py
@@ -44,6 +44,7 @@ class DataCarrier(abc.ABC):
         the product of the dim tuple."""
         return self._cdim
 
+    @abc.abstractmethod
     def increment_dat_version(self):
         pass
 

--- a/pyop2/types/glob.py
+++ b/pyop2/types/glob.py
@@ -399,6 +399,9 @@ class Global(SetFreeDataCarrier, VecAccessMixin):
             data = self._data
             self.comm.Bcast(data, 0)
 
+    def increment_dat_version(self):
+        VecAccessMixin.increment_dat_version(self)
+
 
 # has no comm, can only be READ
 class Constant(SetFreeDataCarrier):
@@ -464,3 +467,6 @@ class Constant(SetFreeDataCarrier):
             dtype=self.dtype,
             name=self.name
         )
+
+    def increment_dat_version(self):
+        pass

--- a/pyop2/types/mat.py
+++ b/pyop2/types/mat.py
@@ -550,6 +550,9 @@ class AbstractMat(DataCarrier, abc.ABC):
         return "Mat(%r, %r, %r)" \
                % (self._sparsity, self._datatype, self._name)
 
+    def increment_dat_version(self):
+        pass
+
 
 class Mat(AbstractMat):
     """OP2 matrix data. A Mat is defined on a sparsity pattern and holds a value


### PR DESCRIPTION
With an associated PETSc Vec, VecAccessMixin deferred its version property to a lambda to avoid allocating the storage until necessary. Unfortunately, this lambda creates a reference cycle to self for all users of the VecAccessMixin. Given that counter accesses should be relatively infrequent, it seems fine to look up the counter type within the method itself.

# Description
Related to https://github.com/firedrakeproject/firedrake/issues/4014. To benchmark, I'm using the following script (very similar to the one in the linked issue, but uses 500 timesteps, a timestepper object, and removes explicit GC calls):
```python3
from firedrake import *
from firedrake.adjoint import *
# from memory_profiler import profile

def test():
    T_c, rf = rf_generator()
    rf.fwd_call = profile(rf.__call__)
    rf.derivative = profile(rf.derivative)

    for i in range(5):
        rf.fwd_call(T_c)
        rf.derivative()

@profile
def rf_generator(checkpoint_to_disk=True):
    tape = get_working_tape()
    tape.clear_tape()
    continue_annotation()

    mesh = RectangleMesh(100, 100, 1.0, 1.0)

    if checkpoint_to_disk:
        enable_disk_checkpointing()
        mesh = checkpointable_mesh(mesh)

    V = VectorFunctionSpace(mesh, "CG", 2)
    Q = FunctionSpace(mesh, "CG", 1)

    # Define the rotation vector field
    X = SpatialCoordinate(mesh)

    w = Function(V, name="rotation").interpolate(as_vector([-X[1] - 0.5, X[0] - 0.5]))
    T_c = Function(Q, name="control")
    T = Function(Q, name="Temperature")
    T_c.interpolate(0.1 * exp(-0.5 * ((X - as_vector((0.75, 0.5))) / Constant(0.1)) ** 2))
    control = Control(T_c)
    T.assign(T_c)

    # for i in ts:
    for i in tape.timestepper(iter(range(500))):
        T.interpolate(T + inner(grad(T), w) * Constant(0.0001))

    objective = assemble(T**2 * dx)

    pause_annotation()
    return T_c, ReducedFunctional(objective, control)


if __name__ == "__main__":
    test()
```
I'm also running this on the #4020 branch to automatically enable the `SingleDiskStorageSchedule` and handle the leak of `function` within `CheckpointFunction`. On the pyadjoint side, I am using https://github.com/dolfin-adjoint/pyadjoint/pull/194.

Here's a pretty simple `mprof` comparison:
![image](https://github.com/user-attachments/assets/54c780fa-e46d-4f7c-a589-9adbd13b58e8)
In **black** is the base, without this branch. In **blue** is the base, but with `gc.collect()` within `Block.recompute` (very eager, and expensive, also doesn't apply to the derivative). In **red** is the result with this branch, _without any explicit gc_. Individual plots follow, but the rescaling means you have to look a bit more closely.

<details>
<summary>Base plot</summary>

![image](https://github.com/user-attachments/assets/afd1136a-f383-44ea-bb70-5e3d930c1211)

</details>
<details>
<summary>GC plot</summary>

![image](https://github.com/user-attachments/assets/22119f8e-99f5-471b-bb47-46624484f0d5)

</details>
<details>
<summary>This PR</summary>

![image](https://github.com/user-attachments/assets/ed8dd1ab-6113-482a-852e-fd69173ff954)

</details>

I think there is a still a bit left out there in terms of making expensive allocations delete through refcounting, and perhaps there's a more elegant way of implementing the change proposed here.