### PR TITLE
Add option to build Docker containers manually

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,11 +16,6 @@ on:
       tag:
         description: Docker image tag
         type: string
-    secrets:
-      DOCKERHUB_USER:
-        required: true
-      DOCKERHUB_TOKEN:
-        required: true
 
 jobs:
   # Firedrake only

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,14 +7,23 @@ on:
         description: Docker image tag
         type: string
     secrets:
-      # Docker login information
+      DOCKERHUB_USER:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Docker image tag
+        type: string
+    secrets:
       DOCKERHUB_USER:
         required: true
       DOCKERHUB_TOKEN:
         required: true
 
 jobs:
-  # Firedrake container (just Firedrake)
+  # Firedrake only
   docker_build_vanilla:
     strategy:
       fail-fast: false
@@ -48,7 +57,7 @@ jobs:
       tag: ${{ inputs.tag }}
     secrets: inherit
 
-  # # Firedrake container (Firedrake and friends)
+  # Firedrake and friends
   docker_build_firedrake:
     needs: docker_merge_vanilla
     uses: ./.github/workflows/docker_build.yml
@@ -72,27 +81,7 @@ jobs:
       tag: ${{ inputs.tag }}
     secrets: inherit
 
-  # # Firedrake container with TeX
-  docker_build_docdeps:
-    needs: docker_merge_vanilla
-    uses: ./.github/workflows/docker_build.yml
-    with:
-      os: Linux
-      platform: linux/amd64
-      target: firedrake-docdeps
-      tag: ${{ inputs.tag }}
-      dockerfile: docker/Dockerfile.docdeps
-    secrets: inherit
-
-  docker_merge_docdeps:
-    uses: ./.github/workflows/docker_merge.yml
-    needs: docker_build_docdeps
-    with:
-      target: firedrake-docdeps
-      tag: ${{ inputs.tag }}
-    secrets: inherit
-
-  # # Firedrake container with Jupyter notebooks
+  # Firedrake with Jupyter notebooks
   docker_build_jupyter:
     needs: docker_merge_firedrake
     uses: ./.github/workflows/docker_build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,10 @@ name: Publish release
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   deploy:
-    if: '!startsWith( github.ref_name, ''Zenodo'' )'
     uses: ./.github/workflows/core.yml
     with:
       source_ref: release
@@ -16,9 +15,8 @@ jobs:
     secrets: inherit
 
   docker:
-    if: '!startsWith( github.ref_name, ''Zenodo'' )'
     name: Build Docker containers
     uses: ./.github/workflows/docker.yml
     with:
-      tag: ${{ github.ref }}
+      tag: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
This is useful because if the release workflow doesn't work for some reason we still want to be able to build the containers. I find adding `workflow_dispatch` to be generally helpful.

Also remove refs to now removed docdeps container.
<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
