### PR TITLE
Fix Submesh.submesh_parent

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -4676,6 +4676,6 @@ def Submesh(mesh, subdim, subdomain_id, label_name=None, name=None):
     submesh = Mesh(subplex, name=name, distribution_parameters={"partition": False,
                                                                 "overlap_type": (DistributedMeshOverlapType.NONE, 0)})
     submesh.topology.submesh_parent = mesh.topology
-    submesh.submesh_parent = mesh
     submesh.init()
+    submesh.submesh_parent = mesh
     return submesh

--- a/tests/firedrake/submesh/test_submesh_basics.py
+++ b/tests/firedrake/submesh/test_submesh_basics.py
@@ -1,0 +1,16 @@
+from firedrake import *
+
+
+def test_submesh_parent():
+    mesh = UnitIntervalMesh(2)
+
+    M = FunctionSpace(mesh, "DG", 0)
+    m = Function(M)
+    m.dat.data[0] = 1
+
+    cell_marker = 100
+    parent = RelabeledMesh(mesh, [m], [cell_marker])
+
+    submesh = Submesh(parent, parent.geometric_dimension(), cell_marker)
+    assert submesh.topology.submesh_parent is parent.topology
+    assert submesh.submesh_parent is parent

--- a/tests/firedrake/submesh/test_submesh_basics.py
+++ b/tests/firedrake/submesh/test_submesh_basics.py
@@ -11,6 +11,6 @@ def test_submesh_parent():
     cell_marker = 100
     parent = RelabeledMesh(mesh, [m], [cell_marker])
 
-    submesh = Submesh(parent, parent.geometric_dimension(), cell_marker)
+    submesh = Submesh(parent, parent.topological_dimension(), cell_marker)
     assert submesh.topology.submesh_parent is parent.topology
     assert submesh.submesh_parent is parent


### PR DESCRIPTION
# Description
The `submesh_parent` attribute was being reset to `None` when calling `submesh.init()`. This PR fixes this by attaching the `submesh_parent` after calling `init()`.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
