### PR TITLE
'Fix' petsc raises

### DIFF
--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -204,9 +204,8 @@ class _petsc_raises:
         pass
 
     def __exit__(self, exc_type, exc_val, traceback):
-        # There appears to be a bug that is fixed between Python 3.12.3 (latest
-        # Docker image) and 3.12.11 (my local machine) where 'exc_val' is
-        # randomly sometimes 'None'.
+        # There is a bug where 'exc_val' is occasionally 'None'. In my tests
+        # this error only exists for Python < 3.12.11.
         if exc_type is PETSc.Error:
             if sys.version_info < (3, 12, 11):
                 if exc_val is None or isinstance(exc_val.__cause__, self.exc_type):


### PR DESCRIPTION
Since https://gitlab.com/petsc/petsc/-/commit/4237731afe36b4db0a3147aff0aed51d4657afa2 and the introduction of `petsc_raises` (https://github.com/firedrakeproject/firedrake/commit/c9d392201d03f1736258a9d8f915e909ca215339) we have been seeing random failures on CI that I have been unable to reproduce locally.

I was able to reproduce the stochastic failures with a Docker image (Python 3.12.3) which appear to go away when I install Python 3.12.11 (matches my local machine). My best guess is therefore that Python fixed things between these releases.

The best approach to me seems to be to allow the more permissive exception check until we reach a Python version that we think should be fine. We can revisit then if the issue continues.

The only other clue I have is we get the following reported error when things fail:

```
/usr/local/lib/python3.12/dist-packages/_pytest/unraisableexception.py:65: PytestUnraisableExceptionWarning: Exception ignored in tp_clear of: <class 'dict'>

  Traceback (most recent call last):
    File "petsc4py/PETSc/libpetsc4py.pyx", line 1004, in petsc4py.PETSc.MatMultTranspose_Python
    File "/opt/firedrake/firedrake/interpolation.py", line 1684, in multTranspose
      raise NotImplementedError(
  NotImplementedError: Can only apply adjoint to expressions consisting of a single argument at the moment.

  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```
The `Exception ignored in tp_clear of: <class 'dict'>` makes it seem like a GC issue.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
