### PR TITLE
Import `get_external_packages` from `petsctools` not `firedrake.petsc`

### DIFF
--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -7,7 +7,8 @@ import os
 os.environ["FIREDRAKE_DISABLE_OPTIONS_LEFT"] = "1"
 
 import pytest
-from firedrake.petsc import PETSc, get_external_packages
+from firedrake.petsc import PETSc
+from petsctools import get_external_packages
 
 
 def _skip_test_dependency(dependency):


### PR DESCRIPTION
Avoid raising our own warnings in our own tests.