### PR TITLE
Fix firedrake-check: tweak locations for cell location tests

### DIFF
--- a/tests/firedrake/regression/test_locate_cell.py
+++ b/tests/firedrake/regression/test_locate_cell.py
@@ -25,13 +25,13 @@ def meshdata(request):
 
 @pytest.mark.parametrize(('point', 'value'),
                          [((0.2, 0.1), 1),
-                          ((0.5, 0.2), 2),
+                          ((0.4, 0.2), 2),
                           ((0.7, 0.1), 3),
                           ((0.2, 0.4), 4),
                           ((0.4, 0.4), 5),
-                          ((0.8, 0.5), 6),
+                          ((0.8, 0.6), 6),
                           ((0.1, 0.7), 7),
-                          ((0.5, 0.9), 8),
+                          ((0.6, 0.9), 8),
                           ((0.9, 0.8), 9)])
 def test_locate_cell(meshdata, point, value):
     m, f = meshdata


### PR DESCRIPTION
The previous approach had points at (0.5, y) or (x, 0.5) which lay exactly on the mesh tolerance of 0.5 and led to failures on some systems (not finding a second candidate cell). This was particularly problematic because these tests are used in firedrake-check.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
