### PR TITLE
Revert `Cofunction.riesz_representation` argument change

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -230,7 +230,7 @@ class Cofunction(ufl.Cofunction, CofunctionMixin):
         return self
 
     def riesz_representation(self, riesz_map='L2', *, bcs=None,
-                             solver_options=None,
+                             solver_parameters=None,
                              form_compiler_parameters=None):
         """Return the Riesz representation of this :class:`Cofunction`.
 
@@ -246,7 +246,7 @@ class Cofunction(ufl.Cofunction, CofunctionMixin):
             callable.
         bcs: DirichletBC or list of DirichletBC
             Boundary conditions to apply to the Riesz map.
-        solver_options: dict
+        solver_parameters: dict
             A dictionary of PETSc options to be passed to the solver.
         form_compiler_parameters: dict
             A dictionary of form compiler parameters to be passed to the
@@ -261,7 +261,7 @@ class Cofunction(ufl.Cofunction, CofunctionMixin):
         if not callable(riesz_map):
             riesz_map = RieszMap(
                 self.function_space(), riesz_map, bcs=bcs,
-                solver_parameters=solver_options,
+                solver_parameters=solver_parameters,
                 form_compiler_parameters=form_compiler_parameters
             )
 

--- a/tests/firedrake/regression/test_cofunction.py
+++ b/tests/firedrake/regression/test_cofunction.py
@@ -67,3 +67,14 @@ def test_cofunction_riesz_representation_l2_dat_version(V):
     version = f.dat.dat_version
     _ = f.riesz_representation(riesz_map="l2")
     assert f.dat.dat_version == version
+
+
+@pytest.mark.parametrize("solver_parameters", [None, {"ksp_type": "preonly", "pc_type": "lu"}])
+def test_cofunction_riesz_representation_L2(V, solver_parameters):
+    mesh = V.mesh()
+    v = TestFunction(V)
+    x, = SpatialCoordinate(mesh)
+    f_ref = assemble(inner(x ** 2, v) * dx)
+    f_r = f_ref.riesz_representation(riesz_map="L2", solver_parameters=solver_parameters)
+    f = assemble(inner(f_r, v) * dx)
+    assert np.allclose(f.dat.data_ro, f_ref.dat.data_ro)


### PR DESCRIPTION
Revert `solver_options` to `solver_parameters`, consistent with release and naming elsewhere in Firedrake.

Opening as PR rather than an issue as it's a small change in previously untested code.