### PR TITLE
Rename 'unmarked' to 'UNMARKED' to make clear that it is a constant

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -90,7 +90,7 @@ from firedrake.preconditioners import (  # noqa: F401
 )
 from firedrake.mesh import (  # noqa: F401
     Mesh, ExtrudedMesh, VertexOnlyMesh, RelabeledMesh,
-    SubDomainData, unmarked, DistributedMeshOverlapType,
+    SubDomainData, UNMARKED, DistributedMeshOverlapType,
     DEFAULT_MESH_NAME, MeshGeometry, MeshTopology,
     AbstractMeshTopology, ExtrudedMeshTopology, Submesh,
     VertexOnlyMeshTopology, VertexOnlyMeshMissingPointsError,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -53,7 +53,7 @@ from finat.element_factory import as_fiat_cell
 
 __all__ = [
     'Mesh', 'ExtrudedMesh', 'VertexOnlyMesh', 'RelabeledMesh',
-    'SubDomainData', 'unmarked', 'DistributedMeshOverlapType',
+    'SubDomainData', 'UNMARKED', 'DistributedMeshOverlapType',
     'DEFAULT_MESH_NAME', 'MeshGeometry', 'MeshTopology',
     'AbstractMeshTopology', 'ExtrudedMeshTopology', 'VertexOnlyMeshTopology',
     'VertexOnlyMeshMissingPointsError',
@@ -76,7 +76,7 @@ _supported_embedded_cell_types_and_gdims = [('interval', 2),
                                             ("interval * interval", 3)]
 
 
-unmarked = -1
+UNMARKED = -1
 """A mesh marker that selects all entities that are not explicitly marked."""
 
 DEFAULT_MESH_NAME = "_".join(["firedrake", "default"])
@@ -247,7 +247,7 @@ class _Facets(object):
         :param markers: integer marker id or an iterable of marker ids
             (or ``None``, for an empty subset).
         """
-        valid_markers = set([unmarked]).union(self.unique_markers)
+        valid_markers = set([UNMARKED]).union(self.unique_markers)
         markers = as_tuple(markers, numbers.Integral)
         try:
             return self._subsets[markers]
@@ -261,7 +261,7 @@ class _Facets(object):
             # markers
             marked_points_list = []
             for i in markers:
-                if i == unmarked:
+                if i == UNMARKED:
                     _markers = self.mesh.topology_dm.getLabelIdIS(dmcommon.FACE_SETS_LABEL).indices
                     # Can exclude points labeled with i\in markers here,
                     # as they will be included in the below anyway.

--- a/tests/firedrake/regression/test_interior_facets.py
+++ b/tests/firedrake/regression/test_interior_facets.py
@@ -156,4 +156,4 @@ def test_interior_facet_integration(circle_in_square_mesh):
     assert np.allclose(assemble(f*dS(2)), 2*pi, rtol=1e-2)
 
     assert np.allclose(assemble(f*dS),
-                       assemble(f*dS(2)) + assemble(f*dS(unmarked)))
+                       assemble(f*dS(2)) + assemble(f*dS(UNMARKED)))

--- a/tests/firedrake/regression/test_mark_entities.py
+++ b/tests/firedrake/regression/test_mark_entities.py
@@ -41,9 +41,9 @@ def test_mark_entities_mark_points_with_function_array():
     assert abs(v - (4 * .5 + 4 * .5 * sqrt(2))) < 1.e-10
     v = assemble(Constant(1) * dS(my_facet_label, domain=mesh))
     assert abs(v - (1 * .5 + 1 * .5 * sqrt(2))) < 1.e-10
-    v = assemble(Constant(1) * dS(unmarked, domain=mesh))
+    v = assemble(Constant(1) * dS(UNMARKED, domain=mesh))
     assert abs(v - (3 * .5 + 3 * .5 * sqrt(2))) < 1.e-10
-    v = assemble(Constant(1) * dS((my_facet_label, unmarked), domain=mesh))
+    v = assemble(Constant(1) * dS((my_facet_label, UNMARKED), domain=mesh))
     assert abs(v - (4 * .5 + 4 * .5 * sqrt(2))) < 1.e-10
 
 
@@ -66,7 +66,7 @@ def test_mark_entities_overlapping_facet_subdomains():
     assert abs(v - 1.5) < 1.e-10
     v = assemble(Constant(1) * ds(removed_label, domain=mesh))
     assert abs(v - 0.0) < 1.e-10
-    v = assemble(Constant(1) * ds(unmarked, domain=mesh))
+    v = assemble(Constant(1) * ds(UNMARKED, domain=mesh))
     assert abs(v - 1.0) < 1.e-10
 
 


### PR DESCRIPTION
This is quite an opinionated change but it confused me the first time I encountered this and I think this is an improvement.

We don't document this anywhere (we hardly discuss facet integrals in the manual) so I think it's very unlikely to break anyone's code.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
