### PR TITLE
Single source of truth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           path: firedrake-repo
 
+      - name: Validate single-source-of-truth
+        run: ./scripts/check-config
+
       - name: Install system dependencies
         run: |
           apt-get update

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,4 @@
+[config]
+petsc-version = 3.23.0
+petsc-version-spec = >=3.23.0
+min-python-version = 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ dependencies = [
   "h5py>3.12.1",
   "libsupermesh",
   "loopy>2024.1",
-  # NOTE: If changing the PETSc/SLEPc version then firedrake-configure also needs
-  # changing (as well as other references to petsc4py and slepc4py here)
   "petsc4py==3.23.0",
   "numpy",
   "packaging",

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+"""Script that makes sure that hardcoded version numbers are consistent.
+
+It reads in Firedrake's 'config.ini' file and makes sure that everywhere a
+version number is hardcoded that it matches the expected value. This allows
+for single-source-of-truth of hardcoded values (via CI).
+
+"""
+
+import configparser
+import pathlib
+import re
+from collections.abc import Mapping
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+class InvalidConfigurationException(Exception):
+    pass
+
+
+def main():
+    config = read_config()
+    check_min_python_version(config["min-python-version"])
+    check_petsc_version(config["petsc-version"])
+    check_petsc_version_spec(config["petsc-version-spec"])
+
+
+def read_config() -> Mapping[str, str]:
+    parser = configparser.ConfigParser()
+    parser.read_file(open(REPO_ROOT / "config.ini"))
+    return parser["config"]
+
+
+def check_min_python_version(min_python_version: str) -> None:
+    check_file_contains_pattern(
+        REPO_ROOT / "pyproject.toml",
+        f"requires-python = \">={min_python_version}\""
+    )
+    check_file_contains_pattern(
+        REPO_ROOT / "docs/source/install.rst",
+        f"Python \\({min_python_version} or greater\\)"
+    )
+
+
+def check_petsc_version(petsc_version: str) -> None:
+    check_file_contains_pattern(
+        REPO_ROOT / "scripts/firedrake-configure",
+        f"SUPPORTED_PETSC_VERSION = \"v{petsc_version}\"",
+    )
+    check_file_contains_pattern(
+        REPO_ROOT / "pyproject.toml",
+        f"petsc4py=={petsc_version}",
+        2,
+    )
+    check_file_contains_pattern(
+        REPO_ROOT / "pyproject.toml",
+        f"slepc4py=={petsc_version}",
+        3,
+    )
+
+
+def check_petsc_version_spec(petsc_version_spec: str) -> None:
+    # TODO when https://github.com/firedrakeproject/firedrake/pull/4194 is merged
+    pass
+
+
+def check_file_contains_pattern(
+    filename: pathlib.Path | str,
+    pattern: str,
+    num_expected_matches: int = 1,
+) -> None:
+    with open(filename) as f:
+        text = f.read()
+    matches = re.findall(pattern, text)
+    if len(matches) != num_expected_matches:
+        raise InvalidConfigurationException(
+            f"Expected to find {num_expected_matches} matches for '{pattern}' in "
+            f"{filename} but found {len(matches)}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -39,8 +39,6 @@ ARCH_DEFAULT = FiredrakeArch.DEFAULT
 ARCH_COMPLEX = FiredrakeArch.COMPLEX
 
 
-# NOTE: When updating this variable corresponding changes must be made inside
-# pyproject.toml
 SUPPORTED_PETSC_VERSION = "v3.23.0"
 
 


### PR DESCRIPTION
This is an idea I've had to ensure single-source-of-truth across the repo. The basic idea is:

* The supported PETSc and Python versions are set in a new `config.ini` file.
* Running the new script `check-config` will read in files and make sure that things match, raising an exception if not.
* This script is then run as part of CI.

I feel like this is a necessary change because with the recent install changes one needs to be careful to change version numbers in all the right places. For example it would have prevented https://github.com/firedrakeproject/firedrake/pull/4230.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
