### PR TITLE
Use VTK in firedrake-vanilla containers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,8 +74,7 @@ jobs:
     with:
       target: firedrake-vanilla-${{ matrix.arch }}
       tag: ${{ inputs.tag }}
-      # UNDO ME
-      tag_latest: false
+      tag_latest: ${{ ! inputs.build_dev }}
     secrets: inherit
 
   # Firedrake and friends
@@ -101,6 +100,5 @@ jobs:
     with:
       target: firedrake
       tag: ${{ inputs.tag }}
-      # UNDO ME
-      tag_latest: false
+      tag_latest: ${{ ! inputs.build_dev }}
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,8 @@ jobs:
     with:
       target: firedrake-vanilla-${{ matrix.arch }}
       tag: ${{ inputs.tag }}
-      tag_latest: ${{ ! inputs.build_dev }}
+      # UNDO ME
+      tag_latest: false
     secrets: inherit
 
   # Firedrake and friends
@@ -83,8 +84,7 @@ jobs:
     needs: docker_merge_vanilla
     uses: ./.github/workflows/docker_build.yml
     # Only build the 'firedrake' container for 'linux/amd64' because
-    # VTK (https://gitlab.kitware.com/vtk/vtk/-/issues/18772) and
-    # netgen-mesher do not have ARM wheels so many Firedrake apps cannot
+    # netgen-mesher does not have ARM wheels so many Firedrake apps cannot
     # be installed.
     with:
       os: Linux
@@ -101,5 +101,6 @@ jobs:
     with:
       target: firedrake
       tag: ${{ inputs.tag }}
-      tag_latest: ${{ ! inputs.build_dev }}
+      # UNDO ME
+      tag_latest: false
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,6 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       tag: vtk-test
-      branch: ${{ github.base_ref }}
+      branch: release
       build_dev: false
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,3 +13,13 @@ jobs:
       # Only run macOS tests if the PR is labelled 'macOS'
       test_macos: ${{ contains(github.event.pull_request.labels.*.name, 'macOS') }}
     secrets: inherit
+
+  # UNDO ME
+  docker:
+    name: Build developer Docker containers
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: vtk-test
+      branch: ${{ github.base_ref }}
+      build_dev: false
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,13 +13,3 @@ jobs:
       # Only run macOS tests if the PR is labelled 'macOS'
       test_macos: ${{ contains(github.event.pull_request.labels.*.name, 'macOS') }}
     secrets: inherit
-
-  # UNDO ME
-  docker:
-    name: Build developer Docker containers
-    uses: ./.github/workflows/docker.yml
-    with:
-      tag: vtk-test
-      branch: release
-      build_dev: false
-    secrets: inherit

--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -5,7 +5,7 @@ FROM firedrakeproject/firedrake-vanilla-default:latest
 # Install optional dependencies
 RUN pip install --verbose \
         --extra-index-url https://download.pytorch.org/whl/cpu \
-        jax ngsPETSc torch vtk
+        jax ngsPETSc torch
 
 # Set PYTHONPATH so netgen can be found
 # (see https://github.com/NGSolve/netgen/issues/213)

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -144,8 +144,7 @@ ENV CFLAGS="-O3 -mtune=generic" CPPFLAGS="-O3 -mtune=generic"
 #     packages. These are installed in editable mode.
 #     The order these are installed is important, e.g. FIAT must be installed
 #     before UFL otherwise `pip install fiat` will reinstall pypi ufl.
-# UNDO ME
-RUN git clone --branch connorjward/arm-vtk-wheels \
+RUN git clone --branch ${BRANCH} \
       https://github.com/firedrakeproject/firedrake.git /opt/firedrake \
    && pip cache purge \
    && pip install --verbose ${PETSC_DIR}/src/binding/petsc4py \

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -144,7 +144,8 @@ ENV CFLAGS="-O3 -mtune=generic" CPPFLAGS="-O3 -mtune=generic"
 #     packages. These are installed in editable mode.
 #     The order these are installed is important, e.g. FIAT must be installed
 #     before UFL otherwise `pip install fiat` will reinstall pypi ufl.
-RUN git clone --branch ${BRANCH} \
+# UNDO ME
+RUN git clone --branch connorjward/arm-vtk-wheels \
       https://github.com/firedrakeproject/firedrake.git /opt/firedrake \
    && pip cache purge \
    && pip install --verbose ${PETSC_DIR}/src/binding/petsc4py \
@@ -168,5 +169,5 @@ ENV PYOP2_CFLAGS=$CFLAGS
 
 # Run the smoke tests.
 RUN cd /opt/firedrake/ \
-    && firedrake-check \
+    && firedrake-check --mpiexec 'mpiexec --oversubscribe -n'
     && firedrake-clean

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -169,5 +169,5 @@ ENV PYOP2_CFLAGS=$CFLAGS
 
 # Run the smoke tests.
 RUN cd /opt/firedrake/ \
-    && firedrake-check --mpiexec 'mpiexec --oversubscribe -n'
+    && firedrake-check --mpiexec 'mpiexec --oversubscribe -n' \
     && firedrake-clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ docker = [  # Used in firedrake-vanilla container
   "pytest-timeout",
   "pytest-xdist",
   "slepc4py==3.23.2",
+  "vtk",
 ]
 
 [build-system]


### PR DESCRIPTION
This fixes a commonly mentioned pain point for macOS users who could not previously reasonably use Firedrake containers due to missing VTK. This should now be fixed since VTK now release ARM wheels.

I have checked and this DTRT.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
