### PR TITLE
Fix linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,6 +171,7 @@ linkcheck_ignore = [
     r'https://www.hilton.com/en/hotels/leehnhn-hilton-leeds-city/',
     r'https://www.radissonhotels.com/*',
     r'https://all.accor.com/hotel/*',
+    r'https://fluids.leeds.ac.uk/',
 ]
 linkcheck_timeout = 30
 


### PR DESCRIPTION
I think this was failing because of a bot check
```
(    firedrake_25: line   13) broken    https://fluids.leeds.ac.uk/ - 403 Client Error: Forbidden for url: https://fluids.leeds.ac.uk/
```
Since this link only exists for an old event I think skipping it is fine.

# Description


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
