### PR TITLE
Inc PETSc to 3.23.1 so macOs no longer needs to download CMake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "loopy>2024.1",
   # NOTE: If changing the PETSc/SLEPc version then firedrake-configure also needs
   # changing (as well as other references to petsc4py and slepc4py here)
-  "petsc4py==3.23.0",
+  "petsc4py==3.23.1",
   "numpy",
   "packaging",
   "pkgconfig",
@@ -92,7 +92,7 @@ netgen = [
   "ngsPETSc",
 ]
 slepc = [
-  "slepc4py==3.23.0",
+  "slepc4py==3.23.1",
 ]
 torch = [  # requires passing '--extra-index-url' to work
   "torch",
@@ -114,7 +114,7 @@ ci = [
   "pytest-split",  # needed for firedrake-run-split-tests
   "pytest-timeout",
   "pytest-xdist",
-  "slepc4py==3.23.0",
+  "slepc4py==3.23.1",
   "torch",  # requires passing '--extra-index-url' to work
   "vtk",
 ]
@@ -128,7 +128,7 @@ docker = [  # Used in firedrake-vanilla container
   "pytest-split",  # needed for firedrake-run-split-tests
   "pytest-timeout",
   "pytest-xdist",
-  "slepc4py==3.23.0",
+  "slepc4py==3.23.1",
 ]
 
 [build-system]
@@ -141,7 +141,7 @@ requires = [
   "pkgconfig",
   "pybind11",
   "setuptools>61.2",
-  "petsc4py==3.23.0",
+  "petsc4py==3.23.1",
   "rtree>=1.2",
 ]
 build-backend = "setuptools.build_meta"

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -41,7 +41,7 @@ ARCH_COMPLEX = FiredrakeArch.COMPLEX
 
 # NOTE: When updating this variable corresponding changes must be made inside
 # pyproject.toml
-SUPPORTED_PETSC_VERSION = "v3.23.0"
+SUPPORTED_PETSC_VERSION = "v3.23.1"
 
 
 def main():
@@ -429,8 +429,6 @@ def prepare_configure_options(
         # Avoid macos + openmpi + mumps segmentation violation issue;
         # see https://github.com/firedrakeproject/firedrake/issues/4102 and https://github.com/firedrakeproject/firedrake/issues/4113.
         configure_options.append("-download-mumps-avoid-mpi-in-place")
-        # PETSc does not support CMake 4.0 (hopefully fixed in v3.23.1)
-        configure_options.append("--download-cmake")
     else:
         configure_options.append(f"--FOPTFLAGS='-O3 -march=native -mtune=native{incflags}{libflags}'")
 


### PR DESCRIPTION
Fixes #4183 

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
