### PR TITLE
FixAtPointBC: support bendy meshes

### DIFF
--- a/demos/boussinesq/boussinesq.py.rst
+++ b/demos/boussinesq/boussinesq.py.rst
@@ -176,12 +176,6 @@ implements a boundary condition that fixes a field at a single point. ::
        @functools.cached_property
        def nodes(self):
            V = self.function_space()
-           if V.mesh().ufl_coordinate_element().degree() != 1:
-               # Ensure a P1 mesh
-               coordinates = V.mesh().coordinates
-               P1 = coordinates.function_space().reconstruct(degree=1)
-               P1_mesh = Mesh(Function(P1).interpolate(coordinates))
-               V = V.reconstruct(mesh=P1_mesh)
 
            point = [tuple(self.sub_domain)]
            vom = VertexOnlyMesh(V.mesh(), point)

--- a/demos/multicomponent/multicomponent.py.rst
+++ b/demos/multicomponent/multicomponent.py.rst
@@ -513,12 +513,6 @@ mathematically valid to do this)::
        @functools.cached_property
        def nodes(self):
            V = self.function_space()
-           if V.mesh().ufl_coordinate_element().degree() != 1:
-               # Ensure a P1 mesh
-               coordinates = V.mesh().coordinates
-               P1 = coordinates.function_space().reconstruct(degree=1)
-               P1_mesh = Mesh(Function(P1).interpolate(coordinates))
-               V = V.reconstruct(mesh=P1_mesh)
 
            point = [tuple(self.sub_domain)]
            vom = VertexOnlyMesh(V.mesh(), point)


### PR DESCRIPTION
# Description
Removes the auxiliary P1 mesh used by `FixAtPointBC` in the demos, as interpolation into VOM supports bendy meshes.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
