### PR TITLE
LinearEigensolver: default to eps_target = 0 is conceptually wrong

### DIFF
--- a/firedrake/eigensolver.py
+++ b/firedrake/eigensolver.py
@@ -142,9 +142,10 @@ class LinearEigensolver(OptionsManager):
         "eps_largest_real": None
     """
 
-    DEFAULT_EPS_PARAMETERS = {"eps_type": "krylovschur",
-                              "eps_tol": 1e-10,
-                              "eps_target": 0.0}
+    DEFAULT_EPS_PARAMETERS = {
+        "eps_type": "krylovschur",
+        "eps_tol": 1e-10,
+    }
 
     def __init__(self, problem, n_evals, *, options_prefix=None,
                  solver_parameters=None, ncv=None, mpd=None):
@@ -158,8 +159,6 @@ class LinearEigensolver(OptionsManager):
         for key in self.DEFAULT_EPS_PARAMETERS:
             value = self.DEFAULT_EPS_PARAMETERS[key]
             solver_parameters.setdefault(key, value)
-        if self._problem.bcs:
-            solver_parameters.setdefault("st_type", "sinvert")
         super().__init__(solver_parameters, options_prefix)
         self.set_from_options(self.es)
 


### PR DESCRIPTION
The presence of the option, together with the `sinvert` option for the `bcs` case, can lead to confusion.
I think it is better to be consistent with whatever SLEPc believes is the proper default
