### PR TITLE
Should the subfunction merge block apply a mask on the adjoint evaluation?

### DIFF
--- a/firedrake/adjoint_utils/blocks/function.py
+++ b/firedrake/adjoint_utils/blocks/function.py
@@ -239,9 +239,11 @@ class FunctionMergeBlock(Block):
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx,
                                prepared=None):
         if idx == 0:
-            return adj_inputs[0].subfunctions[self.idx]
+            return adj_inputs[0].subfunctions[self.idx].copy(deepcopy=True)
         else:
-            return adj_inputs[0]
+            cpt = adj_inputs[0].copy(deepcopy=True)
+            cpt.subfunctions[self.idx].zero()
+            return cpt
 
     def evaluate_tlm(self, markings=False):
         tlm_input = self.get_dependencies()[0].tlm_value

--- a/firedrake/adjoint_utils/blocks/function.py
+++ b/firedrake/adjoint_utils/blocks/function.py
@@ -241,9 +241,8 @@ class FunctionMergeBlock(Block):
         if idx == 0:
             return adj_inputs[0].subfunctions[self.idx].copy(deepcopy=True)
         else:
-            cpt = adj_inputs[0].copy(deepcopy=True)
-            cpt.subfunctions[self.idx].zero()
-            return cpt
+            adj_inputs[0].subfunctions[self.idx].zero()
+            return adj_inputs[0]
 
     def evaluate_tlm(self, markings=False):
         tlm_input = self.get_dependencies()[0].tlm_value

--- a/tests/firedrake/adjoint/test_split_and_subfunctions.py
+++ b/tests/firedrake/adjoint/test_split_and_subfunctions.py
@@ -183,6 +183,7 @@ def test_subfunctions_always_create_blocks():
         # force the subfunctions to be created
         _ = kappa.subfunctions
 
+    continue_annotation()
     with set_working_tape() as tape:
         u.assign(kappa.subfunctions[0])
         J = assemble(inner(u, u)*dx)
@@ -191,3 +192,25 @@ def test_subfunctions_always_create_blocks():
 
     rf.derivative()
     assert control.block_variable.adj_value is not None, "Functional should depend on Control"
+
+
+@pytest.mark.skipcomplex
+def test_writing_to_subfunctions():
+    with stop_annotating():
+        mesh = UnitIntervalMesh(1)
+        R = FunctionSpace(mesh, "R", 0)
+
+        kappa = Function(R).assign(2.0)
+        u = Function(R)
+        usub = u.subfunctions[0]
+
+    continue_annotation()
+    with set_working_tape() as tape:
+        u.assign(kappa)
+        usub *= 2
+        J = assemble(inner(u, u) * dx)
+        print(f"{type(J) = }")
+        rf = ReducedFunctional(J, Control(kappa), tape=tape)
+    pause_annotation()
+
+    assert taylor_test(rf, kappa, Constant(0.1)) > 1.9


### PR DESCRIPTION
### Background

Adjoining subfunctions is hard because it has to know that it doesn't hold its own data, it just views the full function. This means that when a subfunction is used, it also needs to add the full function onto the tape as a dependency so that the correct data is used.
The `pyadjoint.FloatingType` base class does with two custom blocks:
- When a subfunction `usub = u.subfunctions[i]` for component `i` of a full function `u` is added as a dependency to block `block0` on the tape, what actually happens is:
	1. a `SubfunctionBlock` is added to the tape with `u` as a dependency and `usub` as an output. This block just filters the `usub` component.
	2. `usub` is then added as a dependency of `block0`. Now `block0` implicitly depends on the value of `u` after filtering out everything but `usub`.
- When `usub` is added as an output to block `block1` on the tape, what actually happens is:
	1. `usub` is added as an output to block `block1`.
	2.  a `FunctionMergeBlock` is added to the tape with `usub` as a dependency and `u` as an output. This block combines the data in `usub` with all data in `u` except that of component `i`. `block1` now implicitly has `u` as an output, but only for the data in component `i`.

This test just creates a function in the R space, and tapes 1) assigning to it from a control 2) multiplying by 2 and 3) calculating the square. The tapes with/without using subfunctions are shown below, where you can see the extra blocks in the subfunction case. (The odd numbering is just so the code matches the tape).
```python
with stop_annotating():
    mesh = UnitIntervalMesh(1)
    R = FunctionSpace(mesh, "R", 0)

    w2 = Function(R).assign(2.0)
    w4 = Function(R)
    w7 = u.subfunctions[0]

use_subfunctions = True

continue_annotation()
with set_working_tape() as tape:
    w4.assign(w2)
    if use_subfunctions:
        w7 *= 2
    else:
        w4 *= 2
    J = assemble(inner(w4, w4) * dx)
    rf = ReducedFunctional(J, Control(w2), tape=tape)
pause_annotation()

assert taylor_test(rf, w2, Constant(0.1)) > 1.9
```
Without using subfunctions:
![tape_nosub](https://github.com/user-attachments/assets/c1b57e60-d3e1-40f7-8187-d3ec98b3dd9a)

Using subfunctions:
![tape_sub](https://github.com/user-attachments/assets/7fdf6c9a-9176-470f-9c98-8486288cdddd)

### Problem
This test fails if using subfunctions!
We want the `adj_value` of the `i`-th component to depend _only_ on what happens along the subfunction branch, and the `adj_value` of all other components to be whatever they were before the subfunctions split/merge.

Instead, the adjoint of `FunctionMergeBlock` was (correctly) outputting the `i`-th component of the adj_value along the subfunction branch of the tape, but (incorrectly) outputting _all_ components of the adj_value along the full-function branch of the tape.
When these two branches recombined the adj_value for the `i`-th component then had contributions from both branches.

### Solution
The merge `out[i] = usub; out[not i] = u` is a mask. The adjoint of a mask is also a mask, so `FunctionMergeBlock` now applies a mask before returning the adjoint outputs: `output0 = adj_input[i]; output1 = adj_input[not i]`