### PR TITLE
cause actions to trigger when PR target is changed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: Test pull request
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, edited ]
 
 jobs:
   test:


### PR DESCRIPTION
Currently changing the target branch of a PR does not trigger CI. Per https://github.com/orgs/community/discussions/37863 this change fixes this.