### PR TITLE
Projector: deprecate quadrature_degree kwarg

### DIFF
--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -1,5 +1,6 @@
 import abc
 import ufl
+import warnings
 import finat.ufl
 from ufl.domain import extract_unique_domain
 from typing import Optional, Union
@@ -131,6 +132,13 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         form_compiler_parameters=None, constant_jacobian=True,
         use_slate_for_inverse=True, quadrature_degree=None
     ):
+        if quadrature_degree is not None:
+            warnings.warn(f"Passing 'quadrature_degree' to {type(self).__name__} is deprecated, "
+                          "please instead set inside the form compiler parameters", FutureWarning)
+            if "quadrature_degree" in form_compiler_parameters:
+                raise ValueError("Cannot pass quadrature degree twice")
+            form_compiler_parameters = form_compiler_parameters.copy()
+            form_compiler_parameters["quadrature_degree"] = quadrature_degree
         if solver_parameters is None:
             solver_parameters = {}
         else:
@@ -163,7 +171,6 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
             is_variable_layers = True
         self.use_slate_for_inverse = (use_slate_for_inverse and is_dg and not is_variable_layers
                                       and (not complex_mode or SLATE_SUPPORTS_COMPLEX))
-        self.quadrature_degree = quadrature_degree
 
     @cached_property
     def A(self):
@@ -174,19 +181,19 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         if not mixed and isinstance(F.finat_element, HDivTrace):
             if F.extruded:
                 a = (
-                    firedrake.inner(u, v)*firedrake.ds_t(degree=self.quadrature_degree)
-                    + firedrake.inner(u, v)*firedrake.ds_v(degree=self.quadrature_degree)
-                    + firedrake.inner(u, v)*firedrake.ds_b(degree=self.quadrature_degree)
-                    + firedrake.inner(u('+'), v('+'))*firedrake.dS_h(degree=self.quadrature_degree)
-                    + firedrake.inner(u('+'), v('+'))*firedrake.dS_v(degree=self.quadrature_degree)
+                    firedrake.inner(u, v)*firedrake.ds_t
+                    + firedrake.inner(u, v)*firedrake.ds_v
+                    + firedrake.inner(u, v)*firedrake.ds_b
+                    + firedrake.inner(u('+'), v('+'))*firedrake.dS_h
+                    + firedrake.inner(u('+'), v('+'))*firedrake.dS_v
                 )
             else:
                 a = (
-                    firedrake.inner(u, v)*firedrake.ds(degree=self.quadrature_degree)
-                    + firedrake.inner(u('+'), v('+'))*firedrake.dS(degree=self.quadrature_degree)
+                    firedrake.inner(u, v)*firedrake.ds
+                    + firedrake.inner(u('+'), v('+'))*firedrake.dS
                 )
         else:
-            a = firedrake.inner(u, v)*firedrake.dx(degree=self.quadrature_degree)
+            a = firedrake.inner(u, v)*firedrake.dx
         if self.use_slate_for_inverse:
             a = firedrake.Tensor(a).inv
         A = firedrake.assemble(a, bcs=self.bcs,
@@ -245,20 +252,20 @@ class BasicProjector(ProjectorBase):
             # but we only cover DGT.
             if F.extruded:
                 form = (
-                    firedrake.inner(self.source, v)*firedrake.ds_t(degree=self.quadrature_degree)
-                    + firedrake.inner(self.source, v)*firedrake.ds_v(degree=self.quadrature_degree)
-                    + firedrake.inner(self.source, v)*firedrake.ds_b(degree=self.quadrature_degree)
-                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS_h(degree=self.quadrature_degree)
-                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS_v(degree=self.quadrature_degree)
+                    firedrake.inner(self.source, v)*firedrake.ds_t
+                    + firedrake.inner(self.source, v)*firedrake.ds_v
+                    + firedrake.inner(self.source, v)*firedrake.ds_b
+                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS_h
+                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS_v
                 )
             else:
                 form = (
-                    firedrake.inner(self.source, v)*firedrake.ds(degree=self.quadrature_degree)
-                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS(degree=self.quadrature_degree)
+                    firedrake.inner(self.source, v)*firedrake.ds
+                    + firedrake.inner(firedrake.avg(self.source), firedrake.avg(v))*firedrake.dS
                 )
 
         else:
-            form = firedrake.inner(self.source, v)*firedrake.dx(degree=self.quadrature_degree)
+            form = firedrake.inner(self.source, v)*firedrake.dx
         return form
 
     @cached_property


### PR DESCRIPTION
# Description

This PR deprecates the  `quaddrature_degree` kwarg of `Projector`, added in https://github.com/firedrakeproject/firedrake/pull/3707. 

It turns out that this functionality was already possible via the `form_compiler_parameters`.

Fixes https://github.com/firedrakeproject/firedrake/issues/4016

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
