### PR TITLE
Fix Projector if quadrature_degree is not None but form_compiler_parameters is

### DIFF
--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -135,9 +135,12 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         if quadrature_degree is not None:
             warnings.warn(f"Passing 'quadrature_degree' to {type(self).__name__} is deprecated, "
                           "please instead set inside the form compiler parameters", FutureWarning)
-            if "quadrature_degree" in form_compiler_parameters:
-                raise ValueError("Cannot pass quadrature degree twice")
-            form_compiler_parameters = form_compiler_parameters.copy()
+            if form_compiler_parameters is not None:
+                if "quadrature_degree" in form_compiler_parameters:
+                    raise ValueError("Cannot pass quadrature degree twice")
+                form_compiler_parameters = form_compiler_parameters.copy()
+            else:
+                form_compiler_parameters = {}
             form_compiler_parameters["quadrature_degree"] = quadrature_degree
         if solver_parameters is None:
             solver_parameters = {}


### PR DESCRIPTION
The `Projector` object now throws an error if the `quadrature_degree` argument (which has been deprecated) is passed but the `form_compiler_parameters` is not. e.g. there are now some failures in Gusto like:
```
        if quadrature_degree is not None:
            warnings.warn(f"Passing 'quadrature_degree' to {type(self).__name__} is deprecated, "
                          "please instead set inside the form compiler parameters", FutureWarning)
>           if "quadrature_degree" in form_compiler_parameters:
E           TypeError: argument of type 'NoneType' is not iterable

/home/firedrake/firedrake/firedrake/projection.py:138: TypeError
```
I think there was just a bit of logic missing from the `Projector`. This PR attempts to fix that.