### PR TITLE
Warn users about `interpolate` expression renumbering

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -175,9 +175,8 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
         dual_arg = Coargument(V.dual(), 0)
         expr_args = extract_arguments(expr)
         if expr_args and expr_args[0].number() == 0:
-            # In this case we are doing adjoint interpolation
-            # When V is a FunctionSpace and expr contains Argument(0),
-            # we need to change expr argument number to 1 (in our current implementation)
+            warnings.warn("Passing argument numbered 0 in expression for forward interpolation is deprecated. " \
+            "Use a TrialFunction in the expression.")
             v, = expr_args
             expr = replace(expr, {v: v.reconstruct(number=1)})
     else:


### PR DESCRIPTION
If the dual argument to `interpolate` is a function space, we currently renumber `TestFunctions` inside the primal expression into `TrialFunctions`, which is confusing. We should remove this renumbering but since this is an API change we need to warn users. 

I have a https://github.com/FEniCS/ufl/pull/422 PR which adds some checks to `ufl.Interpolate`. Once this passes we can get rid of the junk inside the Firedrake `interpolate` factory function and have it just return an `Interpolate`.