### PR TITLE
Get LinearEigensolver working when no BCs are passed

### DIFF
--- a/firedrake/eigensolver.py
+++ b/firedrake/eigensolver.py
@@ -69,7 +69,7 @@ class LinearEigenproblem:
         if not M:
             M = inner(u, v) * dx
 
-        if restrict and bcs:  # assumed u and v are in the same space here
+        if self.restrict:  # assumed u and v are in the same space here
             V_res = restricted_function_space(self.output_space, extract_subdomain_ids(bcs))
             u_res = TrialFunction(V_res)
             v_res = TestFunction(V_res)

--- a/firedrake/eigensolver.py
+++ b/firedrake/eigensolver.py
@@ -64,7 +64,7 @@ class LinearEigenproblem:
         v, u = args
         self.output_space = u.function_space()
         self.bc_shift = bc_shift
-        self.restrict = restrict
+        self.restrict = restrict and bcs
 
         if not M:
             M = inner(u, v) * dx

--- a/tests/firedrake/regression/test_eigensolver.py
+++ b/tests/firedrake/regression/test_eigensolver.py
@@ -96,6 +96,10 @@ def test_no_bcs():
     ep = LinearEigenproblem(inner(grad(u), grad(v)) * dx,
                             inner(u, v)*dx)
 
-    es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_hermitian": None})
+    es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_hermitian": None,
+                                                     "eps_smallest_magnitude": None})
 
-    es.solve()
+    nconv = es.solve()
+    assert nconv > 0
+    eig = es.eigenvalue(0)
+    assert abs(eig) < 1.0e-14

--- a/tests/firedrake/regression/test_eigensolver.py
+++ b/tests/firedrake/regression/test_eigensolver.py
@@ -96,10 +96,14 @@ def test_no_bcs():
     ep = LinearEigenproblem(inner(grad(u), grad(v)) * dx,
                             inner(u, v)*dx)
 
-    es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_hermitian": None,
+    es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_non_hermitian": None,
                                                      "eps_smallest_magnitude": None})
 
     nconv = es.solve()
     assert nconv > 0
     eig = es.eigenvalue(0)
-    assert abs(eig) < 1.0e-14
+    assert np.isclose(eig, 0, atol=1e-12)
+
+    re, im = es.eigenfunction(0)
+    assert np.allclose(re.dat.data[:], re.dat.data[0])
+    assert np.allclose(im.dat.data[:], im.dat.data[0])

--- a/tests/firedrake/regression/test_eigensolver.py
+++ b/tests/firedrake/regression/test_eigensolver.py
@@ -83,3 +83,18 @@ def test_evals_2d():
     convergence = np.log(errors[:-1]/errors[1:])/np.log(2.0)
 
     assert all(convergence > 2.0)
+
+@pytest.mark.skipslepc
+def test_no_bcs():
+    mesh = SquareMesh(4, 4, pi)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    u = TrialFunction(V)
+    v = TestFunction(V)
+
+    ep = LinearEigenproblem(inner(grad(u), grad(v)) * dx,
+                            inner(u, v)*dx)
+
+    es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_hermitian": None})
+
+    es.solve()

--- a/tests/firedrake/regression/test_eigensolver.py
+++ b/tests/firedrake/regression/test_eigensolver.py
@@ -84,6 +84,7 @@ def test_evals_2d():
 
     assert all(convergence > 2.0)
 
+
 @pytest.mark.skipslepc
 def test_no_bcs():
     mesh = SquareMesh(4, 4, pi)


### PR DESCRIPTION
# Description

Right now `LinearEigensolver` crashes if you try to solve a problem with no BCs:

```
mesh = SquareMesh(4, 4, pi)
V = FunctionSpace(mesh, "CG", 1)

u = TrialFunction(V)
v = TestFunction(V)

ep = LinearEigenproblem(inner(grad(u), grad(v)) * dx,
                        inner(u, v)*dx)

es = LinearEigensolver(ep, 1, solver_parameters={"eps_gen_hermitian": None})

es.solve()
```

raises

```
  File "/home/farrellp/local/firedrake/firedrake-dev-20250320-mpich-mkl-complex/lib/python3.12/site-packages/firedrake/eigensolver.py", line 152, in __init__
    self.es = SLEPc.EPS().create(comm=problem.dm.comm)
                                      ^^^^^^^^^^
  File "/usr/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/farrellp/local/firedrake/firedrake-dev-20250320-mpich-mkl-complex/lib/python3.12/site-packages/firedrake/eigensolver.py", line 94, in dm
    return self.restricted_space.dm
           ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LinearEigenproblem' object has no attribute 'restricted_space'
```

This PR fixes this.
