### PR TITLE
Pin SLEPc using firedrake-configure

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -158,7 +158,7 @@ jobs:
           cd petsc
           python3 ../firedrake-repo/scripts/firedrake-configure \
             --arch ${{ matrix.arch }} --show-petsc-configure-options | \
-            xargs -L1 ./configure --with-make-np=8 --download-slepc
+            xargs -L1 ./configure --with-make-np=8 --download-slepc --download-slepc-commit=$(python3 ./firedrake-repo/scripts/firedrake-configure --show-slepc-version)
           make PETSC_DIR=/__w/firedrake/firedrake/petsc PETSC_ARCH=arch-firedrake-${{ matrix.arch }}
           make check
           {

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -43,7 +43,7 @@ RUN git clone --depth 1 --branch $(python3 /opt/firedrake-configure --show-petsc
     && cd /opt/petsc \
     && python3 /opt/firedrake-configure --arch $ARCH --show-petsc-configure-options | \
         sed "s/-march=native -mtune=native/-mtune=generic/g" | \
-        xargs -L1 ./configure --with-make-np=8 --download-slepc \
+        xargs -L1 ./configure --with-make-np=8 --download-slepc --download-slepc-commit=$(python3 /opt/firedrake-configure --show-slepc-version) \
     && make \
     && make check \
     && rm -rf ./**/externalpackages \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -342,12 +342,14 @@ SLEPc
 To install Firedrake with SLEPc support you should:
 
 #. Pass ``--download-slepc`` and ``--download-slepc-commit`` when running
-   PETSc ``configure`` (see :ref:`Installing PETSc<install_petsc>`)::
+   PETSc ``configure`` (see :ref:`Installing PETSc<install_petsc>`):
 
-   $ python3 ../firedrake-configure --show-petsc-configure-options | \
-     xargs -L1 ./configure \
-     --download-slepc \
-     --download-slepc-commit=$(python3 ../firedrake-configure --show-slepc-version)
+   .. code-block:: text
+
+      $ python3 ../firedrake-configure --show-petsc-configure-options | \
+        xargs -L1 ./configure \
+        --download-slepc \
+        --download-slepc-commit=$(python3 ../firedrake-configure --show-slepc-version)
 
 #. Set ``SLEPC_DIR``::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -341,9 +341,13 @@ SLEPc
 
 To install Firedrake with SLEPc support you should:
 
-#. Pass ``--download-slepc`` when running PETSc ``configure`` (see :ref:`Installing PETSc<install_petsc>`)::
+#. Pass ``--download-slepc`` and ``--download-slepc-commit`` when running
+   PETSc ``configure`` (see :ref:`Installing PETSc<install_petsc>`)::
 
-   $ python3 ../firedrake-configure --show-petsc-configure-options | xargs -L1 ./configure --download-slepc
+   $ python3 ../firedrake-configure --show-petsc-configure-options | \
+     xargs -L1 ./configure \
+     --download-slepc \
+     --download-slepc-commit=$(python3 ../firedrake-configure --show-slepc-version)
 
 #. Set ``SLEPC_DIR``::
 

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -62,9 +62,13 @@ def check_petsc_version() -> None:
 
 
 def check_slepc_version() -> None:
+    slepc_version = check_file_contains_pattern(
+        REPO_ROOT / "scripts/firedrake-configure",
+        "SUPPORTED_SLEPC_VERSION = \"v(.*)\"",
+    )
     check_file_contains_pattern(
         REPO_ROOT / "pyproject.toml",
-        "slepc4py==(.*)",
+        f"slepc4py=={slepc_version}",
         3,
     )
 

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -40,6 +40,7 @@ ARCH_COMPLEX = FiredrakeArch.COMPLEX
 
 
 SUPPORTED_PETSC_VERSION = "v3.23.3"
+SUPPORTED_SLEPC_VERSION = "v3.23.1"
 
 
 def main():
@@ -97,6 +98,11 @@ Please see https://firedrakeproject.org/install for more information."""
         help="Print out the officially supported PETSc version tag.",
     )
     cmd_group.add_argument(
+        "--show-slepc-version",
+        action="store_true",
+        help="Print out the officially supported SLEPc version tag.",
+    )
+    cmd_group.add_argument(
         "--show-env",
         "--env",  # alias
         action="store_true",
@@ -124,6 +130,8 @@ Please see https://firedrakeproject.org/install for more information."""
         print(" ".join(PETSC_CONFIGURE_OPTIONS[package_manager, arch]), end="")
     elif args.show_petsc_version:
         print(SUPPORTED_PETSC_VERSION, end="")
+    elif args.show_slepc_version:
+        print(SUPPORTED_SLEPC_VERSION, end="")
     else:
         assert args.show_env
         print(" ".join(ENVIRONMENT_VARS[package_manager, arch]), end="")


### PR DESCRIPTION
Otherwise the latest SLEPc release is always used and this may not be compatible with the pinned slepc4py.

This should fix the current failure to build on release. It is a little clunky but I think it's OK.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
