### PR TITLE
Add link to release website in warning on `main` webpages

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -257,6 +257,7 @@ rst_prolog = """
 
     .. warning::
         You are reading a version of the website built against the unstable ``main`` branch. This content is liable to change without notice and may be inappropriate for your use case.
+        You can find the documentation for the current stable release `here <https://firedrakeproject.org/>`__.
 """
 
 # -- Options for LaTeX output --------------------------------------------


### PR DESCRIPTION
Unstable warning for main branch webpage should link back to stable release webpage.