### PR TITLE
Fix Hypre auxiliary spaces

### DIFF
--- a/firedrake/preconditioners/hypre_ads.py
+++ b/firedrake/preconditioners/hypre_ads.py
@@ -46,6 +46,7 @@ class HypreADS(PCBase):
             try:
                 G = chop(assemble(interpolate(grad(TrialFunction(P1)), NC1)).petscmat)
             except NotImplementedError:
+                # dual evaluation not yet implemented see https://github.com/firedrakeproject/fiat/issues/109
                 G = tabulate_exterior_derivative(P1, NC1)
         else:
             G = G_callback(P1, NC1)

--- a/firedrake/preconditioners/hypre_ams.py
+++ b/firedrake/preconditioners/hypre_ams.py
@@ -62,6 +62,7 @@ class HypreAMS(PCBase):
             try:
                 G = chop(assemble(interpolate(grad(TrialFunction(P1)), V)).petscmat)
             except NotImplementedError:
+                # dual evaluation not yet implemented see https://github.com/firedrakeproject/fiat/issues/109
                 G = tabulate_exterior_derivative(P1, V)
         else:
             G = G_callback(P1, V)

--- a/tests/firedrake/regression/test_hypre_ads.py
+++ b/tests/firedrake/regression/test_hypre_ads.py
@@ -30,6 +30,7 @@ def test_homogeneous_field(V, mat_type, interface):
     bc = DirichletBC(V, u_exact, (1, 2, 3, 4))
 
     params = {
+        'snes_type': 'ksponly',
         'mat_type': mat_type,
         'pmat_type': 'aij',
         'ksp_type': 'cg',

--- a/tests/firedrake/regression/test_hypre_ams.py
+++ b/tests/firedrake/regression/test_hypre_ams.py
@@ -35,6 +35,7 @@ def test_homogeneous_field(V, mat_type, interface):
     bc = DirichletBC(V, constant_field, (1, 2, 3, 4))
 
     params = {
+        'snes_type': 'ksponly',
         'mat_type': mat_type,
         'pmat_type': 'aij',
         'ksp_type': 'cg',


### PR DESCRIPTION
# Description
Fixes Hypre on hexes by constructing the auxiliary element from scratch instead of reconstructing TensorProductElements and passing a family to the factor elements.

Adds tests on hexes

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
