### PR TITLE
Fix assign for MixedFunctionSpace and correct 'ancester' typo

### DIFF
--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -167,9 +167,9 @@ class Assigner:
         elif len(source_meshes) == 1:
             target_mesh = extract_unique_domain(assignee, expand_mesh_sequence=False)
             source_mesh, = source_meshes
-            if target_mesh is source_mesh:
+            if target_mesh == source_mesh:
                 pass
-            elif target_mesh.submesh_youngest_common_ancester(source_mesh) is None:
+            elif target_mesh.submesh_youngest_common_ancestor(source_mesh) is None:
                 raise ValueError(
                     "All functions in the expression must be defined on a single domain "
                     "that is in the same submesh family as domain of the assignee"

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -183,7 +183,7 @@ class Interpolate(UFLInterpolate):
 
         submesh_interp_implemented = (
             all(isinstance(m.topology, MeshTopology) for m in [target_mesh, source_mesh])
-            and target_mesh.submesh_ancesters[-1] is source_mesh.submesh_ancesters[-1]
+            and target_mesh.submesh_ancestors[-1] is source_mesh.submesh_ancestors[-1]
             and target_mesh.topological_dimension == source_mesh.topological_dimension
         )
         if target_mesh is source_mesh or submesh_interp_implemented:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -940,15 +940,15 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     # submesh
 
     @utils.cached_property
-    def submesh_ancesters(self):
-        """Tuple of submesh ancesters."""
+    def submesh_ancestors(self):
+        """Tuple of submesh ancestors."""
         if self.submesh_parent:
-            return (self, ) + self.submesh_parent.submesh_ancesters
+            return (self, ) + self.submesh_parent.submesh_ancestors
         else:
             return (self, )
 
-    def submesh_youngest_common_ancester(self, other):
-        """Return the youngest common ancester of self and other.
+    def submesh_youngest_common_ancestor(self, other):
+        """Return the youngest common ancestor of self and other.
 
         Parameters
         ----------
@@ -958,18 +958,18 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         Returns
         -------
         AbstractMeshTopology or None
-            Youngest common ancester or None if not found.
+            Youngest common ancestor or None if not found.
 
         """
         # self --- ... --- m --- common --- common --- common
         #                          /
         #       other --- ... --- m
-        self_ancesters = list(self.submesh_ancesters)
-        other_ancesters = list(other.submesh_ancesters)
+        self_ancestors = list(self.submesh_ancestors)
+        other_ancestors = list(other.submesh_ancestors)
         c = None
-        while self_ancesters and other_ancesters:
-            a = self_ancesters.pop()
-            b = other_ancesters.pop()
+        while self_ancestors and other_ancestors:
+            a = self_ancestors.pop()
+            b = other_ancestors.pop()
             if a is b:
                 c = a
             else:
@@ -1014,17 +1014,17 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
             Tuple of `op2.ComposedMap` from other to self, integral_type on self, and points on self.
 
         """
-        common = self.submesh_youngest_common_ancester(other)
+        common = self.submesh_youngest_common_ancestor(other)
         if common is None:
             raise ValueError(f"Unable to create composed map between (sub)meshes: {self} and {other} are unrelated")
         maps = []
         integral_type = other_integral_type
         subset_points = other_subset_points
-        aa = other.submesh_ancesters
+        aa = other.submesh_ancestors
         for a in aa[:aa.index(common)]:
             m, integral_type, subset_points = a.submesh_map_child_parent(integral_type, subset_points)
             maps.append(m)
-        bb = self.submesh_ancesters
+        bb = self.submesh_ancestors
         for b in reversed(bb[:bb.index(common)]):
             m, integral_type, subset_points = b.submesh_map_child_parent(integral_type, subset_points, reverse=True)
             maps.append(m)
@@ -1727,7 +1727,7 @@ class MeshTopology(AbstractMeshTopology):
             `tuple` of `op2.ComposedMap` from base_mesh to `self` and integral_type on `self`.
 
         """
-        common = self.submesh_youngest_common_ancester(base_mesh)
+        common = self.submesh_youngest_common_ancestor(base_mesh)
         if common is None:
             raise NotImplementedError(f"Currently only implemented for (sub)meshes in the same family: got {self} and {base_mesh}")
         elif base_mesh is self:

--- a/tests/firedrake/regression/test_assign.py
+++ b/tests/firedrake/regression/test_assign.py
@@ -1,0 +1,20 @@
+from firedrake import *
+import numpy as np
+
+
+def test_single_mesh_mixed_assign():
+    """Assigning between functions on separately constructed but equivalent
+    MixedFunctionSpaces should work and preserve values."""
+    mesh = UnitSquareMesh(4, 4)
+    V = VectorFunctionSpace(mesh, "CG", 1)
+    W = FunctionSpace(mesh, "CG", 1)
+
+    z = Function(MixedFunctionSpace([V, W]))
+    z.subfunctions[0].assign(Constant((1.0, 2.0)))
+    z.subfunctions[1].assign(3.0)
+
+    w = Function(MixedFunctionSpace([V, W]))
+    w.assign(z)
+
+    assert np.allclose(w.subfunctions[0].dat.data_ro, [1.0, 2.0])
+    assert np.allclose(w.subfunctions[1].dat.data_ro, 3.0)

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -189,7 +189,7 @@ def validate_domains(form):
         # Check that all domains are related to each other
         domain = itg.ufl_domain()
         for other_domain in itg.extra_domain_integral_type_map():
-            if domain.submesh_youngest_common_ancester(other_domain) is None:
+            if domain.submesh_youngest_common_ancestor(other_domain) is None:
                 raise MismatchingDomainError("Assembly of forms over unrelated meshes is not supported. "
                                              "Try using Submeshes or cross-mesh interpolation.")
 


### PR DESCRIPTION
## Summary
- Use equality (`==`) instead of identity (`is`) when comparing meshes in `assign`, so that distinct but equal `MeshSequenceGeometry` objects from separate `MixedFunctionSpace` instances are handled correctly
- Correct the spelling of `ancester` to `ancestor` throughout
- Add regression test for single-mesh mixed function space assign

Fixes #4887
Fixes g-adopt/g-adopt#452