### PR TITLE
adjoint variational solver should get solver parameters from the variational solver not the `solver_parameters` kwarg

### DIFF
--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -48,6 +48,8 @@ class NonlinearVariationalSolverMixin:
             self._ad_problem = problem
             self._ad_args = args
             self._ad_kwargs = kwargs
+            # We'll get the parameters directly from self when `solve` is called.
+            self._ad_kwargs.pop("solver_parameters", None)
             self._ad_solvers = {"forward_nlvs": None, "adjoint_lvs": None,
                                 "recompute_count": 0}
             self._ad_adj_cache = {}


### PR DESCRIPTION
The adjoint decorating for variational solver was grabbing the solver parameters twice: once by the kwarg to `__init__` and once by `self.parameters` in the `solve` wrapper, and passing both to the solve block.

The one grabbed in the `solve` wrapper is correct because it has been processed by `OptionsManager`. The kwarg to `__init__` has not been processed by `OptionsManager` so could be `None`, which causes errors when the solve block tries to process the parameters.