### PR TITLE
default firedrake options prefix for petsctools

### DIFF
--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -274,7 +274,8 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                                                        problem.J.arguments(),
                                                        ksp_defaults=self.DEFAULT_KSP_PARAMETERS,
                                                        snes_defaults=self.DEFAULT_SNES_PARAMETERS)
-        super().__init__(solver_parameters, options_prefix)
+        super().__init__(solver_parameters, options_prefix,
+                         default_prefix="firedrake")
         # Now the correct parameters live in self.parameters (via the
         # OptionsManager mixin)
         mat_type = self.parameters.get("mat_type")


### PR DESCRIPTION
**Depends on a new `petsctools` release!**

Cherry-pick of #4699 into release.