### PR TITLE
Fix broken Stokes test

### DIFF
--- a/tests/firedrake/macro/test_macro_solve.py
+++ b/tests/firedrake/macro/test_macro_solve.py
@@ -144,7 +144,7 @@ def test_stokes(mh, variant, mixed_element):
         Z = V * Q
 
         a, L = stokes_mms(Z, as_vector(zexact))
-        bcs = DirichletBC(Z[0], as_vector(zexact[:dim]), "on_boundary")
+        bcs = DirichletBC(Z.sub(0), as_vector(zexact[:dim]), "on_boundary")
 
         zh = Function(Z)
         nullspace = MixedVectorSpaceBasis(
@@ -176,7 +176,7 @@ def test_stokes(mh, variant, mixed_element):
         # Test div-free
         assert np.allclose(div_err, 0, atol=1E-10)
     elif variant == "th":
-        assert conv_rates(u_err, h)[-1] >= 2.9
+        assert conv_rates(u_err, h)[-1] >= 2.9, (u_err, p_err)
         assert (conv_rates(p_err, h)[-1] >= 1.9
                 or np.allclose(p_err, 0, atol=1E-10))
         assert conv_rates(div_err, h)[-1] >= 1.9

--- a/tests/firedrake/macro/test_macro_solve.py
+++ b/tests/firedrake/macro/test_macro_solve.py
@@ -151,7 +151,7 @@ def test_stokes(mh, variant, mixed_element):
             Z,
             [Z.sub(0), VectorSpaceBasis(constant=True, comm=COMM_WORLD)]
         )
-        solve(a == L, zh, bcs=bcs, nullspace=nullspace)
+        solve(a == L, zh, bcs=bcs, nullspace=nullspace, solver_parameters={"ksp_type": "preonly", "pc_type": "cholesky", "pc_factor_mat_solver_type": "mumps"})
 
         uh, ph = zh.subfunctions
         u_err.append(errornorm(as_vector(uexact), uh))

--- a/tests/firedrake/macro/test_macro_solve.py
+++ b/tests/firedrake/macro/test_macro_solve.py
@@ -176,7 +176,7 @@ def test_stokes(mh, variant, mixed_element):
         # Test div-free
         assert np.allclose(div_err, 0, atol=1E-10)
     elif variant == "th":
-        assert conv_rates(u_err, h)[-1] >= 2.9, (u_err, p_err)
+        assert conv_rates(u_err, h)[-1] >= 2.9
         assert (conv_rates(p_err, h)[-1] >= 1.9
                 or np.allclose(p_err, 0, atol=1E-10))
         assert conv_rates(div_err, h)[-1] >= 1.9


### PR DESCRIPTION
# Description
We were getting a failure on a simple Stokes test involving MUMPS + nullspace. 

`tests/firedrake/macro/test_macro_solve.py::test_stokes[square-th]  - assert np.float64(-8.292409965245584) >= 2.9`

This is an attempt to fix it.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
