### PR TITLE
fix zero-form interpolation

### DIFF
--- a/firedrake/assemble.py
+++ b/firedrake/assemble.py
@@ -873,7 +873,7 @@ class BaseFormAssembler(AbstractFormAssembler):
         # If F: V3 x V2 -> R, then
         # Interpolate(TestFunction(V1), F) <=> Action(Interpolate(TestFunction(V1), TrialFunction(V2.dual())), F).
         # The result is a two-form V3 x V1 -> R.
-        if isinstance(expr, ufl.Interpolate) and isinstance(expr.argument_slots()[0], ufl.form.Form):
+        if isinstance(expr, ufl.Interpolate) and isinstance(expr.argument_slots()[0], ufl.form.Form) and len(expr.argument_slots()[0].arguments()) == 2:
             form, operand = expr.argument_slots()
             vstar = firedrake.Argument(form.arguments()[0].function_space().dual(), 1)
             expr = expr._ufl_expr_reconstruct_(operand, v=vstar)

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -391,7 +391,8 @@ def test_adjoint_dg():
 
 
 @pytest.mark.parametrize("degree", range(1, 4))
-def test_function_cofunction(degree):
+@pytest.mark.parametrize("cofunc", [True, False])
+def test_zeroform(degree, cofunc):
     mesh = UnitSquareMesh(10, 10)
     Pkp1 = FunctionSpace(mesh, "CG", degree+1)
     Pk = FunctionSpace(mesh, "CG", degree)
@@ -400,7 +401,9 @@ def test_function_cofunction(degree):
     x = SpatialCoordinate(mesh)
     f = assemble(interpolate(sin(2*pi*x[0])*sin(2*pi*x[1]), Pk))
 
-    fhat = assemble(f*v1*dx)
+    fhat = f * v1 * dx
+    if cofunc:
+        fhat = assemble(fhat)
     norm_i = assemble(interpolate(f, fhat))
     norm = assemble(f*f*dx)
 


### PR DESCRIPTION
Zero-form interpolation `interpolate(operand, dual_arg)` was broken if `dual_arg` was a one-form and not a Cofunction.