### PR TITLE
Remove old link from docs

### DIFF
--- a/docs/source/team.ini
+++ b/docs/source/team.ini
@@ -101,7 +101,7 @@ Nicolas Loriant:
 Fabio Luporini:
 Scott P. MacLachlan: https://www.math.mun.ca/~smaclachlan/
 Geordie McBain:
-Oliver Meister: https://www5.in.tum.de/wiki/index.php/Dipl.-Inf._Oliver_Meister
+Oliver Meister:
 Eike H. Mueller:
 Alberto Paganini: https://le.ac.uk/people/alberto-paganini
 Francis J. Poulin:


### PR DESCRIPTION
Remove old link failing the linkcheck.