### PR TITLE
install pyadjoint master instead of release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "petsctools",
   "pkgconfig",
   "progress",
+  # TODO RELEASE: use a release
   "pyadjoint-ad @ git+https://github.com/dolfin-adjoint/pyadjoint",
   "pycparser",
   "pytools[siphash]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "petsctools",
   "pkgconfig",
   "progress",
-  "pyadjoint-ad>=2025.04.1",
+  "pyadjoint-ad @ git+https://github.com/dolfin-adjoint/pyadjoint",
   "pycparser",
   "pytools[siphash]",
   "requests",


### PR DESCRIPTION
I forgot that we'd need to change the pyadjoint entry in `pyproject.toml` to install from master rather than the latest pypi release. This will hopefully fix the CI failures from the abstract reduced functional merge.