### PR TITLE
Use the `skipslepc` pytest mark on more tests

### DIFF
--- a/tests/firedrake/adjoint/test_optimisation.py
+++ b/tests/firedrake/adjoint/test_optimisation.py
@@ -183,6 +183,7 @@ class TransformType(Enum):
 
 
 def transform(v, transform_type, *args, mfn_parameters=None, **kwargs):
+    from slepc4py import SLEPc
     with stop_annotating():
         if mfn_parameters is None:
             mfn_parameters = {}

--- a/tests/firedrake/adjoint/test_optimisation.py
+++ b/tests/firedrake/adjoint/test_optimisation.py
@@ -3,14 +3,6 @@ import pytest
 from enum import Enum, auto
 from numpy.testing import assert_allclose
 import numpy as np
-try:
-    import petsc4py.PETSc as PETSc
-except ModuleNotFoundError:
-    PETSc = None
-try:
-    import slepc4py.SLEPc as SLEPc
-except ModuleNotFoundError:
-    SLEPc = None
 from firedrake import *
 from firedrake.adjoint import *
 from pyadjoint import Block, MinimizationProblem, TAOSolver, get_working_tape
@@ -276,7 +268,7 @@ class TransformBlock(Block):
         return transform(v, *self._args, **self._kwargs)
 
 
-@pytest.mark.skipif(SLEPc is None, reason="SLEPc not available")
+@pytest.mark.skipslepc
 @pytest.mark.parametrize("tao_type", ["lmvm",
                                       "blmvm"])
 @pytest.mark.skipcomplex

--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -81,10 +81,22 @@ def _skip_test_dependency(dependency):
         raise ValueError("Unrecognised dependency to check: {dependency = }")
 
 
+dependency_skip_markers_and_reasons = (
+    ("mumps", "skipmumps", "MUMPS not installed with PETSc"),
+    ("hypre", "skiphypre", "hypre not installed with PETSc"),
+    ("slepc", "skipslepc", "SLEPc is not installed"),
+    ("pytorch", "skiptorch", "PyTorch is not installed"),
+    ("jax", "skipjax", "JAX is not installed"),
+    ("matplotlib", "skipplot", "Matplotlib is not installed"),
+    ("netgen", "skipnetgen", "Netgen and ngsPETSc are not installed"),
+    ("vtk", "skipvtk", "VTK is not installed")
+)
+
+
 # This allows us to check test dependencies within tests e.g. the demo tests
 @pytest.fixture
 def skip_dependency():
-    return _skip_test_dependency
+    return _skip_test_dependency, dependency_skip_markers_and_reasons
 
 
 def pytest_configure(config):
@@ -148,29 +160,9 @@ def pytest_collection_modifyitems(session, config, items):
             if item.get_closest_marker("skipreal") is not None:
                 item.add_marker(pytest.mark.skip(reason="Test makes no sense unless in complex mode"))
 
-        if _skip_test_dependency("mumps") and item.get_closest_marker("skipmumps") is not None:
-            item.add_marker(pytest.mark.skip("MUMPS not installed with PETSc"))
-
-        if _skip_test_dependency("hypre") and item.get_closest_marker("skiphypre") is not None:
-            item.add_marker(pytest.mark.skip("hypre not installed with PETSc"))
-
-        if _skip_test_dependency("slepc") and item.get_closest_marker("skipslepc") is not None:
-            item.add_marker(pytest.mark.skip(reason="SLEPc is not installed"))
-
-        if _skip_test_dependency("pytorch") and item.get_closest_marker("skiptorch") is not None:
-            item.add_marker(pytest.mark.skip(reason="PyTorch is not installed"))
-
-        if _skip_test_dependency("jax") and item.get_closest_marker("skipjax") is not None:
-            item.add_marker(pytest.mark.skip(reason="JAX is not installed"))
-
-        if _skip_test_dependency("matplotlib") and item.get_closest_marker("skipplot") is not None:
-            item.add_marker(pytest.mark.skip(reason="Matplotlib is not installed"))
-
-        if _skip_test_dependency("netgen") and item.get_closest_marker("skipnetgen") is not None:
-            item.add_marker(pytest.mark.skip(reason="Netgen and ngsPETSc are not installed"))
-
-        if _skip_test_dependency("vtk") and item.get_closest_marker("skipvtk") is not None:
-            item.add_marker(pytest.mark.skip(reason="VTK is not installed"))
+        for dep, marker, reason in dependency_skip_markers_and_reasons:
+            if _skip_test_dependency(dep) and item.get_closest_marker(marker) is not None:
+                item.add_marker(pytest.mark.skip(reason))
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -81,6 +81,12 @@ def _skip_test_dependency(dependency):
         raise ValueError("Unrecognised dependency to check: {dependency = }")
 
 
+# This allows us to check test dependencies within tests e.g. the demo tests
+@pytest.fixture
+def skip_dependency():
+    return _skip_test_dependency
+
+
 def pytest_configure(config):
     """Register an additional marker."""
     config.addinivalue_line(

--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -148,31 +148,29 @@ def pytest_collection_modifyitems(session, config, items):
             if item.get_closest_marker("skipreal") is not None:
                 item.add_marker(pytest.mark.skip(reason="Test makes no sense unless in complex mode"))
 
-        # Do not skip tests when CI is running
-        if os.getenv("FIREDRAKE_CI") != "1":
-            if _skip_test_dependency("mumps") and item.get_closest_marker("skipmumps") is not None:
-                item.add_marker(pytest.mark.skip("MUMPS not installed with PETSc"))
+        if _skip_test_dependency("mumps") and item.get_closest_marker("skipmumps") is not None:
+            item.add_marker(pytest.mark.skip("MUMPS not installed with PETSc"))
 
-            if _skip_test_dependency("hypre") and item.get_closest_marker("skiphypre") is not None:
-                item.add_marker(pytest.mark.skip("hypre not installed with PETSc"))
+        if _skip_test_dependency("hypre") and item.get_closest_marker("skiphypre") is not None:
+            item.add_marker(pytest.mark.skip("hypre not installed with PETSc"))
 
-            if _skip_test_dependency("slepc") and item.get_closest_marker("skipslepc") is not None:
-                item.add_marker(pytest.mark.skip(reason="SLEPc is not installed"))
+        if _skip_test_dependency("slepc") and item.get_closest_marker("skipslepc") is not None:
+            item.add_marker(pytest.mark.skip(reason="SLEPc is not installed"))
 
-            if _skip_test_dependency("pytorch") and item.get_closest_marker("skiptorch") is not None:
-                item.add_marker(pytest.mark.skip(reason="PyTorch is not installed"))
+        if _skip_test_dependency("pytorch") and item.get_closest_marker("skiptorch") is not None:
+            item.add_marker(pytest.mark.skip(reason="PyTorch is not installed"))
 
-            if _skip_test_dependency("jax") and item.get_closest_marker("skipjax") is not None:
-                item.add_marker(pytest.mark.skip(reason="JAX is not installed"))
+        if _skip_test_dependency("jax") and item.get_closest_marker("skipjax") is not None:
+            item.add_marker(pytest.mark.skip(reason="JAX is not installed"))
 
-            if _skip_test_dependency("matplotlib") and item.get_closest_marker("skipplot") is not None:
-                item.add_marker(pytest.mark.skip(reason="Matplotlib is not installed"))
+        if _skip_test_dependency("matplotlib") and item.get_closest_marker("skipplot") is not None:
+            item.add_marker(pytest.mark.skip(reason="Matplotlib is not installed"))
 
-            if _skip_test_dependency("netgen") and item.get_closest_marker("skipnetgen") is not None:
-                item.add_marker(pytest.mark.skip(reason="Netgen and ngsPETSc are not installed"))
+        if _skip_test_dependency("netgen") and item.get_closest_marker("skipnetgen") is not None:
+            item.add_marker(pytest.mark.skip(reason="Netgen and ngsPETSc are not installed"))
 
-            if _skip_test_dependency("vtk") and item.get_closest_marker("skipvtk") is not None:
-                item.add_marker(pytest.mark.skip(reason="VTK is not installed"))
+        if _skip_test_dependency("vtk") and item.get_closest_marker("skipvtk") is not None:
+            item.add_marker(pytest.mark.skip(reason="VTK is not installed"))
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -26,7 +26,7 @@ def _skip_test_dependency(dependency):
 
     if dependency == "slepc":
         try:
-            from slepc4py import SLEPc
+            from slepc4py import SLEPc  # noqa: F401
             del SLEPc
             return not skip
         except ImportError:
@@ -34,7 +34,7 @@ def _skip_test_dependency(dependency):
 
     elif dependency == 'matplotlib':
         try:
-            import matplotlib
+            import matplotlib  # noqa: F401
             del matplotlib
             return not skip
         except ImportError:
@@ -42,7 +42,7 @@ def _skip_test_dependency(dependency):
 
     elif dependency == "pytorch":
         try:
-            import firedrake.ml.pytorch as fd_torch
+            import firedrake.ml.pytorch as fd_torch  # noqa: F401
             del fd_torch
             return not skip
         except ImportError:
@@ -50,7 +50,7 @@ def _skip_test_dependency(dependency):
 
     elif dependency == "jax":
         try:
-            import firedrake.ml.jax as fd_jax
+            import firedrake.ml.jax as fd_jax  # noqa: F401
             del fd_jax
             return not skip
         except ImportError:
@@ -58,9 +58,9 @@ def _skip_test_dependency(dependency):
 
     elif dependency == "netgen":
         try:
-            import netgen
+            import netgen  # noqa: F401
             del netgen
-            import ngsPETSc
+            import ngsPETSc  # noqa: F401
             del ngsPETSc
             return not skip
         except ImportError:
@@ -68,7 +68,7 @@ def _skip_test_dependency(dependency):
 
     elif dependency == "vtk":
         try:
-            from firedrake.output import VTKFile
+            from firedrake.output import VTKFile  # noqa: F401
             del VTKFile
             return not skip
         except ImportError:

--- a/tests/firedrake/demos/test_demos_run.py
+++ b/tests/firedrake/demos/test_demos_run.py
@@ -71,31 +71,12 @@ def test_no_missing_demos():
 
 
 def _maybe_skip_demo(demo, skip_dependency):
+    skip_dep, dependency_skip_markers_and_reasons = skip_dependency
     # Add pytest skips for missing imports or packages
 
-    if "mumps" in demo.requirements and skip_dependency("mumps"):
-        pytest.skip("MUMPS not installed with PETSc")
-
-    if "hypre" in demo.requirements and skip_dependency("hypre"):
-        pytest.skip("hypre not installed with PETSc")
-
-    if "slepc" in demo.requirements and skip_dependency("slepc"):
-        pytest.skip("SLEPc is not installed")
-
-    if "matplotlib" in demo.requirements and skip_dependency("matplotlib"):
-        pytest.skip("Matplotlib is not installed")
-
-    if "netgen" in demo.requirements and skip_dependency("netgen"):
-        pytest.skip("Netgen and ngsPETSc are not installed")
-
-    if "vtk" in demo.requirements and skip_dependency("vtk"):
-        pytest.skip("VTK is not installed")
-
-    if "pytorch" in demo.requirements and skip_dependency("pytorch"):
-        pytest.skip("PyTorch is not installed")
-
-    if "jax" in demo.requirements and skip_dependency("jax"):
-        pytest.skip("JAX is not installed")
+    for dep, _, reason in dependency_skip_markers_and_reasons:
+        if dep in demo.requirements and skip_dep(dep):
+            pytest.skip(reason)
 
 
 def _prepare_demo(demo, monkeypatch, tmpdir):

--- a/tests/firedrake/demos/test_demos_run.py
+++ b/tests/firedrake/demos/test_demos_run.py
@@ -10,8 +10,6 @@ from os.path import abspath, basename, dirname, join, splitext
 import pyadjoint
 import pytest
 
-from firedrake.petsc import get_external_packages
-
 
 Demo = namedtuple("Demo", ["loc", "requirements"])
 
@@ -37,7 +35,7 @@ SERIAL_DEMOS = [
     Demo(("matrix_free", "rayleigh-benard"), ["hypre", "mumps", "vtk"]),
     Demo(("matrix_free", "stokes"), ["hypre", "mumps", "vtk"]),
     Demo(("multigrid", "geometric_multigrid"), ["vtk"]),
-    Demo(("netgen", "netgen_mesh"), ["mumps", "ngsPETSc", "netgen", "slepc", "vtk"]),
+    Demo(("netgen", "netgen_mesh"), ["mumps", "netgen", "slepc", "vtk"]),
     Demo(("nonlinear_QG_winddrivengyre", "qg_winddrivengyre"), ["vtk"]),
     Demo(("parallel-printing", "parprint"), []),
     Demo(("poisson", "poisson_mixed"), ["vtk"]),
@@ -74,37 +72,31 @@ def test_no_missing_demos():
 
 def _maybe_skip_demo(demo):
     # Add pytest skips for missing imports or packages
-    if "mumps" in demo.requirements and "mumps" not in get_external_packages():
+    from conftest import _skip_test_dependency
+
+    if "mumps" in demo.requirements and _skip_test_dependency("mumps"):
         pytest.skip("MUMPS not installed with PETSc")
 
-    if "hypre" in demo.requirements and "hypre" not in get_external_packages():
+    if "hypre" in demo.requirements and _skip_test_dependency("hypre"):
         pytest.skip("hypre not installed with PETSc")
 
-    if "slepc" in demo.requirements:
-        try:
-            # Do not use `pytest.importorskip` to check for slepc4py:
-            # It isn't sufficient to actually detect whether slepc4py
-            # is installed. Both petsc4py and slepc4py require
-            # `from xy4py import Xy`
-            # to actually load the library.
-            from slepc4py import SLEPc  # noqa: F401
-        except ImportError:
-            pytest.skip("SLEPc unavailable")
+    if "slepc" in demo.requirements and _skip_test_dependency("slepc"):
+        pytest.skip("SLEPc is not installed")
 
-    if "matplotlib" in demo.requirements:
-        pytest.importorskip("matplotlib", reason="Matplotlib unavailable")
+    if "matplotlib" in demo.requirements and _skip_test_dependency("matplotlib"):
+        pytest.skip("Matplotlib is not installed")
 
-    if "netgen" in demo.requirements:
-        pytest.importorskip("netgen", reason="Netgen unavailable")
+    if "netgen" in demo.requirements and _skip_test_dependency("netgen"):
+        pytest.skip("Netgen and ngsPETSc are not installed")
 
-    if "ngsPETSc" in demo.requirements:
-        pytest.importorskip("ngsPETSc", reason="ngsPETSc unavailable")
+    if "vtk" in demo.requirements and _skip_test_dependency("vtk"):
+        pytest.skip("VTK is not installed")
 
-    if "vtk" in demo.requirements:
-        try:
-            import vtkmodules.vtkCommonDataModel  # noqa: F401
-        except ImportError:
-            pytest.skip("VTK unavailable")
+    if "pytorch" in demo.requirements and _skip_test_dependency("pytorch"):
+        pytest.skip("PyTorch is not installed")
+
+    if "jax" in demo.requirements and _skip_test_dependency("jax"):
+        pytest.skip("JAX is not installed")
 
 
 def _prepare_demo(demo, monkeypatch, tmpdir):

--- a/tests/firedrake/demos/test_demos_run.py
+++ b/tests/firedrake/demos/test_demos_run.py
@@ -70,32 +70,31 @@ def test_no_missing_demos():
     assert not all_demo_locs, "Unrecognised demos listed"
 
 
-def _maybe_skip_demo(demo):
+def _maybe_skip_demo(demo, skip_dependency):
     # Add pytest skips for missing imports or packages
-    from conftest import _skip_test_dependency
 
-    if "mumps" in demo.requirements and _skip_test_dependency("mumps"):
+    if "mumps" in demo.requirements and skip_dependency("mumps"):
         pytest.skip("MUMPS not installed with PETSc")
 
-    if "hypre" in demo.requirements and _skip_test_dependency("hypre"):
+    if "hypre" in demo.requirements and skip_dependency("hypre"):
         pytest.skip("hypre not installed with PETSc")
 
-    if "slepc" in demo.requirements and _skip_test_dependency("slepc"):
+    if "slepc" in demo.requirements and skip_dependency("slepc"):
         pytest.skip("SLEPc is not installed")
 
-    if "matplotlib" in demo.requirements and _skip_test_dependency("matplotlib"):
+    if "matplotlib" in demo.requirements and skip_dependency("matplotlib"):
         pytest.skip("Matplotlib is not installed")
 
-    if "netgen" in demo.requirements and _skip_test_dependency("netgen"):
+    if "netgen" in demo.requirements and skip_dependency("netgen"):
         pytest.skip("Netgen and ngsPETSc are not installed")
 
-    if "vtk" in demo.requirements and _skip_test_dependency("vtk"):
+    if "vtk" in demo.requirements and skip_dependency("vtk"):
         pytest.skip("VTK is not installed")
 
-    if "pytorch" in demo.requirements and _skip_test_dependency("pytorch"):
+    if "pytorch" in demo.requirements and skip_dependency("pytorch"):
         pytest.skip("PyTorch is not installed")
 
-    if "jax" in demo.requirements and _skip_test_dependency("jax"):
+    if "jax" in demo.requirements and skip_dependency("jax"):
         pytest.skip("JAX is not installed")
 
 
@@ -138,8 +137,8 @@ def _exec_file(py_file):
 
 @pytest.mark.skipcomplex
 @pytest.mark.parametrize("demo", SERIAL_DEMOS, ids=["/".join(d.loc) for d in SERIAL_DEMOS])
-def test_serial_demo(demo, env, monkeypatch, tmpdir):
-    _maybe_skip_demo(demo)
+def test_serial_demo(demo, env, monkeypatch, tmpdir, skip_dependency):
+    _maybe_skip_demo(demo, skip_dependency)
     py_file = _prepare_demo(demo, monkeypatch, tmpdir)
     _exec_file(py_file)
 
@@ -151,8 +150,8 @@ def test_serial_demo(demo, env, monkeypatch, tmpdir):
 @pytest.mark.parallel(2)
 @pytest.mark.skipcomplex
 @pytest.mark.parametrize("demo", PARALLEL_DEMOS, ids=["/".join(d.loc) for d in PARALLEL_DEMOS])
-def test_parallel_demo(demo, env, monkeypatch, tmpdir):
-    _maybe_skip_demo(demo)
+def test_parallel_demo(demo, env, monkeypatch, tmpdir, skip_dependency):
+    _maybe_skip_demo(demo, skip_dependency)
     py_file = _prepare_demo(demo, monkeypatch, tmpdir)
     _exec_file(py_file)
 

--- a/tests/firedrake/demos/test_notebooks_run.py
+++ b/tests/firedrake/demos/test_notebooks_run.py
@@ -21,8 +21,9 @@ def ipynb_file(request):
 @pytest.mark.skipcomplex  # Will need to add a seperate case for a complex tutorial.
 @pytest.mark.skipplot
 def test_notebook_runs(ipynb_file, tmpdir, monkeypatch, skip_dependency):
+    skip_dep, dependency_skip_markers_and_reasons = skip_dependency
     if os.path.basename(ipynb_file) in ("08-composable-solvers.ipynb", "12-HPC_demo.ipynb"):
-        if skip_dependency("mumps"):
+        if skip_dep("mumps"):
             pytest.skip("MUMPS not installed with PETSc")
 
     monkeypatch.chdir(tmpdir)

--- a/tests/firedrake/demos/test_notebooks_run.py
+++ b/tests/firedrake/demos/test_notebooks_run.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 
 import pytest
-from firedrake.petsc import get_external_packages
 
 
 cwd = os.path.abspath(os.path.dirname(__file__))
@@ -21,9 +20,9 @@ def ipynb_file(request):
 
 @pytest.mark.skipcomplex  # Will need to add a seperate case for a complex tutorial.
 @pytest.mark.skipplot
-def test_notebook_runs(ipynb_file, tmpdir, monkeypatch):
+def test_notebook_runs(ipynb_file, tmpdir, monkeypatch, skip_dependency):
     if os.path.basename(ipynb_file) in ("08-composable-solvers.ipynb", "12-HPC_demo.ipynb"):
-        if "mumps" not in get_external_packages():
+        if skip_dependency("mumps"):
             pytest.skip("MUMPS not installed with PETSc")
 
     monkeypatch.chdir(tmpdir)

--- a/tests/firedrake/regression/test_moore_spence.py
+++ b/tests/firedrake/regression/test_moore_spence.py
@@ -3,12 +3,8 @@ from firedrake import *
 from firedrake.petsc import PETSc
 
 
+@pytest.mark.skipslepc
 def test_moore_spence():
-
-    try:
-        from slepc4py import SLEPc
-    except ImportError:
-        pytest.skip(reason="SLEPc unavailable, skipping eigenvalue test")
 
     msh = IntervalMesh(1000, 1)
     V = FunctionSpace(msh, "CG", 1)

--- a/tests/firedrake/regression/test_moore_spence.py
+++ b/tests/firedrake/regression/test_moore_spence.py
@@ -5,6 +5,7 @@ from firedrake.petsc import PETSc
 
 @pytest.mark.skipslepc
 def test_moore_spence():
+    from slepc4py import SLEPc
 
     msh = IntervalMesh(1000, 1)
     V = FunctionSpace(msh, "CG", 1)

--- a/tests/firedrake/regression/test_slepc.py
+++ b/tests/firedrake/regression/test_slepc.py
@@ -10,6 +10,7 @@ def topetsc(A):
 
 @pytest.mark.skipslepc
 def test_laplace_physical_ev(parallel=False):
+    from slepc4py import SLEPc
 
     mesh = UnitSquareMesh(64, 64)
     V = FunctionSpace(mesh, 'CG', 1)

--- a/tests/firedrake/regression/test_slepc.py
+++ b/tests/firedrake/regression/test_slepc.py
@@ -8,11 +8,8 @@ def topetsc(A):
     return A.petscmat
 
 
+@pytest.mark.skipslepc
 def test_laplace_physical_ev(parallel=False):
-    try:
-        from slepc4py import SLEPc
-    except ImportError:
-        pytest.skip(reason="SLEPc unavailable, skipping eigenvalue test")
 
     mesh = UnitSquareMesh(64, 64)
     V = FunctionSpace(mesh, 'CG', 1)
@@ -64,6 +61,7 @@ def test_laplace_physical_ev(parallel=False):
     assert np.allclose(ev_exact, np.array(ev)[:3], atol=1e-1)
 
 
+@pytest.mark.skipslepc
 @pytest.mark.parallel
 def test_laplace_parallel():
     test_laplace_physical_ev(parallel=True)


### PR DESCRIPTION
# Description

Tests using SLEPc should be marked with the `skipslepc` marker so that a) they are skipped for most users when they don't have SLEPc but b) they aren't skipped by CI.

This PR just adds this marker to tests that got missed previously and were sniffing SLEPc themselves.