### PR TITLE
Use appropriate user in CI to avoid permissions errors on later runs

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -86,6 +86,8 @@ jobs:
       sdist_conclusion: ${{ steps.report_sdist.outputs.conclusion }}
       docs_conclusion: ${{ steps.report_docs.outputs.conclusion }}
     env:
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
       FIREDRAKE_CI: 1
@@ -95,17 +97,12 @@ jobs:
       # 'make test_durations' inside a 'firedrake:latest' Docker image.
       EXTRA_PYTEST_ARGS: --splitting-algorithm least_duration --timeout=600 --timeout-method=thread -o faulthandler_timeout=660 --durations-path=./firedrake-repo/tests/test_durations.json
       PYTEST_MPI_MAX_NPROCS: 8
-    defaults:
-      run:
-        # Run (almost) all commands as an unprivileged user with the same UID
-        # as on CI to avoid permissions issues
-        shell: sudo -u ubuntu bash -e {0}
     steps:
-      - name: Install sudo
-        shell: bash -e {0}
-        run: |
-          apt-get update
-          apt-get -y install sudo
+      - name: Fix HOME
+        # For unknown reasons GitHub actions overwrite HOME to /github/home
+        # which will break everything unless fixed
+        # (https://github.com/actions/runner/issues/863)
+        run: echo "HOME=/root" >> "$GITHUB_ENV"
 
       - name: Pre-run cleanup
         # Make sure the current directory is empty
@@ -116,25 +113,18 @@ jobs:
       # (https://askubuntu.com/questions/1549622/problem-with-archive-ubuntu-com-most-of-the-servers-are-not-responding)
       # The mirror was chosen from https://launchpad.net/ubuntu/+archivemirrors.
       - name: Configure apt
-        shell: bash -e {0}
         run: |
           sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
           apt-get update
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
-        shell: bash -e {0}
-        run: |
-          apt-get -y install git python3
+        run: apt-get -y install git python3
 
       - uses: actions/checkout@v5
         with:
           path: firedrake-repo
           ref: ${{ inputs.source_ref }}
-
-      - name: Fix permissions
-        shell: bash -e {0}
-        run: chown -R ubuntu:ubuntu firedrake-repo
 
       - name: Validate single source of truth
         run: ./firedrake-repo/scripts/check-config
@@ -146,6 +136,8 @@ jobs:
         run: |
           latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
           docker_version=$(grep FROM firedrake-repo/docker/Dockerfile.vanilla | cut -d ':' -f 2)
+          echo Latest version: $latest_version
+          echo Docker version: $docker_version
           if [[ "$docker_version" != "$latest_version" ]]; then
             echo "Ubuntu version ${docker_version} in Dockerfile is out of date with latest version ${latest_version}"
             exit 1
@@ -163,7 +155,6 @@ jobs:
           fi
 
       - name: Install system dependencies (2)
-        shell: bash -e {0}
         run: |
           apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages)
@@ -392,7 +383,6 @@ jobs:
 
       - name: Install system dependencies (3)
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
-        shell: bash -e {0}
         run: apt-get -y install inkscape texlive-full
 
       - name: Check bibtex

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -95,12 +95,15 @@ jobs:
       # 'make test_durations' inside a 'firedrake:latest' Docker image.
       EXTRA_PYTEST_ARGS: --splitting-algorithm least_duration --timeout=600 --timeout-method=thread -o faulthandler_timeout=660 --durations-path=./firedrake-repo/tests/test_durations.json
       PYTEST_MPI_MAX_NPROCS: 8
+    defaults:
+      run:
+        shell: sudo -u ubuntu bash -e {0}
     steps:
-      - name: Setup privileges
+      - name: Install sudo
+        shell: bash -e {0}
         run: |
           apt-get update
           apt-get -y install sudo
-          su ubuntu
 
       - name: Pre-run cleanup
         # Make sure the current directory is empty
@@ -115,12 +118,15 @@ jobs:
       # The mirror was chosen from https://launchpad.net/ubuntu/+archivemirrors.
       - name: Configure apt
         run: |
+          su ubuntu
           sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get update
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
-        run: apt-get -y install git python3
+        run: |
+          su ubuntu
+          sudo apt-get -y install git python3
 
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -88,8 +88,6 @@ jobs:
       sdist_conclusion: ${{ steps.report_sdist.outputs.conclusion }}
       docs_conclusion: ${{ steps.report_docs.outputs.conclusion }}
     env:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
       FIREDRAKE_CI: 1
@@ -104,23 +102,11 @@ jobs:
         # For unknown reasons GitHub actions overwrite HOME to /github/home
         # which will break everything unless fixed
         # (https://github.com/actions/runner/issues/863)
-        run: echo "HOME=/root" >> "$GITHUB_ENV"
+        run: echo "HOME=/home/ubuntu" >> "$GITHUB_ENV"
 
       - name: Pre-run cleanup
         # Make sure the current directory is empty
         run: find . -delete
-
-      # Check that the Dockerfile is using the latest Ubuntu version.
-      # The version is hardcoded into the Dockerfile so that the OS
-      # for each release is fixed.
-      - name: Check Dockerfile Ubuntu version
-        run: |
-          latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
-          docker_version=$(grep FROM docker/Dockerfile.vanilla | cut -d ':' -f 2)
-          if [[ "$docker_version" != "$latest_version" ]]; then
-            echo "Ubuntu version ${docker_version} in Dockerfile is out of date with latest version ${latest_version}"
-            exit 1
-          fi
 
       # Use a different mirror to fetch apt packages from to get around
       # temporary outage.
@@ -128,12 +114,12 @@ jobs:
       # The mirror was chosen from https://launchpad.net/ubuntu/+archivemirrors.
       - name: Configure apt
         run: |
-          sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
-          apt-get update
+          sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
-        run: apt-get -y install git python3
+        run: sudo apt-get -y install git python3
 
       - uses: actions/checkout@v5
         with:
@@ -142,6 +128,18 @@ jobs:
 
       - name: Validate single source of truth
         run: ./firedrake-repo/scripts/check-config
+
+      # Check that the Dockerfile is using the latest Ubuntu version.
+      # The version is hardcoded into the Dockerfile so that the OS
+      # for each release is fixed.
+      - name: Check Dockerfile Ubuntu version
+        run: |
+          latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
+          docker_version=$(grep FROM firedrake-repo/docker/Dockerfile.vanilla | cut -d ':' -f 2)
+          if [[ "$docker_version" != "$latest_version" ]]; then
+            echo "Ubuntu version ${docker_version} in Dockerfile is out of date with latest version ${latest_version}"
+            exit 1
+          fi
 
       # Raise an error if any 'TODO RELEASE' comments remain
       - name: Check no 'TODO RELEASE' comments (release only)
@@ -156,11 +154,11 @@ jobs:
 
       - name: Install system dependencies (2)
         run: |
-          apt-get -y install \
+          sudo apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages)
-          apt-get -y install python3-venv
+          sudo apt-get -y install python3-venv
           : # Dependencies needed to run the test suite
-          apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
+          sudo apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
 
       - name: Install PETSc
         run: |
@@ -383,7 +381,7 @@ jobs:
 
       - name: Install system dependencies (3)
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
-        run: apt-get -y install inkscape texlive-full
+        run: sudo apt-get -y install inkscape texlive-full
 
       - name: Check bibtex
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -136,8 +136,8 @@ jobs:
         run: |
           latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
           docker_version=$(grep FROM firedrake-repo/docker/Dockerfile.vanilla | cut -d ':' -f 2)
-          echo Latest version: $latest_version
-          echo Docker version: $docker_version
+          echo "Latest version: $latest_version"
+          echo "Docker version: $docker_version"
           if [[ "$docker_version" != "$latest_version" ]]; then
             echo "Ubuntu version ${docker_version} in Dockerfile is out of date with latest version ${latest_version}"
             exit 1

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -97,6 +97,8 @@ jobs:
       PYTEST_MPI_MAX_NPROCS: 8
     defaults:
       run:
+        # Run (almost) all commands as an unprivileged user with the same UID
+        # as on CI to avoid permissions issues
         shell: sudo -u ubuntu bash -e {0}
     steps:
       - name: Install sudo
@@ -107,10 +109,7 @@ jobs:
 
       - name: Pre-run cleanup
         # Make sure the current directory is empty
-        run: |
-          id
-          find . -delete
-          exit 1
+        run: find . -delete
 
       # Use a different mirror to fetch apt packages from to get around
       # temporary outage.
@@ -118,14 +117,12 @@ jobs:
       # The mirror was chosen from https://launchpad.net/ubuntu/+archivemirrors.
       - name: Configure apt
         run: |
-          su ubuntu
           sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get update
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
         run: |
-          su ubuntu
           sudo apt-get -y install git python3
 
       - uses: actions/checkout@v5
@@ -141,7 +138,6 @@ jobs:
       # for each release is fixed.
       - name: Check Dockerfile Ubuntu version
         run: |
-          su ubuntu
           latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
           docker_version=$(grep FROM firedrake-repo/docker/Dockerfile.vanilla | cut -d ':' -f 2)
           if [[ "$docker_version" != "$latest_version" ]]; then
@@ -162,11 +158,11 @@ jobs:
 
       - name: Install system dependencies (2)
         run: |
-          apt-get -y install \
+          sudo apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages)
-          apt-get -y install python3-venv
+          sudo apt-get -y install python3-venv
           : # Dependencies needed to run the test suite
-          apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
+          sudo apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
 
       - name: Install PETSc
         run: |
@@ -389,7 +385,7 @@ jobs:
 
       - name: Install system dependencies (3)
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
-        run: apt-get -y install inkscape texlive-full
+        run: sudo apt-get -y install inkscape texlive-full
 
       - name: Check bibtex
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Setup privileges
         run: |
           apt-get update
-          apt-get install sudo
+          apt-get -y install sudo
           su ubuntu
 
       - name: Pre-run cleanup

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -82,8 +82,6 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: ubuntu:latest
-      # match the UID of the 'github' user on the runner
-      options: --user 1000
     outputs:
       sdist_conclusion: ${{ steps.report_sdist.outputs.conclusion }}
       docs_conclusion: ${{ steps.report_docs.outputs.conclusion }}
@@ -98,15 +96,18 @@ jobs:
       EXTRA_PYTEST_ARGS: --splitting-algorithm least_duration --timeout=600 --timeout-method=thread -o faulthandler_timeout=660 --durations-path=./firedrake-repo/tests/test_durations.json
       PYTEST_MPI_MAX_NPROCS: 8
     steps:
-      - name: Fix HOME
-        # For unknown reasons GitHub actions overwrite HOME to /github/home
-        # which will break everything unless fixed
-        # (https://github.com/actions/runner/issues/863)
-        run: echo "HOME=/home/ubuntu" >> "$GITHUB_ENV"
+      - name: Setup privileges
+        run: |
+          apt-get update
+          apt-get install sudo
+          su ubuntu
 
       - name: Pre-run cleanup
         # Make sure the current directory is empty
-        run: find . -delete
+        run: |
+          id
+          find . -delete
+          exit 1
 
       # Use a different mirror to fetch apt packages from to get around
       # temporary outage.
@@ -119,7 +120,7 @@ jobs:
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
-        run: sudo apt-get -y install git python3
+        run: apt-get -y install git python3
 
       - uses: actions/checkout@v5
         with:
@@ -134,6 +135,7 @@ jobs:
       # for each release is fixed.
       - name: Check Dockerfile Ubuntu version
         run: |
+          su ubuntu
           latest_version=$(grep "VERSION_ID=" /etc/os-release | cut -d '"' -f 2)
           docker_version=$(grep FROM firedrake-repo/docker/Dockerfile.vanilla | cut -d ':' -f 2)
           if [[ "$docker_version" != "$latest_version" ]]; then
@@ -154,11 +156,11 @@ jobs:
 
       - name: Install system dependencies (2)
         run: |
-          sudo apt-get -y install \
+          apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages)
-          sudo apt-get -y install python3-venv
+          apt-get -y install python3-venv
           : # Dependencies needed to run the test suite
-          sudo apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
+          apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
 
       - name: Install PETSc
         run: |
@@ -381,7 +383,7 @@ jobs:
 
       - name: Install system dependencies (3)
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
-        run: sudo apt-get -y install inkscape texlive-full
+        run: apt-get -y install inkscape texlive-full
 
       - name: Check bibtex
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -116,12 +116,14 @@ jobs:
       # (https://askubuntu.com/questions/1549622/problem-with-archive-ubuntu-com-most-of-the-servers-are-not-responding)
       # The mirror was chosen from https://launchpad.net/ubuntu/+archivemirrors.
       - name: Configure apt
+        shell: bash -e {0}
         run: |
-          sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
-          sudo apt-get update
+          sed -i 's|http://archive.ubuntu.com/ubuntu|http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/ubuntu.sources
+          apt-get update
 
       # Git is needed for actions/checkout and Python for firedrake-configure
       - name: Install system dependencies (1)
+        shell: bash -e {0}
         run: |
           sudo apt-get -y install git python3
 
@@ -157,12 +159,13 @@ jobs:
           fi
 
       - name: Install system dependencies (2)
+        shell: bash -e {0}
         run: |
-          sudo apt-get -y install \
+          apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-system-packages)
-          sudo apt-get -y install python3-venv
+          apt-get -y install python3-venv
           : # Dependencies needed to run the test suite
-          sudo apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
+          apt-get -y install fonts-dejavu graphviz graphviz-dev parallel poppler-utils
 
       - name: Install PETSc
         run: |
@@ -385,7 +388,8 @@ jobs:
 
       - name: Install system dependencies (3)
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'
-        run: sudo apt-get -y install inkscape texlive-full
+        shell: bash -e {0}
+        run: apt-get -y install inkscape texlive-full
 
       - name: Check bibtex
         if: (success() || steps.install.conclusion == 'success') && matrix.arch == 'default'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -82,6 +82,8 @@ jobs:
     runs-on: [self-hosted, Linux]
     container:
       image: ubuntu:latest
+      # match the UID of the 'github' user on the runner
+      options: --user 1000
     outputs:
       sdist_conclusion: ${{ steps.report_sdist.outputs.conclusion }}
       docs_conclusion: ${{ steps.report_docs.outputs.conclusion }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -125,12 +125,16 @@ jobs:
       - name: Install system dependencies (1)
         shell: bash -e {0}
         run: |
-          sudo apt-get -y install git python3
+          apt-get -y install git python3
 
       - uses: actions/checkout@v5
         with:
           path: firedrake-repo
           ref: ${{ inputs.source_ref }}
+
+      - name: Fix permissions
+        shell: bash -e {0}
+        run: chown -R ubuntu:ubuntu firedrake-repo
 
       - name: Validate single source of truth
         run: ./firedrake-repo/scripts/check-config

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -86,17 +86,16 @@ jobs:
 
       - name: Export digest
         run: |
-          : # Create a file in <tempdir>/digests with name matching the pushed image hash
-          rm -rf ${{ runner.temp }}/digests
-          mkdir -p ${{ runner.temp }}/digests
+          : # Create a file in './digests' with name matching the pushed image hash
+          mkdir digests
           digest="${{ steps.build.outputs.imageid }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests_${{ inputs.target }}_${{ inputs.os }}
-          path: ${{ runner.temp }}/digests/*
+          path: digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -144,16 +143,15 @@ jobs:
       - name: Export digest
         run: |
           : # Create a file in <tempdir>/digests with name matching the pushed image hash
-          rm -rf ${{ runner.temp }}/digests
-          mkdir -p ${{ runner.temp }}/digests
+          mkdir digests
           digest="${{ steps.build.outputs.imageid }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests_${{ inputs.target }}_${{ inputs.os }}
-          path: ${{ runner.temp }}/digests/*
+          path: digests/*
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -54,8 +54,7 @@ jobs:
     steps:
       - name: Pre-cleanup
         if: always()
-        run: |
-          rm -rf ${{ runner.temp }}/digests
+        run: find . -delete
 
       - name: Add homebrew to PATH
         if: inputs.os == 'macOS'
@@ -104,5 +103,4 @@ jobs:
 
       - name: Post-cleanup
         if: always()
-        run: |
-          rm -rf ${{ runner.temp }}/digests
+        run: find . -delete

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -56,10 +56,11 @@ jobs:
         if: always()
         run: find . -delete
 
-      - name: Install Docker
+      - name: Set up Docker
         run: |
           apt-get update
           apt-get -y install docker.io
+          systemctl start docker.service
 
       - name: Check out the repo
         uses: actions/checkout@v5

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Export digest
         run: |
-          : # Create a file in <tempdir>/digests with name matching the pushed image hash
+          : # Create a file in digests with name matching the pushed image hash
           mkdir digests
           digest="${{ steps.build.outputs.imageid }}"
           touch "digests/${digest#sha256:}"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -46,11 +46,63 @@ on:
         required: true
 
 jobs:
-  docker_build:
-    name: "Build the ${{ inputs.target }} container"
-    strategy:
-      fail-fast: false
-    runs-on: [self-hosted, "${{ inputs.os }}"]
+  docker_build_linux:
+    name: Build the ${{ inputs.target }} container (Linux)
+    if: inputs.os == Linux
+    runs-on: [self-hosted, Linux]
+    container: ubuntu:latest
+    steps:
+      - name: Pre-cleanup
+        if: always()
+        run: find . -delete
+
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ inputs.target }}
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ inputs.platform }}
+          file: ${{ inputs.dockerfile }}
+          build-args: |
+            ARCH=${{ inputs.arch }}
+            BRANCH=${{ inputs.branch }}
+          outputs: type=image,name=firedrakeproject/${{ inputs.target }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          : # Create a file in <tempdir>/digests with name matching the pushed image hash
+          rm -rf ${{ runner.temp }}/digests
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.imageid }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests_${{ inputs.target }}_${{ inputs.os }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Post-cleanup
+        if: always()
+        run: find . -delete
+
+  docker_build_macos:
+    name: Build the ${{ inputs.target }} container (macOS)
+    if: inputs.os == macOS
+    runs-on: [self-hosted, macOS]
     steps:
       - name: Pre-cleanup
         if: always()

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   docker_build_linux:
     name: Build the ${{ inputs.target }} container (Linux)
-    if: inputs.os == Linux
+    if: inputs.os == 'Linux'
     runs-on: [self-hosted, Linux]
     container: ubuntu:latest
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   docker_build_macos:
     name: Build the ${{ inputs.target }} container (macOS)
-    if: inputs.os == macOS
+    if: inputs.os == 'macOS'
     runs-on: [self-hosted, macOS]
     steps:
       - name: Pre-cleanup
@@ -109,7 +109,6 @@ jobs:
         run: find . -delete
 
       - name: Add homebrew to PATH
-        if: inputs.os == 'macOS'
         run: |
           : # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           apt-get update
           apt-get -y install docker.io
-          systemctl start docker.service
 
       - name: Check out the repo
         uses: actions/checkout@v5

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Docker
         run: |
           apt-get update
-          apt-get -y install docker
+          apt-get -y install docker.io
 
       - name: Check out the repo
         uses: actions/checkout@v5

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -56,6 +56,11 @@ jobs:
         if: always()
         run: find . -delete
 
+      - name: Install Docker
+        run: |
+          apt-get update
+          apt-get -y install docker
+
       - name: Check out the repo
         uses: actions/checkout@v5
 

--- a/.github/workflows/docker_merge.yml
+++ b/.github/workflows/docker_merge.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
+          path: digests
           pattern: digests_${{ inputs.target }}_*
           merge-multiple: true
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Merge and push the per-platform images (release)
         if: inputs.tag_latest
-        working-directory: ${{ runner.temp }}/digests
+        working-directory: digests
         run: |
           docker buildx imagetools create \
             -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \
@@ -66,7 +66,7 @@ jobs:
 
       - name: Merge and push the per-platform images (dev)
         if: ${{ ! inputs.tag_latest }}
-        working-directory: ${{ runner.temp }}/digests
+        working-directory: digests
         run: |
           docker buildx imagetools create \
             -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \

--- a/.github/workflows/docker_merge.yml
+++ b/.github/workflows/docker_merge.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   docker_merge:
     runs-on: [self-hosted, Linux]
-    container: ubuntu-latest
+    container: ubuntu:latest
     steps:
       - name: Pre-cleanup
         if: always()

--- a/.github/workflows/docker_merge.yml
+++ b/.github/workflows/docker_merge.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Pre-cleanup
         if: always()
-        run: rm -rf ${{ runner.temp }}/digests
+        run: find . -delete
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -71,4 +71,4 @@ jobs:
 
       - name: Post-cleanup
         if: always()
-        run: rm -rf ${{ runner.temp }}/digests
+        run: find . -delete

--- a/.github/workflows/docker_merge.yml
+++ b/.github/workflows/docker_merge.yml
@@ -28,10 +28,16 @@ on:
 jobs:
   docker_merge:
     runs-on: [self-hosted, Linux]
+    container: ubuntu-latest
     steps:
       - name: Pre-cleanup
         if: always()
         run: find . -delete
+
+      - name: Set up Docker
+        run: |
+          apt-get update
+          apt-get -y install docker.io
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -49,21 +55,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # NOTE: This action pushes a new image with the given tag but also updates
-      # the 'latest' tag.
-      - name: Merge and push the per-platform images
+      - name: Merge and push the per-platform images (release)
+        if: inputs.tag_latest
         working-directory: ${{ runner.temp }}/digests
         run: |
-          if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
-            docker buildx imagetools create \
-              -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \
-              -t firedrakeproject/${{ inputs.target }}:latest \
-              $(printf "firedrakeproject/${{ inputs.target }}@sha256:%s " *)
-          else
-            docker buildx imagetools create \
-              -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \
-              $(printf "firedrakeproject/${{ inputs.target }}@sha256:%s " *)
-          fi
+          docker buildx imagetools create \
+            -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \
+            -t firedrakeproject/${{ inputs.target }}:latest \
+            $(printf "firedrakeproject/${{ inputs.target }}@sha256:%s " *)
+
+      - name: Merge and push the per-platform images (dev)
+        if: ! inputs.tag_latest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t firedrakeproject/${{ inputs.target }}:${{ inputs.tag }} \
+            $(printf "firedrakeproject/${{ inputs.target }}@sha256:%s " *)
 
       - name: Inspect image
         run: |

--- a/.github/workflows/docker_merge.yml
+++ b/.github/workflows/docker_merge.yml
@@ -65,7 +65,7 @@ jobs:
             $(printf "firedrakeproject/${{ inputs.target }}@sha256:%s " *)
 
       - name: Merge and push the per-platform images (dev)
-        if: ! inputs.tag_latest
+        if: ${{ ! inputs.tag_latest }}
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ jobs:
       test_macos: ${{ contains(github.event.pull_request.labels.*.name, 'macOS') }}
     secrets: inherit
 
+  # UNDO ME
   docker:
     name: Build developer Docker containers
     uses: ./.github/workflows/docker.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build developer Docker containers
     uses: ./.github/workflows/docker.yml
     with:
-      tag: connorjwardtest-dev-${{ github.ref_name }}
-      branch: ${{ github.ref_name }}
+      tag: connorjwardtest-dev-${{ github.base_ref }}
+      branch: ${{ github.base_ref }}
       build_dev: true
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,3 +13,12 @@ jobs:
       # Only run macOS tests if the PR is labelled 'macOS'
       test_macos: ${{ contains(github.event.pull_request.labels.*.name, 'macOS') }}
     secrets: inherit
+
+  docker:
+    name: Build developer Docker containers
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: connorjwardtest-dev-${{ github.ref_name }}
+      branch: ${{ github.ref_name }}
+      build_dev: true
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,13 +13,3 @@ jobs:
       # Only run macOS tests if the PR is labelled 'macOS'
       test_macos: ${{ contains(github.event.pull_request.labels.*.name, 'macOS') }}
     secrets: inherit
-
-  # UNDO ME
-  docker:
-    name: Build developer Docker containers
-    uses: ./.github/workflows/docker.yml
-    with:
-      tag: connorjwardtest-dev-${{ github.base_ref }}
-      branch: ${{ github.base_ref }}
-      build_dev: true
-    secrets: inherit


### PR DESCRIPTION
This should fix the permissions issues that we saw building Docker images on CI.

The issue was that the regular CI runs are run in a Docker container as the root user and this means that if a job is cancelled then a bunch of files are left behind that are owned by `root`. If we subsequently build a Docker image on the same runner we would crash because that workflow is run as an unprivileged user.

I tried to make the regular CI runs use an unprivileged user but I don't think that it is possible. Instead the solution I've found here is to build the Docker images inside another container, and hence as root.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
