### PR TITLE
Change 'layers' to 'IntType' in pointeval_utils.py and pointquery_utils.py

### DIFF
--- a/firedrake/pointeval_utils.py
+++ b/firedrake/pointeval_utils.py
@@ -117,7 +117,7 @@ def compile_element(expression, coordinates, parameters=None):
 
     code = {
         "geometric_dimension": domain.geometric_dimension(),
-        "layers_arg": ", int const *__restrict__ layers" if extruded else "",
+        "layers_arg": f", {as_cstr(IntType)} const *__restrict__ layers" if extruded else "",
         "layers": ", layers" if extruded else "",
         "extruded_define": "1" if extruded else "0",
         "IntType": as_cstr(IntType),
@@ -151,8 +151,8 @@ int evaluate(struct Function *f, double *x, %(scalar_type)s *result)
         return 0;
     }
 #if %(extruded_define)s
-    int layers[2] = {0, 0};
-    int nlayers = f->n_layers;
+    %(IntType)s layers[2] = {0, 0};
+    %(IntType)s nlayers = f->n_layers;
     layers[1] = cell %% nlayers + 2;
     cell = cell / nlayers;
 #endif

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -233,7 +233,7 @@ def compile_coordinate_element(mesh: MeshGeometry, contains_eps: float, paramete
         "convergence_epsilon": 1e-12,
         "dX_norm_square": dX_norm_square(mesh.topological_dimension()),
         "X_isub_dX": X_isub_dX(mesh.topological_dimension()),
-        "extruded_arg": ", int const *__restrict__ layers" if mesh.extruded else "",
+        "extruded_arg": f", {as_cstr(IntType)} const *__restrict__ layers" if mesh.extruded else "",
         "extr_comment_out": "//" if mesh.extruded else "",
         "non_extr_comment_out": "//" if not mesh.extruded else "",
         "IntType": as_cstr(IntType),
@@ -291,7 +291,7 @@ static inline void wrap_to_reference_coords(
 %(RealType)s to_reference_coords_xtr(void *result_, struct Function *f, int cell, int layer, double *x)
 {
     %(RealType)s cell_dist_l1 = 0.0;
-    %(non_extr_comment_out)sint layers[2] = {0, layer+2};  // +2 because the layer loop goes to layers[1]-1, which is nlayers-1
+    %(non_extr_comment_out)s%(IntType)s layers[2] = {0, layer+2};  // +2 because the layer loop goes to layers[1]-1, which is nlayers-1
     %(non_extr_comment_out)swrap_to_reference_coords(result_, x, &cell_dist_l1, cell, cell+1, layers, f->coords, f->coords_map);
     return cell_dist_l1;
 }


### PR DESCRIPTION
Fixes #4044, PyOP2 compiler error in pointeval_utils.py and pointquery_utils.py on extruded meshes when 64-bit PETSc integers are used.
