### PR TITLE
Comment out dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,14 +91,14 @@ docs = [
 jax = [
   "jax",
 ]
-netgen = [
-  # TODO RELEASE
-  # "ngsPETSc>=0.1.1",
-]
-slepc = [
-  # TODO RELEASE
-  # "slepc4py==3.24.0",
-]
+# TODO RELEASE
+# netgen = [
+#   "ngsPETSc>=0.1.1",
+# ]
+# TODO RELEASE
+# slepc = [
+#   "slepc4py==3.24.0",
+# ]
 torch = [  # requires passing '--extra-index-url' to work
   "torch",
 ]


### PR DESCRIPTION
We can't install the [netgen] or [slepc] optional dependencies on `main` because pip ends up installing the wrong versions of petsc4py. This PR removes the dependency group entirely, instead of having it empty, so pip should raise a useful warning about unrecognised dependency groups instead of silently doing nothing.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
