### PR TITLE
remove version limitation on decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 requires-python = ">=3.10"
 dependencies = [
   "cachetools",
-  "decorator<=4.4.2",
+  "decorator",
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
   # TODO: We are only using our fork here because the most recent PyPI release


### PR DESCRIPTION
as far as i have tested on my firedrake [develop enviroment](https://github.com/[qbisi/nix-develop](https://github.com/qbisi/nix-develop)) built with nix, decorator 5.1.1 works well, and no test fails cause of newer version of decorator.

since old version of decorator conflict with ipykernel which is built with decorator 5.1.1.

can you test remove the version limitation of decorator on other platform.


Update:
these 4 pyop2 tests failed with decorator 5.1.1
```
FAILED tests/pyop2/test_api.py::TestDatAPI::test_dat_illegal_set - AttributeError: 'str' object has no attribute 'total_size'
FAILED tests/pyop2/test_api.py::TestDatAPI::test_dat_illegal_name[1] - Failed: DID NOT RAISE <class 'pyop2.exceptions.NameTypeError'>
FAILED tests/pyop2/test_api.py::TestDatAPI::test_dat_illegal_name[2] - Failed: DID NOT RAISE <class 'pyop2.exceptions.NameTypeError'>
FAILED tests/pyop2/test_api.py::TestDatAPI::test_dat_illegal_name[dset2] - Failed: DID NOT RAISE <class 'pyop2.exceptions.NameTypeError'>
```
<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
