### PR TITLE
Raise an error if `bounds` are passed to a variational solver while annotations are active.

### DIFF
--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -65,6 +65,11 @@ class NonlinearVariationalSolverMixin:
             from firedrake import LinearVariationalSolver
             annotate = annotate_tape(kwargs)
             if annotate:
+                bounds = kwargs.pop("bounds", None)
+                if bounds is not None:
+                    raise ValueError(
+                        "MissingMathsError: we do not know how to differentiate through a variational inequality")
+
                 tape = get_working_tape()
                 problem = self._ad_problem
                 sb_kwargs = NonlinearVariationalSolveBlock.pop_kwargs(kwargs)


### PR DESCRIPTION
We don't know how to handle bounds constraints with the adjoint, so we should raise an error if someone attempts this.

Because this pops the `bounds` from `kwargs`, this also prevents a bug where if `bounds=None` was passed to `solve`, it was erroneously passed through to the constructor of the adjoint solvers.