### PR TITLE
wraps `VomOntoVomDummyMat` as petsc4py mat

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1616,7 +1616,7 @@ class VomOntoVomDummyMat(object):
         )
 
     def broadcast(self, source_vec, target_vec):
-        source_arr = source_vec.getArray()
+        source_arr = source_vec.getArray(readonly=True)
         target_arr = target_vec.getArray()
         self.sf.bcastBegin(
             self.mpi_type,

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1631,7 +1631,7 @@ class VomOntoVomDummyMat(object):
             MPI.REPLACE,
         )
 
-    def mult(self, source_vec, target_vec):
+    def mult(self, mat, source_vec, target_vec):
         # need to evaluate expression before doing mult
         coeff = self.expr_as_coeff(source_vec)
         with coeff.dat.vec_ro as coeff_vec:

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1670,6 +1670,9 @@ class VomOntoVomDummyMat(object):
             target_vec.zeroEntries()
             self.reduce(source_vec, target_vec)
 
+    def duplicate(self, mat=None, op=None):
+        return self._create_petsc_mat()
+
     def _create_petsc_mat(self):
         mat = PETSc.Mat().create(comm=self.V.comm)
         element = self.V.ufl_element()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1640,7 +1640,10 @@ class VomOntoVomDummyMat(object):
             else:
                 self.broadcast(coeff_vec, target_vec)
 
-    def multHermitian(self, source_vec, target_vec):
+    def multHermitian(self, mat, source_vec, target_vec):
+        self.multTranspose(mat, source_vec, target_vec)
+
+    def multTranspose(self, mat, source_vec, target_vec):
         # can only do adjoint if our expression exclusively contains a
         # single argument, making the application of the adjoint operator
         # straightforward (haven't worked out how to do this otherwise!)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1515,7 +1515,7 @@ class VomOntoVomWrapper(object):
     def forward_operation(self, target_dat):
         coeff = self.dummy_mat.expr_as_coeff()
         with coeff.dat.vec_ro as coeff_vec, target_dat.vec_wo as target_vec:
-            self.dummy_mat.mult(coeff_vec, target_vec)
+            self.handle.mult(coeff_vec, target_vec)
 
 
 class VomOntoVomDummyMat(object):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1489,12 +1489,13 @@ class VomOntoVomWrapper(object):
             )
         self.V = V
         self.source_vom = source_vom
+        self.target_vom = target_vom
         self.expr = expr
         self.arguments = arguments
         self.reduce = reduce
         # note that interpolation doesn't include halo cells
         self.handle = VomOntoVomDummyMat(
-            original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, expr, arguments
+            original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, target_vom, expr, arguments
         )
 
     @property
@@ -1542,11 +1543,12 @@ class VomOntoVomDummyMat(object):
         The arguments in the expression.
     """
 
-    def __init__(self, sf, forward_reduce, V, source_vom, expr, arguments):
+    def __init__(self, sf, forward_reduce, V, source_vom, target_vom, expr, arguments):
         self.sf = sf
         self.forward_reduce = forward_reduce
         self.V = V
         self.source_vom = source_vom
+        self.target_vom = target_vom
         self.expr = expr
         self.arguments = arguments
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1494,9 +1494,10 @@ class VomOntoVomWrapper(object):
         self.arguments = arguments
         self.reduce = reduce
         # note that interpolation doesn't include halo cells
-        self.handle = VomOntoVomDummyMat(
+        self.dummy_mat = VomOntoVomDummyMat(
             original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, target_vom, expr, arguments
         )
+        self.handle = self.dummy_mat._create_petsc_mat()
 
     @property
     def mpi_type(self):
@@ -1505,16 +1506,16 @@ class VomOntoVomWrapper(object):
 
         Should correspond to the underlying data type of the PETSc Vec.
         """
-        return self.handle.mpi_type
+        return self.dummy_mat.mpi_type
 
     @mpi_type.setter
     def mpi_type(self, val):
-        self.handle.mpi_type = val
+        self.dummy_mat.mpi_type = val
 
     def forward_operation(self, target_dat):
-        coeff = self.handle.expr_as_coeff()
+        coeff = self.dummy_mat.expr_as_coeff()
         with coeff.dat.vec_ro as coeff_vec, target_dat.vec_wo as target_vec:
-            self.handle.mult(coeff_vec, target_vec)
+            self.dummy_mat.mult(coeff_vec, target_vec)
 
 
 class VomOntoVomDummyMat(object):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1685,4 +1685,4 @@ class VomOntoVomDummyMat(object):
         mat.setPythonContext(self)
         mat.setUp()
         return mat
-    
+ 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1685,4 +1685,3 @@ class VomOntoVomDummyMat(object):
         mat.setPythonContext(self)
         mat.setUp()
         return mat
- 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1600,7 +1600,7 @@ class VomOntoVomDummyMat(object):
         return coeff
 
     def reduce(self, source_vec, target_vec):
-        source_arr = source_vec.getArray()
+        source_arr = source_vec.getArray(readonly=True)
         target_arr = target_vec.getArray()
         self.sf.reduceBegin(
             self.mpi_type,

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1665,3 +1665,17 @@ class VomOntoVomDummyMat(object):
             # matrix will then have rows of zeros for those points.
             target_vec.zeroEntries()
             self.reduce(source_vec, target_vec)
+
+    def _create_petsc_mat(self):
+        mat = PETSc.Mat().create(comm=self.V.comm)
+        element = self.V.ufl_element()
+        P0DG_source = firedrake.FunctionSpace(self.source_vom, element)
+        P0DG_target = firedrake.FunctionSpace(self.target_vom, element)
+        source_size = P0DG_source.dof_dset.layout_vec.getSizes()
+        target_size = P0DG_target.dof_dset.layout_vec.getSizes()
+        mat.setSizes((target_size, source_size))
+        mat.setType(PETSc.Mat().Type.PYTHON)
+        mat.setPythonContext(self)
+        mat.setUp()
+        return mat
+    

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -159,7 +159,7 @@ def functionspace_tests(vm):
             g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
             assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
         except PETSc.Error as e:
-            raise e.__cause__ from None 
+            raise e.__cause__ from None
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -155,8 +155,11 @@ def functionspace_tests(vm):
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+        try:
+            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+            assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+        except PETSc.Error as e:
+            raise e.__cause__ from None 
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -167,8 +170,11 @@ def functionspace_tests(vm):
 
     with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+        try:
+            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+            assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+        except PETSc.Error as e:
+            raise e.__cause__ from None
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -260,8 +266,11 @@ def vectorfunctionspace_tests(vm):
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
     with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+        try:
+            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+            assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+        except PETSc.Error as e:
+            raise e.__cause__ from None
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -270,8 +279,11 @@ def vectorfunctionspace_tests(vm):
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
     with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+        try:
+            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+            assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+        except PETSc.Error as e:
+            raise e.__cause__ from None
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))


### PR DESCRIPTION
# Description

This wraps the `VomOntoVomDummyMat` as a petsc4py mat. This allows us to get the permutation "matrix" from one vom to it's input ordering by doing `fd.assemble(interpolate(fd.TestFunction(P0DG), vom_input_ordering))`
