### PR TITLE
Fix solver parameters for Stokes test

### DIFF
--- a/tests/firedrake/macro/test_macro_solve.py
+++ b/tests/firedrake/macro/test_macro_solve.py
@@ -151,7 +151,7 @@ def test_stokes(mh, variant, mixed_element):
             Z,
             [Z.sub(0), VectorSpaceBasis(constant=True, comm=COMM_WORLD)]
         )
-        solve(a == L, zh, bcs=bcs, nullspace=nullspace, solver_parameters={"ksp_type": "preonly", "pc_type": "cholesky", "pc_factor_mat_solver_type": "mumps"})
+        solve(a == L, zh, bcs=bcs, nullspace=nullspace)
 
         uh, ph = zh.subfunctions
         u_err.append(errornorm(as_vector(uexact), uh))


### PR DESCRIPTION
# Description
There were some redudant flops caused by poor handling of `gem.Delta` where we were casting it into dense identity matrices in code generated for `VectorElement`. MUMPS LU seems happy after restoring the original behavior without the dense identity firedrakeproject/fiat#166

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
