### PR TITLE
Add additional transitive build dependency

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -13,3 +13,4 @@ rtree>=1.2
 # Transitive build dependencies
 hatchling
 meson-python
+scikit_build_core


### PR DESCRIPTION
This partially fixes the macOS runners (now they have 3.14). We are still waiting on VTK for another wheel. They are aware of the issue though so I anticipate a fix soon.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
