### PR TITLE
Set -options_left=no when running under pytest

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -6,15 +6,11 @@ from firedrake.configuration import setup_cache_dirs
 setup_cache_dirs()
 
 # Ensure petsc is initialised by us before anything else gets in there.
-#
-# When running with pytest-xdist (i.e. pytest -n <#procs>) PETSc finalize will
-# crash (see https://github.com/firedrakeproject/firedrake/issues/3247). This
-# is because PETSc wants to complain about unused options to stderr, but by this
-# point the worker's stderr stream has already been destroyed by xdist, causing
-# a crash. To prevent this we disable unused options checking in PETSc when
-# running with xdist.
+# We conditionally pass '-options_left no' as in some circumstances (e.g.
+# when running pytest) PETSc complains that command line options are not
+# PETSc options.
 import petsc4py
-if "PYTEST_XDIST_WORKER" in os.environ:
+if os.getenv("FIREDRAKE_DISABLE_OPTIONS_LEFT") == "1":
     petsc4py.init(sys.argv + ["-options_left", "no"])
 else:
     petsc4py.init(sys.argv)

--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -2,6 +2,10 @@
 
 import os
 
+# Disable warnings for missing options when running with pytest as PETSc does
+# not know what to do with the pytest arguments.
+os.environ["FIREDRAKE_DISABLE_OPTIONS_LEFT"] = "1"
+
 import pytest
 from firedrake.petsc import PETSc, get_external_packages
 


### PR DESCRIPTION
# Description

This stops a lot of annoying warnings.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
