### PR TITLE
Remove CI test annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,8 +175,8 @@ jobs:
           make -C g-adopt-repo/demos/mantle_convection/base_case check
         timeout-minutes: 5
 
-      - name: Publish test report
-        uses: mikepenz/action-junit-report@v5.0.0-a02
+      - name: Annotate failing tests
+        uses: mikepenz/action-junit-report@v5
         # To avoid permissions issues do not run with forked repos
         # (see https://github.com/mikepenz/action-junit-report/issues/23)
         if: |
@@ -185,10 +185,8 @@ jobs:
           && (github.event.pull_request.head.repo.full_name == github.repository)
         with:
           report_paths: 'firedrake*.xml'
-          comment: true
-          check_name: "Firedrake ${{ matrix.arch }}"
-          updateComment: true
-          flaky_summary: true
+          annotate_only: true
+          annotations_limit: 20
 
       - name: Upload log files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,56 +101,56 @@ jobs:
           . venv/bin/activate
           : # Use pytest-xdist here so we can have a single collated output (not possible
           : # for parallel tests)
-          firedrake-run-split-tests 1 1 "-n 12 $EXTRA_PYTEST_ARGS --junit-xml=firedrake1_{#}.xml"
+          firedrake-run-split-tests 1 1 "-n 12 $EXTRA_PYTEST_ARGS"
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 2)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 2 6 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake2_{#}.xml"
+          firedrake-run-split-tests 2 6 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 30
 
       - name: Run tests (nprocs = 3)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 3 4 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake3_{#}.xml"
+          firedrake-run-split-tests 3 4 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 4)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 4 3 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake4_{#}.xml"
+          firedrake-run-split-tests 4 3 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 5)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 5 2 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake5_{#}.xml"
+          firedrake-run-split-tests 5 2 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 6)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 6 2 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake6_{#}.xml"
+          firedrake-run-split-tests 6 2 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 7)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 7 1 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake7_{#}.xml"
+          firedrake-run-split-tests 7 1 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 8)
         if: ${{ success() || steps.install.conclusion == 'success' }}
         run: |
           . venv/bin/activate
-          firedrake-run-split-tests 8 1 "$EXTRA_PYTEST_ARGS --junit-xml=firedrake8_{#}.xml"
+          firedrake-run-split-tests 8 1 "$EXTRA_PYTEST_ARGS"
         timeout-minutes: 15
 
       - name: Run Gusto smoke tests
@@ -174,19 +174,6 @@ jobs:
           pip install --verbose ./g-adopt-repo
           make -C g-adopt-repo/demos/mantle_convection/base_case check
         timeout-minutes: 5
-
-      - name: Annotate failing tests
-        uses: mikepenz/action-junit-report@v5
-        # To avoid permissions issues do not run with forked repos
-        # (see https://github.com/mikepenz/action-junit-report/issues/23)
-        if: |
-          (success() || steps.install.conclusion == 'success')
-          && (github.ref != 'refs/heads/master')
-          && (github.event.pull_request.head.repo.full_name == github.repository)
-        with:
-          report_paths: 'firedrake*.xml'
-          annotate_only: true
-          annotations_limit: 20
 
       - name: Upload log files
         uses: actions/upload-artifact@v4

--- a/tests/firedrake/regression/test_assemble.py
+++ b/tests/firedrake/regression/test_assemble.py
@@ -86,6 +86,8 @@ def M(fs):
 
 
 def test_one_form(M, f):
+    # to test the new action, obvs undo me
+    assert False
     one_form = assemble(action(M, f))
     assert isinstance(one_form, Cofunction)
     for f in one_form.subfunctions:

--- a/tests/firedrake/regression/test_assemble.py
+++ b/tests/firedrake/regression/test_assemble.py
@@ -86,8 +86,6 @@ def M(fs):
 
 
 def test_one_form(M, f):
-    # to test the new action, obvs undo me
-    assert False
     one_form = assemble(action(M, f))
     assert isinstance(one_form, Cofunction)
     for f in one_form.subfunctions:


### PR DESCRIPTION
I am proposing that we remove the https://github.com/mikepenz/action-junit-report step from our CI. The step is there to annotate the "Files changed" tab with information about the failing tests but it creates another GitHub check called "Firedrake default" or "Firedrake complex" that gets associated with the wrong workflow ([example](https://github.com/firedrakeproject/firedrake/pull/4082/checks?check_run_id=38136954898)) ([issue](https://github.com/mikepenz/action-junit-report/issues/40)).

I think it makes things more confusing when it is supposed to do the opposite.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
