### PR TITLE
fix `firedrake-run-split-tests` for macos

### DIFF
--- a/scripts/firedrake-run-split-tests
+++ b/scripts/firedrake-run-split-tests
@@ -61,7 +61,7 @@ set -x
 # * Uses tee to pipe stdout+stderr to both stdout and a log file
 # * Writes pytest's exit code to a file called jobN.errcode (for later inspection)
 parallel --line-buffer --tag \
-    "${pytest_cmd} |& tee ${log_file_prefix}{#}.log; \
+    "${pytest_cmd} 2>&1 | tee ${log_file_prefix}{#}.log; \
     echo \${PIPESTATUS[0]} > job{#}.errcode" \
     ::: $(seq ${num_jobs})
 


### PR DESCRIPTION
Replacing `|&` with the equivalent `2>&1 |` lets me run `firedrake-run-split-tests` on macos