### PR TITLE
Do not install petsc4py using pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
           apt-get -y install python3
           apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages) python3-venv parallel
+          : # Needed because the apt numpy package is too old (v1.x not v2.x)
+          python3 -m pip install --break-system-packages numpy
 
       - name: Install PETSc
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ pyop2.log
 .tox
 .vagrant
 
-# Configuration
-firedrake/config.ini
-
 # Meshes
 *.edge
 *.ele

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ pyop2.log
 .tox
 .vagrant
 
+# Configuration
+firedrake/config.ini
+
 # Meshes
 *.edge
 *.ele

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -228,18 +228,6 @@ install Firedrake. To do this perform the following steps:
    should follow the instructions :ref:`below<dev_install>`.
 
 .. note::
-   During the installation Firedrake will compile and install petsc4py_. If
-   you have previously installed petsc4py on your computer with a different
-   PETSc then ``pip`` will erroneously reuse the existing petsc4py which is 
-   linked against the wrong library. To avoid this you need to run the
-   command::
-
-       pip cache remove petsc4py
-
-   Equivalent commands may also be necessary for mpi4py and h5py if you are
-   changing the MPI and/or HDF5 libraries in use.
-
-.. note::
    If you are using an MPI installed into a nonstandard location it may be
    necessary to set some additional environment variables before installation including:
 

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -1,4 +1,33 @@
-import sys
+def init_petsc4py():
+    import configparser
+    import os
+    import pathlib
+    import sys
+
+    # try:
+    #     import petsc4py
+    #     return
+    # except ImportError:
+    #     pass
+
+
+    config = configparser.ConfigParser()
+    dir = pathlib.Path(__file__).parent
+    with open(dir / "config.ini", "r") as f:
+        config.read_file(f)
+
+    petsc_dir = config["PETSC_DIR"]
+    petsc_arch = config["PETSC_ARCH"]
+    sys.path.insert(0, os.path.join(petsc_dir, petsc_arch, "lib"))
+
+    try:
+        import petsc4py
+    except ImportError:
+        raise Exception("can't find petsc4py, bad install?")
+
+
+init_petsc4py()
+
 from firedrake.configuration import setup_cache_dirs
 
 # Set up the cache directories before importing PyOP2.
@@ -9,12 +38,13 @@ setup_cache_dirs()
 # when running pytest) PETSc complains that command line options are not
 # PETSc options.
 import os
+import sys
 import petsc4py
 if os.getenv("FIREDRAKE_DISABLE_OPTIONS_LEFT") == "1":
     petsc4py.init(sys.argv + ["-options_left", "no"])
 else:
     petsc4py.init(sys.argv)
-del os, petsc4py
+del os, sys, petsc4py
 
 # Initialise PETSc events for both import and entire duration of program
 from firedrake import petsc

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -4,24 +4,23 @@ def init_petsc4py():
     import pathlib
     import sys
 
-    # try:
-    #     import petsc4py
-    #     return
-    # except ImportError:
-    #     pass
-
+    try:
+        import petsc4py  # noqa: F401
+        return
+    except ImportError:
+        pass
 
     config = configparser.ConfigParser()
     dir = pathlib.Path(__file__).parent
     with open(dir / "config.ini", "r") as f:
         config.read_file(f)
 
-    petsc_dir = config["PETSC_DIR"]
-    petsc_arch = config["PETSC_ARCH"]
+    petsc_dir = config["settings"]["petsc_dir"]
+    petsc_arch = config["settings"]["petsc_arch"]
     sys.path.insert(0, os.path.join(petsc_dir, petsc_arch, "lib"))
 
     try:
-        import petsc4py
+        import petsc4py  # noqa: F401, F811
     except ImportError:
         raise Exception("can't find petsc4py, bad install?")
 
@@ -116,6 +115,7 @@ from firedrake._deprecation import plot, File  # noqa: F401
 #   from firedrake._deprecation import output
 #   sys.modules["firedrake.output"] = output
 from firedrake.output import *
+import sys
 sys.modules["firedrake.plot"] = plot
 from firedrake.plot import *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ dependencies = [
   "mpi4py; python_version < '3.13'",
   "h5py>3.12.1",
   "libsupermesh",
-  # NOTE: If changing the PETSc/SLEPc version then firedrake-configure also needs
-  # changing (as well as other references to petsc4py and slepc4py here)
-  "petsc4py==3.22.2",
   "numpy",
   "packaging",
   "pkgconfig",
@@ -84,7 +81,6 @@ ci = [
   "pytest-split",  # needed for firedrake-run-split-tests
   "pytest-timeout",
   "pytest-xdist",
-  "slepc4py==3.22.2",
   "torch",  # requires passing '--extra-index-url' to work
   "vtk",
 ]
@@ -98,7 +94,6 @@ docker = [  # Used in firedrake-vanilla container
   "pytest-split",  # needed for firedrake-run-split-tests
   "pytest-timeout",
   "pytest-xdist",
-  "slepc4py==3.22.2",
 ]
 # Dependencies needed to build the docs
 docs = [
@@ -134,7 +129,6 @@ requires = [
   "pkgconfig",
   "pybind11",
   "setuptools>61.2",
-  "petsc4py==3.22.2",
   "rtree>=1.2",
 ]
 build-backend = "setuptools.build_meta"
@@ -149,6 +143,6 @@ script-files = [
 [tool.setuptools.package-data]
 # Unless specified these files will not be installed along with the
 # rest of the package
-firedrake = ["evaluate.h", "locate.c", "icons/*.png"]
+firedrake = ["config.ini", "evaluate.h", "locate.c", "icons/*.png"]
 firedrake_check = ["Makefile", "tests/firedrake/conftest.py", "tests/*/*/*.py"]
 pyop2 = ["*.h", "*.pxd", "*.pyx", "codegen/c/*.c"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "libsupermesh",
   "numpy",
   "packaging",
+  "petsctools @ git+https://github.com/connorjward/petsctools.git",
   "pkgconfig",
   "progress",
   "pycparser",
@@ -127,6 +128,7 @@ requires = [
   "mpi4py; python_version < '3.13'",
   "numpy",
   "pkgconfig",
+  "petsctools @ git+https://github.com/connorjward/petsctools.git",
   "pybind11",
   "setuptools>61.2",
   "rtree>=1.2",
@@ -143,6 +145,6 @@ script-files = [
 [tool.setuptools.package-data]
 # Unless specified these files will not be installed along with the
 # rest of the package
-firedrake = ["config.ini", "evaluate.h", "locate.c", "icons/*.png"]
+firedrake = ["evaluate.h", "locate.c", "icons/*.png"]
 firedrake_check = ["Makefile", "tests/firedrake/conftest.py", "tests/*/*/*.py"]
 pyop2 = ["*.h", "*.pxd", "*.pyx", "codegen/c/*.c"]

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -188,6 +188,7 @@ BASE_LINUX_APT_PACKAGES = (
     "ninja-build",
     "pkg-config",
     "python3-dev",
+    "python3-numpy",
     "python3-pip",
 )
 
@@ -209,6 +210,7 @@ BASE_MACOS_HOMEBREW_PACKAGES = (
     "libtool",
     "make",
     "ninja",
+    "numpy",
     "openblas",
     "openmpi",
     "pkg-config",

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -236,6 +236,7 @@ COMMON_PETSC_CONFIGURE_OPTIONS = (
     "--with-fortran-bindings=0",
     "--with-shared-libraries=1",
     "--with-strict-petscerrorcode",
+    "--with-petsc4py=1",
 )
 
 # Placeholder value to use when we want PETSc to autodetect the package

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -188,7 +188,6 @@ BASE_LINUX_APT_PACKAGES = (
     "ninja-build",
     "pkg-config",
     "python3-dev",
-    "python3-numpy",
     "python3-pip",
 )
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ numpy_ = ExternalDependency(include_dirs=[np.get_include()])
 # example:
 # gcc -I$PETSC_DIR/include -I$PETSC_DIR/$PETSC_ARCH/include -I/petsc4py/include
 # gcc -L$PETSC_DIR/$PETSC_ARCH/lib -lpetsc -Wl,-rpath,$PETSC_DIR/$PETSC_ARCH/lib
-petsc_dir, petsc_arch = petsctools.get_petsc_config()
+petsc_dir, petsc_arch = petsctools.get_config()
 petsc_dirs = [petsc_dir, os.path.join(petsc_dir, petsc_arch)]
 petsc_ = ExternalDependency(
     libraries=["petsc"],
@@ -78,7 +78,7 @@ petsc_ = ExternalDependency(
     library_dirs=[os.path.join(petsc_dirs[-1], "lib")],
     runtime_library_dirs=[os.path.join(petsc_dirs[-1], "lib")],
 )
-petsc_variables = petsctools.get_petsc_variables()
+petsc_variables = petsctools.get_petscvariables()
 petsc_hdf5_compile_args = petsc_variables.get("HDF5_INCLUDE", "")
 petsc_hdf5_link_args = petsc_variables.get("HDF5_LIB", "")
 


### PR DESCRIPTION
This PR is a first stab at an idea I've had to avoid what I think may be an upcoming versioning issue. Things are very rough but I think there's enough there to see what I mean.

### The problem

PETSc and petsc4py must be installed using the exact same version but they are installed using different code paths. One from source and one from PyPI.

This is fine for most users currently because we fix the specific PETSc that they use, but I think this means we might hit issues with system installs of PETSc, both for HPC installs and a possible future `apt` package. I can easily imagine someone trying to install the latest Firedrake using a slightly out-of-date PETSc and thus having a mismatch between PETSc and petsc4py versions.

### The solution

I think the way to fix this is to use a petsc4py installed alongside PETSc (`--with-petsc4py=1`) and we can tweak `sys.path` to find it (using `PETSC_DIR` and `PETSC_ARCH`). Then we have single source of truth for the version.

Feedback welcome.

---

As another benefit I think we are realising that petsc4py install isn't very robust as it's the cause of most of our current install problems.

### TODOs

- [ ] Add numpy hack to the docs
- [ ] Fixup Dockerfile


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
