### PR TITLE
fix test pyop2 kernel compilation error with gcc14

### DIFF
--- a/pyop2/global_kernel.py
+++ b/pyop2/global_kernel.py
@@ -389,6 +389,7 @@ class GlobalKernel:
         cppargs = [f"-I{d}/include" for d in get_petsc_dir()]
         cppargs.extend(f"-I{d}" for d in self.local_kernel.include_dirs)
         cppargs.append(f"-I{os.path.abspath(os.path.dirname(__file__))}")
+        cppargs.append("-Wno-incompatible-pointer-types")
         return tuple(cppargs)
 
     @cached_property


### PR DESCRIPTION
# Description
Since gcc14, some -Wincompatible-pointer-types are treated as error,
especially when you define func (int a[2][3]) {...}
and pass func with a pointer int p[6].

This pr might not be the best solution, however, one should fix the op2 kernel code in tests/pyop2/test_vector_map.py. e.g.
```
    k = """
    static void k(int d[2], int vd[1][2]) {
    d[0] = vd[0][0];
    d[1] = vd[0][1];
    }"""
```
to 
```
    k = """
    static void k(int d[2], int vd[2]) {
    d[0] = vd[0];
    d[1] = vd[1];
    }"""
```
at the cost of less human readability.

related issue: https://github.com/firedrakeproject/firedrake/issues/4096

I am a nixpkgs commiter on the roadmap to build/test/package firedrake/petsc with the power of nix build system which claim a reproducible firedrake environment.

Glad to see the Modernization of the installation of firedrake and its component.
<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
