### PR TITLE
Explicitly assemble the interpolate adjoint matrix

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -609,15 +609,6 @@ class BaseFormAssembler(AbstractFormAssembler):
             # Get the interpolator
             interp_data = expr.interp_data.copy()
             default_missing_val = interp_data.pop('default_missing_val', None)
-
-            target_mesh = V.mesh()
-            source_mesh = extract_unique_domain(operand) or target_mesh
-            if (source_mesh is target_mesh) and ((is_adjoint and rank == 1) or rank == 0):
-                # Adjoint interpolation of a Cofunction or the action of a
-                # Cofunction on an interpolated Function require INC access
-                # on the output tensor
-                interp_data["access"] = op2.INC
-
             if rank == 1 and isinstance(tensor, firedrake.Function):
                 V = tensor
             interpolator = firedrake.Interpolator(expr, V, **interp_data)

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -605,13 +605,6 @@ class BaseFormAssembler(AbstractFormAssembler):
                     assemble(sub_interp, tensor=tensor.subfunctions[i])
                 return tensor
 
-            # Workaround: Renumber argument when needed since Interpolator assumes it takes a zero-numbered argument.
-            if not is_adjoint and rank == 2:
-                v0, v1 = expr.arguments()
-                expr = ufl.replace(expr, {v0: v0.reconstruct(number=v1.number()),
-                                          v1: v1.reconstruct(number=v0.number())})
-                v, operand = expr.argument_slots()
-
             # Matrix-free adjoint interpolation is only implemented by SameMeshInterpolator
             # so we need assemble the interpolator matrix if the meshes are different
             target_mesh = V.mesh()
@@ -653,7 +646,7 @@ class BaseFormAssembler(AbstractFormAssembler):
                 # Get the interpolation matrix
                 op2_mat = interpolator.callable()
                 petsc_mat = op2_mat.handle
-                if is_adjoint:
+                if is_adjoint and (source_mesh is not target_mesh):
                     # Out-of-place Hermitian transpose
                     petsc_mat.hermitianTranspose(out=res)
                 elif res:

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -567,12 +567,6 @@ class BaseFormAssembler(AbstractFormAssembler):
             if (v, operand) != expr.argument_slots():
                 expr = reconstruct_interp(operand, v=v)
 
-            # Different assembly procedures:
-            # 1) Interpolate(Argument(V1, 1), Argument(V2.dual(), 0)) -> Jacobian (Interpolate matrix)
-            # 2) Interpolate(Coefficient(...), Argument(V2.dual(), 0)) -> Operator (or Jacobian action)
-            # 3) Interpolate(Argument(V1, 0), Argument(V2.dual(), 1)) -> Jacobian adjoint
-            # 4) Interpolate(Argument(V1, 0), Cofunction(...)) -> Action of the Jacobian adjoint
-            # This can be generalized to the case where the first slot is an arbitray expression.
             rank = len(expr.arguments())
             if rank > 2:
                 raise ValueError("Cannot assemble an Interpolate with more than two arguments")

--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -609,7 +609,7 @@ class BaseFormAssembler(AbstractFormAssembler):
             # so we need assemble the interpolator matrix if the meshes are different
             target_mesh = V.mesh()
             source_mesh = extract_unique_domain(operand) or target_mesh
-            if is_adjoint and rank < 2 and source_mesh is not target_mesh:
+            if is_adjoint and rank < 2 and (source_mesh is not target_mesh):
                 expr = reconstruct_interp(operand, v=V)
             matfree = (rank == len(expr.arguments())) and (rank < 2)
 

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -293,7 +293,12 @@ class Interpolator(abc.ABC):
         # CrossMeshInterpolator is not yet aware of self.ufl_interpolate (which carries the dual arguments).
         # Instead, we always construct the forward ufl_interpolate and externally operate on the adjoint and
         # supply the cofunctions within assemble().
-        if not isinstance(self, SameMeshInterpolator):
+        target_mesh = as_domain(V)
+        source_mesh = extract_unique_domain(operand) or target_mesh
+        vom_onto_other_vom = ((source_mesh is not target_mesh)
+                              and isinstance(source_mesh.topology, VertexOnlyMeshTopology)
+                              and isinstance(target_mesh.topology, VertexOnlyMeshTopology))
+        if not isinstance(self, SameMeshInterpolator) or vom_onto_other_vom:
             if not isinstance(dual_arg, ufl.Coargument):
                 expr = expr._ufl_expr_reconstruct_(operand, dual_arg.function_space().dual())
             expr_args = extract_arguments(operand)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -290,19 +290,31 @@ class Interpolator(abc.ABC):
         self.matfree = matfree
         self.callable = None
 
-        # CrossMeshInterpolator is not yet aware of self.ufl_interpolate (which carries the dual arguments).
-        # Instead, we always construct the forward ufl_interpolate and externally operate on the adjoint and
-        # supply the cofunctions within assemble().
+        # TODO CrossMeshInterpolator and VomOntoVomXXX are not yet aware of
+        # self.ufl_interpolate (which carries the dual argument).
         target_mesh = as_domain(V)
         source_mesh = extract_unique_domain(operand) or target_mesh
         vom_onto_other_vom = ((source_mesh is not target_mesh)
                               and isinstance(source_mesh.topology, VertexOnlyMeshTopology)
                               and isinstance(target_mesh.topology, VertexOnlyMeshTopology))
         if not isinstance(self, SameMeshInterpolator) or vom_onto_other_vom:
+            # For bespoke interpolation, we currently rely on different assembly procedures:
+            # 1) Interpolate(Argument(V1, 1), Argument(V2.dual(), 0)) -> Forward operator (2-form)
+            # 2) Interpolate(Argument(V1, 0), Argument(V2.dual(), 1)) -> Adjoint operator (2-form)
+            # 3) Interpolate(Coefficient(V1), Argument(V2.dual(), 0)) -> Forward action (1-form)
+            # 4) Interpolate(Argument(V1, 0), Cofunction(V2.dual()) -> Adjoint action (1-form)
+            # 5) Interpolate(Coefficient(V1), Cofunction(V2.dual()) -> Double action (0-form)
+
+            # CrossMeshInterpolator._interpolate only supports forward interpolation (cases 1 and 3).
+            # For case 2, we first redundantly assemble case 1 and then construct the transpose.
+            # For cases 4 and 5, we take the forward Interpolate that corresponds to dropping the Cofunction,
+            # and we separately compute the action againt the dropped Cofunction within assemble().
             if not isinstance(dual_arg, ufl.Coargument):
+                # Drop the Cofunction
                 expr = expr._ufl_expr_reconstruct_(operand, dual_arg.function_space().dual())
             expr_args = extract_arguments(operand)
             if expr_args and expr_args[0].number() == 0:
+                # Construct the symbolic forward Interpolate
                 v0, v1 = expr.arguments()
                 expr = ufl.replace(expr, {v0: v0.reconstruct(number=v1.number()),
                                           v1: v1.reconstruct(number=v0.number())})
@@ -339,7 +351,7 @@ class Interpolator(abc.ABC):
     def assemble(self, tensor=None, default_missing_val=None):
         """Assemble the operator (or its action)."""
         from firedrake.assemble import assemble
-        renumbered = self.ufl_interpolate_renumbered != self.ufl_interpolate
+        needs_adjoint = self.ufl_interpolate_renumbered != self.ufl_interpolate
         arguments = self.ufl_interpolate.arguments()
         if len(arguments) == 2:
             # Assembling the operator
@@ -347,7 +359,7 @@ class Interpolator(abc.ABC):
             # Get the interpolation matrix
             op2mat = self.callable()
             petsc_mat = op2mat.handle
-            if renumbered:
+            if needs_adjoint:
                 # Out-of-place Hermitian transpose
                 petsc_mat.hermitianTranspose(out=res)
             elif res:
@@ -360,18 +372,18 @@ class Interpolator(abc.ABC):
         else:
             # Assembling the action
             cofunctions = ()
-            if renumbered:
+            if needs_adjoint:
                 # The renumbered Interpolate has dropped Cofunctions.
                 # We need to explicitly operate on them.
                 dual_arg, _ = self.ufl_interpolate.argument_slots()
                 if not isinstance(dual_arg, ufl.Coargument):
                     cofunctions = (dual_arg,)
 
-            if renumbered and len(arguments) == 0:
+            if needs_adjoint and len(arguments) == 0:
                 Iu = self._interpolate(default_missing_val=default_missing_val)
                 return assemble(ufl.Action(*cofunctions, Iu), tensor=tensor)
             else:
-                return self._interpolate(*cofunctions, output=tensor, adjoint=renumbered,
+                return self._interpolate(*cofunctions, output=tensor, adjoint=needs_adjoint,
                                          default_missing_val=default_missing_val)
 
 
@@ -847,11 +859,9 @@ def make_interpolator(expr, V, subset, access, bcs=None, matfree=True):
     dual_arg, operand = expr.argument_slots()
     target_mesh = as_domain(dual_arg)
     source_mesh = extract_unique_domain(operand) or target_mesh
-    vom_onto_other_vom = (
-        isinstance(target_mesh.topology, VertexOnlyMeshTopology)
-        and isinstance(source_mesh.topology, VertexOnlyMeshTopology)
-        and target_mesh is not source_mesh
-    )
+    vom_onto_other_vom = ((source_mesh is not target_mesh)
+                          and isinstance(source_mesh.topology, VertexOnlyMeshTopology)
+                          and isinstance(target_mesh.topology, VertexOnlyMeshTopology))
 
     arguments = expr.arguments()
     rank = len(arguments)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -462,8 +462,6 @@ class CrossMeshInterpolator(Interpolator):
             # Probably just need to pass freeze_expr to the various
             # interpolators for this to work.
             raise NotImplementedError("freeze_expr not implemented")
-        if access != op2.WRITE:
-            raise NotImplementedError("access other than op2.WRITE not implemented")
         if bcs:
             raise NotImplementedError("bcs not implemented")
         if V.ufl_element().mapping() != "identity":
@@ -475,6 +473,9 @@ class CrossMeshInterpolator(Interpolator):
                 "Can only interpolate into spaces with point evaluation nodes."
             )
         super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs, matfree)
+
+        if self.access != op2.WRITE:
+            raise NotImplementedError("access other than op2.WRITE not implemented")
 
         expr = self.expr_renumbered
         self.arguments = extract_arguments(expr)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -576,7 +576,6 @@ class CrossMeshInterpolator(Interpolator):
             raise ValueError(
                 "Can currently only apply adjoint interpolation with arguments."
             )
-
         if self.nargs != len(function):
             raise ValueError(
                 "Passed %d Functions to interpolate, expected %d"

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1185,7 +1185,11 @@ def _interpolator(V, tensor, expr, subset, arguments, access, bcs=None):
 
 
 def get_interp_node_map(source_mesh, target_mesh, fs):
-    """Return the cell-to-node map required by a parloop on the target_mesh.cell_set."""
+    """Return the map between cells of the target mesh and nodes of the function space. 
+    
+    If the function space is defined on the source mesh then the node map is composed 
+    with a map between target and source cells.
+    """
     if isinstance(target_mesh.topology, VertexOnlyMeshTopology):
         coeff_mesh = fs.mesh()
         m_ = fs.cell_node_map()

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -292,6 +292,7 @@ class Interpolator(abc.ABC):
 
         # TODO CrossMeshInterpolator and VomOntoVomXXX are not yet aware of
         # self.ufl_interpolate (which carries the dual argument).
+        # See github issue https://github.com/firedrakeproject/firedrake/issues/4592
         target_mesh = as_domain(V)
         source_mesh = extract_unique_domain(operand) or target_mesh
         vom_onto_other_vom = ((source_mesh is not target_mesh)

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -308,7 +308,7 @@ class Interpolator(abc.ABC):
             # CrossMeshInterpolator._interpolate only supports forward interpolation (cases 1 and 3).
             # For case 2, we first redundantly assemble case 1 and then construct the transpose.
             # For cases 4 and 5, we take the forward Interpolate that corresponds to dropping the Cofunction,
-            # and we separately compute the action againt the dropped Cofunction within assemble().
+            # and we separately compute the action against the dropped Cofunction within assemble().
             if not isinstance(dual_arg, ufl.Coargument):
                 # Drop the Cofunction
                 expr = expr._ufl_expr_reconstruct_(operand, dual_arg.function_space().dual())

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import abc
 import warnings
+from collections.abc import Iterable
+from typing import Literal
 from functools import partial, singledispatch
 from typing import Hashable
 
@@ -23,6 +25,7 @@ import gem
 import finat
 
 import firedrake
+import firedrake.bcs
 from firedrake import tsfc_interface, utils, functionspaceimpl
 from firedrake.ufl_expr import Argument, Coargument, action, adjoint as expr_adjoint
 from firedrake.mesh import MissingPointsBehaviour, VertexOnlyMeshMissingPointsError, VertexOnlyMeshTopology
@@ -47,7 +50,7 @@ class Interpolate(ufl.Interpolate):
 
     def __init__(self, expr, v,
                  subset=None,
-                 access=op2.WRITE,
+                 access=None,
                  allow_missing_dofs=False,
                  default_missing_val=None,
                  matfree=True):
@@ -122,7 +125,7 @@ class Interpolate(ufl.Interpolate):
 
 
 @PETSc.Log.EventDecorator()
-def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False, default_missing_val=None, matfree=True):
+def interpolate(expr, V, subset=None, access=None, allow_missing_dofs=False, default_missing_val=None, matfree=True):
     """Returns a UFL expression for the interpolation operation of ``expr`` into ``V``.
 
     :arg expr: a UFL expression.
@@ -202,25 +205,34 @@ def interpolate(expr, V, subset=None, access=op2.WRITE, allow_missing_dofs=False
 class Interpolator(abc.ABC):
     """A reusable interpolation object.
 
-    :arg expr: The expression to interpolate.
-    :arg V: The :class:`.FunctionSpace` or :class:`.Function` to
+    Parameters
+    ----------
+    expr
+        The underlying ufl.Interpolate or the operand to the ufl.Interpolate.
+    V
+        The :class:`.FunctionSpace` or :class:`.Function` to
         interpolate into.
-    :kwarg subset: An optional :class:`pyop2.types.set.Subset` to apply the
+    subset
+        An optional :class:`pyop2.types.set.Subset` to apply the
         interpolation over. Cannot, at present, be used when interpolating
         across meshes unless the target mesh is a :func:`.VertexOnlyMesh`.
-    :kwarg freeze_expr: Set to True to prevent the expression being
+    freeze_expr
+        Set to True to prevent the expression being
         re-evaluated on each call. Cannot, at present, be used when
         interpolating across meshes unless the target mesh is a
         :func:`.VertexOnlyMesh`.
-    :kwarg access: The pyop2 access descriptor for combining updates to shared
-        DoFs. Possible values include ``WRITE`` and ``INC``. Only ``WRITE`` is
-        supported at present when interpolating across meshes. See note in
-        :func:`.interpolate` if changing this from default.
-    :kwarg bcs: An optional list of boundary conditions to zero-out in the
+    access
+        The pyop2 access descriptor for combining updates to shared DoFs.
+        Only ``op2.WRITE`` is supported at present when interpolating across meshes.
+        Only ``op2.INC`` is supported for the matrix-free adjoint interpolation.
+        See note in :func:`.interpolate` if changing this from default.
+    bcs
+        An optional list of boundary conditions to zero-out in the
         output function space. Interpolator rows or columns which are
         associated with boundary condition nodes are zeroed out when this is
         specified.
-    :kwarg allow_missing_dofs: For interpolation across meshes: allow
+    allow_missing_dofs
+        For interpolation across meshes: allow
         degrees of freedom (aka DoFs/nodes) in the target mesh that cannot be
         defined on the source mesh. For example, where nodes are point
         evaluations, points in the target mesh that are not in the source mesh.
@@ -232,14 +244,16 @@ class Interpolator(abc.ABC):
         Ignored if interpolating within the same mesh or onto a
         :func:`.VertexOnlyMesh` (the behaviour of a :func:`.VertexOnlyMesh` in
         this scenario is, at present, set when it is created).
-    :kwarg matfree: If ``False``, then construct the permutation matrix for interpolating
+    matfree
+        If ``False``, then construct the permutation matrix for interpolating
         between a VOM and its input ordering. Defaults to ``True`` which uses SF broadcast
         and reduce operations.
 
     This object can be used to carry out the same interpolation
     multiple times (for example in a timestepping loop).
 
-    .. note::
+    Note
+    ----
 
        The :class:`Interpolator` holds a reference to the provided
        arguments (such that they won't be collected until the
@@ -266,14 +280,14 @@ class Interpolator(abc.ABC):
 
     def __init__(
         self,
-        expr,
-        V,
-        subset=None,
-        freeze_expr=False,
-        access=op2.WRITE,
-        bcs=None,
-        allow_missing_dofs=False,
-        matfree=True
+        expr: ufl.Interpolate | ufl.classes.Expr,
+        V: ufl.FunctionSpace | firedrake.function.Function,
+        subset: op2.Subset | None = None,
+        freeze_expr: bool = False,
+        access: Literal[op2.WRITE, op2.MIN, op2.MAX, op2.INC] | None = None,
+        bcs: Iterable[firedrake.bcs.BCBase] | None = None,
+        allow_missing_dofs: bool = False,
+        matfree: bool = True
     ):
         if not isinstance(expr, ufl.Interpolate):
             fs = V if isinstance(V, ufl.FunctionSpace) else V.function_space()
@@ -284,7 +298,6 @@ class Interpolator(abc.ABC):
         self.V = V
         self.subset = subset
         self.freeze_expr = freeze_expr
-        self.access = access
         self.bcs = bcs
         self._allow_missing_dofs = allow_missing_dofs
         self.matfree = matfree
@@ -323,9 +336,16 @@ class Interpolator(abc.ABC):
         dual_arg, operand = expr.argument_slots()
         self.expr_renumbered = operand
         self.ufl_interpolate_renumbered = expr
+
         if not isinstance(dual_arg, ufl.Coargument):
             # Matrix-free assembly of 0-form or 1-form requires INC access
-            self.access = op2.INC
+            if access and access != op2.INC:
+                raise ValueError("Matfree adjoint interpolation requires INC access")
+            access = op2.INC
+        elif access is None:
+            # Default access for forward 1-form or 2-form (forward and adjoint)
+            access = op2.WRITE
+        self.access = access
 
     def interpolate(self, *function, transpose=None, adjoint=False, default_missing_val=None):
         """
@@ -431,7 +451,7 @@ class CrossMeshInterpolator(Interpolator):
         V,
         subset=None,
         freeze_expr=False,
-        access=op2.WRITE,
+        access=None,
         bcs=None,
         allow_missing_dofs=False,
         matfree=True
@@ -755,7 +775,7 @@ class SameMeshInterpolator(Interpolator):
     """
 
     @no_annotations
-    def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE,
+    def __init__(self, expr, V, subset=None, freeze_expr=False, access=None,
                  bcs=None, matfree=True, allow_missing_dofs=False, **kwargs):
         if subset is None:
             if isinstance(expr, ufl.Interpolate):
@@ -1186,9 +1206,9 @@ def _interpolator(V, tensor, expr, subset, arguments, access, bcs=None):
 
 
 def get_interp_node_map(source_mesh, target_mesh, fs):
-    """Return the map between cells of the target mesh and nodes of the function space. 
-    
-    If the function space is defined on the source mesh then the node map is composed 
+    """Return the map between cells of the target mesh and nodes of the function space.
+
+    If the function space is defined on the source mesh then the node map is composed
     with a map between target and source cells.
     """
     if isinstance(target_mesh.topology, VertexOnlyMeshTopology):

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -277,8 +277,9 @@ class Interpolator(abc.ABC):
     ):
         if not isinstance(expr, ufl.Interpolate):
             fs = V if isinstance(V, ufl.FunctionSpace) else V.function_space()
-            expr = firedrake.Interpolate(expr, fs)
-        operand, = expr.ufl_operands
+            expr = Interpolate(expr, fs)
+        dual_arg, operand = expr.argument_slots()
+        self.ufl_interpolate = expr
         self.expr = operand
         self.V = V
         self.subset = subset
@@ -288,18 +289,20 @@ class Interpolator(abc.ABC):
         self._allow_missing_dofs = allow_missing_dofs
         self.matfree = matfree
         self.callable = None
-        # Workaround for matrix-explicit adjoint of cross-mesh interpolation
-        # Return instead the forward operator
+        # Workaround for adjoint of cross-mesh interpolation
+        # Assemble the forward operator and then take its adjoint
         target_mesh = as_domain(V)
         source_mesh = extract_unique_domain(operand) or target_mesh
-        if len(expr.arguments()) == 2 and (target_mesh is not source_mesh):
+        if target_mesh is not source_mesh:
+            if not isinstance(dual_arg, ufl.Coargument):
+                expr = expr._ufl_expr_reconstruct_(operand, dual_arg.function_space().dual())
             expr_args = extract_arguments(operand)
             if expr_args and expr_args[0].number() == 0:
                 v0, v1 = expr.arguments()
                 expr = ufl.replace(expr, {v0: v0.reconstruct(number=v1.number()),
                                           v1: v1.reconstruct(number=v0.number())})
         self.expr_renumbered, = expr.ufl_operands
-        self.ufl_interpolate = expr
+        self.ufl_interpolate_renumbered = expr
 
     def interpolate(self, *function, transpose=None, adjoint=False, default_missing_val=None):
         """
@@ -322,6 +325,42 @@ class Interpolator(abc.ABC):
             This method is called when an :class:`Interpolate` object is being assembled.
         """
         pass
+
+    def assemble(self, tensor=None, default_missing_val=None):
+        """Assemble the operator (or its action)."""
+        from firedrake.assemble import assemble
+        renumbered = self.ufl_interpolate_renumbered != self.ufl_interpolate
+        arguments = self.ufl_interpolate.arguments()
+        if len(arguments) == 2:
+            # Assembling the operator
+            res = tensor.petscmat if tensor else PETSc.Mat()
+            # Get the interpolation matrix
+            op2mat = self.callable()
+            petsc_mat = op2mat.handle
+            if renumbered:
+                # Out-of-place Hermitian transpose
+                petsc_mat.hermitianTranspose(out=res)
+            elif res:
+                petsc_mat.copy(res)
+            else:
+                res = petsc_mat
+            if tensor is None:
+                tensor = firedrake.AssembledMatrix(arguments, self.bcs, res)
+            return tensor
+        else:
+            # Assembling the action
+            missing_args = ()
+            if renumbered:
+                dual_arg, _ = self.ufl_interpolate.argument_slots()
+                if not isinstance(dual_arg, ufl.Coargument):
+                    missing_args = (dual_arg,)
+
+            if renumbered and len(arguments) == 0:
+                Iu = self._interpolate(default_missing_val=default_missing_val)
+                return assemble(ufl.Action(*missing_args, Iu), tensor=tensor)
+            else:
+                return self._interpolate(*missing_args, output=tensor, adjoint=renumbered,
+                                         default_missing_val=default_missing_val)
 
 
 class DofNotDefinedError(Exception):
@@ -390,10 +429,6 @@ class CrossMeshInterpolator(Interpolator):
             raise NotImplementedError(
                 "Can only interpolate into spaces with point evaluation nodes."
             )
-        if isinstance(expr, ufl.Interpolate):
-            dual_arg, operand = expr.argument_slots()
-            if not isinstance(dual_arg, ufl.Coargument):
-                raise NotImplementedError(f"{type(self).__name__} does not support matrix-free adjoint action.")
         super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs, matfree)
 
         expr = self.expr_renumbered
@@ -541,6 +576,7 @@ class CrossMeshInterpolator(Interpolator):
             raise ValueError(
                 "Can currently only apply adjoint interpolation with arguments."
             )
+
         if self.nargs != len(function):
             raise ValueError(
                 "Passed %d Functions to interpolate, expected %d"
@@ -722,7 +758,7 @@ class SameMeshInterpolator(Interpolator):
                     pass
         super().__init__(expr, V, subset=subset, freeze_expr=freeze_expr,
                          access=access, bcs=bcs, matfree=matfree, allow_missing_dofs=allow_missing_dofs)
-        expr = self.ufl_interpolate
+        expr = self.ufl_interpolate_renumbered
         try:
             self.callable = make_interpolator(expr, V, subset, access, bcs=bcs, matfree=matfree)
         except FIAT.hdiv_trace.TraceError:
@@ -798,7 +834,6 @@ def make_interpolator(expr, V, subset, access, bcs=None, matfree=True):
     if not isinstance(expr, ufl.Interpolate):
         raise ValueError(f"Expecting to interpolate a ufl.Interpolate, got {type(expr).__name__}.")
     dual_arg, operand = expr.argument_slots()
-
     target_mesh = as_domain(dual_arg)
     source_mesh = extract_unique_domain(operand) or target_mesh
     vom_onto_other_vom = (

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -288,19 +288,18 @@ class Interpolator(abc.ABC):
         self._allow_missing_dofs = allow_missing_dofs
         self.matfree = matfree
         self.callable = None
-        # Cope with the different convention of `Interpolate` and `Interpolator`:
-        #  -> Interpolate(Argument(V1, 1), Argument(V2.dual(), 0))
-        #  -> Interpolator(Argument(V1, 0), V2)
+        # Workaround for matrix-explicit adjoint of cross-mesh interpolation
+        # Return instead the forward operator
         target_mesh = as_domain(V)
         source_mesh = extract_unique_domain(operand) or target_mesh
-        if len(expr.arguments()) == 2 and target_mesh is not source_mesh:
+        if len(expr.arguments()) == 2 and (target_mesh is not source_mesh):
             expr_args = extract_arguments(operand)
             if expr_args and expr_args[0].number() == 0:
                 v0, v1 = expr.arguments()
                 expr = ufl.replace(expr, {v0: v0.reconstruct(number=v1.number()),
                                           v1: v1.reconstruct(number=v0.number())})
         self.expr_renumbered, = expr.ufl_operands
-        self.interpolate = expr
+        self.ufl_interpolate = expr
 
     def interpolate(self, *function, transpose=None, adjoint=False, default_missing_val=None):
         """
@@ -391,16 +390,14 @@ class CrossMeshInterpolator(Interpolator):
             raise NotImplementedError(
                 "Can only interpolate into spaces with point evaluation nodes."
             )
-        if not isinstance(expr, ufl.Interpolate):
-            fs = V if isinstance(V, ufl.FunctionSpace) else V.function_space()
-            expr = Interpolate(expr, fs)
-        dual_arg, expr = expr.argument_slots()
-        if not isinstance(dual_arg, Coargument):
-            raise NotImplementedError(f"{type(self).__name__} does not support matrix-free adjoint interpolation.")
-
+        if isinstance(expr, ufl.Interpolate):
+            dual_arg, operand = expr.argument_slots()
+            if not isinstance(dual_arg, ufl.Coargument):
+                raise NotImplementedError(f"{type(self).__name__} does not support matrix-free adjoint action.")
         super().__init__(expr, V, subset, freeze_expr, access, bcs, allow_missing_dofs, matfree)
 
-        self.arguments = extract_arguments(self.expr_renumbered)
+        expr = self.expr_renumbered
+        self.arguments = extract_arguments(expr)
         self.nargs = len(self.arguments)
 
         if self._allow_missing_dofs:
@@ -700,11 +697,11 @@ class SameMeshInterpolator(Interpolator):
     @no_annotations
     def __init__(self, expr, V, subset=None, freeze_expr=False, access=op2.WRITE,
                  bcs=None, matfree=True, allow_missing_dofs=False, **kwargs):
-        if not isinstance(expr, ufl.Interpolate):
-            fs = V if isinstance(V, ufl.FunctionSpace) else V.function_space()
-            expr = Interpolate(expr, fs)
         if subset is None:
-            operand, = expr.ufl_operands
+            if isinstance(expr, ufl.Interpolate):
+                operand, = expr.ufl_operands
+            else:
+                operand = expr
             target_mesh = as_domain(V)
             source_mesh = extract_unique_domain(operand) or target_mesh
             target = target_mesh.topology
@@ -725,7 +722,7 @@ class SameMeshInterpolator(Interpolator):
                     pass
         super().__init__(expr, V, subset=subset, freeze_expr=freeze_expr,
                          access=access, bcs=bcs, matfree=matfree, allow_missing_dofs=allow_missing_dofs)
-        expr = self.interpolate
+        expr = self.ufl_interpolate
         try:
             self.callable = make_interpolator(expr, V, subset, access, bcs=bcs, matfree=matfree)
         except FIAT.hdiv_trace.TraceError:

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -202,7 +202,7 @@ class HiptmairPC(TwoLevelPC):
 
         coarse_space_bcs = tuple(coarse_space_bcs)
         if G_callback is None:
-            interp_petscmat = chop(Interpolator(dminus(test), V, bcs=bcs + coarse_space_bcs).callable().handle)
+            interp_petscmat = chop(Interpolator(dminus(trial), V, bcs=bcs + coarse_space_bcs).callable().handle)
         else:
             interp_petscmat = G_callback(coarse_space, V, coarse_space_bcs, bcs)
 

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -1457,7 +1457,7 @@ class StandaloneInterpolationMatrix(object):
         except KeyError:
             pass
         prolong_kernel, _ = prolongation_transfer_kernel_action(Vf, self.uc)
-        matrix_kernel, coefficients = prolongation_transfer_kernel_action(Vf, firedrake.TestFunction(Vc))
+        matrix_kernel, coefficients = prolongation_transfer_kernel_action(Vf, firedrake.TrialFunction(Vc))
 
         # The way we transpose the prolongation kernel is suboptimal.
         # A local matrix is generated each time the kernel is executed.
@@ -1593,7 +1593,7 @@ def prolongation_matrix_aij(P1, Pk, P1_bcs=[], Pk_bcs=[]):
                          for bc in chain(Pk_bcs_i, P1_bcs_i) if bc is not None)
             matarg = mat[i, i](op2.WRITE, (Pk.sub(i).cell_node_map(), P1.sub(i).cell_node_map()),
                                lgmaps=((rlgmap, clgmap), ), unroll_map=unroll)
-            expr = firedrake.TestFunction(P1.sub(i))
+            expr = firedrake.TrialFunction(P1.sub(i))
             kernel, coefficients = prolongation_transfer_kernel_action(Pk.sub(i), expr)
             parloop_args = [kernel, mesh.cell_set, matarg]
             for coefficient in coefficients:
@@ -1610,7 +1610,7 @@ def prolongation_matrix_aij(P1, Pk, P1_bcs=[], Pk_bcs=[]):
                      for bc in chain(Pk_bcs, P1_bcs) if bc is not None)
         matarg = mat(op2.WRITE, (Pk.cell_node_map(), P1.cell_node_map()),
                      lgmaps=((rlgmap, clgmap), ), unroll_map=unroll)
-        expr = firedrake.TestFunction(P1)
+        expr = firedrake.TrialFunction(P1)
         kernel, coefficients = prolongation_transfer_kernel_action(Pk, expr)
         parloop_args = [kernel, mesh.cell_set, matarg]
         for coefficient in coefficients:

--- a/tests/firedrake/regression/test_interp_dual.py
+++ b/tests/firedrake/regression/test_interp_dual.py
@@ -106,7 +106,11 @@ def test_assemble_interp_adjoint_matrix(V1, V2):
     # Interpolation from V2* to V1*
     c1 = Cofunction(V1.dual()).interpolate(c2)
     # Interpolation matrix (V2* -> V1*)
-    a = assemble(adjoint(Iv1))
+    adj_Iv1 = adjoint(Iv1)
+    a = assemble(adj_Iv1)
+    assert a.arguments() == adj_Iv1.arguments()
+    assert a.petscmat.getSize() == (V1.dim(), V2.dim())
+
     res = Cofunction(V1.dual())
     with c2.dat.vec_ro as x, res.dat.vec_ro as y:
         a.petscmat.mult(x, y)

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -1,7 +1,6 @@
 import pytest
 from firedrake import *
 import numpy as np
-from mpi4py import MPI
 from ufl.conditional import GT, LT
 from os.path import abspath, dirname, join
 
@@ -328,12 +327,11 @@ def test_submesh_interpolate_adjoint(fe_fesub):
 
     expected_primal = assemble(action(I, u1))
     test1 = np.allclose(Iu1.dat.data, expected_primal.dat.data)
-    test1 = V2.comm.allreduce(test1, MPI.LAND)
-    assert test1 == expected_to_pass
+    assert test1 or not expected_to_pass
 
     result_forward_1 = assemble(action(ustar2, Iu1))
     test0 = np.isclose(result_forward_1, expected)
-    assert test0 == expected_to_pass
+    assert test0 or not expected_to_pass
 
     # Test adjoint 1-form
     ustar2I = assemble(interpolate(TestFunction(V1), ustar2, allow_missing_dofs=True))

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -224,6 +224,7 @@ def compile_expression_dual_evaluation(expression, to_element, ufl_element, *,
     # Apply UFL preprocessing
     operand = ufl_utils.preprocess_expression(operand, complex_mode=complex_mode)
 
+    # Reconstructed Interpolate with mapped operand
     expression = ufl.Interpolate(operand, v)
 
     # Initialise kernel builder


### PR DESCRIPTION
# Description
Enables code generation for all possible argument combinations in `Interpolate`: 

1. Forward 2-form: `Interpolate(Argument(1), Coargument(0))`
2. Adjoint 2-form: `Interpolate(Argument(0), Coargument(1)) `
3. Forward 1-form: `Interpolate({Functoin | Expr}, Coargument(0))`
4. Adjoint 1-form: `Interpolate(Argument(0), Cofunction) `
5. 0-form: `Interpolate({Function | Expr}, Cofunction)`

Previously we indirectly obtained 2 and 4 from the transpose of 1, and 5 via a dot product involving 3. 

The big win is that code generation does not deal with these 5 cases as special cases, and we always do matrix-free computations (unless a 2-form is explicitly requested).

Depends on https://github.com/firedrakeproject/firedrake/pull/4552 which mainly addresses 4 and 5.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
