### PR TITLE
Add simple G-ADOPT test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,15 @@ jobs:
             gusto-repo/integration-tests/transport/test_embedded_dg_advection.py
         timeout-minutes: 10
 
+      - name: Run G-ADOPT smoke tests
+        if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
+        run: |
+          . venv/bin/activate
+          git clone --depth 1 https://github.com/g-adopt/g-adopt.git g-adopt-repo
+          pip install --verbose ./g-adopt-repo
+          make -C g-adopt-repo/demos/mantle_convection/base_case check
+        timeout-minutes: 5
+
       - name: Publish test report
         uses: mikepenz/action-junit-report@v5.0.0-a02
         # To avoid permissions issues do not run with forked repos


### PR DESCRIPTION
# Description

Similar to the other downstream tests, this should just be a simple integration to make sure nothing is massively broken. Other g-adopt folks could chime in with useful tests that are a bit more complex in terms of code paths exercised than the simple base case (or perhaps this could be driven from the g-adopt side, and the test here in Firedrake will just run the minimal suite).

- [x] Requires https://github.com/g-adopt/g-adopt/pull/178