### PR TITLE
introduce `PointEvaluator` object

### DIFF
--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -278,7 +278,7 @@ and :ref:`here <tolerance>` respectively) can be set when creating the :py:class
 and will be passed to the :func:`~.VertexOnlyMesh` it creates internally.
 
 If the :ref:`mesh coordinates are changed <changing_coordinate_fs>`, then the vertex-only mesh
-will be re-immersed in the new mesh the next time :meth:`~.PointEvaluator.evaluate` is called.
+will be reconstructed on the new mesh the next time :meth:`~.PointEvaluator.evaluate` is called.
 
 
 Expressions with point evaluations

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -242,12 +242,16 @@ warning or switched off entirely:
    :start-after: [test_vom_manual_points_outside_domain 5]
    :end-before: [test_vom_manual_points_outside_domain 6]
 
+.. _point_evaluator:
 
 ``PointEvaluator`` convenience object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :py:class:`~.PointEvaluator` class performs point evaluation using vertex-only meshes,
-as described above. First, create a :py:class:`~.PointEvaluator` object by passing the 
+as described above. This is a convenience object for users who want to evaluate
+functions at points without writing the vertex-only mesh boilerplate code each time.
+
+First, create a :py:class:`~.PointEvaluator` object by passing the 
 parent mesh and the points to evaluate at:
 
 .. code-block:: python3
@@ -264,7 +268,9 @@ we use :meth:`~.PointEvaluator.evaluate`:
 
 Under the hood, this creates the appropriate P0DG function space on the vertex-only mesh
 and performs the interpolation. The points are then reordered to match the input ordering,
-as described in :ref:`the section on the input ordering property <input_ordering>`.
+as described in :ref:`the section on the input ordering property <input_ordering>`. The result
+is a Numpy array containing the values of ``f`` at the given points, in the order the points were
+provided to the :py:class:`~.PointEvaluator` constructor.
 
 If ``redundant=True`` (the default) was used when creating the :py:class:`~.PointEvaluator`,
 then only the points given to the constructor on rank 0 will be evaluated. The result is then
@@ -277,7 +283,8 @@ The parameters ``missing_points_behaviour`` and ``tolerance`` (discussed :ref:`h
 and :ref:`here <tolerance>` respectively) can be set when creating the :py:class:`~.PointEvaluator` 
 and will be passed to the :func:`~.VertexOnlyMesh` it creates internally.
 
-If the :ref:`mesh coordinates are changed <changing_coordinate_fs>`, then the vertex-only mesh
+If the :ref:`coordinates <changing_coordinate_fs>` or the :ref:`tolerance <tolerance>` of the parent mesh
+are changed after creating the :py:class:`~.PointEvaluator`, then the vertex-only mesh
 will be reconstructed on the new mesh the next time :meth:`~.PointEvaluator.evaluate` is called.
 
 

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -214,6 +214,7 @@ be a new vertex: this is true for both ``redundant = True`` and
 and switch from ``redundant = True`` to ``redundant = False`` we will get point
 duplication.
 
+.. _missing_points:
 
 Points outside the domain
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -240,6 +241,40 @@ warning or switched off entirely:
    :dedent:
    :start-after: [test_vom_manual_points_outside_domain 5]
    :end-before: [test_vom_manual_points_outside_domain 6]
+
+
+``PointEvaluator`` convenience object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :py:class:`~.PointEvaluator` class performs point evaluation using vertex-only meshes,
+as described above. First, create a :py:class:`~.PointEvaluator` object by passing the 
+parent mesh and the points to evaluate at:
+
+.. code-block:: python3
+
+   point_evaluator = PointEvaluator(mesh, points)
+
+Then to evaluate a :py:class:`~.Function` defined on the parent mesh at the given points,
+we use :meth:`~.PointEvaluator.evaluate`:
+
+.. code-block:: python3
+
+   f_at_points = point_evaluator.evaluate(f)
+
+Under the hood, this creates the appropriate P0DG function space on the vertex-only mesh
+and performs the interpolation. The points are then reordered to match the input ordering,
+as described in :ref:`the section on the input ordering property <input_ordering>`.
+
+If ``redundant=True`` (the default) was used when creating the :py:class:`~.PointEvaluator`,
+then only the points given to the constructor on rank 0 will be evaluated. The result is then
+broadcast to all ranks. Use this option if the same points are given on all ranks.
+If ``redundant=False`` was used when creating the :py:class:`~.PointEvaluator`, then
+each rank will evaluate the points it was given. Use this option if different points are given
+on different ranks, for example when using external point data.
+
+The parameters ``missing_points_behaviour`` and ``tolerance`` (discussed :ref:`here <missing_points>` 
+and :ref:`here <tolerance>` respectively) can be set when creating the :py:class:`~.PointEvaluator` 
+and will be passed to the :func:`~.VertexOnlyMesh` it creates internally.
 
 
 Expressions with point evaluations

--- a/docs/source/point-evaluation.rst
+++ b/docs/source/point-evaluation.rst
@@ -254,7 +254,8 @@ parent mesh and the points to evaluate at:
 
    point_evaluator = PointEvaluator(mesh, points)
 
-Then to evaluate a :py:class:`~.Function` defined on the parent mesh at the given points,
+Internally, this creates a vertex-only mesh at the given points, immersed in the given mesh.
+To evaluate a :py:class:`~.Function` defined on the parent mesh at the given points,
 we use :meth:`~.PointEvaluator.evaluate`:
 
 .. code-block:: python3
@@ -275,6 +276,9 @@ on different ranks, for example when using external point data.
 The parameters ``missing_points_behaviour`` and ``tolerance`` (discussed :ref:`here <missing_points>` 
 and :ref:`here <tolerance>` respectively) can be set when creating the :py:class:`~.PointEvaluator` 
 and will be passed to the :func:`~.VertexOnlyMesh` it creates internally.
+
+If the :ref:`mesh coordinates are changed <changing_coordinate_fs>`, then the vertex-only mesh
+will be re-immersed in the new mesh the next time :meth:`~.PointEvaluator.evaluate` is called.
 
 
 Expressions with point evaluations

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -25,7 +25,8 @@ from firedrake.cofunction import Cofunction, RieszMap
 from firedrake import utils
 from firedrake.adjoint_utils import FunctionMixin
 from firedrake.petsc import PETSc
-from firedrake.mesh import MeshGeometry
+from firedrake.mesh import MeshGeometry, VertexOnlyMesh
+from firedrake.functionspace import FunctionSpace, VectorFunctionSpace, TensorFunctionSpace
 
 __all__ = ['Function', 'PointNotInDomainError', 'CoordinatelessFunction', 'PointEvaluator']
 
@@ -725,7 +726,6 @@ class PointEvaluator:
             external data that is already distributed across ranks.
             Default is True.
         """
-        from firedrake.mesh import VertexOnlyMesh
         self.mesh = mesh
         self.points = np.asarray(points, dtype=utils.ScalarType)
         self.redundant = redundant
@@ -752,12 +752,11 @@ class PointEvaluator:
             (len(points), n, m). If the function is a mixed function, a tuple of Numpy arrays is returned,
             one for each subfunction.
         """
+        from firedrake import assemble, interpolate
         if not isinstance(function, Function):
             raise TypeError(f"Expected a Function, got f{type(function).__name__}")
         if function.function_space().mesh() is not self.mesh:
             raise ValueError("Function mesh must be the same Mesh object as the PointEvaluator mesh.")
-        from firedrake import interpolate, assemble, FunctionSpace, VectorFunctionSpace, TensorFunctionSpace
-
         subfunctions = function.subfunctions
         if len(subfunctions) > 1:
             return tuple(self.evaluate(subfunction) for subfunction in subfunctions)

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -705,7 +705,7 @@ class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
     def __init__(self, mesh: MeshGeometry, points: np.ndarray | list, tolerance: float | None = None,
-                 missing_points_behaviour: str | None = "error", redundant: bool = True) -> None:
+                 missing_points_behaviour: str = "error", redundant: bool = True) -> None:
         r"""
         Parameters
         ----------
@@ -715,11 +715,11 @@ class PointEvaluator:
             Array of points to evaluate the function at.
         tolerance : float | None
             Tolerance to use when checking if a point is in a cell. Default is the `tolerance` of the :class:`MeshGeometry`.
-        missing_points_behaviour : str | None
+        missing_points_behaviour : str
             Behaviour when a point is not found in the mesh. Options are:
             "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh.
             "warn": warn if a point is not found in the mesh, but continue.
-            None: ignore points not found in the mesh.
+            "ignore": ignore points not found in the mesh.
         redundant : bool
             If True, only the points on rank 0 are evaluated, and the result is broadcast to all ranks.
             If False, each rank evaluates the points it has been given. False is useful if you are inputting

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -734,7 +734,7 @@ class PointEvaluator:
             redundant=redundant, tolerance=tolerance
         )
 
-    def evaluate(self, function: Function) -> np.ndarray | Tuple[np.ndarray]:
+    def evaluate(self, function: Function) -> np.ndarray | Tuple[np.ndarray, ...]:
         r"""Evaluate the :class:`Function`.
         Points that were not found in the mesh will be evaluated to np.nan.
 
@@ -745,7 +745,7 @@ class PointEvaluator:
 
         Returns
         -------
-        np.ndarray | Tuple[np.ndarray]
+        np.ndarray | Tuple[np.ndarray, ...]
             A Numpy array of values at the points. If the function is scalar-valued, the Numpy array
             has shape (len(points),). If the function is vector-valued with shape (n,), the Numpy array has shape
             (len(points), n). If the function is tensor-valued with shape (n, m), the Numpy array has shape

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -703,7 +703,7 @@ class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
     def __init__(self, mesh: MeshGeometry, points: np.ndarray | list, tolerance: float | None = None, 
-                 missing_points_behaviour: str | None = "error") -> None:
+                 missing_points_behaviour: str | None = "error", redundant: bool = True) -> None:
         r"""
         Parameters
         ----------
@@ -722,7 +722,7 @@ class PointEvaluator:
         from firedrake.mesh import VertexOnlyMesh
         self.mesh = mesh
         self.points = np.asarray(points, dtype=utils.ScalarType)
-        self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour=missing_points_behaviour, redundant=False, tolerance=tolerance)
+        self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour=missing_points_behaviour, redundant=redundant, tolerance=tolerance)
 
     def evaluate(self, function: Function, input_ordered: bool = True) -> np.ndarray | list[np.ndarray]:
         r"""Evaluate the given :class:`Function` at the points provided to this

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -728,7 +728,7 @@ class PointEvaluator:
         self.points = np.asarray(points, dtype=utils.ScalarType)
         self.redundant = redundant
         self.vom = VertexOnlyMesh(
-            mesh, points, missing_points_behaviour=missing_points_behaviour, 
+            mesh, points, missing_points_behaviour=missing_points_behaviour,
             redundant=redundant, tolerance=tolerance
         )
 
@@ -748,7 +748,7 @@ class PointEvaluator:
             A Numpy array of values at the points. If the function is scalar-valued, the Numpy array
             has shape (len(points),). If the function is vector-valued with shape (n,), the Numpy array has shape
             (len(points), n). If the function is tensor-valued with shape (n, m), the Numpy array has shape
-            (len(points), n, m). If the function is a mixed function, a list of Numpy arrays is returned, 
+            (len(points), n, m). If the function is a mixed function, a list of Numpy arrays is returned,
             one for each subfunction.
         """
         if not isinstance(function, Function):

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -705,7 +705,7 @@ class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
     def __init__(self, mesh: MeshGeometry, points: np.ndarray | list, tolerance: float | None = None,
-                 missing_points_behaviour: str = "error", redundant: bool = True) -> None:
+                 missing_points_behaviour: str | None = "error", redundant: bool = True) -> None:
         r"""
         Parameters
         ----------
@@ -715,11 +715,11 @@ class PointEvaluator:
             Array of points to evaluate the function at.
         tolerance : float | None
             Tolerance to use when checking if a point is in a cell. Default is the `tolerance` of the :class:`MeshGeometry`.
-        missing_points_behaviour : str
+        missing_points_behaviour : str | None
             Behaviour when a point is not found in the mesh. Options are:
             "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh.
             "warn": warn if a point is not found in the mesh, but continue.
-            "ignore": ignore points not found in the mesh.
+            None: ignore points not found in the mesh.
         redundant : bool
             If True, only the points on rank 0 are evaluated, and the result is broadcast to all ranks.
             If False, each rank evaluates the points it has been given. False is useful if you are inputting

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -753,6 +753,13 @@ class PointEvaluator:
             ``(len(points), n)``. If the function is tensor-valued with shape ``(n, m)``, the Numpy array has shape
             ``(len(points), n, m)``. If the function is a mixed function, a tuple of Numpy arrays is returned,
             one for each subfunction.
+
+
+        .. warning::
+
+            This method returns a numpy array and hence isn't taped for use with firedrake-adjoint.
+            If you want to use point evaluation with the adjoint, create a :class:`~.VertexOnlyMesh`
+            as described in the manual.
         """
         from firedrake import assemble, interpolate
         if not isinstance(function, Function):
@@ -762,6 +769,7 @@ class PointEvaluator:
         if function_mesh is not self.mesh:
             raise ValueError("Function mesh must be the same Mesh object as the PointEvaluator mesh.")
         if coord_changed := function_mesh.coordinates.dat.dat_version != self.mesh._saved_coordinate_dat_version:
+            # TODO: This is here until https://github.com/firedrakeproject/firedrake/issues/4540 is solved
             self.mesh = function_mesh
         if tol_changed := self.mesh.tolerance != self.tolerance:
             self.tolerance = self.mesh.tolerance

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -701,7 +701,7 @@ class PointNotInDomainError(Exception):
 class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
-    def __init__(self, mesh, points, tolerance=None, missing_points_behaviour: str = "error", input_ordered=True):
+    def __init__(self, mesh, points, tolerance=None, missing_points_behaviour: str = "error"):
         r"""
         :arg mesh: The :class:`Mesh` on which the :class:`Function` is defined.
         :arg points: Array of points to evaluate the function at.
@@ -711,20 +711,19 @@ class PointEvaluator:
         "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh. 
         "warn": warn if a point is not found in the mesh, but continue.
         "ignore": ignore points not found in the mesh.
-        :kwarg input_ordered: If ``True``, return results in the order of the input points.
         """
         from firedrake.mesh import VertexOnlyMesh
         self.mesh = mesh
         self.points = np.asarray(points, dtype=utils.ScalarType)
         self.tolerance = tolerance or mesh.tolerance
-        self.input_ordered = input_ordered
         self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour=missing_points_behaviour, redundant=False, tolerance=tolerance)
 
-    def evaluate(self, function):
+    def evaluate(self, function: Function, input_ordered: bool = True):
         r"""Evaluate the given :class:`Function` at the points provided to this
         :class:`PointEvaluator`.
 
         :arg function: The :class:`Function` to evaluate.
+        :kwarg input_ordered: If ``True``, return results in the order of the input points.
         :returns: A NumPy array of values at the points.
         """
         if not isinstance(function, Function):
@@ -733,7 +732,7 @@ class PointEvaluator:
 
         P0DG = FunctionSpace(self.vom, "DG", 0)
         f_at_points = assemble(interpolate(function, P0DG))
-        if self.input_ordered:
+        if input_ordered:
             P0DG_io = FunctionSpace(self.vom.input_ordering, "DG", 0)
             f_at_points = assemble(interpolate(f_at_points, P0DG_io))
         return f_at_points.dat.data_ro

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -727,7 +727,10 @@ class PointEvaluator:
         self.mesh = mesh
         self.points = np.asarray(points, dtype=utils.ScalarType)
         self.redundant = redundant
-        self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour=missing_points_behaviour, redundant=redundant, tolerance=tolerance)
+        self.vom = VertexOnlyMesh(
+            mesh, points, missing_points_behaviour=missing_points_behaviour, 
+            redundant=redundant, tolerance=tolerance
+        )
 
     def evaluate(self, function: Function) -> np.ndarray | list[np.ndarray]:
         r"""Evaluate the given :class:`Function` at the points provided to this
@@ -745,7 +748,8 @@ class PointEvaluator:
             A Numpy array of values at the points. If the function is scalar-valued, the Numpy array
             has shape (len(points),). If the function is vector-valued with shape (n,), the Numpy array has shape
             (len(points), n). If the function is tensor-valued with shape (n, m), the Numpy array has shape
-            (len(points), n, m). If the function is a mixed function, a list of Numpy arrays is returned, one for each subfunction.
+            (len(points), n, m). If the function is a mixed function, a list of Numpy arrays is returned, 
+            one for each subfunction.
         """
         if not isinstance(function, Function):
             raise TypeError(f"Expected a Function, got f{type(function).__name__}")

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -701,22 +701,24 @@ class PointNotInDomainError(Exception):
 class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
-    def __init__(self, mesh, points, tolerance=None, ignore_missing_points=False, input_ordered=True):
+    def __init__(self, mesh, points, tolerance=None, missing_points_behaviour: str = "error", input_ordered=True):
         r"""
         :arg mesh: The :class:`Mesh` on which the :class:`Function` is defined.
         :arg points: Array of points to evaluate the function at.
         :kwarg tolerance: Tolerance to use when checking if a point is
             in a cell. Default is the ``tolerance`` of the :class:`Mesh`.
-        :kwarg ignore_missing_points: If ``True``, do not raise an error if a point is not found.
+        :kwarg missing_points_behaviour: Behaviour when a point is not found in the mesh. Options are:
+        "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh. 
+        "warn": warn if a point is not found in the mesh, but continue.
+        "ignore": ignore points not found in the mesh.
         :kwarg input_ordered: If ``True``, return results in the order of the input points.
         """
         from firedrake.mesh import VertexOnlyMesh
         self.mesh = mesh
         self.points = np.asarray(points, dtype=utils.ScalarType)
         self.tolerance = tolerance or mesh.tolerance
-        self.ignore_missing_points = ignore_missing_points
         self.input_ordered = input_ordered
-        self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour="warn", redundant=False, tolerance=tolerance)
+        self.vom = VertexOnlyMesh(mesh, points, missing_points_behaviour=missing_points_behaviour, redundant=False, tolerance=tolerance)
 
     def evaluate(self, function):
         r"""Evaluate the given :class:`Function` at the points provided to this

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -735,7 +735,7 @@ class PointEvaluator:
         self.points = self.points.reshape(-1, gdim)
 
         self.mesh = mesh
-        
+
         self.redundant = redundant
         self.missing_points_behaviour = missing_points_behaviour
         self.tolerance = tolerance

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -731,7 +731,8 @@ class PointEvaluator:
 
     def evaluate(self, function: Function) -> np.ndarray | list[np.ndarray]:
         r"""Evaluate the given :class:`Function` at the points provided to this
-        :class:`PointEvaluator`.
+        :class:`PointEvaluator`. Points that were not found in the mesh will be
+        evaluated to np.nan.
 
         Parameters
         ----------
@@ -763,7 +764,7 @@ class PointEvaluator:
         if len(shape) == 0:
             fs = FunctionSpace
         elif len(shape) == 1:
-            fs = VectorFunctionSpace
+            fs = partial(VectorFunctionSpace, dim=shape[0])
         else:
             fs = partial(TensorFunctionSpace, shape=shape)
         P0DG = fs(self.vom, "DG", 0)
@@ -777,7 +778,7 @@ class PointEvaluator:
         if self.redundant and self.mesh.comm.size > 1:
             if self.mesh.comm.rank != 0:
                 result = np.empty((len(self.points),) + shape, dtype=utils.ScalarType)
-            self.mesh.comm.Bcast(result, root=0)
+            self.mesh.comm.Bcast(result)
         return result
 
 

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -702,7 +702,7 @@ class PointNotInDomainError(Exception):
 class PointEvaluator:
     r"""Convenience class for evaluating a :class:`Function` at a set of points."""
 
-    def __init__(self, mesh: MeshGeometry, points: np.ndarray | list, tolerance: float | None = None, 
+    def __init__(self, mesh: MeshGeometry, points: np.ndarray | list, tolerance: float | None = None,
                  missing_points_behaviour: str | None = "error", redundant: bool = True) -> None:
         r"""
         Parameters
@@ -715,7 +715,7 @@ class PointEvaluator:
             Tolerance to use when checking if a point is in a cell. Default is the ``tolerance`` of the :class:`Mesh`.
         missing_points_behaviour : str | None
             Behaviour when a point is not found in the mesh. Options are:
-            "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh. 
+            "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh.
             "warn": warn if a point is not found in the mesh, but continue.
             None: ignore points not found in the mesh.
         redundant : bool
@@ -779,6 +779,7 @@ class PointEvaluator:
                 result = np.empty((len(self.points),) + shape, dtype=utils.ScalarType)
             self.mesh.comm.Bcast(result, root=0)
         return result
+
 
 @PETSc.Log.EventDecorator()
 def make_c_evaluate(function, c_name="evaluate", ldargs=None, tolerance=None):

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -723,7 +723,8 @@ class PointEvaluator:
         :class:`PointEvaluator`.
 
         :arg function: The :class:`Function` to evaluate.
-        :kwarg input_ordered: If ``True``, return results in the order of the input points.
+        :kwarg input_ordered: If ``True``, return results in the order of the input points. If any 
+        points were not found in the mesh, they will be return as np.nan.
         :returns: A NumPy array of values at the points.
         """
         if not isinstance(function, Function):
@@ -734,8 +735,11 @@ class PointEvaluator:
         f_at_points = assemble(interpolate(function, P0DG))
         if input_ordered:
             P0DG_io = FunctionSpace(self.vom.input_ordering, "DG", 0)
-            f_at_points = assemble(interpolate(f_at_points, P0DG_io))
-        return f_at_points.dat.data_ro
+            f_at_points_io = Function(P0DG_io).assign(np.nan)
+            f_at_points_io.interpolate(f_at_points)
+            return f_at_points_io.dat.data_ro
+        else:
+            return f_at_points.dat.data_ro
 
 
 @PETSc.Log.EventDecorator()

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -718,6 +718,10 @@ class PointEvaluator:
             "error": raise a :class:`VertexOnlyMeshMissingPointsError` if a point is not found in the mesh. 
             "warn": warn if a point is not found in the mesh, but continue.
             None: ignore points not found in the mesh.
+        redundant : bool
+            If True, only the points on rank 0 are evaluated, and the result is broadcast to all ranks.
+            If False, each rank evaluates the points it has been given.
+            Default is True.
         """
         from firedrake.mesh import VertexOnlyMesh
         self.mesh = mesh
@@ -733,9 +737,6 @@ class PointEvaluator:
         ----------
         function : :class:`Function`
             The :class:`Function` to evaluate.
-        input_ordered : bool
-            If ``True``, return results in the order of the input points. If any 
-            points were not found in the mesh, they will be return as np.nan.
 
         Returns
         -------
@@ -747,6 +748,8 @@ class PointEvaluator:
         """
         if not isinstance(function, Function):
             raise TypeError(f"Expected a Function, got f{type(function).__name__}")
+        if function.function_space().mesh() is not self.mesh:
+            raise ValueError("Function mesh must be the same Mesh object as the PointEvaluator mesh.")
         from firedrake import interpolate, assemble, FunctionSpace, VectorFunctionSpace, TensorFunctionSpace
 
         subfunctions = function.subfunctions

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3319,7 +3319,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
 
 
 class MissingPointsBehaviour(enum.Enum):
-    IGNORE = None
+    IGNORE = "ignore"
     ERROR = "error"
     WARN = "warn"
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3319,7 +3319,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
 
 
 class MissingPointsBehaviour(enum.Enum):
-    IGNORE = "ignore"
+    IGNORE = None
     ERROR = "error"
     WARN = "warn"
 

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -282,3 +282,62 @@ def test_point_evaluator_tolerance():
         ev.evaluate(f)
     ev = PointEvaluator(mesh, [[-1e-12, 0.4]])
     assert np.allclose([-1e-12, 0.4], ev.evaluate(f))
+
+
+def test_point_evaluator_inputs_1d():
+    mesh = UnitIntervalMesh(1)
+    f = mesh.coordinates
+
+    # one point
+    for input in [0.2, (0.2,), [0.2], np.array([0.2])]:
+        e = PointEvaluator(mesh, input)
+        assert np.allclose(0.2, e.evaluate(f))
+
+    # multiple points as tuples/list
+    for input in [
+        (0.2, 0.3), ((0.2,), (0.3,)), ([0.2], [0.3]),
+        (np.array(0.2), np.array(0.3)), (np.array([0.2]), np.array([0.3]))
+    ]:
+        e2 = PointEvaluator(mesh, input)
+        assert np.allclose([[0.2, 0.3]], e2.evaluate(f))
+        e3 = PointEvaluator(mesh, list(input))
+        assert np.allclose([[0.2, 0.3]], e3.evaluate(f))
+
+    # multiple points as numpy array
+    for input in [np.array([0.2, 0.3]), np.array([[0.2], [0.3]])]:
+        e = PointEvaluator(mesh, input)
+        assert np.allclose([[0.2, 0.3]], e.evaluate(f))
+
+    # test incorrect inputs
+    for input in [[[0.2, 0.3]], ([0.2, 0.3], [0.4, 0.5]), np.array([[0.2, 0.3]])]:
+        with pytest.raises(ValueError):
+            PointEvaluator(mesh, input)
+
+
+def test_point_evaluator_inputs_2d():
+    mesh = UnitSquareMesh(1, 1)
+    f = mesh.coordinates
+
+    # one point
+    for input in [(0.2, 0.4), [0.2, 0.4], [[0.2, 0.4]], np.array([0.2, 0.4])]:
+        e = PointEvaluator(mesh, input)
+        assert np.allclose([0.2, 0.4], e.evaluate(f))
+
+    # multiple points as tuple
+    for input in [
+        ((0.2, 0.4), (0.3, 0.5)), ([0.2, 0.4], [0.3, 0.5]),
+        (np.array([0.2, 0.4]), np.array([0.3, 0.5]))
+    ]:
+        e1 = PointEvaluator(mesh, input)
+        assert np.allclose([[0.2, 0.4], [0.3, 0.5]], e1.evaluate(f))
+        e2 = PointEvaluator(mesh, list(input))
+        assert np.allclose([[0.2, 0.4], [0.3, 0.5]], e2.evaluate(f))
+
+    # multiple points as numpy array
+    e = PointEvaluator(mesh, np.array([[0.2, 0.4], [0.3, 0.5]]))
+    assert np.allclose([[0.2, 0.4], [0.3, 0.5]], e.evaluate(f))
+
+    # test incorrect inputs
+    for input in [0.2, [0.2]]:
+        with pytest.raises(ValueError):
+            PointEvaluator(mesh, input)

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -227,7 +227,7 @@ def test_point_evaluator_nonredundant(mesh_and_points):
     if mesh.comm.rank == 0:
         points = [[0.1, 0.1]]
     elif mesh.comm.rank == 1:
-        points = [[0.4, 0.4]]
+        points = [[0.4, 0.4], [0.5, 0.5]]
     else:
         points = [[0.8, 0.8]]
     V = FunctionSpace(mesh, "CG", 1)
@@ -239,6 +239,6 @@ def test_point_evaluator_nonredundant(mesh_and_points):
     if mesh.comm.rank == 0:
         assert np.allclose(f_at_points, [0.2])
     elif mesh.comm.rank == 1:
-        assert np.allclose(f_at_points, [0.8])
+        assert np.allclose(f_at_points, [0.8, 1.0])
     else:
         assert np.allclose(f_at_points, [1.6])

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -185,7 +185,7 @@ def test_point_evaluator_scalar(mesh_and_points):
     assert np.allclose(f_at_points, [0.2, 0.4, 0.6])
 
     # Test standard scalar function with missing points
-    eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour=None)
+    eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour="ignore")
     f_at_points_missing = eval_missing.evaluate(f)
     assert np.isnan(f_at_points_missing[-1])
 

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -187,10 +187,8 @@ def test_point_evaluator_scalar(mesh_and_points):
 
     # Test standard scalar function with missing points
     eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour=None)
-    f_at_points_missing = eval_missing.evaluate(f, input_ordered=False)
-    assert not np.isnan(f_at_points_missing).any()
-    f_at_points_missing_io = eval_missing.evaluate(f)
-    assert np.isnan(f_at_points_missing_io[-1])
+    f_at_points_missing = eval_missing.evaluate(f)
+    assert np.isnan(f_at_points_missing[-1])
 
 @pytest.mark.parallel([1, 3])
 def test_point_evaluator_vector_tensor_mixed(mesh_and_points):

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -161,3 +161,62 @@ def test_tolerance():
     with pytest.raises(PointNotInDomainError):
         f.at((-0.1, 0.4))
     assert np.allclose([-1e-12, 0.4], f.at((-1e-12, 0.4)))
+
+
+@pytest.fixture(scope="module")
+def mesh_and_points():
+    points = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
+    mesh = UnitSquareMesh(10, 10)
+    evaluator = PointEvaluator(mesh, points)
+    return mesh, evaluator
+
+
+@pytest.mark.parallel([1, 3])
+def test_point_evaluator_scalar(mesh_and_points):
+    mesh, evaluator = mesh_and_points
+    points = evaluator.points
+    V = FunctionSpace(mesh, "CG", 1)
+    f = Function(V)
+    x, y = SpatialCoordinate(mesh)
+    f.interpolate(x + y)
+
+    # Test standard scalar function evaluation at points
+    eval = PointEvaluator(mesh, points)
+    f_at_points = eval.evaluate(f)
+    assert np.allclose(f_at_points, [0.2, 0.4, 0.6])
+
+    # Test standard scalar function with missing points
+    eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour=None)
+    f_at_points_missing = eval_missing.evaluate(f, input_ordered=False)
+    assert not np.isnan(f_at_points_missing).any()
+    f_at_points_missing_io = eval_missing.evaluate(f)
+    assert np.isnan(f_at_points_missing_io[-1])
+
+@pytest.mark.parallel([1, 3])
+def test_point_evaluator_vector_tensor_mixed(mesh_and_points):
+    mesh, evaluator = mesh_and_points
+    V_vec = VectorFunctionSpace(mesh, "CG", 1)
+    f_vec = Function(V_vec)
+    x, y = SpatialCoordinate(mesh)
+    f_vec.interpolate(as_vector([x, y]))
+    f_vec_at_points = evaluator.evaluate(f_vec)
+    vec_expected = np.array([[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]])
+    assert np.allclose(f_vec_at_points, vec_expected)
+
+    V_tensor = TensorFunctionSpace(mesh, "CG", 1, shape=(2, 3))
+    f_tensor = Function(V_tensor)
+    f_tensor.interpolate(as_matrix([[x, y, x*y], [y, x, x*y]]))
+    f_tensor_at_points = evaluator.evaluate(f_tensor)
+    tensor_expected = np.array([[[0.1, 0.1, 0.01], [0.1, 0.1, 0.01]], 
+                                [[0.2, 0.2, 0.04], [0.2, 0.2, 0.04]], 
+                                [[0.3, 0.3, 0.09], [0.3, 0.3, 0.09]]])
+    assert np.allclose(f_tensor_at_points, tensor_expected)
+
+    V_mixed = V_vec * V_tensor
+    f_mixed = Function(V_mixed)
+    f_vec, f_tensor = f_mixed.subfunctions
+    f_vec.interpolate(as_vector([x, y]))
+    f_tensor.interpolate(as_matrix([[x, y, x*y], [y, x, x*y]]))
+    f_mixed_at_points = evaluator.evaluate(f_mixed)
+    assert np.allclose(f_mixed_at_points[0], vec_expected)
+    assert np.allclose(f_mixed_at_points[1], tensor_expected)

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -185,7 +185,7 @@ def test_point_evaluator_scalar(mesh_and_points):
     assert np.allclose(f_at_points, [0.2, 0.4, 0.6])
 
     # Test standard scalar function with missing points
-    eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour="ignore")
+    eval_missing = PointEvaluator(mesh, np.append(points, [[1.5, 1.5]], axis=0), missing_points_behaviour=None)
     f_at_points_missing = eval_missing.evaluate(f)
     assert np.isnan(f_at_points_missing[-1])
 

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -190,6 +190,7 @@ def test_point_evaluator_scalar(mesh_and_points):
     f_at_points_missing = eval_missing.evaluate(f)
     assert np.isnan(f_at_points_missing[-1])
 
+
 @pytest.mark.parallel([1, 3])
 def test_point_evaluator_vector_tensor_mixed(mesh_and_points):
     mesh, evaluator = mesh_and_points
@@ -205,8 +206,8 @@ def test_point_evaluator_vector_tensor_mixed(mesh_and_points):
     f_tensor = Function(V_tensor)
     f_tensor.interpolate(as_matrix([[x, y, x*y], [y, x, x*y]]))
     f_tensor_at_points = evaluator.evaluate(f_tensor)
-    tensor_expected = np.array([[[0.1, 0.1, 0.01], [0.1, 0.1, 0.01]], 
-                                [[0.2, 0.2, 0.04], [0.2, 0.2, 0.04]], 
+    tensor_expected = np.array([[[0.1, 0.1, 0.01], [0.1, 0.1, 0.01]],
+                                [[0.2, 0.2, 0.04], [0.2, 0.2, 0.04]],
                                 [[0.3, 0.3, 0.09], [0.3, 0.3, 0.09]]])
     assert np.allclose(f_tensor_at_points, tensor_expected)
 
@@ -218,6 +219,7 @@ def test_point_evaluator_vector_tensor_mixed(mesh_and_points):
     f_mixed_at_points = evaluator.evaluate(f_mixed)
     assert np.allclose(f_mixed_at_points[0], vec_expected)
     assert np.allclose(f_mixed_at_points[1], tensor_expected)
+
 
 @pytest.mark.parallel(3)
 def test_point_evaluator_nonredundant(mesh_and_points):

--- a/tests/firedrake/regression/test_point_eval_api.py
+++ b/tests/firedrake/regression/test_point_eval_api.py
@@ -181,8 +181,7 @@ def test_point_evaluator_scalar(mesh_and_points):
     f.interpolate(x + y)
 
     # Test standard scalar function evaluation at points
-    eval = PointEvaluator(mesh, points)
-    f_at_points = eval.evaluate(f)
+    f_at_points = evaluator.evaluate(f)
     assert np.allclose(f_at_points, [0.2, 0.4, 0.6])
 
     # Test standard scalar function with missing points


### PR DESCRIPTION
`PointEvaluator` is a convenience object for evaluating a `Function` at a set of points. The idea is for the user to avoid the boilerplate when point evaluating using a VertexOnlyMesh. Now that https://github.com/firedrakeproject/firedrake/pull/4484 is merged we should be able to deprecate `.at()` in favour of this API.

The basic usage is:
```
evaluator = PointEvaluator(mesh, points)
function_at_points = evaluator.evaluate(function)
```

The kwargs you can pass to `PointEvaluator` are `tolerance` and `missing_points_behaviour` which are self-explanatory, and `redundant`. If `redundant=True` (the default) then only the points on rank 0 are evaluated, and we broadcast the result to all other ranks. If `redundant=False` then each rank evaluates the points it has been given and returns the results on that rank. This is useful for e.g. external data input.