### PR TITLE
Include ROL in optimisation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "petsctools",
   "pkgconfig",
   "progress",
-  "pyadjoint-ad>=2025.10.0",
+  "pyadjoint-ad @ git+https://github.com/dolfin-adjoint/pyadjoint.git@master",
   "pycparser",
   "pytools[siphash]",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ci = [
   "pdf2image",
   "pygraphviz",
   "pylit",
+  "pyroltrilinos",
   "pytest",
   "pytest-split",  # needed for firedrake-run-split-tests
   "pytest-timeout",


### PR DESCRIPTION
# Description

Install ROL through `pyroltrilinos` into the `ci` dependency set, and add to some of the parameterised optimisation tests. Requires https://github.com/dolfin-adjoint/pyadjoint/pull/223.

In the default configurations, TAO's NLS does very well compared to a default Lin-More trust region in ROL. Very likely these tests should use a line search in ROL, I just need to figure out what the parameters are actually called... Even though the tests (seem to) pass, the optimisation doesn't actually converge to the specified tolerance!