### PR TITLE
Cache TLM and Hessian solvers for NLVS blocks

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -30,6 +30,7 @@ class Solver(Enum):
     FORWARD = 0
     ADJOINT = 1
     TLM = 2
+    HESSIAN = 3
 
 
 class GenericSolveBlock(Block):
@@ -237,6 +238,9 @@ class GenericSolveBlock(Block):
 
         return adj_sol, adj_sol_bdy
 
+    def _hessian_solve(self, *args):
+        return self._assemble_and_solve_adj_eq(*args)
+
     def _compute_adj_bdy(self, adj_sol, adj_sol_bdy, dFdu_adj_form, dJdu):
         adj_sol_bdy = firedrake.assemble(dJdu - firedrake.action(dFdu_adj_form, adj_sol))
         return adj_sol_bdy.riesz_representation("l2")
@@ -390,8 +394,7 @@ class GenericSolveBlock(Block):
         b = self._assemble_soa_eq_rhs(dFdu_form, adj_sol, hessian_input,
                                       d2Fdu2)
         dFdu_form = firedrake.adjoint(dFdu_form)
-        adj_sol2, adj_sol2_bdy = self._assemble_and_solve_adj_eq(dFdu_form, b,
-                                                                 compute_bdy)
+        adj_sol2, adj_sol2_bdy = self._hessian_solve(dFdu_form, b, compute_bdy)
         if self.adj2_cb is not None:
             self.adj2_cb(adj_sol2)
         if self.adj2_bdy_cb is not None and compute_bdy:
@@ -687,6 +690,22 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
                 u_sol, adj_sol_bdy, jac_adj, dJdu_copy)
         return u_sol, adj_sol_bdy
 
+    def _hessian_solve(self, adj_form, rhs, compute_bdy):
+        # self._ad_solver_replace_forms(Solver.HESSIAN)
+        # self._ad_solvers["hessian_lvs"].invalidate_jacobian()
+        self._ad_solvers["hessian_lvs"]._problem.F._components[1].assign(rhs)
+        self._ad_solvers["hessian_lvs"].solve()
+        u_sol = self._ad_solvers["hessian_lvs"]._problem.u
+
+        adj_sol_bdy = None
+        if compute_bdy:
+            jac_adj = self._ad_solvers["hessian_lvs"]._problem.J
+            adj_sol_bdy = self._compute_adj_bdy(
+                u_sol, adj_sol_bdy, jac_adj, rhs.copy()
+            )
+
+        return u_sol, adj_sol_bdy
+
     def _ad_assign_map(self, form, solver):
         if solver == Solver.FORWARD:
             count_map = self._ad_solvers["forward_nlvs"]._problem._ad_count_map
@@ -705,8 +724,10 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
                            firedrake.Cofunction)):
                 coeff_count = coeff.count()
                 if coeff_count in form_ad_count_map:
-                    assign_map[form_ad_count_map[coeff_count]] = \
-                        block_variable.saved_output
+                    if solver == Solver.HESSIAN:
+                        assign_map[form_ad_count_map[coeff_count]] = block_variable.tlm_value
+                    else:
+                        assign_map[form_ad_count_map[coeff_count]] = block_variable.saved_output
 
         if (
             solver == Solver.ADJOINT
@@ -717,6 +738,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
             if coeff_count in form_ad_count_map:
                 assign_map[form_ad_count_map[coeff_count]] = \
                     block_variable.saved_output
+
         return assign_map
 
     def _ad_assign_coefficients(self, form, solver):
@@ -735,6 +757,10 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         elif solver == Solver.TLM:
             self._ad_assign_coefficients(
                 self._ad_solvers["tlm_lvs"]._problem.J, solver
+            )
+        elif solver == Solver.HESSIAN:
+            self._ad_assign_coefficients(
+                self._ad_solvers["hessian_lvs"]._problem.J, solver
             )
 
     def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
@@ -862,11 +888,6 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
 
         self._ad_solvers["tlm_lvs"].solve()
         return self._ad_solvers["tlm_lvs"]._problem.u
-        # return self._assemble_and_solve_tlm_eq(
-        #     firedrake.assemble(dFdu, bcs=bcs, **self.assemble_kwargs),
-        #     dFdm, dudm, bcs
-        # )
-
 
 
 class ProjectBlock(SolveVarFormBlock):

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -29,6 +29,7 @@ class Solver(Enum):
     """Enum for solver types."""
     FORWARD = 0
     ADJOINT = 1
+    TLM = 2
 
 
 class GenericSolveBlock(Block):
@@ -689,8 +690,11 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
     def _ad_assign_map(self, form, solver):
         if solver == Solver.FORWARD:
             count_map = self._ad_solvers["forward_nlvs"]._problem._ad_count_map
-        else:
+        elif solver == Solver.ADJOINT:
             count_map = self._ad_solvers["adjoint_lvs"]._problem._ad_count_map
+        elif solver == Solver.TLM:
+            count_map = self._ad_solvers["tlm_lvs"]._problem._ad_count_map
+
         assign_map = {}
         form_ad_count_map = dict((count_map[coeff], coeff)
                                  for coeff in form.coefficients())
@@ -725,9 +729,13 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
             problem = self._ad_solvers["forward_nlvs"]._problem
             self._ad_assign_coefficients(problem.F, solver)
             self._ad_assign_coefficients(problem.J, solver)
-        else:
+        elif solver == Solver.ADJOINT:
             self._ad_assign_coefficients(
                 self._ad_solvers["adjoint_lvs"]._problem.J, solver)
+        elif solver == Solver.TLM:
+            self._ad_assign_coefficients(
+                self._ad_solvers["tlm_lvs"]._problem.J, solver
+            )
 
     def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
         compute_bdy = self._should_compute_boundary_adjoint(
@@ -806,6 +814,59 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         dFdm = firedrake.assemble(dFdm, **self.assemble_kwargs)
 
         return dFdm
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx,
+                               prepared=None):
+        F_form = prepared["form"]
+        dFdu = prepared["dFdu"]
+
+        bcs = []
+        dFdm = 0.
+        for block_variable in self.get_dependencies():
+            tlm_value = block_variable.tlm_value
+            c = block_variable.output
+            c_rep = block_variable.saved_output
+
+            if isinstance(c, firedrake.DirichletBC):
+                if tlm_value is None:
+                    bcs.append(c.reconstruct(g=0))
+                else:
+                    bcs.append(tlm_value)
+                continue
+            elif isinstance(c, firedrake.MeshGeometry):
+                X = firedrake.SpatialCoordinate(c)
+                c_rep = X
+
+            if tlm_value is None:
+                continue
+
+            if c == self.func and not self.linear:
+                continue
+
+            dFdm += firedrake.derivative(-F_form, c_rep, tlm_value)
+
+        if isinstance(dFdm, float):
+            v = dFdu.arguments()[0]
+            dFdm = firedrake.inner(
+                firedrake.Constant(numpy.zeros(v.ufl_shape)), v
+            ) * firedrake.dx
+
+        dFdm = ufl.algorithms.expand_derivatives(dFdm)
+        dFdm = firedrake.assemble(dFdm)
+
+        # XXX I dunno how this works
+        self._ad_solver_replace_forms(Solver.TLM)
+        self._ad_solvers["tlm_lvs"].invalidate_jacobian()
+        # update RHS
+        self._ad_solvers["tlm_lvs"]._problem.F._components[1].assign(dFdm)
+
+        self._ad_solvers["tlm_lvs"].solve()
+        return self._ad_solvers["tlm_lvs"]._problem.u
+        # return self._assemble_and_solve_tlm_eq(
+        #     firedrake.assemble(dFdu, bcs=bcs, **self.assemble_kwargs),
+        #     dFdm, dudm, bcs
+        # )
+
 
 
 class ProjectBlock(SolveVarFormBlock):


### PR DESCRIPTION
# Description

Computing the adjoint on a `NonlinearVariationalSolve` block has a few optimisations: in effect the LVP and LVS are only initialised once when the block is created, then only the RHS is updated during adjoint evaluation (with some extra fiddling for the non-constant Jacobian case).

The TLM and Hessian *should* look similar to this, but they currently go through the slower code path on `GenericSolveBlock` that does assembly and solver creation on every evaluation, making them significantly slower. For very ballpark figures, a simple Stokes box model takes ~20s for a forward or adjoint evaluation, but ~180 for the first Hessian evaluation (involving a couple of compilation phases, I guess) and ~100 for subsequent Hessians. I think the theory dictates that this should be closer to only 2x the adjoint.

This PR is some pretty horrific code-mangling to attempt to bring parity across the different evaluation types. Currently, it sets up the LVP and LVS for TLM and Hessian on a NLVS block initialisation. I think it's fair to assume that in *most* cases the adjoint LVS is useful, but the TLM and Hessian are less common. Perhaps they can be gated by a flag if you know you'll need them, or initialised lazily (maybe a little more fiddly).

I also have completely hacked my way around the form replacement and constant Jacobian business, and they're almost certainly completely wrong. This probably deserves a more careful eye once the overall approach is a bit more settled. Indeed, maybe the form replacement mechanism could be re-engineered somewhat.

With the changes here, the same box model takes 100s for the first Hessian, then ~65 thereafter. There's still a bunch of time being spent on assembly and form manipulation for the second-order adjoint, and I assume that only needs to happen once. My model also has a couple of `ProjectBlock` that go through the slow path, but they are a tiny percentage of the overall runtime. It does mean it's a bit complicated to follow the logic through, depending on whether the `GenericSolveBlock` or `NonlinearVariationalSolveBlock` implementations of adj/tlm/hess are being used.