### PR TITLE
Test using apt MUMPS with petsc fix branch

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -156,7 +156,7 @@ jobs:
               --branch $(python3 ./firedrake-repo/scripts/firedrake-configure --show-petsc-version) \
               https://gitlab.com/petsc/petsc.git
           else
-            git clone --depth 1 --branch jczhang/2025-10-20/fix-mumps https://gitlab.com/petsc/petsc.git
+            git clone --depth 1 https://gitlab.com/petsc/petsc.git
           fi
           cd petsc
           python3 ../firedrake-repo/scripts/firedrake-configure \


### PR DESCRIPTION
Revert https://github.com/firedrakeproject/firedrake/pull/4661 because PETSc have removed the version requirement for MUMPS>=5.7 in this MR: https://gitlab.com/petsc/petsc/-/merge_requests/8801

Closes https://github.com/firedrakeproject/firedrake/issues/4662