### PR TITLE
Use `PETSc.ScalarType(0)` in `Function.zero`

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -168,7 +168,7 @@ class Cofunction(ufl.Cofunction, CofunctionMixin):
         firedrake.cofunction.Cofunction
             Returns `self`
         """
-        return self.assign(ScalarType(0), subset=subset)
+        return self.assign(PETSc.ScalarType(0), subset=subset)
 
     @PETSc.Log.EventDecorator()
     @utils.known_pyop2_safe

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -403,7 +403,7 @@ class Function(ufl.Coefficient, FunctionMixin):
         """
         # Use assign here so we can reuse _ad_annotate_assign instead of needing
         # to write an _ad_annotate_zero function
-        return self.assign(ScalarType(0), subset=subset)
+        return self.assign(PETSc.ScalarType(0), subset=subset)
 
     @PETSc.Log.EventDecorator()
     @FunctionMixin._ad_annotate_assign


### PR DESCRIPTION
When the tape is re-run it will complain if you use `Function.assign(0)` because it doesn't know how to handle an `int`. In reality it just converts it to a float and everything is fine, but we're raising unnecessary warnings whenever someone uses `Function.zero` while taping.