### PR TITLE
Use A.petscmat as the preferred way of accessing the PETSc.Mat

### DIFF
--- a/demos/netgen/netgen_mesh.py.rst
+++ b/demos/netgen/netgen_mesh.py.rst
@@ -156,7 +156,8 @@ Then a SLEPc Eigenvalue Problem Solver (`EPS`) is initialised and set up to use 
         bc = DirichletBC(V, 0, labels)
         A = assemble(a, bcs=bc)
         M = assemble(m, bcs=bc, weight=0.)
-        Asc, Msc = A.M.handle, M.M.handle
+        Asc = A.petscmat
+        Msc = M.petscmat
         E = SLEPc.EPS().create()
         E.setType(SLEPc.EPS.Type.ARNOLDI)
         E.setProblemType(SLEPc.EPS.ProblemType.GHEP)

--- a/docs/source/petsc-interface.rst
+++ b/docs/source/petsc-interface.rst
@@ -51,7 +51,7 @@ different.  For a bilinear form, the matrix is obtained with:
 
 .. code-block:: python3
 
-   petsc_mat = assemble(bilinear_form).M.handle
+   petsc_mat = assemble(bilinear_form).petscmat
 
 For a linear form, we need to use a context manager.  There are two
 options available here, depending on whether we want read-only or
@@ -136,7 +136,7 @@ newly defined class to compute the matrix action:
 
    # Assemble the bilinear form that defines A and get the concrete
    # PETSc matrix
-   A = assemble(bilinear_form).M.handle
+   A = assemble(bilinear_form).petscmat
 
    # Now do the same for the linear forms for u and v, making a copy
 

--- a/docs/source/solving-interface.rst
+++ b/docs/source/solving-interface.rst
@@ -932,7 +932,7 @@ with the following:
 .. code-block:: python3
 
    A = assemble(a)  # use bcs keyword if there are boundary conditions
-   print A.M.handle.isSymmetric(tol=1e-13)
+   print A.petscmat.isSymmetric(tol=1e-13)
 
 If the problem is not symmetric, try using a method such as GMRES
 instead.  PETSc uses restarted GMRES with a default restart of 30, for

--- a/firedrake/eigensolver.py
+++ b/firedrake/eigensolver.py
@@ -186,11 +186,11 @@ class LinearEigensolver(OptionsManager):
         int
             The number of Eigenvalues found.
         """
-        self.A_mat = assemble(self._problem.A, bcs=self._problem.bcs).M.handle
+        self.A_mat = assemble(self._problem.A, bcs=self._problem.bcs).petscmat
         self.M_mat = assemble(
             self._problem.M, bcs=self._problem.bcs,
             weight=self._problem.bc_shift and 1./self._problem.bc_shift
-        ).M.handle
+        ).petscmat
 
         self.es.setDimensions(nev=self.n_evals, ncv=self.ncv, mpd=self.mpd)
         self.es.setOperators(self.A_mat, self.M_mat)

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -193,7 +193,7 @@ each supermesh cell.
     V_S_A = FunctionSpace(reference_mesh, V_A.ufl_element())
     V_S_B = FunctionSpace(reference_mesh, V_B.ufl_element())
     M_SS = assemble(inner(TrialFunction(V_S_A), TestFunction(V_S_B)) * dx)
-    M_SS = M_SS.M.handle[:, :]
+    M_SS = M_SS.petscmat[:, :]
     node_locations_A = utils.physical_node_locations(V_S_A).dat.data_ro_with_halos
     node_locations_B = utils.physical_node_locations(V_S_B).dat.data_ro_with_halos
     num_nodes_A = node_locations_A.shape[0]

--- a/tests/firedrake/regression/test_custom_pc_python_pmat.py
+++ b/tests/firedrake/regression/test_custom_pc_python_pmat.py
@@ -32,7 +32,7 @@ def test_python_pc_valueerror():
     u = TrialFunction(V)
     v = TestFunction(V)
 
-    A = assemble(inner(u, v) * dx).M.handle
+    A = assemble(inner(u, v) * dx).petscmat
     pc = PETSc.PC().create(comm=mesh.comm)
     pc.setType(pc.Type.PYTHON)
     pc.setOperators(A, A)

--- a/tests/firedrake/regression/test_matrix.py
+++ b/tests/firedrake/regression/test_matrix.py
@@ -22,7 +22,7 @@ def trial(V):
 
 @pytest.fixture
 def a(test, trial):
-    return inner(trial, test)*dx
+    return inner(trial, test) * dx
 
 
 @pytest.fixture(params=["nest", "aij", "matfree"])
@@ -36,17 +36,13 @@ def test_assemble_returns_matrix(a):
     assert isinstance(A, matrix.Matrix)
 
 
-def test_solve_with_assembled_matrix():
-    mesh = UnitIntervalMesh(3)
-    V = FunctionSpace(mesh, "CG", 1)
-
-    u = TrialFunction(V)
-    v = TestFunction(V)
-    x, = SpatialCoordinate(mesh)
+def test_solve_with_assembled_matrix(a):
+    (v, u) = a.arguments()
+    V = v.function_space()
+    x, = SpatialCoordinate(V.mesh())
     f = Function(V).interpolate(x)
 
-    a = inner(u, v) * dx
-    A = AssembledMatrix((v, u), bcs=(), petscmat=assemble(a).M.handle)
+    A = AssembledMatrix((v, u), bcs=(), petscmat=assemble(a).petscmat)
     L = inner(f, v) * dx
 
     solution = Function(V)

--- a/tests/firedrake/regression/test_projection_zany.py
+++ b/tests/firedrake/regression/test_projection_zany.py
@@ -88,8 +88,7 @@ def test_mass_conditioning(element, degree, hierarchy):
         u = TrialFunction(V)
         v = TestFunction(V)
         a = inner(u, v)*dx
-        B = assemble(a, mat_type="aij").M.handle
-        A = B.convert("dense").getDenseArray()
+        A = assemble(a, mat_type="aij").petscmat[:, :]
         kappa = np.linalg.cond(A)
 
         mass_cond.append(kappa)

--- a/tests/firedrake/regression/test_stress_elements.py
+++ b/tests/firedrake/regression/test_stress_elements.py
@@ -152,8 +152,7 @@ def test_mass_conditioning(stress_element, mesh_hierarchy):
         tau = TestFunction(Sig)
         mass = inner(sigh, tau)*dx
         a = derivative(mass, sigh)
-        B = assemble(a, mat_type="aij").M.handle
-        A = B.convert("dense").getDenseArray()
+        A = assemble(a, mat_type="aij").petscmat[:, :]
         kappa = np.linalg.cond(A)
 
         mass_cond.append(kappa)

--- a/tests/firedrake/regression/test_vfs_component_bcs.py
+++ b/tests/firedrake/regression/test_vfs_component_bcs.py
@@ -214,15 +214,12 @@ def test_component_full_bcs(V):
     v = TestFunction(V)
     a = inner(grad(u), grad(v))*dx
 
-    def asarray(A):
-        return A.M.handle[:, :]
+    A_full = assemble(a, bcs=bcs_full, mat_type="aij")
+    A_cmp = assemble(a, bcs=bcs_cmp, mat_type="aij")
+    A_mixed = assemble(a, bcs=bcs_mixed, mat_type="aij")
 
-    A_full = asarray(assemble(a, bcs=bcs_full, mat_type="aij"))
-    A_cmp = asarray(assemble(a, bcs=bcs_cmp, mat_type="aij"))
-    A_mixed = asarray(assemble(a, bcs=bcs_mixed, mat_type="aij"))
-
-    assert np.allclose(A_full, A_cmp)
-    assert np.allclose(A_mixed, A_full)
+    assert A_full.petscmat.equal(A_cmp.petscmat)
+    assert A_mixed.petscmat.equal(A_full.petscmat)
 
 
 def test_component_full_bcs_overlap(V):
@@ -240,10 +237,7 @@ def test_component_full_bcs_overlap(V):
 
     a = inner(grad(u), grad(v)) * dx
 
-    def asarray(A):
-        return A.M.handle[:, :]
+    A_1 = assemble(a, bcs=bcs_1, mat_type="aij")
+    A_2 = assemble(a, bcs=bcs_2, mat_type="aij")
 
-    A_1 = asarray(assemble(a, bcs=bcs_1, mat_type="aij"))
-    A_2 = asarray(assemble(a, bcs=bcs_2, mat_type="aij"))
-
-    assert np.allclose(A_1, A_2)
+    assert A_1.petscmat.equal(A_2.petscmat)

--- a/tests/firedrake/supermesh/test_assemble_mixed_mass_matrix.py
+++ b/tests/firedrake/supermesh/test_assemble_mixed_mass_matrix.py
@@ -49,7 +49,7 @@ def test_assemble_mixed_mass_matrix(mesh, family_A, family_B, degree_A, degree_B
     M = assemble_mixed_mass_matrix(V_A, V_B)
 
     M_ex = assemble(inner(TrialFunction(V_A), TestFunction(V_B)) * dx)
-    M_ex = M_ex.M.handle
+    M_ex = M_ex.petscmat
 
     M_ex.axpy(-1.0, M)
     nrm = M_ex.norm(PETSc.NormType.NORM_INFINITY)


### PR DESCRIPTION
# Description
There are two equivalent ways of accessing the underlying `PETSc.Mat` of a `firedrake.MatrixBase`. These are `A.M.handle` and `A.petscmat`, in fact `A.petscmat is A.M.handle`.  This PR favours `A.petscmat` over `A.M.handle` for the sake of clarity. 

`A.M` is the underlying pyop2 tensor, but for generic `AssembledMatrices`, `A.M` is just a `NameSpace` that emulates the pyop2 tensor.  The pyop2 tensor can be useful in some cases, for example it provides convenient access to each block of a MatNest via `A.M[i, j]`, but in most cases it is more convenient and clear to access `A.petscmat` directly.

This PR does not change API, it is just to improve clarity.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
