### PR TITLE
Use python3 in firedrake-run-split-tests so it works in the Docker containers

### DIFF
--- a/scripts/firedrake-run-split-tests
+++ b/scripts/firedrake-run-split-tests
@@ -36,10 +36,10 @@ cache_cmd="PYOP2_CACHE_DIR=\$VIRTUAL_ENV/.cache/pyop2/job{#} \
            FIREDRAKE_TSFC_KERNEL_CACHE_DIR=\$VIRTUAL_ENV/.cache/tsfc/job{#}"
 
 if [ $num_procs = 1 ]; then
-    pytest_exec="python -m pytest"
+    pytest_exec="python3 -m pytest"
     marker_spec="\"parallel[1] or not parallel\""
 else
-    pytest_exec="mpiexec -n ${num_procs} python -m pytest"
+    pytest_exec="mpiexec -n ${num_procs} python3 -m pytest"
     marker_spec="parallel[${num_procs}]"
 fi
 


### PR DESCRIPTION
In `firedrake-split-tests` we use `python -m pytest` to run the tests.
However, by default Ubuntu has no `python` command, instead requiring `python3` explicitly so the script doesn't work in the Docker containers.

It used to work previously because we created a venv in the containers so `python` was in `$VIRTUAL_ENV/bin`.