### PR TITLE
Proposal: use upstream UFL instead of our fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "mpi4py; python_version < '3.13'",
   # TODO RELEASE: use releases
   "fenics-ufl @ git+https://github.com/FEniCS/ufl.git",
-  "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git",
+  # UNDO ME
+  "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git@connorjward/upstream-ufl",
   "h5py>3.12.1",
   "libsupermesh",
   "loopy>2024.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
   # TODO RELEASE: use releases
-  "fenics-ufl @ git+https://github.com/firedrakeproject/ufl.git",
+  "fenics-ufl @ git+https://github.com/FEniCS/ufl.git",
   "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git",
   "h5py>3.12.1",
   "libsupermesh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ dependencies = [
   "mpi4py; python_version < '3.13'",
   # TODO RELEASE: use releases
   "fenics-ufl @ git+https://github.com/FEniCS/ufl.git",
-  # UNDO ME
-  "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git@connorjward/upstream-ufl",
+  "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git",
   "h5py>3.12.1",
   "libsupermesh",
   "loopy>2024.1",


### PR DESCRIPTION
I don't think that we should be using our own fork of UFL any more. It means that we have to keep updating it periodically and it doesn't affect the user experience anyway since Firedrake `release` depends on a released version of UFL. We already point Firedrake `master` to PETSc `main` which is a much faster moving target than UFL `main`.

Goes with https://github.com/firedrakeproject/fiat/pull/147

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
