### PR TITLE
Fix dumpdir fixture

### DIFF
--- a/tests/firedrake/output/conftest.py
+++ b/tests/firedrake/output/conftest.py
@@ -1,10 +1,13 @@
+import os
 import tempfile
+
 import pytest
+from mpi4py import MPI
 
 
 @pytest.fixture
-def dumpdir(mesh):
-    comm = mesh.comm
+def dumpdir():
+    comm = MPI.COMM_WORLD
     if comm.rank == 0:
         tmp = tempfile.TemporaryDirectory()
         yield comm.bcast(tmp.name, root=0)
@@ -13,3 +16,8 @@ def dumpdir(mesh):
     else:
         yield comm.bcast(None, root=0)
         comm.barrier()
+
+
+@pytest.fixture
+def dumpfile(dumpdir):
+    yield os.path.join(dumpdir, "dump")

--- a/tests/firedrake/output/test_dumb_checkpoint.py
+++ b/tests/firedrake/output/test_dumb_checkpoint.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from firedrake import *
 import numpy as np
 
@@ -19,11 +18,6 @@ def degree(request):
 @pytest.fixture(params=["CG"])
 def fs(request):
     return request.param
-
-
-@pytest.fixture
-def dumpfile(dumpdir):
-    return os.path.join(dumpdir, "dump")
 
 
 @pytest.fixture(scope="module")

--- a/tests/firedrake/output/test_hdf5file_checkpoint.py
+++ b/tests/firedrake/output/test_hdf5file_checkpoint.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from firedrake import *
 import numpy as np
 from mpi4py import MPI
@@ -21,11 +20,6 @@ def degree(request):
 @pytest.fixture(params=["CG"])
 def fs(request):
     return request.param
-
-
-@pytest.fixture
-def dumpfile(dumpdir):
-    return os.path.join(dumpdir, "dump")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Previously the `dumpdir` fixture would rely on the `mesh` fixture. This lead to some confusing behaviour where

```
$ pytest tests/firedrake/output/test_pvd_output.py::test_bad_cell --co
```

was giving the very confusing result of

```
collected 8 items                                                                                                     

<Dir firedrake>
  <Dir tests>
    <Dir firedrake>
      <Dir output>
        <Module test_pvd_output.py>
          <Function test_bad_cell[interval]>
          <Function test_bad_cell[square[tri]]>
          <Function test_bad_cell[square[quad]]>
          <Function test_bad_cell[box[tet]]>
          <Function test_bad_cell[box[quad x interval]]>
          <Function test_bad_cell[box[hex]]>
          <Function test_bad_cell[sphere[tri]]>
          <Function test_bad_cell[sphere[quad]]>

```

despite `test_bad_cell` not needing the `mesh` fixture.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
