### PR TITLE
Fix for vom-to-vom permutation matrix on Vector-valued function spaces

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1574,7 +1574,7 @@ class VomOntoVomDummyMat(object):
                     raise ValueError("Need to provide a source dat for the argument!")
                 arg = self.arguments[0]
                 arg_coeff = firedrake.Function(arg.function_space())
-                arg_coeff.dat.data_wo[:] = source_vec.getArray().reshape(
+                arg_coeff.dat.data_wo[:] = source_vec.getArray(readonly=True).reshape(
                     arg_coeff.dat.data_wo.shape
                 )
                 coeff_expr = ufl.replace(self.expr, {arg: arg_coeff})

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1530,10 +1530,10 @@ class VomOntoVomDummyMat(object):
         self.arguments = arguments
         # Calculate correct local and global sizes for the matrix
         nroots, leaves, _ = sf.getGraph()
-        nleaves = len(leaves)
+        self.nleaves = len(leaves)
         self._local_sizes = V.comm.allgather(nroots)
         self.source_size = (nroots, sum(self._local_sizes))
-        self.target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
+        self.target_size = (self.nleaves, self.V.comm.allreduce(self.nleaves, op=MPI.SUM))
 
     @property
     def mpi_type(self):
@@ -1651,14 +1651,6 @@ class VomOntoVomDummyMat(object):
             # matrix will then have rows of zeros for those points.
             target_vec.zeroEntries()
             self.reduce(source_vec, target_vec)
-
-    def _get_sizes(self):
-        nroots, leaves, _ = self.sf.getGraph()
-        nleaves = len(leaves)
-        local_sizes = self.V.comm.allgather(nroots)
-        source_size = (nroots, sum(local_sizes))
-        target_size = (nleaves, self.V.comm.allreduce(nleaves, op=MPI.SUM))
-        return source_size, target_size
 
     def _create_permutation_mat(self):
         """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1528,12 +1528,17 @@ class VomOntoVomDummyMat(object):
         self.source_vom = source_vom
         self.expr = expr
         self.arguments = arguments
+        # Value size of data we are moving, e.g. 1 for scalar, 2 for vector in R^2, etc.
+        self.dim = self.V.value_size
         # Calculate correct local and global sizes for the matrix
         nroots, leaves, _ = sf.getGraph()
         self.nleaves = len(leaves)
         self._local_sizes = V.comm.allgather(nroots)
-        self.source_size = (nroots, sum(self._local_sizes))
-        self.target_size = (self.nleaves, self.V.comm.allreduce(self.nleaves, op=MPI.SUM))
+        self.source_size = (self.dim * nroots, self.dim * sum(self._local_sizes))
+        self.target_size = (
+            self.dim * self.nleaves,
+            self.dim * V.comm.allreduce(self.nleaves, op=MPI.SUM),
+        )
 
     @property
     def mpi_type(self):
@@ -1655,19 +1660,16 @@ class VomOntoVomDummyMat(object):
     def _create_permutation_mat(self):
         """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
         its input ordering vertex-only mesh"""
-        dim = self.V.value_size
-        target_size = tuple(dim * s for s in self.target_size)
-        source_size = tuple(dim * s for s in self.source_size)
-        mat = PETSc.Mat().createAIJ((target_size, source_size), nnz=1, comm=self.V.comm)
+        mat = PETSc.Mat().createAIJ((self.target_size, self.source_size), nnz=1, comm=self.V.comm)
         mat.setUp()
         start = sum(self._local_sizes[:self.V.comm.rank])
         end = start + self.source_size[0]
         contiguous_indices = numpy.arange(start, end, dtype=utils.IntType)
-        perm = numpy.zeros(self.target_size[0], dtype=utils.IntType)
+        perm = numpy.zeros(self.nleaves, dtype=utils.IntType)
         self.sf.bcastBegin(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
         self.sf.bcastEnd(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
-        rows = numpy.arange(target_size[0] + 1, dtype=utils.IntType)
-        cols = (dim * perm[:, None] + numpy.arange(dim, dtype=utils.IntType)[None, :]).reshape(-1)
+        rows = numpy.arange(self.target_size[0] + 1, dtype=utils.IntType)
+        cols = (self.dim * perm[:, None] + numpy.arange(self.dim, dtype=utils.IntType)[None, :]).reshape(-1)
         mat.setValuesCSR(rows, cols, numpy.ones_like(cols, dtype=utils.IntType))
         mat.assemble()
         if self.forward_reduce:
@@ -1676,13 +1678,10 @@ class VomOntoVomDummyMat(object):
 
     def _wrap_dummy_mat(self):
         mat = PETSc.Mat().create(comm=self.V.comm)
-        dim = self.V.value_size
-        source_size = tuple(dim * i for i in self.source_size)
-        target_size = tuple(dim * i for i in self.target_size)
         if self.forward_reduce:
-            mat_size = (source_size, target_size)
+            mat_size = (self.source_size, self.target_size)
         else:
-            mat_size = (target_size, source_size)
+            mat_size = (self.target_size, self.source_size)
         mat.setSizes(mat_size)
         mat.setType(mat.Type.PYTHON)
         mat.setPythonContext(self)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1663,7 +1663,10 @@ class VomOntoVomDummyMat(object):
     def _create_permutation_mat(self):
         """Creates the PETSc matrix that represents the interpolation operator from a vertex-only mesh to
         its input ordering vertex-only mesh"""
-        mat = PETSc.Mat().createAIJ((self.target_size, self.source_size), nnz=1, comm=self.V.comm)
+        dim = self.V.value_size
+        target_size = tuple(dim * s for s in self.target_size)
+        source_size = tuple(dim * s for s in self.source_size)
+        mat = PETSc.Mat().createAIJ((target_size, source_size), nnz=1, comm=self.V.comm)
         mat.setUp()
         start = sum(self._local_sizes[:self.V.comm.rank])
         end = start + self.source_size[0]
@@ -1671,8 +1674,9 @@ class VomOntoVomDummyMat(object):
         perm = numpy.zeros(self.target_size[0], dtype=utils.IntType)
         self.sf.bcastBegin(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
         self.sf.bcastEnd(MPI.INT, contiguous_indices, perm, MPI.REPLACE)
-        rows = numpy.arange(self.target_size[0] + 1, dtype=utils.IntType)
-        mat.setValuesCSR(rows, perm, numpy.ones_like(perm, dtype=utils.IntType))
+        rows = numpy.arange(target_size[0] + 1, dtype=utils.IntType)
+        cols = (dim * perm[:, None] + numpy.arange(dim, dtype=utils.IntType)[None, :]).reshape(-1)
+        mat.setValuesCSR(rows, cols, numpy.ones_like(cols, dtype=utils.IntType))
         mat.assemble()
         if self.forward_reduce:
             mat.transpose()


### PR DESCRIPTION
Fixes vom-to-vom permutation matrix to work with vector-valued function spaces. The underlying PETSc Vec of a Function
is just a flattened out list of it's coefficients, so we just need to pad out the matrix correctly