### PR TITLE
Download MUMPS on Linux because PETSc now assumes a higher version

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -204,7 +204,6 @@ PETSC_EXTRAS_LINUX_APT_PACKAGES = (
     "libfftw3-mpi-dev",
     "libhwloc-dev",
     "libhdf5-mpi-dev",
-    "libmumps-ptscotch-dev",
     "libmetis-dev",
     "libnetcdf-dev",
     "libpnetcdf-dev",
@@ -317,8 +316,8 @@ PETSC_EXTERNAL_PACKAGE_SPECS = {
         MACOS_HOMEBREW_ARM64: "/opt/homebrew",
     },
     "mumps": {
-        LINUX_APT_X86_64: PETSC_AUTODETECT,
-        LINUX_APT_AARCH64: PETSC_AUTODETECT,
+        LINUX_APT_X86_64: PETSC_DOWNLOAD,
+        LINUX_APT_AARCH64: PETSC_DOWNLOAD,
         MACOS_HOMEBREW_ARM64: PETSC_DOWNLOAD,
     },
     "netcdf": {


### PR DESCRIPTION
[This PETSc PR](https://gitlab.com/petsc/petsc/-/merge_requests/8715) below increased the minimum acceptable MUMPS version, so the MUMPS 5.6 that is shipped with Ubuntu24.04 no longer works with PETSc main.

This PR swaps Firedrake to asking PETSc to download MUMPS instead so we get a recent enough version.