### PR TITLE
Revert "Dependency groups (#4463)"

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -205,10 +205,7 @@ jobs:
           pip install --verbose $EXTRA_PIP_FLAGS \
             --no-binary h5py \
             --extra-index-url https://download.pytorch.org/whl/cpu \
-            "$(echo ./firedrake-repo/dist/firedrake-*.tar.gz)"
-
-          pip install -U pip
-          pip install --group ./firedrake-repo/pyproject.toml:ci
+            "$(echo ./firedrake-repo/dist/firedrake-*.tar.gz)[ci,docs]"
 
           firedrake-clean
           pip list

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -61,6 +61,5 @@ ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
 
 # Install Firedrake
-RUN pip install -U pip \
-    && git clone https://github.com/firedrakeproject/firedrake.git /opt/firedrake --branch release \
-    && pip install --verbose --no-binary h5py --editable /opt/firedrake --group /opt/firedrake/pyproject.toml:docker
+RUN pip install --verbose --no-binary h5py --src /opt \
+        --editable git+https://github.com/firedrakeproject/firedrake.git@release#egg=firedrake[docker]

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -586,14 +586,10 @@ should be followed:
       $ pip install $PETSC_DIR/src/binding/petsc4py
       $ pip install -r ./firedrake/requirements-build.txt
 
-#. Install Firedrake in editable mode without build isolation along with
-   any developer dependencies::
+#. Install Firedrake in editable mode without build isolation::
 
-   $ pip install --no-build-isolation --no-binary h5py --editable './firedrake' --group ./firedrake/pyproject.toml:dev
+   $ pip install --no-build-isolation --no-binary h5py --editable './firedrake[check]'
 
-   .. note::
-      Installing the developer dependencies requires pip to be version 25.1
-      or greater. You may need to run ``pip install -U pip`` first.
 
 Editing subpackages
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,25 @@ firedrake-preprocess-bibtex = "firedrake.scripts.firedrake_preprocess_bibtex:mai
 firedrake-status = "firedrake.scripts.firedrake_status:main"
 pyop2-clean = "pyop2.compilation:clear_compiler_disk_cache"
 
+
 [project.optional-dependencies]
 check = [
   "mpi-pytest>=2025.7",
   "pytest",
+]
+docs = [
+  "bibtexparser",
+  "matplotlib",  # needed to resolve API
+  "numpydoc",
+  "pylit",
+  "sphinx<8.2.0",  # https://github.com/firedrakeproject/firedrake/issues/4059
+  "sphinx-autobuild",
+  "sphinx-reredirects",
+  "sphinxcontrib-bibtex",
+  "sphinxcontrib-jquery",
+  "sphinxcontrib-svg2pdfconverter",
+  "sphinxcontrib-youtube",
+  "vtk",  # needed to resolve API
 ]
 jax = [
   "jax",
@@ -82,6 +97,42 @@ vtk = [
   "vtk",
 ]
 
+# Dependencies needed to run the full test suite
+ci = [
+  "ipympl",  # needed for notebook testing
+  "jax",
+  "matplotlib",
+  "mpi-pytest>=2025.7",
+  "nbval",
+  "networkx",
+  "ngsPETSc",
+  "pdf2image",
+  "pygraphviz",
+  "pylit",
+  "pytest",
+  "pytest-split",  # needed for firedrake-run-split-tests
+  "pytest-timeout",
+  "pytest-xdist",
+  "slepc4py==3.23.2",
+  "torch",  # requires passing '--extra-index-url' to work
+  "vtk",
+]
+docker = [  # Used in firedrake-vanilla container
+  "ipympl",  # needed for notebook testing
+  "matplotlib",
+  "mpi-pytest>=2025.7",
+  "nbval",
+  "networkx",
+  "pdf2image",
+  "pygraphviz",
+  "pylit",
+  "pytest",
+  "pytest-split",  # needed for firedrake-run-split-tests
+  "pytest-timeout",
+  "pytest-xdist",
+  "slepc4py==3.23.2",
+]
+
 [build-system]
 requires = [
   "Cython>=3.0",
@@ -96,57 +147,6 @@ requires = [
   "rtree>=1.2",
 ]
 build-backend = "setuptools.build_meta"
-
-[dependency-groups]
-docs = [
-  "bibtexparser",
-  "matplotlib",  # needed to resolve API
-  "numpydoc",
-  "pylit",
-  "sphinx<8.2.0",  # https://github.com/firedrakeproject/firedrake/issues/4059
-  "sphinx-autobuild",
-  "sphinx-reredirects",
-  "sphinxcontrib-bibtex",
-  "sphinxcontrib-jquery",
-  "sphinxcontrib-svg2pdfconverter",
-  "sphinxcontrib-youtube",
-  "vtk",  # needed to resolve API
-]
-test = [
-  "pytest",
-  "mpi-pytest>=2025.7",
-]
-dev = [
-  {include-group = "docs"},
-  {include-group = "test"},
-  "pytest-timeout",
-  "pytest-xdist",
-]
-fulltest = [
-  {include-group = "test"},
-  "ipympl",  # needed for notebook testing
-  "jax",
-  "matplotlib",
-  "nbval",
-  "networkx",
-  "ngsPETSc",
-  "pdf2image",
-  "pygraphviz",
-  "pylit",
-  "slepc4py==3.23.2",
-  "torch",  # requires passing '--extra-index-url' to work
-  "vtk",
-]
-docker = [  # used in firedrake-vanilla containers
-  {include-group = "fulltest"},
-  "pytest-split",  # needed for firedrake-run-split-tests
-  "pytest-timeout",
-  "pytest-xdist",
-]
-ci = [
-  {include-group = "docs"},
-  {include-group = "docker"},
-]
 
 # TODO: Convert firedrake-zenodo to a proper entrypoint script.
 [tool.setuptools]

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -65,7 +65,7 @@ def check_slepc_version() -> None:
     check_file_contains_pattern(
         REPO_ROOT / "pyproject.toml",
         "slepc4py==(.*)",
-        2,
+        3,
     )
 
 


### PR DESCRIPTION
This reverts #4463.
Pip dependency groups are too recent to work with the pip available from apt on Ubuntu 24. Because we do not use a virtual environment in the Docker containers any more, we can't run `pip install -U pip` because apt is responsible for the system pip install.

Unfortunately, we'll have to wait to use dependency groups until the Ubuntu system pip supports them.