### PR TITLE
Use h5py from PyPI regardless of python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "decorator<=4.4.2",
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
-  "h5py",
+  "h5py>3.12.1",
   "libsupermesh",
   "petsc4py",
   "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,7 @@ dependencies = [
   "decorator<=4.4.2",
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
-  # TODO: We are only using our fork here because the most recent PyPI release
-  # does not yet work with build isolation for Python 3.13. Once a version
-  # newer than 3.12.1 is released we can revert to simply using "h5py".
-  "h5py @ git+https://github.com/firedrakeproject/h5py.git ; python_version >= '3.13'",
-  "h5py; python_version < '3.13'",
+  "h5py",
   "libsupermesh",
   "petsc4py",
   "numpy",


### PR DESCRIPTION
# Description

I can see a `h5py 3.13.0` on PyPI which has
```
h5py-3.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.9 MB view details)
Uploaded Feb 18, 2025 CPython 3.13 manylinux: glibc 2.17+ x86-64

h5py-3.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.7 MB view details)
Uploaded Feb 18, 2025 CPython 3.13 manylinux: glibc 2.17+ ARM64
```
among the `Built Distributions`, hopefully it's enough to remove the pin.
