### PR TITLE
Fix pre_apply_bcs=False throwing an error with EquationBC

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -414,6 +414,7 @@ class _SNESContext(object):
         :arg X: the current guess (a Vec)
         :arg F: the residual at X (a Vec)
         """
+        from firedrake.bcs import DirichletBC
         dm = snes.getDM()
         ctx = dmhooks.get_appctx(dm)
         # X may not be the same vector as the vec behind self._x, so
@@ -427,7 +428,8 @@ class _SNESContext(object):
         if not ctx.pre_apply_bcs:
             # Compute DirichletBC residual
             for bc in ctx.bcs_F:
-                bc.apply(ctx._bc_residual, u=ctx._x)
+                if isinstance(bc, DirichletBC):
+                    bc.apply(ctx._bc_residual, u=ctx._x)
 
         ctx._assemble_residual(tensor=ctx._F, current_state=ctx._x)
 

--- a/tests/firedrake/equation_bcs/test_equation_bcs.py
+++ b/tests/firedrake/equation_bcs/test_equation_bcs.py
@@ -8,7 +8,7 @@ from firedrake.petsc import DEFAULT_DIRECT_SOLVER
 import math
 
 
-def nonlinear_poisson(solver_parameters, mesh_num, porder):
+def nonlinear_poisson(solver_parameters, mesh_num, porder, pre_apply_bcs=True):
 
     mesh = UnitSquareMesh(mesh_num, mesh_num)
 
@@ -29,7 +29,7 @@ def nonlinear_poisson(solver_parameters, mesh_num, porder):
     e2 = as_vector([0., 1.])
     bc1 = EquationBC((-inner(dot(grad(u), e2), dot(grad(v), e2)) + 3 * pi * pi * inner(u, v) + 1 * pi * pi * inner(g, v)) * ds(1) == 0, u, 1)
 
-    solve(a - L == 0, u, bcs=[bc1], solver_parameters=solver_parameters)
+    solve(a - L == 0, u, bcs=[bc1], solver_parameters=solver_parameters, pre_apply_bcs=pre_apply_bcs)
 
     f = cos(x * pi * 2) * cos(y * pi * 2)
     return sqrt(assemble(inner(u - f, u - f) * dx))
@@ -199,7 +199,13 @@ def linear_poisson_mixed(solver_parameters, mesh_num, porder):
 
 @pytest.mark.parametrize("eq_type", ["linear", "nonlinear"])
 @pytest.mark.parametrize("with_bbc", [False, True])
-def test_EquationBC_poisson_matrix(eq_type, with_bbc):
+@pytest.mark.parametrize("pre_apply_bcs", [False, True])
+def test_EquationBC_poisson_matrix(eq_type, with_bbc, pre_apply_bcs):
+
+    # Only test pre_apply_bcs=False for nonlinear case
+    if not pre_apply_bcs and (eq_type == "linear" or with_bbc):
+        pytest.skip(reason="Only test pre_apply_bcs=False in the nonlinear case")
+
     mat_type = "aij"
     porder = 2
     # Test standard poisson with EquationBCs
@@ -225,7 +231,7 @@ def test_EquationBC_poisson_matrix(eq_type, with_bbc):
                 err.append(linear_poisson(solver_parameters, mesh_num, porder))
         elif eq_type == "nonlinear":
             for mesh_num in mesh_sizes:
-                err.append(nonlinear_poisson(solver_parameters, mesh_num, porder))
+                err.append(nonlinear_poisson(solver_parameters, mesh_num, porder, pre_apply_bcs=pre_apply_bcs))
 
     assert abs(math.log2(err[0]) - math.log2(err[1]) - (porder+1)) < 0.05
 


### PR DESCRIPTION
When `pre_apply_bcs=False` only `apply()` the `bc` if it is a `DirichletBC`.

Also added a test case for `pre_apply_bcs=False`.