### PR TITLE
always() install system dependencies in CI

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -370,6 +370,7 @@ jobs:
           path: pytest_*.log
 
       - name: Install system dependencies (3)
+        if: always()
         run: apt-get -y install inkscape texlive-full
 
       - name: Check bibtex


### PR DESCRIPTION
This means we don't get spurious docs build failures when (e.g.) G-ADOPT fails tests.

E.g. https://github.com/firedrakeproject/firedrake/actions/runs/15439928116/job/43455103099

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
