### PR TITLE
skip timing out backwards compat io tests on CI until we debug them

### DIFF
--- a/tests/firedrake/output/test_io_backward_compat.py
+++ b/tests/firedrake/output/test_io_backward_compat.py
@@ -1,5 +1,6 @@
 import pytest
-from os.path import abspath, dirname, join, exists, getenv
+import os
+from os.path import abspath, dirname, join, exists
 from firedrake import *
 from firedrake.mesh import make_mesh_from_coordinates
 from firedrake.utils import IntType
@@ -274,7 +275,7 @@ def test_io_backward_compat_timestepping_save(version):
 @pytest.mark.parallel(nprocs=4)
 @pytest.mark.parametrize('version', ["2024_01_27"])
 def test_io_backward_compat_timestepping_load(version):
-    if getenv("FIREDRAKE_CI") == "1":
+    if os.getenv("FIREDRAKE_CI") == "1":
         pytest.skip("Skipping on CI to avoid unidentified timeout")
     filename = join(filedir, "_".join([basename, version, "timestepping" + ".h5"]))
     with CheckpointFile(filename, "r") as afile:
@@ -291,7 +292,7 @@ def test_io_backward_compat_timestepping_load(version):
 @pytest.mark.parallel(nprocs=3)
 @pytest.mark.parametrize('version', ["2024_01_27"])
 def test_io_backward_compat_timestepping_append(version, tmpdir):
-    if getenv("FIREDRAKE_CI") == "1":
+    if os.getenv("FIREDRAKE_CI") == "1":
         pytest.skip("Skipping on CI to avoid unidentified timeout")
     filename = join(filedir, "_".join([basename, version, "timestepping" + ".h5"]))
     copyname = join(str(tmpdir), "test_io_backward_compat_timestepping_append_dump.h5")


### PR DESCRIPTION
These tests are currently timing out on CI, even though they pass on local machines e.g. in https://github.com/firedrakeproject/firedrake/actions/runs/20917770881/job/60095483484?pr=4815

If a test fails due to a timeout it exits the entire pytest job, so no tests after that are run. Until we find out why these tests are timing out on CI we'll skip them on CI so that the rest of the tests are all run.