### PR TITLE
`RieszMap` fixes/suggestions

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -485,6 +485,7 @@ class RieszMap:
             else:
                 solve, rhs, soln = self._solver
                 rhs.assign(value)
+                soln.zero()
                 solve()
                 output.assign(soln)
         elif ufl.duals.is_primal(value):

--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -486,7 +486,6 @@ class RieszMap:
                 solve, rhs, soln = self._solver
                 rhs.assign(value)
                 solve()
-                output = Function(self._function_space)
                 output.assign(soln)
         elif ufl.duals.is_primal(value):
             if value.function_space() != self._function_space:


### PR DESCRIPTION
Fixes based on reading the code.

1. Handle boundary conditions in the Riesz map inverse. This seems to be the consistent way to apply this, but should be reviewed.
2. Zero guess the Riesz map linear solver. Required for consistent behaviour, e.g. if changing the order of mappings.

Minor fixes

3. Remove an unnecessary allocation.
4. Catch the case where boundary conditions are supplied with an $l_2$ Riesz map.