### PR TITLE
Add `petsctools` to `build-system.requires` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ requires = [
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
   "numpy",
+  "petsctools",
   "pkgconfig",
   "pybind11",
   "setuptools>=77.0.3",


### PR DESCRIPTION
Seems to me that `petsctools` should be listed as a requirement for the build system, because `setup.py` is importing it.