### PR TITLE
Cache VertexOnlyMesh for cross-mesh interpolation

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -463,7 +463,20 @@ class CrossMeshInterpolator(Interpolator):
             self.dest_element = dest_element
 
     @cached_property
-    def vom(self):
+    def vom(self) -> MeshGeometry:
+        """The VertexOnlyMesh consisting of the target space's dofs immersed in the
+        source space's mesh.
+
+        Returns
+        -------
+        MeshGeometry
+            The VertexOnlyMesh.
+
+        Raises
+        ------
+        DofNotDefinedError
+            If any DoFs in the target mesh cannot be defined in the source mesh.
+        """
         from firedrake.assemble import assemble
         # Immerse coordinates of target space point evaluation dofs in src_mesh
         target_space_vec = VectorFunctionSpace(self.target_mesh, self.dest_element)
@@ -484,7 +497,6 @@ class CrossMeshInterpolator(Interpolator):
                                      "source mesh. To disable this error, set allow_missing_dofs=True.")
         return source_vom
 
-
     def _get_symbolic_expressions(self) -> tuple[Interpolate, Interpolate]:
         """Return the symbolic ``Interpolate`` expressions for point evaluation and
         re-ordering into the input-ordering VertexOnlyMesh.
@@ -494,11 +506,6 @@ class CrossMeshInterpolator(Interpolator):
         tuple[Interpolate, Interpolate]
             A tuple containing the point evaluation interpolation and the
             input-ordering interpolation.
-
-        Raises
-        ------
-        DofNotDefinedError
-            If any DoFs in the target mesh cannot be defined in the source mesh.
         """
         # Get the correct type of function space
         shape = self.target_space.ufl_function_space().value_shape


### PR DESCRIPTION
Cache the vom used for cross-mesh interpolation. Consider the following

```
V = FunctionSpace(mesh1, "CG", 1)
W = FunctionSpace(mesh2, "CG", 1)

f1 = Function(V)
f2 = Function(V)

h1 = assemble(interpolate(f1, W))  # ~30s at 500,000 dofs
h2 = assemble(interpolate(f2, W))
```

The assembly of `h2` previously took ~5s on my machine, with caching it now takes ~0.012s