### PR TITLE
Fix homogeneous DirichletBC residual

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -451,7 +451,11 @@ class DirichletBC(BCBase, DirichletBCMixin):
             if u:
                 u = u.sub(idx)
         if u:
-            r.assign(u - self.function_arg, subset=self.node_set)
+            if self.function_arg == 0:
+                bc_residual = u
+            else:
+                bc_residual = u - self.function_arg
+            r.assign(bc_residual, subset=self.node_set)
         else:
             r.assign(self.function_arg, subset=self.node_set)
 

--- a/tests/firedrake/regression/test_bcs.py
+++ b/tests/firedrake/regression/test_bcs.py
@@ -439,3 +439,18 @@ def test_bcs_mixed_real_vector():
     A = assemble(a, bcs=[bc, ])
     assert np.allclose(A.M[0][1].values, [[[0.25], [0.], [0.25], [0.], [0.25], [0.25], [0.25], [0.25]]])
     assert np.allclose(A.M[1][0].values, [[0.25, 0., 0.25, 0., 0.25, 0.25, 0.25, 0.25]])
+
+
+def test_homogeneous_bc_residual():
+    mesh = UnitSquareMesh(2, 2)
+    V = VectorFunctionSpace(mesh, "CG", 1)
+    bc = DirichletBC(V, 0, "on_boundary")
+
+    u = Function(V).assign(42)
+    r = Function(V).assign(333)
+    bc.apply(r, u=u)
+
+    assert np.allclose(r.dat.data_ro[bc.nodes], u.dat.data_ro[bc.nodes])
+
+    interior = np.setdiff1d(range(r.dat.data_ro.shape[0]), bc.nodes)
+    assert np.allclose(r.dat.data_ro[interior], 333)


### PR DESCRIPTION
# Description
Fixes the BC residual calculation `DirichletBC(V, 0, sub).apply(r, u=u)` when imposing a homogeneous bc with a scalar 0 on vector-valued `V`

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
