### PR TITLE
Eagerly import petscp4y in setup.py (but don't initialise)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import libsupermesh
 import numpy as np
 import pybind11
+import petsc4py
 import petsctools
 import rtree
 from Cython.Build import cythonize
@@ -20,7 +21,6 @@ from setuptools.command.sdist import sdist as _sdist
 
 # Ensure that the PETSc getting linked against is compatible
 petsctools.init(version_spec=">=3.23.0")
-import petsc4py
 
 
 @dataclass


### PR DESCRIPTION
This leads to a much clearer error message than "petsctools has no attribute init" which happens if petsc4py isn't available. This error can happen if a user forgets to pass '--no-build-isolation' for a developer build.



<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
