### PR TITLE
Removed line that sets topology attributes on the MeshGeometry object

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2936,9 +2936,7 @@ values from f.)"""
         self._cell_orientations = cell_orientations.topological
 
     def __getattr__(self, name):
-        val = getattr(self._topology, name)
-        setattr(self, name, val)
-        return val
+        return getattr(self._topology, name)
 
     def __dir__(self):
         current = super(MeshGeometry, self).__dir__()


### PR DESCRIPTION
While updating the internal structure of a `VertexMeshOnly`, I realised that the attributes from the underlying `MeshTopology` are being stored on `MeshGeometry`. As a result, invalidating cached properties in `MeshTopology` wasn't sufficient to obtain a fully updated VOM as stale caches persisted on the geometry. Removing the line that set these attributes fixes the caching behaviour without interfering with the rest of the mesh.