### PR TITLE
Make `interpolate` function avoid using `Interpolator`

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -217,10 +217,9 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         expr = replace(expr, {v: v.reconstruct(number=1)})
 
     interp = Interpolate(expr, function_space,
-                        subset=subset,
-                        access=access,
-                        allow_missing_dofs=allow_missing_dofs,
-                        default_missing_val=default_missing_val)
+                         subset=subset, access=access,
+                         allow_missing_dofs=allow_missing_dofs,
+                         default_missing_val=default_missing_val)
     if adjoint:
         interp = expr_adjoint(interp)
 
@@ -229,7 +228,6 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         interp = action(interp, V)
 
     return interp
-
 
 
 class Interpolator(abc.ABC):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -214,7 +214,7 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
     elif isinstance(V, functionspaceimpl.WithGeometry):
         function_space = V
     else:
-        raise TypeError("V must be a FunctionSpace, Function or Cofunction, not %s" % type(V))
+        raise TypeError(f"V must be a FunctionSpace, Function or Cofunction, not {type(V)}")
 
     # Cope with the different convention of `Interpolate` and `Interpolator`:
     #  -> Interpolate(Argument(V1, 1), Argument(V2.dual(), 0))

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -183,7 +183,6 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         some ``output`` is given to the :meth:`interpolate` method or (b) set
         to zero. Ignored if interpolating within the same mesh or onto a
         :func:`.VertexOnlyMesh`.
-    :kwarg ad_block_tag: An optional string for tagging the resulting assemble block on the Pyadjoint tape.
     :returns: A symbolic :class:`.Interpolate` object
 
     .. note::
@@ -197,13 +196,6 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
        then it is assumed that its values should take part in the
        reduction (hence using MIN will compute the MIN between the
        existing values and any new values).
-
-    .. note::
-
-       If you find interpolating the same expression again and again
-       (for example in a time loop) you may find you get better
-       performance by using an :class:`Interpolator` instead.
-
     """
     adjoint = False
     if isinstance(V, Cofunction):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -233,7 +233,6 @@ def interpolate(expr, V, *function, subset=None, access=op2.WRITE, allow_missing
         # Passing in a function is equivalent to taking the action.
         interp = action(interp, f)
 
-    # Return the `ufl.Interpolate` object
     return interp
 
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -199,7 +199,6 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
        reduction (hence using MIN will compute the MIN between the
        existing values and any new values).
     """
-    adjoint = False
     if isinstance(V, (Cofunction, Coargument)):
         coargument = V
     elif isinstance(V, functionspaceimpl.WithGeometry):
@@ -207,7 +206,7 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         expr_args = extract_arguments(expr)
         if expr_args and expr_args[0].number() == 0:
             # In this case we are doing adjoint interpolation
-            # When V is a FunctionSpace and expr contains Argument(0), 
+            # When V is a FunctionSpace and expr contains Argument(0),
             # we need to change expr argument number to 1 (in our current implementation)
             v, = expr_args
             expr = replace(expr, {v: v.reconstruct(number=1)})

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -217,7 +217,7 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
             v, = expr_args
             expr = replace(expr, {v: v.reconstruct(number=1)})
     else:
-        raise TypeError(f"V must be a FunctionSpace, Cofunction, Coargument or one-form, not {type(V).__name__}")
+        raise TypeError(f"V must be a FunctionSpace, Cofunction, Coargument or one-form, not a {type(V).__name__}")
 
     interp = Interpolate(expr, dual_arg,
                          subset=subset, access=access,

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -9,7 +9,7 @@ from typing import Hashable
 import FIAT
 import ufl
 import finat.ufl
-from ufl.algorithms import ad, extract_arguments, extract_coefficients, replace
+from ufl.algorithms import extract_arguments, extract_coefficients, replace
 from ufl.domain import as_domain, extract_unique_domain
 
 from pyop2 import op2

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -9,7 +9,7 @@ from typing import Hashable
 import FIAT
 import ufl
 import finat.ufl
-from ufl.algorithms import extract_arguments, extract_coefficients, replace
+from ufl.algorithms import ad, extract_arguments, extract_coefficients, replace
 from ufl.domain import as_domain, extract_unique_domain
 
 from pyop2 import op2
@@ -205,6 +205,7 @@ def interpolate(expr, V, *function, subset=None, access=op2.WRITE, allow_missing
        performance by using an :class:`Interpolator` instead.
 
     """
+    adjoint = False
     if isinstance(V, Cofunction):
         V = V.function_space().dual()
         adjoint = bool(extract_arguments(expr))
@@ -217,9 +218,9 @@ def interpolate(expr, V, *function, subset=None, access=op2.WRITE, allow_missing
     expr_args = extract_arguments(expr)
     if expr_args and expr_args[0].number() == 0:
         v, = expr_args
-        expr_renumbered = replace(expr, {v: v.reconstruct(number=1)})
+        expr = replace(expr, {v: v.reconstruct(number=1)})
 
-    interp = Interpolate(expr_renumbered, V,
+    interp = Interpolate(expr, V,
                         subset=subset,
                         access=access,
                         allow_missing_dofs=allow_missing_dofs,

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -189,7 +189,7 @@ def interpolate(expr, V, *function, subset=None, access=op2.WRITE, allow_missing
     .. note::
 
        If you use an access descriptor other than ``WRITE``, the
-       behaviour of interpolation is changes if interpolating into a
+       behaviour of interpolation changes if interpolating into a
        function space, or an existing function. If the former, then
        the newly allocated function will be initialised with
        appropriate values (e.g. for MIN access, it will be initialised

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -212,7 +212,7 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         # In this case we are doing adjoint interpolation, currently we factor this into
         # the action of the adjoint Interpolate operation
         # TODO: Should be able to remove this; assembly should handle this
-        # Case V is a FunctionSpace, expr contains Argument(0), we need to change expr argument number to 1 (currently)
+        # Case V is a FunctionSpace, expr contains Argument(0), we need to change expr argument number to 1 (in our current implementation)
         v, = expr_args
         expr = replace(expr, {v: v.reconstruct(number=1)})
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -223,10 +223,6 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
     if adjoint:
         interp = expr_adjoint(interp)
 
-    if isinstance(V, (Function, Cofunction)):
-        # Passing in a function / cofunction is equivalent to taking the action.
-        interp = action(interp, V)
-
     return interp
 
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -223,6 +223,9 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
     if adjoint:
         interp = expr_adjoint(interp)
 
+    if isinstance(V, Cofunction):
+        interp = action(interp, V)
+
     return interp
 
 

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -403,6 +403,10 @@ def test_adjoint_Pk(degree):
 
     assert np.allclose(u_Pk.dat.data, v_adj.dat.data)
 
+    v_adj_form = assemble(interpolate(TestFunction(Pk), v * dx))
+    
+    assert np.allclose(v_adj_form.dat.data, v_adj.dat.data)
+
 
 def test_adjoint_quads():
     mesh = UnitSquareMesh(10, 10)

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -404,7 +404,7 @@ def test_adjoint_Pk(degree):
     assert np.allclose(u_Pk.dat.data, v_adj.dat.data)
 
     v_adj_form = assemble(interpolate(TestFunction(Pk), v * dx))
-    
+
     assert np.allclose(v_adj_form.dat.data, v_adj.dat.data)
 
 


### PR DESCRIPTION
The `interpolate` function now returns a symbolic `Interpolate` without using`Interpolator.interpolate`