### PR TITLE
Redo release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,73 @@
 name: Publish release
 
 on:
-  release:
-    types: [released]
+  workflow_call:
+    inputs:
+      branch:
+        description: The branch to release from
+        type: string
+        required: true
+      version:
+        description: The version number to release
+        type: string
+        required: true
 
 jobs:
-  deploy:
+  check:
+    name: Pre-release checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: firedrake-repo
+          ref: ${{ inputs.branch }}
+
+      - name: Check no 'TODO RELEASE' comments remain
+        working-directory: firedrake-repo
+        run: |
+          if [ -z "$( grep -r --exclude-dir='.*' 'TODO RELEASE' )" ]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+      - name: Check version number matches
+        working-directory: firedrake-repo
+        run: |
+          if [ -z $( grep "version = \"${{ inputs.version }}\"" pyproject.toml ) ]; then
+            exit 1
+          else
+            exit 0
+          fi
+
+  pypi:
     uses: ./.github/workflows/core.yml
+    needs: check
     with:
-      source_ref: release
+      source_ref: ${{ inputs.branch }}
       target_branch: release
       run_tests: false
       upload_pypi: true
     secrets: inherit
 
+  github_release:
+    name: Create GitHub release
+    needs: pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ inputs.version }} --title ${{ inputs.version }} --generate-notes
+
   docker:
     name: Build Docker containers
     uses: ./.github/workflows/docker.yml
+    needs: pypi
     with:
-      tag: ${{ github.ref_name }}
-      branch: ${{ github.ref_name }}
+      tag: ${{ inputs.version }}
+      branch: ${{ inputs.branch }}
       build_dev: false
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
           fi
 
   pypi:
+    # UNDO ME
+    if: false
     uses: ./.github/workflows/core.yml
     needs: check
     with:
@@ -51,6 +53,8 @@ jobs:
     secrets: inherit
 
   github_release:
+    # UNDO ME
+    if: false
     name: Create GitHub release
     needs: pypi
     runs-on: ubuntu-latest
@@ -63,11 +67,12 @@ jobs:
         run: gh release create ${{ inputs.version }} --title ${{ inputs.version }} --generate-notes
 
   docker:
+    # UNDO ME
+    if: false
     name: Build Docker containers
     uses: ./.github/workflows/docker.yml
     needs: pypi
     with:
       tag: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
-      build_dev: false
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "firedrake"
 # <year>.<month>.<patch>
-version = "2025.4.2"
+# TODO RELEASE: remove '.dev0'
+version = "2025.4.3.dev0"
 description = "An automated system for the portable solution of partial differential equations using the finite element method"
 readme = "README.rst"
 license = "LGPL-3.0-or-later"
@@ -20,7 +21,8 @@ dependencies = [
   "mpi4py>3; python_version >= '3.13'",
   "mpi4py; python_version < '3.13'",
   "fenics-ufl>=2025.1.0",
-  "firedrake-fiat>=2025.4.0",
+  # TODO RELEASE
+  "firedrake-fiat @ git+https://github.com/firedrakeproject/fiat.git@release",
   "h5py>3.12.1",
   "libsupermesh",
   "loopy>2024.1",


### PR DESCRIPTION
Summary of changes:
* Instead of making a release via the GUI triggering a PyPI publishing workflow the new approach is to trigger a workflow manually. That way we can do some safety checks before publishing.
* We now make releases from branches *off* `release`. This means that we can test the FIAT `release` branch against our own and also means that the version number in the `pyproject.toml` can have a `.dev0` suffix. This is useful because it means Python can distinguish between an install of the `release` branch and an actual release.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
