### PR TITLE
FML: fix dunder methods and support BaseForm

### DIFF
--- a/firedrake/fml/form_manipulation_language.py
+++ b/firedrake/fml/form_manipulation_language.py
@@ -93,7 +93,7 @@ class Term(object):
 
     __slots__ = ["form", "labels"]
 
-    def __init__(self, form: ufl.Form, label_dict: Mapping = None):
+    def __init__(self, form: ufl.BaseForm, label_dict: Mapping = None):
         """
 
         Parameters
@@ -216,6 +216,9 @@ class Term(object):
 
     __rmul__ = __mul__
 
+    def __neg__(self):
+        return -1 * self
+
     def __truediv__(
         self,
         other: Union[float, Constant, ufl.algebra.Product]
@@ -274,7 +277,7 @@ class LabelledForm(object):
 
     def __add__(
         self,
-        other: Union[ufl.Form, Term, "LabelledForm"]
+        other: Union[ufl.BaseForm, Term, "LabelledForm"]
     ) -> "LabelledForm":
         """Add a form, term or labelled form to this labelled form.
 
@@ -289,12 +292,12 @@ class LabelledForm(object):
             A labelled form containing the terms.
 
         """
-        if isinstance(other, ufl.Form):
-            return LabelledForm(*self, Term(other))
-        elif type(other) is Term:
+        if type(other) is Term:
             return LabelledForm(*self, other)
         elif type(other) is LabelledForm:
             return LabelledForm(*self, *other)
+        elif isinstance(other, ufl.BaseForm):
+            return LabelledForm(*self, Term(other))
         elif other is None:
             return self
         else:
@@ -304,7 +307,7 @@ class LabelledForm(object):
 
     def __sub__(
         self,
-        other: Union[ufl.Form, Term, "LabelledForm"]
+        other: Union[ufl.BaseForm, Term, "LabelledForm"]
     ) -> "LabelledForm":
         """Subtract a form, term or labelled form from this labelled form.
 
@@ -320,14 +323,17 @@ class LabelledForm(object):
 
         """
         if type(other) is Term:
-            return LabelledForm(*self, Constant(-1.)*other)
+            return LabelledForm(*self, -other)
         elif type(other) is LabelledForm:
-            return LabelledForm(*self, *[Constant(-1.)*t for t in other])
+            return LabelledForm(*self, *[-t for t in other])
         elif other is None:
             return self
         else:
             # Make new Term for other and subtract it
             return LabelledForm(*self, Term(Constant(-1.)*other))
+
+    def __rsub__(self, other):
+        return other + (-self)
 
     def __mul__(
         self,
@@ -370,6 +376,9 @@ class LabelledForm(object):
         return self * (Constant(1.0) / other)
 
     __rmul__ = __mul__
+
+    def __neg__(self):
+        return -1 * self
 
     def __iter__(self) -> Sequence:
         """Iterable of the terms in the labelled form."""
@@ -427,7 +436,7 @@ class LabelledForm(object):
         return new_labelled_form
 
     @property
-    def form(self) -> ufl.Form:
+    def form(self) -> ufl.BaseForm:
         """Provide the whole form from the labelled form.
 
         Raises
@@ -437,7 +446,7 @@ class LabelledForm(object):
 
         Returns
         -------
-        ufl.Form
+        ufl.BaseForm
             The whole form corresponding to all the terms.
 
         """
@@ -479,7 +488,7 @@ class Label(object):
 
     def __call__(
         self,
-        target: Union[ufl.Form, Term, LabelledForm],
+        target: Union[ufl.BaseForm, Term, LabelledForm],
         value: Any = None
     ) -> Union[Term, LabelledForm]:
         """Apply the label to a form or term.
@@ -494,7 +503,7 @@ class Label(object):
         Raises
         ------
         ValueError
-            If the `target` is not a ufl.Form, Term or
+            If the `target` is not a ufl.BaseForm, Term or
             LabelledForm.
 
         Returns
@@ -514,7 +523,7 @@ class Label(object):
             self.value = self.default_value
         if isinstance(target, LabelledForm):
             return LabelledForm(*(self(t, value) for t in target.terms))
-        elif isinstance(target, ufl.Form):
+        elif isinstance(target, ufl.BaseForm):
             return LabelledForm(Term(target, {self.label: self.value}))
         elif isinstance(target, Term):
             new_labels = target.labels.copy()

--- a/tests/firedrake/regression/test_fml.py
+++ b/tests/firedrake/regression/test_fml.py
@@ -9,9 +9,12 @@ from firedrake import (
     PeriodicUnitSquareMesh, FunctionSpace, Constant,
     MixedFunctionSpace, TestFunctions, Function, split, inner, dx,
     SpatialCoordinate, as_vector, pi, sin, div,
-    NonlinearVariationalProblem, NonlinearVariationalSolver
+    NonlinearVariationalProblem, NonlinearVariationalSolver,
+    UnitIntervalMesh, Cofunction, TestFunction, interpolate
 )
-from firedrake.fml import subject, replace_subject, keep, drop, Label
+from firedrake.fml import subject, replace_subject, keep, drop, Label, LabelledForm
+
+import pytest
 
 
 def test_fml():
@@ -121,3 +124,44 @@ def test_fml():
     X.assign(X_np1)
     implicit_solver.solve()
     X.assign(X_np1)
+
+
+@pytest.fixture
+def V():
+    mesh = UnitIntervalMesh(2)
+    return FunctionSpace(mesh, "CG", 1)
+
+
+@pytest.mark.parametrize("baseform", ("form", "cofunction", "interpolate"))
+def test_fml_baseform(V, baseform):
+    if baseform == "form":
+        form = inner(1, TestFunction(V))*dx
+
+    elif baseform == "cofunction":
+        form = Cofunction(V.dual())
+        form.assign(42)
+
+    elif baseform == "interpolate":
+        W = V.reconstruct(degree=2)
+        w = Cofunction(W.dual())
+        w.assign(42)
+        form = interpolate(TestFunction(V), w)
+
+    # Test that we can wrap this BaseForm with a Label
+    has_labels = lambda term: len(term.labels) > 0
+    label = Label("label")
+    F = label(form)
+    assert isinstance(F, LabelledForm)
+    assert F.label_map(has_labels, map_if_true=keep, map_if_false=drop).form == form
+
+    # Test that we can linearly combine this BaseForm with a LabelledForm
+    Fcombs = [form + label(form),
+              label(form) + form,
+              label(form) - form]
+    for F2 in Fcombs:
+        assert isinstance(F2, LabelledForm)
+        assert F2.label_map(has_labels, map_if_true=keep, map_if_false=drop).form == form
+
+    F3 = form - label(form)
+    assert isinstance(F3, LabelledForm)
+    assert F3.label_map(has_labels, map_if_true=keep, map_if_false=drop).form == -form


### PR DESCRIPTION
# Description

Fixes subtraction involving `LabelledForm` by implementing `LabelledForm.__neg__` and `LabelledForm.__rsub__`

Enables labelling `BaseForm`

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
