### PR TITLE
CI: Only install docs system dependencies when the docs will be built.

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -368,7 +368,7 @@ jobs:
           path: pytest_*.log
 
       - name: Install system dependencies (3)
-        if: always()
+        if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
         run: apt-get -y install inkscape texlive-full
 
       - name: Check bibtex


### PR DESCRIPTION
The CI installs a full texlive before building the docs, which is quite a large installation. However, we only run the docs build steps for the default arch, so for anything else we don't need to run this step.