### PR TITLE
add meson-python requirement to requirements-build.txt

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -11,3 +11,4 @@ rtree>=1.2
 
 # Transitive build dependencies
 hatchling
+meson-python


### PR DESCRIPTION
# Description

Adds [meson-python](https://pypi.org/project/meson-python/) to `requirements-build.txt`.
