### PR TITLE
Do not use Makefile for firedrake-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,33 +88,6 @@ clean:
 	@echo "    RM tinyasm/*.so"
 	-@rm -f tinyasm/*.so > /dev/null 2>&1
 
-# Do verbose checking if running on CI and always set no:cacheprovider because
-# we don't want to generate any cache files in $VIRTUAL_ENV/lib/.../firedrake/_check
-check_flags =
-ifeq ($(FIREDRAKE_CI), 1)
-	check_flags = --verbose -p no:cacheprovider
-else
-	check_flags = --quiet -p no:cacheprovider
-endif
-
-CHECK_PYTEST_ARGS =
-
-.PHONY: check
-check:
-	@echo "    Running serial smoke tests"
-	@python3 -m pytest $(check_flags) $(CHECK_PYTEST_ARGS) \
-		tests/firedrake/regression/test_stokes_mini.py::test_stokes_mini \
-		tests/firedrake/regression/test_locate_cell.py  `# spatialindex` \
-		tests/firedrake/supermesh/test_assemble_mixed_mass_matrix.py::test_assemble_mixed_mass_matrix[2-CG-CG-0-0]  `# supermesh` \
-		tests/firedrake/regression/test_matrix_free.py::test_fieldsplitting[parameters3-cofunc_rhs-variational]  `# fieldsplit` \
-		tests/firedrake/regression/test_nullspace.py::test_near_nullspace  `# near nullspace`
-	@echo "    Serial tests passed"
-	@echo "    Running parallel smoke tests"
-	@mpiexec -n 3 python3 -m pytest $(check_flags) $(CHECK_PYTEST_ARGS) -m parallel[3] \
-		tests/firedrake/regression/test_dg_advection.py::test_dg_advection_icosahedral_sphere \
-		tests/firedrake/regression/test_interpolate_cross_mesh.py::test_interpolate_cross_mesh_parallel[extrudedcube]  `# vertex-only mesh`
-	@echo "    Parallel tests passed"
-
 .PHONY: durations
 durations:
 	@echo "    Generate timings to optimise pytest-split"

--- a/firedrake/_check/__init__.py
+++ b/firedrake/_check/__init__.py
@@ -1,9 +1,0 @@
-"""Run the Firedrake smoke tests."""
-
-import pathlib
-import subprocess
-
-
-def main() -> None:
-    dir = pathlib.Path(__file__).parent
-    subprocess.run(f"make -C {dir} check".split(), errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ Repository = "https://github.com/firedrakeproject/firedrake"
 Issues = "https://github.com/firedrakeproject/firedrake/issues/new/choose"
 
 [project.scripts]
-firedrake-check = "firedrake._check:main"
 firedrake-clean = "firedrake.scripts.firedrake_clean:main"
 firedrake-preprocess-bibtex = "firedrake.scripts.firedrake_preprocess_bibtex:main"
 firedrake-status = "firedrake.scripts.firedrake_status:main"
@@ -65,7 +64,7 @@ pyop2-clean = "pyop2.compilation:clear_compiler_disk_cache"
 
 [project.optional-dependencies]
 check = [
-  "mpi-pytest",
+  "mpi-pytest>=2025.7",
   "pytest",
 ]
 docs = [
@@ -103,7 +102,7 @@ ci = [
   "ipympl",  # needed for notebook testing
   "jax",
   "matplotlib",
-  "mpi-pytest",
+  "mpi-pytest>=2025.7",
   "nbval",
   "ngsPETSc",
   "pylit",
@@ -118,7 +117,7 @@ ci = [
 docker = [  # Used in firedrake-vanilla container
   "ipympl",  # needed for notebook testing
   "matplotlib",
-  "mpi-pytest",
+  "mpi-pytest>=2025.7",
   "nbval",
   "pylit",
   "pytest",
@@ -147,6 +146,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 script-files = [
   "firedrake/scripts/firedrake-zenodo",
+  "scripts/firedrake-check",
   "scripts/firedrake-run-split-tests",
   "pyop2/scripts/spydump",
 ]

--- a/scripts/firedrake-check
+++ b/scripts/firedrake-check
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""Run the Firedrake smoke tests."""
+
+import argparse
+import logging
+import importlib
+import os
+import pathlib
+import subprocess
+import sys
+
+
+# smoke tests grouped by number of processors
+TESTS = {
+    1: (
+        "tests/firedrake/regression/test_stokes_mini.py::test_stokes_mini",
+        # spatialindex
+        "tests/firedrake/regression/test_locate_cell.py",
+        # supermesh
+        "tests/firedrake/supermesh/test_assemble_mixed_mass_matrix.py::test_assemble_mixed_mass_matrix[2-CG-CG-0-0]",
+        # fieldsplit
+        "tests/firedrake/regression/test_matrix_free.py::test_fieldsplitting[parameters3-cofunc_rhs-variational]",
+        # near nullspace
+        "tests/firedrake/regression/test_nullspace.py::test_near_nullspace",
+    ),
+    3: (
+        "tests/firedrake/regression/test_dg_advection.py::test_dg_advection_icosahedral_sphere[nprocs=3]",
+        # vertex-only mesh
+        "tests/firedrake/regression/test_interpolate_cross_mesh.py::test_interpolate_cross_mesh_parallel[extrudedcube]",
+    ),
+}
+
+
+# log to terminal at INFO level
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+
+def main() -> None:
+    args = parse_args()
+
+    for nprocs, tests in TESTS.items():
+        if nprocs == 1:
+            logging.info("    Running serial smoke tests")
+        else:
+            logging.info(f"    Running parallel smoke tests (nprocs={nprocs})")
+        run_tests(tests, nprocs, args.mpiexec)
+        logging.info("    Tests passed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mpiexec",
+        type=str,
+        default="mpiexec -n",
+        help=(
+            "Command used to launch MPI. The command must end with the flag "
+            "taking the number of processors, e.g. '-n' for mpiexec."
+        ),
+    )
+    return parser.parse_args()
+
+
+def run_tests(tests: tuple[str], nprocs: int, mpiexec: str) -> None:
+    # Find the path to firedrake._check. Don't actually import Firedrake here
+    # because that will initialise MPI and can prevent us calling 'mpiexec'
+    # below. This only causes issues on some systems.
+    firedrake_dir = pathlib.Path(
+        importlib.util.find_spec("firedrake").origin
+    ).parent
+    test_dir = firedrake_dir / "_check"
+
+    # Do verbose checking if running on CI and always set no:cacheprovider because
+    # we don't want to generate any cache files in $VIRTUAL_ENV/lib/.../firedrake/_check
+    if "FIREDRAKE_CI" in os.environ:
+        check_flags = "--verbose -p no:cacheprovider"
+    else:
+        check_flags = "--quiet -p no:cacheprovider"
+
+    cmd = f"{mpiexec} {nprocs} {sys.executable} -m pytest {check_flags} -m parallel[{nprocs}]".split()
+    cmd.extend(tests)
+
+    subprocess.run(cmd, cwd=test_dir, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/firedrake-run-split-tests
+++ b/scripts/firedrake-run-split-tests
@@ -35,13 +35,8 @@ extra_args=${@:3}
 cache_cmd="PYOP2_CACHE_DIR=\$VIRTUAL_ENV/.cache/pyop2/job{#} \
            FIREDRAKE_TSFC_KERNEL_CACHE_DIR=\$VIRTUAL_ENV/.cache/tsfc/job{#}"
 
-if [ $num_procs = 1 ]; then
-    pytest_exec="python3 -m pytest"
-    marker_spec="\"parallel[1] or not parallel\""
-else
-    pytest_exec="mpiexec -n ${num_procs} python3 -m pytest"
-    marker_spec="parallel[${num_procs}]"
-fi
+pytest_exec="mpiexec -n ${num_procs} python -m pytest"
+marker_spec="parallel[${num_procs}]"
 
 pytest_cmd="${pytest_exec} -v \
             --splits ${num_jobs} --group {#} \

--- a/setup.py
+++ b/setup.py
@@ -237,9 +237,7 @@ def extensions():
     return cythonize(cython_list) + pybind11_list
 
 
-# TODO: It would be good to have a single source of truth for these files
 FIREDRAKE_CHECK_FILES = (
-    "Makefile",
     "tests/firedrake/conftest.py",
     "tests/firedrake/regression/test_stokes_mini.py",
     "tests/firedrake/regression/test_locate_cell.py",


### PR DESCRIPTION
* The previous approach led to issues for a number of users for whom 'mpiexec' did not work inside the Makefile.
* We now support a '--mpiexec' argument for those requiring extra commands like '--oversubscribe' or 'srun'.
* Adapts to mpi-pytest change so parallel[1] covers all serial tests.

**This is approved an can be merged once a new release of mpi-pytest is made.** (now done)


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
