### PR TITLE
Update bcs for adjoints

### DIFF
--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -450,12 +450,15 @@ class DirichletBC(BCBase, DirichletBCMixin):
             r = r.sub(idx)
             if u:
                 u = u.sub(idx)
+
+        bc_checkpointed = self.block_variable.checkpoint
+        bc = bc_checkpointed.checkpoint \
+            if bc_checkpointed is not None else self.function_arg
+
         if u:
-            r.assign(u - self.function_arg, subset=self.node_set)
-        elif self.block_variable.checkpoint is not None:
-            r.assign(self.block_variable.checkpoint.checkpoint, subset=self.node_set)
+            r.assign(u - bc, subset=self.node_set)
         else:
-            r.assign(self.function_arg, subset=self.node_set)
+            r.assign(bc, subset=self.node_set)
 
     def integrals(self):
         return []

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -452,6 +452,8 @@ class DirichletBC(BCBase, DirichletBCMixin):
                 u = u.sub(idx)
         if u:
             r.assign(u - self.function_arg, subset=self.node_set)
+        elif self.block_variable.checkpoint is not None:
+            r.assign(self.block_variable.checkpoint.checkpoint, subset=self.node_set)
         else:
             r.assign(self.function_arg, subset=self.node_set)
 

--- a/tests/firedrake/regression/test_adjoint_operators.py
+++ b/tests/firedrake/regression/test_adjoint_operators.py
@@ -1050,3 +1050,5 @@ def test_bdy_control():
     # tape._blocks[1] is the DirichletBC block for the right boundary
     assert isinstance(tape._blocks[1], DirichletBCBlock) and \
         tape._blocks[1]._outputs[0].checkpoint.checkpoint is not bc_right._original_arg
+    # taylor test
+    taylor_test(J_hat, [a, b], [Function(R, val=0.1), Function(R, val=0.2)])

--- a/tests/firedrake/regression/test_adjoint_operators.py
+++ b/tests/firedrake/regression/test_adjoint_operators.py
@@ -1050,8 +1050,7 @@ def test_bdy_control():
     # tape._blocks[1] is the DirichletBC block for the right boundary
     assert isinstance(tape._blocks[1], DirichletBCBlock) and \
         tape._blocks[1]._outputs[0].checkpoint.checkpoint is not bc_right._original_arg
-    # taylor test
-    taylor_test(J_hat, [a, b], [Function(R, val=0.1), Function(R, val=0.2)])
+
 
 @pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
 def test_bdy_update():

--- a/tests/firedrake/regression/test_adjoint_operators.py
+++ b/tests/firedrake/regression/test_adjoint_operators.py
@@ -1052,3 +1052,24 @@ def test_bdy_control():
         tape._blocks[1]._outputs[0].checkpoint.checkpoint is not bc_right._original_arg
     # taylor test
     taylor_test(J_hat, [a, b], [Function(R, val=0.1), Function(R, val=0.2)])
+
+@pytest.mark.skipcomplex  # Taping for complex-valued 0-forms not yet done
+def test_bdy_update():
+    # Fix the issue https://github.com/firedrakeproject/firedrake/issues/4387
+    mesh = UnitSquareMesh(5, 5)
+    V = FunctionSpace(mesh, "CG", 1)
+    R = FunctionSpace(mesh, "R", 0)
+
+    bc_func = Function(R, val=2.0)
+    bc = DirichletBC(V, bc_func, 1)
+    u_ = Function(V)
+
+    v = TestFunction(V)
+    problem = NonlinearVariationalProblem(
+        inner(grad(u_), grad(v)) * dx - v * dx, u_, bcs=bc)
+    solver = NonlinearVariationalSolver(problem)
+    solver.solve()
+    J = assemble(u_**2 * dx)
+    c = Control(bc_func)
+    Jhat = ReducedFunctional(J, c)
+    assert taylor_test(Jhat, bc_func, Function(R, val=0.1)) > 1.9


### PR DESCRIPTION
# Description

This PR seeks to fix the [issue #4387](https://github.com/firedrakeproject/firedrake/issues/4387), which is related to the Nonlinear Variational Solve not updating the Dirichlet boundary conditions based on the checkpointed functions.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
