### PR TITLE
Allow construction of interpolation matrix between a `VertexOnlyMesh` and its input-ordering

### DIFF
--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -372,8 +372,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         subset=None,
         allow_missing_dofs=False,
         default_missing_val=None,
-        ad_block_tag=None,
-        matfree=True
+        ad_block_tag=None
     ):
         r"""Interpolate an expression onto this :class:`Function`.
 
@@ -397,17 +396,13 @@ class Function(ufl.Coefficient, FunctionMixin):
             within the same mesh or onto a :func:`.VertexOnlyMesh`.
         :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on
             the Pyadjoint tape.
-        :kwarg matfree: If ``False``, then construct the permutation matrix for interpolating
-            between a VOM and its input ordering. Defaults to ``True`` which uses SF broadcast
-            and reduce operations.
         :returns: this :class:`Function` object"""
         from firedrake import interpolation, assemble
         V = self.function_space()
         interp = interpolation.Interpolate(expression, V,
                                            subset=subset,
                                            allow_missing_dofs=allow_missing_dofs,
-                                           default_missing_val=default_missing_val,
-                                           matfree=matfree)
+                                           default_missing_val=default_missing_val)
         return assemble(interp, tensor=self, ad_block_tag=ad_block_tag)
 
     def zero(self, subset=None):

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -372,7 +372,8 @@ class Function(ufl.Coefficient, FunctionMixin):
         subset=None,
         allow_missing_dofs=False,
         default_missing_val=None,
-        ad_block_tag=None
+        ad_block_tag=None,
+        matfree=True
     ):
         r"""Interpolate an expression onto this :class:`Function`.
 
@@ -396,13 +397,17 @@ class Function(ufl.Coefficient, FunctionMixin):
             within the same mesh or onto a :func:`.VertexOnlyMesh`.
         :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on
             the Pyadjoint tape.
+        :kwarg matfree: If ``False``, then construct the permutation matrix for interpolating
+            between a VOM and its input ordering. Defaults to ``True`` which uses SF broadcast
+            and reduce operations.
         :returns: this :class:`Function` object"""
         from firedrake import interpolation, assemble
         V = self.function_space()
         interp = interpolation.Interpolate(expression, V,
                                            subset=subset,
                                            allow_missing_dofs=allow_missing_dofs,
-                                           default_missing_val=default_missing_val)
+                                           default_missing_val=default_missing_val,
+                                           matfree=matfree)
         return assemble(interp, tensor=self, ad_block_tag=ad_block_tag)
 
     def zero(self, subset=None):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -182,7 +182,7 @@ def interpolate(expr, V, *args, **kwargs):
         to zero. Ignored if interpolating within the same mesh or onto a
         :func:`.VertexOnlyMesh`.
     :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on the Pyadjoint tape.
-    :returns: A synbolic :class:`.Interpolate` object
+    :returns: A symbolic :class:`.Interpolate` object
 
     .. note::
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -48,7 +48,8 @@ class Interpolate(ufl.Interpolate):
                  subset=None,
                  access=op2.WRITE,
                  allow_missing_dofs=False,
-                 default_missing_val=None):
+                 default_missing_val=None,
+                 matfree=True):
         """Symbolic representation of the interpolation operator.
 
         Parameters
@@ -85,6 +86,10 @@ class Interpolate(ufl.Interpolate):
                               then the values are either (a) unchanged if some ``output`` is given to
                               the :meth:`interpolate` method or (b) set to zero.
                               Ignored if interpolating within the same mesh or onto a :func:`.VertexOnlyMesh`.
+        matfree : bool
+                If ``False``, then construct the permutation matrix for interpolating
+                between a VOM and its input ordering. Defaults to ``True`` which uses SF broadcast
+                and reduce operations.
         """
         # Check function space
         if isinstance(v, functionspaceimpl.WithGeometry):
@@ -97,7 +102,8 @@ class Interpolate(ufl.Interpolate):
         self.interp_data = {"subset": subset,
                             "access": access,
                             "allow_missing_dofs": allow_missing_dofs,
-                            "default_missing_val": default_missing_val}
+                            "default_missing_val": default_missing_val,
+                            "matfree": matfree}
 
     function_space = ufl.Interpolate.ufl_function_space
 
@@ -239,6 +245,9 @@ class Interpolator(abc.ABC):
         Ignored if interpolating within the same mesh or onto a
         :func:`.VertexOnlyMesh` (the behaviour of a :func:`.VertexOnlyMesh` in
         this scenario is, at present, set when it is created).
+    :kwarg matfree: If ``False``, then construct the permutation matrix for interpolating
+        between a VOM and its input ordering. Defaults to ``True`` which uses SF broadcast
+        and reduce operations.
 
     This object can be used to carry out the same interpolation
     multiple times (for example in a timestepping loop).
@@ -275,6 +284,7 @@ class Interpolator(abc.ABC):
         access=op2.WRITE,
         bcs=None,
         allow_missing_dofs=False,
+        matfree=True
     ):
         self.expr = expr
         self.V = V
@@ -283,6 +293,7 @@ class Interpolator(abc.ABC):
         self.access = access
         self.bcs = bcs
         self._allow_missing_dofs = allow_missing_dofs
+        self.matfree = matfree
         self.callable = None
         # Cope with the different convention of `Interpolate` and `Interpolator`:
         #  -> Interpolate(Argument(V1, 1), Argument(V2.dual(), 0))
@@ -329,7 +340,8 @@ class Interpolator(abc.ABC):
                              subset=self.subset,
                              access=self.access,
                              allow_missing_dofs=self._allow_missing_dofs,
-                             default_missing_val=default_missing_val)
+                             default_missing_val=default_missing_val,
+                             matfree=self.matfree)
         if transpose is not None:
             warnings.warn("'transpose' argument is deprecated, use 'adjoint' instead", FutureWarning)
             adjoint = transpose or adjoint
@@ -737,10 +749,21 @@ class SameMeshInterpolator(Interpolator):
     """
 
     @no_annotations
-    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, bcs=None, **kwargs):
-        super().__init__(expr, V, subset, freeze_expr, access, bcs)
+    def __init__(self, expr, V, 
+                 subset=None, 
+                 freeze_expr=False, 
+                 access=op2.WRITE, 
+                 bcs=None, 
+                 matfree=True, 
+                 **kwargs):
+        super().__init__(expr, V, 
+                         subset=subset, 
+                         freeze_expr=freeze_expr, 
+                         access=access, 
+                         bcs=bcs,
+                         matfree=matfree)
         try:
-            self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs)
+            self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs, matfree=matfree)
         except FIAT.hdiv_trace.TraceError:
             raise NotImplementedError("Can't interpolate onto traces sorry")
         self.arguments = arguments
@@ -811,7 +834,7 @@ class SameMeshInterpolator(Interpolator):
 
 
 @PETSc.Log.EventDecorator()
-def make_interpolator(expr, V, subset, access, bcs=None):
+def make_interpolator(expr, V, subset, access, bcs=None, matfree=True):
     assert isinstance(expr, ufl.classes.Expr)
     arguments = extract_arguments(expr)
     target_mesh = as_domain(V)
@@ -886,8 +909,7 @@ def make_interpolator(expr, V, subset, access, bcs=None):
         raise ValueError("Cannot interpolate an expression with %d arguments" % len(arguments))
 
     if vom_onto_other_vom:
-        # To interpolate between vertex-only meshes we use a PETSc SF
-        wrapper = VomOntoVomWrapper(V, source_mesh, target_mesh, expr, arguments)
+        wrapper = VomOntoVomWrapper(V, source_mesh, target_mesh, expr, arguments, matfree)
         # NOTE: get_dat_mpi_type ensures we get the correct MPI type for the
         # data, including the correct data size and dimensional information
         # (so for vector function spaces in 2 dimensions we might need a
@@ -904,6 +926,8 @@ def make_interpolator(expr, V, subset, access, bcs=None):
                 return f
         else:
             assert len(arguments) == 1
+            if matfree:
+                raise ValueError("Pass matfree=False to assemble interpolation matrix")
             assert tensor is None
             # we know we will be outputting either a function or a cofunction,
             # both of which will use a dat as a data carrier. At present, the
@@ -915,7 +939,10 @@ def make_interpolator(expr, V, subset, access, bcs=None):
             wrapper.mpi_type, _ = get_dat_mpi_type(temp_source_func.dat)
 
             # Leave wrapper inside a callable so we can access the handle
-            # property (which is pretending to be a petsc mat)
+            # property. If matfree is True, then the handle is a PETSc SF 
+            # pretending to be a PETSc Mat. If matfree is False, then this
+            # will be a PETSc Mat representing the equivalent permutation
+            # matrix 
             def callable():
                 return wrapper
 
@@ -1391,9 +1418,14 @@ class VomOntoVomWrapper(object):
     arguments : list of `ufl.Argument`
         The arguments in the expression. These are not extracted from expr here
         since, where we use this, we already have them.
+    matfree : bool
+        If ``False``, the matrix representating the permutation of the points is
+        constructed and used to perform the interpolation. If ``True``, then the
+        interpolation is performed using the broadcast and reduce operations on the
+        PETSc Star Forest.
     """
 
-    def __init__(self, V, source_vom, target_vom, expr, arguments):
+    def __init__(self, V, source_vom, target_vom, expr, arguments, matfree):
         reduce = False
         if source_vom.input_ordering is target_vom:
             reduce = True
@@ -1414,7 +1446,12 @@ class VomOntoVomWrapper(object):
         self.dummy_mat = VomOntoVomDummyMat(
             original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, target_vom, expr, arguments
         )
-        self.handle = self.dummy_mat._create_petsc_mat()
+        if matfree:
+            # If matfree, we use the SF to perform the interpolation
+            self.handle = self.dummy_mat
+        else:
+            # Otherwise we create the permutation matrix
+            self.handle = self.dummy_mat._create_petsc_mat()
 
     @property
     def mpi_type(self):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1550,7 +1550,7 @@ class VomOntoVomDummyMat(object):
         return coeff
 
     def reduce(self, source_vec, target_vec):
-        source_arr = source_vec.getArray()
+        source_arr = source_vec.getArray(readonly=True)
         target_arr = target_vec.getArray()
         self.sf.reduceBegin(
             self.mpi_type,
@@ -1566,7 +1566,7 @@ class VomOntoVomDummyMat(object):
         )
 
     def broadcast(self, source_vec, target_vec):
-        source_arr = source_vec.getArray()
+        source_arr = source_vec.getArray(readonly=True)
         target_arr = target_vec.getArray()
         self.sf.bcastBegin(
             self.mpi_type,
@@ -1581,7 +1581,7 @@ class VomOntoVomDummyMat(object):
             MPI.REPLACE,
         )
 
-    def mult(self, source_vec, target_vec):
+    def mult(self, mat, source_vec, target_vec):
         # need to evaluate expression before doing mult
         coeff = self.expr_as_coeff(source_vec)
         with coeff.dat.vec_ro as coeff_vec:
@@ -1590,7 +1590,10 @@ class VomOntoVomDummyMat(object):
             else:
                 self.broadcast(coeff_vec, target_vec)
 
-    def multHermitian(self, source_vec, target_vec):
+    def multHermitian(self, mat, source_vec, target_vec):
+        self.multTranspose(mat, source_vec, target_vec)
+
+    def multTranspose(self, mat, source_vec, target_vec):
         # can only do adjoint if our expression exclusively contains a
         # single argument, making the application of the adjoint operator
         # straightforward (haven't worked out how to do this otherwise!)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1590,15 +1590,23 @@ class VomOntoVomDummyMat(object):
         P0DG_target = firedrake.FunctionSpace(self.target_vom, element)
         source_size = P0DG_source.dof_dset.layout_vec.getSizes()
         target_size = P0DG_target.dof_dset.layout_vec.getSizes()
+        # We create an identity matrix and use `MatPermute` to get the permutation matrix
         mat = PETSc.Mat().createConstantDiagonal((target_size, source_size), 1.0, self.V.comm)
-        mat.convert(mat_type=PETSc.Mat().Type.AIJ)
-        # perm = self.sf.getGraph()[2][:,1]
-        nroots, ilocal, iremote = self.sf.getGraph()
-        root_indices = numpy.arange(nroots, dtype=numpy.int32)
-        perm = numpy.empty_like(ilocal, dtype=numpy.int32)
-        self.sf.bcastBegin(MPI.INT, root_indices, perm, MPI.REPLACE)
-        self.sf.bcastEnd(MPI.INT, root_indices, perm, MPI.REPLACE)
-        col_is = PETSc.IS().createGeneral(perm, comm=self.V.comm)
-        row_is = PETSc.IS().createGeneral(numpy.arange(perm.shape[0], dtype=numpy.int32), comm=self.V.comm)
+        mat.convert(mat_type=mat.Type.BAIJ)
+        _, _, iremote = self.sf.getGraph()
+        SF = PETSc.SF().create(comm=self.V.comm)
+        local_sizes = self.V.comm.allgather(source_size[0])
+        start = sum(local_sizes[:self.V.comm.rank])
+        end = start + source_size[0]
+        contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
+        SF.setGraph(source_size[0], contiguous_indices, iremote)
+        root_indices = numpy.arange(target_size[1], dtype=numpy.int32)
+        result = numpy.zeros_like(root_indices, dtype=numpy.int32)
+        SF.reduceBegin(MPI.INT, root_indices, result, MPI.REPLACE)
+        SF.reduceEnd(MPI.INT, root_indices, result, MPI.REPLACE)
+        perm = result[:target_size[0]]
+        row_is = PETSc.IS().createGeneral(perm, comm=self.V.comm)
+        col_is = PETSc.IS().createGeneral(numpy.arange(target_size[1], dtype=numpy.int32), comm=self.V.comm)
         mat = mat.permute(row_is, col_is)
+        mat.view()
         return mat

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1648,10 +1648,11 @@ class VomOntoVomDummyMat(object):
 
     def _wrap_dummy_mat(self):
         mat = PETSc.Mat().create(comm=self.V.comm)
+        dim = self.V.value_size
         if self.forward_reduce:
-            mat_size = (self.source_size, self.target_size)
+            mat_size = (tuple(dim * i for i in self.source_size), tuple(dim * i for i in self.target_size))
         else:
-            mat_size = (self.target_size, self.source_size)
+            mat_size = (tuple(dim * i for i in self.target_size), tuple(dim * i for i in self.source_size))
         mat.setSizes(mat_size)
         mat.setType(mat.Type.PYTHON)
         mat.setPythonContext(self)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1585,28 +1585,31 @@ class VomOntoVomDummyMat(object):
             self.reduce(source_vec, target_vec)
 
     def _create_petsc_mat(self):
+        """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
+        its input ordering vertex-only mesh"""
         element = self.V.ufl_element()
         P0DG_source = firedrake.FunctionSpace(self.source_vom, element)
         P0DG_target = firedrake.FunctionSpace(self.target_vom, element)
-        source_size = P0DG_source.dof_dset.layout_vec.getSizes()
-        target_size = P0DG_target.dof_dset.layout_vec.getSizes()
+        source_size = P0DG_source.dof_dset.layout_vec.getSizes()  # (local_souce_size, global_source_size)
+        target_size = P0DG_target.dof_dset.layout_vec.getSizes()  # (local_target_size, global_target_size)
         # We create an identity matrix and use `MatPermute` to get the permutation matrix
         mat = PETSc.Mat().createConstantDiagonal((target_size, source_size), 1.0, self.V.comm)
-        mat.convert(mat_type=mat.Type.BAIJ)
-        _, _, iremote = self.sf.getGraph()
+        mat.convert(mat_type=mat.Type.BAIJ)  # `MatPermute` only seems to work in parallel with BAIJ
+        # We create a new SF and set the indices of the leaves to be contiguous
         SF = PETSc.SF().create(comm=self.V.comm)
         local_sizes = self.V.comm.allgather(source_size[0])
         start = sum(local_sizes[:self.V.comm.rank])
         end = start + source_size[0]
         contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
+        _, _, iremote = self.sf.getGraph()
         SF.setGraph(source_size[0], contiguous_indices, iremote)
+        # We reduce the array [0, 1, 2, ... , global_target_size - 1] to get the permutation of the rows
         root_indices = numpy.arange(target_size[1], dtype=numpy.int32)
-        result = numpy.zeros_like(root_indices, dtype=numpy.int32)
-        SF.reduceBegin(MPI.INT, root_indices, result, MPI.REPLACE)
-        SF.reduceEnd(MPI.INT, root_indices, result, MPI.REPLACE)
-        perm = result[:target_size[0]]
+        perm = numpy.zeros(target_size[0], dtype=numpy.int32)
+        SF.reduceBegin(MPI.INT, root_indices, perm, MPI.REPLACE)
+        SF.reduceEnd(MPI.INT, root_indices, perm, MPI.REPLACE)
         row_is = PETSc.IS().createGeneral(perm, comm=self.V.comm)
+        # For the columns we use the identity permutation
         col_is = PETSc.IS().createGeneral(numpy.arange(target_size[1], dtype=numpy.int32), comm=self.V.comm)
         mat = mat.permute(row_is, col_is)
-        mat.view()
         return mat

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -414,6 +414,7 @@ class CrossMeshInterpolator(Interpolator):
         access=op2.WRITE,
         bcs=None,
         allow_missing_dofs=False,
+        matfree=True
     ):
         if subset:
             raise NotImplementedError("subset not implemented")
@@ -434,7 +435,7 @@ class CrossMeshInterpolator(Interpolator):
                 "Can only interpolate into spaces with point evaluation nodes."
             )
 
-        super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs)
+        super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs, matfree)
 
         self.arguments = extract_arguments(expr)
         self.nargs = len(self.arguments)
@@ -749,19 +750,10 @@ class SameMeshInterpolator(Interpolator):
     """
 
     @no_annotations
-    def __init__(self, expr, V, 
-                 subset=None, 
-                 freeze_expr=False, 
-                 access=op2.WRITE, 
-                 bcs=None, 
-                 matfree=True, 
-                 **kwargs):
-        super().__init__(expr, V, 
-                         subset=subset, 
-                         freeze_expr=freeze_expr, 
-                         access=access, 
-                         bcs=bcs,
-                         matfree=matfree)
+    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, 
+                 bcs=None, matfree=True, **kwargs):
+        super().__init__(expr, V, subset=subset, freeze_expr=freeze_expr, 
+                         access=access, bcs=bcs, matfree=matfree)
         try:
             self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs, matfree=matfree)
         except FIAT.hdiv_trace.TraceError:
@@ -926,8 +918,6 @@ def make_interpolator(expr, V, subset, access, bcs=None, matfree=True):
                 return f
         else:
             assert len(arguments) == 1
-            if matfree:
-                raise ValueError("Pass matfree=False to assemble interpolation matrix")
             assert tensor is None
             # we know we will be outputting either a function or a cofunction,
             # both of which will use a dat as a data carrier. At present, the
@@ -1624,13 +1614,13 @@ class VomOntoVomDummyMat(object):
     def _create_petsc_mat(self):
         """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
         its input ordering vertex-only mesh"""
-        nroots = self.sf.getGraph()[0]
-        nleaves = len(self.sf.getGraph()[1])
-        source_size = (nroots, self.V.comm.allreduce(nroots, op=MPI.SUM))
+        nroots, leaves, _ = self.sf.getGraph()
+        nleaves = len(leaves)
+        local_sizes = self.V.comm.allgather(nroots)
+        source_size = (nroots, sum(local_sizes))
         target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
         mat = PETSc.Mat().createAIJ((target_size, source_size), nnz=1, comm=self.V.comm)
         mat.setUp()
-        local_sizes = self.V.comm.allgather(nroots)
         start = sum(local_sizes[:self.V.comm.rank])
         end = start + nroots
         contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
@@ -1640,4 +1630,6 @@ class VomOntoVomDummyMat(object):
         rows = numpy.arange(target_size[0] + 1, dtype=numpy.int32)
         mat.setValuesCSR(rows, perm, numpy.ones_like(perm, dtype=numpy.int32))
         mat.assemble()
-        return mat.createTranspose(mat)
+        if self.reduce:
+            mat.transpose()
+        return mat

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1587,23 +1587,19 @@ class VomOntoVomDummyMat(object):
     def _create_petsc_mat(self):
         """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
         its input ordering vertex-only mesh"""
-        element = self.V.ufl_element()
-        P0DG_source = firedrake.FunctionSpace(self.source_vom, element)
-        P0DG_target = firedrake.FunctionSpace(self.target_vom, element)
-        source_size = P0DG_source.dof_dset.layout_vec.getSizes()  # (local_souce_size, global_source_size)
-        target_size = P0DG_target.dof_dset.layout_vec.getSizes()  # (local_target_size, global_target_size)
-        # print(f"rank {self.V.comm.rank} source size: {source_size}")
-        # print(f"rank {self.V.comm.rank} target size: {target_size}")
+        nroots = self.sf.getGraph()[0]
+        nleaves = len(self.sf.getGraph()[1])
+        source_size = (nroots, self.V.comm.allreduce(nroots, op=MPI.SUM))
+        target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
         mat = PETSc.Mat().createAIJ((target_size, source_size), nnz=1, comm=self.V.comm)
         mat.setUp()
-        local_sizes = self.V.comm.allgather(source_size[0])
+        local_sizes = self.V.comm.allgather(nroots)
         start = sum(local_sizes[:self.V.comm.rank])
-        end = start + source_size[0]
+        end = start + nroots
         contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
         perm = numpy.zeros(target_size[0], dtype=numpy.int32)
         self.sf.bcastBegin(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
         self.sf.bcastEnd(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
-        print(f"rank {self.V.comm.rank} perm: {perm}")
         rows = numpy.arange(target_size[0] + 1, dtype=numpy.int32)
         mat.setValuesCSR(rows, perm, numpy.ones_like(perm, dtype=numpy.int32))
         mat.assemble()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1642,13 +1642,17 @@ class VomOntoVomDummyMat(object):
         rows = numpy.arange(self.target_size[0] + 1, dtype=numpy.int32)
         mat.setValuesCSR(rows, perm, numpy.ones_like(perm, dtype=numpy.int32))
         mat.assemble()
-        if self.reduce:
+        if self.forward_reduce:
             mat.transpose()
         return mat
 
     def _wrap_dummy_mat(self):
         mat = PETSc.Mat().create(comm=self.V.comm)
-        mat.setSizes((self.target_size, self.source_size))
+        if self.forward_reduce:
+            mat_size = (self.source_size, self.target_size)
+        else:
+            mat_size = (self.target_size, self.source_size)
+        mat.setSizes(mat_size)
         mat.setType(mat.Type.PYTHON)
         mat.setPythonContext(self)
         mat.setUp()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1438,7 +1438,7 @@ class VomOntoVomWrapper(object):
         )
         if matfree:
             # If matfree, we use the SF to perform the interpolation
-            self.handle = self.dummy_mat
+            self.handle = self.dummy_mat._wrap_dummy_mat()
         else:
             # Otherwise we create the permutation matrix
             self.handle = self.dummy_mat._create_permutation_mat()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1441,7 +1441,7 @@ class VomOntoVomWrapper(object):
             self.handle = self.dummy_mat
         else:
             # Otherwise we create the permutation matrix
-            self.handle = self.dummy_mat._create_petsc_mat()
+            self.handle = self.dummy_mat._create_permutation_mat()
 
     @property
     def mpi_type(self):
@@ -1496,6 +1496,12 @@ class VomOntoVomDummyMat(object):
         self.target_vom = target_vom
         self.expr = expr
         self.arguments = arguments
+        # Calculate correct local and global sizes for the matrix
+        nroots, leaves, _ = sf.getGraph()
+        nleaves = len(leaves)
+        self.local_sizes = V.comm.allgather(nroots)
+        self.source_size = (nroots, sum(self.local_sizes))
+        self.target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
 
     @property
     def mpi_type(self):
@@ -1611,25 +1617,39 @@ class VomOntoVomDummyMat(object):
             target_vec.zeroEntries()
             self.reduce(source_vec, target_vec)
 
-    def _create_petsc_mat(self):
-        """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
-        its input ordering vertex-only mesh"""
+    def _get_sizes(self):
         nroots, leaves, _ = self.sf.getGraph()
         nleaves = len(leaves)
         local_sizes = self.V.comm.allgather(nroots)
         source_size = (nroots, sum(local_sizes))
         target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
-        mat = PETSc.Mat().createAIJ((target_size, source_size), nnz=1, comm=self.V.comm)
+        return source_size, target_size
+
+    def _create_permutation_mat(self):
+        """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
+        its input ordering vertex-only mesh"""
+        mat = PETSc.Mat().createAIJ((self.target_size, self.source_size), nnz=1, comm=self.V.comm)
         mat.setUp()
-        start = sum(local_sizes[:self.V.comm.rank])
-        end = start + nroots
+        start = sum(self.local_sizes[:self.V.comm.rank])
+        end = start + self.source_size[0]
         contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
-        perm = numpy.zeros(target_size[0], dtype=numpy.int32)
+        perm = numpy.zeros(self.target_size[0], dtype=numpy.int32)
         self.sf.bcastBegin(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
         self.sf.bcastEnd(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
-        rows = numpy.arange(target_size[0] + 1, dtype=numpy.int32)
+        rows = numpy.arange(self.target_size[0] + 1, dtype=numpy.int32)
         mat.setValuesCSR(rows, perm, numpy.ones_like(perm, dtype=numpy.int32))
         mat.assemble()
         if self.reduce:
             mat.transpose()
         return mat
+
+    def _wrap_dummy_mat(self):
+        mat = PETSc.Mat().create(comm=self.V.comm)
+        mat.setSizes((self.target_size, self.source_size))
+        mat.setType(mat.Type.PYTHON)
+        mat.setPythonContext(self)
+        mat.setUp()
+        return mat
+    
+    def duplicate(self, mat=None, op=None):
+        return self._wrap_dummy_mat()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1596,21 +1596,21 @@ class VomOntoVomDummyMat(object):
         mat = PETSc.Mat().createConstantDiagonal((target_size, source_size), 1.0, self.V.comm)
         mat.convert(mat_type=mat.Type.BAIJ)  # `MatPermute` only seems to work in parallel with BAIJ
         # We create a new SF and set the indices of the leaves to be contiguous
-        SF = PETSc.SF().create(comm=self.V.comm)
+        # SF = PETSc.SF().create(comm=self.V.comm)
         local_sizes = self.V.comm.allgather(source_size[0])
         start = sum(local_sizes[:self.V.comm.rank])
         end = start + source_size[0]
         contiguous_indices = numpy.arange(start, end, dtype=numpy.int32)
-        _, _, iremote = self.sf.getGraph()
-        SF.setGraph(source_size[0], contiguous_indices, iremote)
+        # _, _, iremote = self.sf.getGraph()
+        # SF.setGraph(source_size[0], contiguous_indices, iremote)
         # We reduce the array [0, 1, 2, ... , global_target_size - 1] to get the permutation of the rows
-        root_indices = numpy.arange(target_size[1], dtype=numpy.int32)
-        perm = numpy.zeros(target_size[0], dtype=numpy.int32)
-        SF.reduceBegin(MPI.INT, root_indices, perm, MPI.REPLACE)
-        SF.reduceEnd(MPI.INT, root_indices, perm, MPI.REPLACE)
-        row_is = PETSc.IS().createGeneral(perm, comm=self.V.comm)
+        # root_indices = numpy.arange(target_size[1], dtype=numpy.int32)
+        perm = numpy.zeros(source_size[0], dtype=numpy.int32)
+        self.sf.bcastBegin(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
+        self.sf.bcastEnd(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
+        col_is = PETSc.IS().createGeneral(perm, comm=self.V.comm)
         # For the columns we use the identity permutation
-        col_is = PETSc.IS().createGeneral(numpy.arange(target_size[1], dtype=numpy.int32), comm=self.V.comm)
+        row_is = PETSc.IS().createGeneral(numpy.arange(target_size[1], dtype=numpy.int32), comm=self.V.comm)
         mat = mat.permute(row_is, col_is)
         mat.convert(mat_type=mat.Type.AIJ)
         return mat

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -750,9 +750,9 @@ class SameMeshInterpolator(Interpolator):
     """
 
     @no_annotations
-    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE, 
+    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE,
                  bcs=None, matfree=True, **kwargs):
-        super().__init__(expr, V, subset=subset, freeze_expr=freeze_expr, 
+        super().__init__(expr, V, subset=subset, freeze_expr=freeze_expr,
                          access=access, bcs=bcs, matfree=matfree)
         try:
             self.callable, arguments = make_interpolator(expr, V, subset, access, bcs=bcs, matfree=matfree)
@@ -929,10 +929,10 @@ def make_interpolator(expr, V, subset, access, bcs=None, matfree=True):
             wrapper.mpi_type, _ = get_dat_mpi_type(temp_source_func.dat)
 
             # Leave wrapper inside a callable so we can access the handle
-            # property. If matfree is True, then the handle is a PETSc SF 
+            # property. If matfree is True, then the handle is a PETSc SF
             # pretending to be a PETSc Mat. If matfree is False, then this
             # will be a PETSc Mat representing the equivalent permutation
-            # matrix 
+            # matrix
             def callable():
                 return wrapper
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1612,4 +1612,5 @@ class VomOntoVomDummyMat(object):
         # For the columns we use the identity permutation
         col_is = PETSc.IS().createGeneral(numpy.arange(target_size[1], dtype=numpy.int32), comm=self.V.comm)
         mat = mat.permute(row_is, col_is)
+        mat.convert(mat_type=mat.Type.AIJ)
         return mat

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1658,6 +1658,6 @@ class VomOntoVomDummyMat(object):
         mat.setPythonContext(self)
         mat.setUp()
         return mat
-    
+
     def duplicate(self, mat=None, op=None):
         return self._wrap_dummy_mat()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1428,13 +1428,12 @@ class VomOntoVomWrapper(object):
             )
         self.V = V
         self.source_vom = source_vom
-        self.target_vom = target_vom
         self.expr = expr
         self.arguments = arguments
         self.reduce = reduce
         # note that interpolation doesn't include halo cells
         self.dummy_mat = VomOntoVomDummyMat(
-            original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, target_vom, expr, arguments
+            original_vom.input_ordering_without_halos_sf, reduce, V, source_vom, expr, arguments
         )
         if matfree:
             # If matfree, we use the SF to perform the interpolation
@@ -1488,12 +1487,11 @@ class VomOntoVomDummyMat(object):
         The arguments in the expression.
     """
 
-    def __init__(self, sf, forward_reduce, V, source_vom, target_vom, expr, arguments):
+    def __init__(self, sf, forward_reduce, V, source_vom, expr, arguments):
         self.sf = sf
         self.forward_reduce = forward_reduce
         self.V = V
         self.source_vom = source_vom
-        self.target_vom = target_vom
         self.expr = expr
         self.arguments = arguments
         # Calculate correct local and global sizes for the matrix

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -778,7 +778,9 @@ def test_interpolate_matrix_cross_mesh():
     # B is the interpolation matrix from P0DG to vom.input_ordering
     # C is direct assignment to the function in V
     interp_mat = assemble(Action(B, A))
-    f_interp2 = assemble(interp_mat @ f)
+    f_at_points_correct_order3 = assemble(interp_mat @ f)
+    f_interp2 = Function(V)
+    f_interp2.dat.data_wo[:] = f_at_points_correct_order3.dat.data_ro[:]
     assert np.allclose(f_interp2.dat.data_ro, g.dat.data_ro)
 
 

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -736,6 +736,52 @@ def test_line_integral():
     assert np.isclose(assemble(f_line_square * dx), 1.0)
 
 
+def test_interpolate_matrix_cross_mesh():
+    source_mesh = UnitSquareMesh(4, 4)
+    target_mesh = UnitSquareMesh(5, 5)
+    U = FunctionSpace(source_mesh, "CG", 2)
+    V = FunctionSpace(target_mesh, "CG", 3)
+
+    # For comparison later
+    x, y = SpatialCoordinate(source_mesh)
+    f = Function(U).interpolate(x**2 + y**2)
+    x2, y2 = SpatialCoordinate(target_mesh)
+    g = Function(V).interpolate(x2**2 + y2**2)
+
+    # We get the VOM at the point evaluation node coords of the target FS
+    w = VectorFunctionSpace(target_mesh, V.ufl_element())
+    X = assemble(interpolate(target_mesh.coordinates, w))
+    vom = VertexOnlyMesh(source_mesh, X.dat.data_ro, redundant=False)
+    P0DG = FunctionSpace(vom, "DG", 0)
+    # We get the interpolation matrix U -> P0DG which performs point evaluation
+    A = assemble(interpolate(TestFunction(U), P0DG))
+    f_at_points = assemble(A @ f)
+    f_at_points2 = assemble(interpolate(f, P0DG))
+    assert np.allclose(f_at_points.dat.data_ro, f_at_points2.dat.data_ro)
+    # To get the points in the correct order in V we interpolate into vom.input_ordering
+    # We pass matfree=False which constructs the permutation matrix instead of using SFs
+    P0DG_io = FunctionSpace(vom.input_ordering, "DG", 0)
+    B = assemble(interpolate(TestFunction(P0DG), P0DG_io, matfree=False))
+    f_at_points_correct_order = assemble(B @ f_at_points)
+    f_at_points_correct_order2 = assemble(interpolate(f_at_points, P0DG_io))
+    assert np.allclose(f_at_points_correct_order.dat.data_ro, f_at_points_correct_order2.dat.data_ro)
+
+    # f_at_points_correct_order has the correct coefficients of the function in V
+    # It is a function in P0DG_io, so we just directly assign it to a function in V
+    f_interp = Function(V)
+    f_interp.dat.data_wo[:] = f_at_points_correct_order.dat.data_ro[:]
+    assert np.allclose(f_interp.dat.data_ro, g.dat.data_ro)
+
+    # Hence interpolation from U to V is the product of the following three matrices:
+    # C*B*A
+    # A is the interpolation matrix from U to P0DG
+    # B is the interpolation matrix from P0DG to vom.input_ordering
+    # C is direct assignment to the function in V
+    interp_mat = assemble(Action(B, A))
+    f_interp2 = assemble(interp_mat @ f)
+    assert np.allclose(f_interp2.dat.data_ro, g.dat.data_ro)
+
+
 @pytest.mark.parallel
 def test_interpolate_cross_mesh_parallel(parameters):
     test_interpolate_cross_mesh(parameters)
@@ -754,6 +800,11 @@ def test_missing_dofs_parallel():
 @pytest.mark.parallel
 def test_exact_refinement_parallel():
     test_exact_refinement()
+
+
+@pytest.mark.parallel
+def test_interpolate_matrix_cross_mesh_parallel():
+    test_interpolate_matrix_cross_mesh()
 
 
 def voting_algorithm_edgecases(nprocs):

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -2,6 +2,7 @@ from firedrake import *
 import pytest
 import numpy as np
 from mpi4py import MPI
+from petsc4py.PETSc import Error
 
 
 # Utility Functions
@@ -153,10 +154,10 @@ def functionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    # with petsc_raises(NotImplementedError):
-    #     # Can't use adjoint on interpolators with expressions yet
-    #     g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    #     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+    with pytest.raises(Error):
+        # Can't use adjoint on interpolators with expressions yet
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -164,10 +165,10 @@ def functionspace_tests(vm, petsc_raises):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    # with petsc_raises(NotImplementedError):
-    #     # Can't use adjoint on interpolators with expressions yet
-    #     h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    #     assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+    with pytest.raises(Error):
+        # Can't use adjoint on interpolators with expressions yet
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -257,20 +258,20 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    # with petsc_raises(NotImplementedError):
-    #     # Can't use adjoint on interpolators with expressions yet
-    #     g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    #     assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+    with pytest.raises(Error):
+        # Can't use adjoint on interpolators with expressions yet
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    # with petsc_raises(NotImplementedError):
-    #     # Can't use adjoint on interpolators with expressions yet
-    #     h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    #     assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+    with pytest.raises(Error):
+        # Can't use adjoint on interpolators with expressions yet
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -153,10 +153,10 @@ def functionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    with petsc_raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+    # with petsc_raises(NotImplementedError):
+    #     # Can't use adjoint on interpolators with expressions yet
+    #     g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    #     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -164,10 +164,10 @@ def functionspace_tests(vm, petsc_raises):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with petsc_raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+    # with petsc_raises(NotImplementedError):
+    #     # Can't use adjoint on interpolators with expressions yet
+    #     h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    #     assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -257,20 +257,20 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    with petsc_raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+    # with petsc_raises(NotImplementedError):
+    #     # Can't use adjoint on interpolators with expressions yet
+    #     g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    #     assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with petsc_raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+    # with petsc_raises(NotImplementedError):
+    #     # Can't use adjoint on interpolators with expressions yet
+    #     h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    #     assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -68,7 +68,7 @@ def pseudo_random_coords(size):
 
 # Function Space Generation Tests
 
-def functionspace_tests(vm, petsc_raises):
+def functionspace_tests(vm):
     # Prep
     num_cells = len(vm.coordinates.dat.data_ro)
     num_cells_mpi_global = MPI.COMM_WORLD.allreduce(num_cells, op=MPI.SUM)
@@ -153,7 +153,7 @@ def functionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    with petsc_raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         try:
             g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
@@ -167,7 +167,7 @@ def functionspace_tests(vm, petsc_raises):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with petsc_raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         try:
             h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
@@ -180,7 +180,7 @@ def functionspace_tests(vm, petsc_raises):
     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
 
-def vectorfunctionspace_tests(vm, petsc_raises):
+def vectorfunctionspace_tests(vm):
     # Prep
     gdim = vm.geometric_dimension()
     num_cells = len(vm.coordinates.dat.data_ro)
@@ -263,7 +263,7 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    with petsc_raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         try:
             g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
@@ -292,12 +292,12 @@ def vectorfunctionspace_tests(vm, petsc_raises):
 
 
 @pytest.mark.parallel([1, 3])
-def test_functionspaces(parentmesh, vertexcoords, petsc_raises):
+def test_functionspaces(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
-    functionspace_tests(vm, petsc_raises)
-    vectorfunctionspace_tests(vm, petsc_raises)
-    functionspace_tests(vm.input_ordering, petsc_raises)
-    vectorfunctionspace_tests(vm.input_ordering, petsc_raises)
+    functionspace_tests(vm)
+    vectorfunctionspace_tests(vm)
+    functionspace_tests(vm.input_ordering)
+    vectorfunctionspace_tests(vm.input_ordering)
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -152,9 +152,10 @@ def functionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    # can use adjoint on interpolators with expressions now
-    g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+
+    # Can't use adjoint on interpolators with expressions in them
+    # g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    # assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -162,9 +163,9 @@ def functionspace_tests(vm):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    # can use adjoint on interpolators with expressions now
-    h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+
+    # h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    # assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
 
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
@@ -255,18 +256,17 @@ def vectorfunctionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    # Can use adjoint on interpolators with expressions now
-    g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
+    # g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    # assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    # Can use adjoint on interpolators with expressions now
-    h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+
+    # h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    # assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -69,7 +69,7 @@ def pseudo_random_coords(size):
 
 # Function Space Generation Tests
 
-def functionspace_tests(vm, petsc_raises):
+def functionspace_tests(vm):
     # Prep
     num_cells = len(vm.coordinates.dat.data_ro)
     num_cells_mpi_global = MPI.COMM_WORLD.allreduce(num_cells, op=MPI.SUM)
@@ -175,7 +175,7 @@ def functionspace_tests(vm, petsc_raises):
     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
 
-def vectorfunctionspace_tests(vm, petsc_raises):
+def vectorfunctionspace_tests(vm):
     # Prep
     gdim = vm.geometric_dimension()
     num_cells = len(vm.coordinates.dat.data_ro)
@@ -280,17 +280,17 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
 
-def test_functionspaces(parentmesh, vertexcoords, petsc_raises):
+def test_functionspaces(parentmesh, vertexcoords):
     vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
-    functionspace_tests(vm, petsc_raises)
-    vectorfunctionspace_tests(vm, petsc_raises)
-    functionspace_tests(vm.input_ordering, petsc_raises)
-    vectorfunctionspace_tests(vm.input_ordering, petsc_raises)
+    functionspace_tests(vm)
+    vectorfunctionspace_tests(vm)
+    functionspace_tests(vm.input_ordering)
+    vectorfunctionspace_tests(vm.input_ordering)
 
 
 @pytest.mark.parallel
-def test_functionspaces_parallel(parentmesh, vertexcoords, petsc_raises):
-    test_functionspaces(parentmesh, vertexcoords, petsc_raises)
+def test_functionspaces_parallel(parentmesh, vertexcoords):
+    test_functionspaces(parentmesh, vertexcoords)
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -152,10 +152,9 @@ def functionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    with pytest.raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+    # can use adjoint on interpolators with expressions now
+    g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -163,11 +162,10 @@ def functionspace_tests(vm):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
+    # can use adjoint on interpolators with expressions now
+    h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
 
-    with pytest.raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -257,20 +255,18 @@ def vectorfunctionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    with pytest.raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+    # Can use adjoint on interpolators with expressions now
+    g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+    assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with pytest.raises(NotImplementedError):
-        # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+    # Can use adjoint on interpolators with expressions now
+    h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+    assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -278,7 +278,7 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
     with pytest.raises(NotImplementedError):
         try:
-        # Can't use adjoint on interpolators with expressions yet
+            # Can't use adjoint on interpolators with expressions yet
             h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
             assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
         except PETSc.Error as e:

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -69,7 +69,7 @@ def pseudo_random_coords(size):
 
 # Function Space Generation Tests
 
-def functionspace_tests(vm):
+def functionspace_tests(vm, petsc_raises):
     # Prep
     num_cells = len(vm.coordinates.dat.data_ro)
     num_cells_mpi_global = MPI.COMM_WORLD.allreduce(num_cells, op=MPI.SUM)
@@ -154,7 +154,7 @@ def functionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    with pytest.raises(Error):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
         assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
@@ -165,7 +165,7 @@ def functionspace_tests(vm):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with pytest.raises(Error):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
         assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
@@ -175,7 +175,7 @@ def functionspace_tests(vm):
     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
 
-def vectorfunctionspace_tests(vm):
+def vectorfunctionspace_tests(vm, petsc_raises):
     # Prep
     gdim = vm.geometric_dimension()
     num_cells = len(vm.coordinates.dat.data_ro)
@@ -258,7 +258,7 @@ def vectorfunctionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    with pytest.raises(Error):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
         assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
@@ -268,7 +268,7 @@ def vectorfunctionspace_tests(vm):
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with pytest.raises(Error):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
         h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
         assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
@@ -280,17 +280,13 @@ def vectorfunctionspace_tests(vm):
     assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
 
-def test_functionspaces(parentmesh, vertexcoords):
+@pytest.mark.parallel([1, 3])
+def test_functionspaces(parentmesh, vertexcoords, petsc_raises):
     vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
-    functionspace_tests(vm)
-    vectorfunctionspace_tests(vm)
-    functionspace_tests(vm.input_ordering)
-    vectorfunctionspace_tests(vm.input_ordering)
-
-
-@pytest.mark.parallel
-def test_functionspaces_parallel(parentmesh, vertexcoords):
-    test_functionspaces(parentmesh, vertexcoords)
+    functionspace_tests(vm, petsc_raises)
+    vectorfunctionspace_tests(vm, petsc_raises)
+    functionspace_tests(vm.input_ordering, petsc_raises)
+    vectorfunctionspace_tests(vm.input_ordering, petsc_raises)
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -111,8 +111,11 @@ def functionspace_tests(vm):
     # Can interpolate onto the input ordering VOM and we retain values from the
     # expresson on the main VOM
     W = FunctionSpace(vm.input_ordering, "DG", 0)
+    h_mat = Function(W)
     h = Function(W)
+    h_mat.dat.data_wo_with_halos[:] = -1
     h.dat.data_wo_with_halos[:] = -1
+    h_mat.interpolate(g, matfree=False)  # matfree=False means we calculate the permutation matrix
     h.interpolate(g)
     # Exclude points which we know are missing - these should all be equal to -1
     input_ordering_parent_cell_nums = vm.input_ordering.topology_dm.getField("parentcellnum").ravel()
@@ -120,6 +123,10 @@ def functionspace_tests(vm):
     idxs_to_include = input_ordering_parent_cell_nums != -1
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == -1)
+    # with matfree=False the missing points correspond to a column of zeros hence the -1 becomes 0
+    assert np.all(h_mat.dat.data_ro_with_halos[~idxs_to_include] == 0)
+    # Otherwise they are the same
+    assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], h_mat.dat.data_ro_with_halos[idxs_to_include])
     # check other interpolation APIs work identically
     h2 = assemble(interpolate(g, W))
     assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], h.dat.data_ro_with_halos[idxs_to_include])
@@ -152,10 +159,10 @@ def functionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-
-    # Can't use adjoint on interpolators with expressions in them
-    # g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    # assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+    with pytest.raises(NotImplementedError):
+        # Can't use adjoint on interpolators with expressions yet
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -164,9 +171,10 @@ def functionspace_tests(vm):
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
 
-    # h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    # assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
-
+    with pytest.raises(NotImplementedError):
+        # Can't use adjoint on interpolators with expressions yet
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -256,17 +264,20 @@ def vectorfunctionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
+    with pytest.raises(NotImplementedError):
+        # Can't use adjoint on interpolators with expressions yet
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
-    # g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-    # assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-
-    # h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-    # assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+    with pytest.raises(NotImplementedError):
+        # Can't use adjoint on interpolators with expressions yet
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -68,7 +68,7 @@ def pseudo_random_coords(size):
 
 # Function Space Generation Tests
 
-def functionspace_tests(vm):
+def functionspace_tests(vm, petsc_raises):
     # Prep
     num_cells = len(vm.coordinates.dat.data_ro)
     num_cells_mpi_global = MPI.COMM_WORLD.allreduce(num_cells, op=MPI.SUM)
@@ -153,13 +153,10 @@ def functionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-    with pytest.raises(NotImplementedError):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        try:
-            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-            assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
-        except PETSc.Error as e:
-            raise e.__cause__ from None
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -167,21 +164,17 @@ def functionspace_tests(vm):
     h = h_star.riesz_representation(riesz_map="l2")
     assert np.allclose(h.dat.data_ro_with_halos[idxs_to_include], np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
-
-    with pytest.raises(NotImplementedError):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        try:
-            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-            assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
-        except PETSc.Error as e:
-            raise e.__cause__ from None
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
     assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
 
 
-def vectorfunctionspace_tests(vm):
+def vectorfunctionspace_tests(vm, petsc_raises):
     # Prep
     gdim = vm.geometric_dimension()
     num_cells = len(vm.coordinates.dat.data_ro)
@@ -264,26 +257,20 @@ def vectorfunctionspace_tests(vm):
     h_star = h.riesz_representation(riesz_map="l2")
     g = assemble(I_io.interpolate(h_star, adjoint=True))
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
-    with pytest.raises(NotImplementedError):
+    with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        try:
-            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-            assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
-        except PETSc.Error as e:
-            raise e.__cause__ from None
+        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with pytest.raises(NotImplementedError):
-        try:
-            # Can't use adjoint on interpolators with expressions yet
-            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-            assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
-        except PETSc.Error as e:
-            raise e.__cause__ from None
+    with petsc_raises(NotImplementedError):
+        # Can't use adjoint on interpolators with expressions yet
+        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))
@@ -292,17 +279,17 @@ def vectorfunctionspace_tests(vm):
     assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
 
 
-def test_functionspaces(parentmesh, vertexcoords):
+def test_functionspaces(parentmesh, vertexcoords, petsc_raises):
     vm = VertexOnlyMesh(parentmesh, vertexcoords, missing_points_behaviour=None)
-    functionspace_tests(vm)
-    vectorfunctionspace_tests(vm)
-    functionspace_tests(vm.input_ordering)
-    vectorfunctionspace_tests(vm.input_ordering)
+    functionspace_tests(vm, petsc_raises)
+    vectorfunctionspace_tests(vm, petsc_raises)
+    functionspace_tests(vm.input_ordering, petsc_raises)
+    vectorfunctionspace_tests(vm.input_ordering, petsc_raises)
 
 
 @pytest.mark.parallel
-def test_functionspaces_parallel(parentmesh, vertexcoords):
-    test_functionspaces(parentmesh, vertexcoords)
+def test_functionspaces_parallel(parentmesh, vertexcoords, petsc_raises):
+    test_functionspaces(parentmesh, vertexcoords, petsc_raises)
 
 
 @pytest.mark.parallel(nprocs=2)

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -279,7 +279,7 @@ def vectorfunctionspace_tests(vm):
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
     with pytest.raises(NotImplementedError):
         try:
-        # Can't use adjoint on interpolators with expressions yet
+            # Can't use adjoint on interpolators with expressions yet
             h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
             assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
         except PETSc.Error as e:

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -155,8 +155,11 @@ def functionspace_tests(vm, petsc_raises):
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+        try:
+            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+            assert np.allclose(g2.dat.data_ro_with_halos, 2*np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
+        except PETSc.Error as e:
+            raise e.__cause__ from None
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
@@ -166,8 +169,11 @@ def functionspace_tests(vm, petsc_raises):
     assert np.all(h.dat.data_ro_with_halos[~idxs_to_include] == 0)
     with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+        try:
+            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+            assert np.allclose(h2.dat.data_ro_with_halos[idxs_to_include], 2*np.prod(vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include].reshape(-1, vm.input_ordering.geometric_dimension()), axis=1))
+        except PETSc.Error as e:
+            raise e.__cause__ from None
     g = assemble(I_io_adjoint.interpolate(h))
     assert np.allclose(g.dat.data_ro_with_halos, np.prod(vm.coordinates.dat.data_ro_with_halos.reshape(-1, vm.geometric_dimension()), axis=1))
     g2 = assemble(I2_io_adjoint.interpolate(h))
@@ -259,18 +265,24 @@ def vectorfunctionspace_tests(vm, petsc_raises):
     assert np.allclose(g.dat.data_ro_with_halos, 2*vm.coordinates.dat.data_ro_with_halos)
     with petsc_raises(NotImplementedError):
         # Can't use adjoint on interpolators with expressions yet
-        g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
-        assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+        try:
+            g2 = assemble(I2_io.interpolate(h_star, adjoint=True))
+            assert np.allclose(g2.dat.data_ro_with_halos, 4*vm.coordinates.dat.data_ro_with_halos)
+        except PETSc.Error as e:
+            raise e.__cause__ from None
 
     I_io_adjoint = Interpolator(TestFunction(W), V)
     I2_io_adjoint = Interpolator(2*TestFunction(W), V)
     h_star = assemble(I_io_adjoint.interpolate(g, adjoint=True))
     assert np.allclose(h_star.dat.data_ro[idxs_to_include], 2*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
     assert np.all(h_star.dat.data_ro_with_halos[~idxs_to_include] == 0)
-    with petsc_raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
+        try:
         # Can't use adjoint on interpolators with expressions yet
-        h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
-        assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+            h2 = assemble(I2_io_adjoint.interpolate(g, adjoint=True))
+            assert np.allclose(h2.dat.data_ro[idxs_to_include], 4*vm.input_ordering.coordinates.dat.data_ro_with_halos[idxs_to_include])
+        except PETSc.Error as e:
+            raise e.__cause__ from None
 
     h = h_star.riesz_representation(riesz_map="l2")
     g = assemble(I_io_adjoint.interpolate(h))

--- a/tests/firedrake/vertexonly/test_vertex_only_fs.py
+++ b/tests/firedrake/vertexonly/test_vertex_only_fs.py
@@ -2,7 +2,6 @@ from firedrake import *
 import pytest
 import numpy as np
 from mpi4py import MPI
-from petsc4py.PETSc import Error
 
 
 # Utility Functions


### PR DESCRIPTION
# Description

Allows construction of the interpolation matrix between a VOM and its input-ordering. This is a permutation matrix which is used for cross-mesh interpolation to redistribute the points correctly on the target mesh.

Set the keyword argument `matfree=False` to construct the matrix. By default `matfree=True` which uses the current way of SF reduce and broadcasts.

```
P0DG = FunctionSpace(vom, "DG", 0)
P0DG_io = FunctionSpace(vom.input_ordering, "DG", 0)
B = assemble(interpolate(TestFunction(P0DG), P0DG_io, matfree=False))
```