### PR TITLE
Purge the pip cache in CI

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -177,10 +177,8 @@ jobs:
           python3 -m venv venv
           . venv/bin/activate
 
-          : # Force a rebuild of petsc4py as the cached one will not link to the fresh
-          : # install of PETSc.
-          pip cache remove petsc4py
-          pip cache remove slepc4py
+          : # Empty the pip cache to ensure that everything is compiled from scratch
+          pip cache purge
 
           if [ ${{ inputs.target_branch }} = 'release' ]; then
             EXTRA_BUILD_ARGS=''
@@ -428,14 +426,8 @@ jobs:
           python3 -m venv venv
           . venv/bin/activate
 
-          : # Force a rebuild of petsc4py as the cached one will not link to the fresh
-          : # install of PETSc. A similar trick may be needed for compiled dependencies
-          : # like h5py or mpi4py if changing HDF5/MPI libraries.
-          pip cache remove petsc4py
-
-          : # Hotfix for petsc4py build, see https://gitlab.com/petsc/petsc/-/issues/1759
-          echo 'Cython<3.1' > constraints.txt
-          export PIP_CONSTRAINT=constraints.txt
+          : # Empty the pip cache to ensure that everything is compiled from scratch
+          pip cache purge
 
           if [ ${{ inputs.target_branch }} = 'release' ]; then
             EXTRA_PIP_FLAGS=''


### PR DESCRIPTION
This will fix the failing macOS CI run as it will force a rebuild of the h5py wheel.




<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
