### PR TITLE
Propagate distribution_parameters to Submesh and RelabeledMesh

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -4862,7 +4862,7 @@ def RelabeledMesh(mesh, indicator_functions, subdomain_ids, **kwargs):
         dmlabel = plex1.getLabel(dmlabel_name)
         section = f.topological.function_space().dm.getSection()
         dmcommon.mark_points_with_function_array(plex, section, height, f.dat.data_ro_with_halos.real.astype(IntType), dmlabel, subid)
-    reorder_noop = False
+    reorder_noop = None
     tmesh1 = MeshTopology(plex1, name=plex1.getName(), reorder=reorder_noop,
                           distribution_parameters=DISTRIBUTION_PARAMETERS_NOOP,
                           perm_is=tmesh._dm_renumbering,
@@ -4872,6 +4872,7 @@ def RelabeledMesh(mesh, indicator_functions, subdomain_ids, **kwargs):
     rmesh = make_mesh_from_mesh_topology(tmesh1, name1)
     # Tag the relabeled mesh with the original distribution parameters
     rmesh._distribution_parameters = mesh._distribution_parameters
+    rmesh._did_reordering = mesh._did_reordering
     return rmesh
 
 
@@ -4923,7 +4924,8 @@ def Submesh(mesh, subdim, subdomain_id, label_name=None, name=None, ignore_halo=
     ignore_halo : bool
         Whether to exclude the halo from the submesh.
     reorder : bool | None
-        Whether to reorder the mesh entities.
+        Whether to reorder the mesh entities. By default,
+        the submesh will be reordered if the parent mesh was reordered.
     comm : PETSc.Comm | None
         An optional sub-communicator to define the submesh.
         By default, the submesh is defined on `mesh.comm`.
@@ -4985,6 +4987,10 @@ def Submesh(mesh, subdim, subdomain_id, label_name=None, name=None, ignore_halo=
     subplex.setName(_generate_default_mesh_topology_name(name))
     if subplex.getDimension() != subdim:
         raise RuntimeError(f"Found subplex dim ({subplex.getDimension()}) != expected ({subdim})")
+    if reorder is None:
+        # Ideally we should set perm_is = mesh.dm_reordering[label_indices]
+        reorder = mesh._did_reordering
+
     submesh = Mesh(
         subplex,
         submesh_parent=mesh,

--- a/tests/firedrake/regression/test_mesh_overlaps.py
+++ b/tests/firedrake/regression/test_mesh_overlaps.py
@@ -101,13 +101,18 @@ def test_override_distribution_parameters(overlap):
 
 
 @pytest.mark.parallel(nprocs=2)
-def test_submesh_distribution_parameters(overlap):
+@pytest.mark.parametrize("reorder", [False, True])
+def test_submesh_distribution_parameters(overlap, reorder):
+    # Test that mesh._distribution_parameters and mesh._did_reordering
+    # are propagated
     partition = True
     params = {"partition": partition,
               "overlap_type": overlap}
-    mesh = UnitSquareMesh(2, 2, reorder=False,
+    mesh = UnitSquareMesh(2, 2, reorder=reorder,
                           distribution_parameters=params)
     orig_params = mesh._distribution_parameters
+    did_reordering = mesh._did_reordering
+    assert did_reordering == reorder
 
     x, *_ = SpatialCoordinate(mesh)
     DG0 = FunctionSpace(mesh, "DG", 0)
@@ -115,7 +120,9 @@ def test_submesh_distribution_parameters(overlap):
     label = 111
     rmesh = RelabeledMesh(mesh, [ind], [label])
     assert rmesh._distribution_parameters == orig_params
+    assert rmesh._did_reordering == did_reordering
 
     dim = mesh.topological_dimension
     submesh = Submesh(rmesh, dim, label)
     assert submesh._distribution_parameters == orig_params
+    assert submesh._did_reordering == did_reordering


### PR DESCRIPTION
# Description
Submesh and RelabeledMesh do not redistribute the mesh, meaning that they inherit the parent mesh's distribution. However it was not possible to infer the overlap type and the overlap distance from the `distribution_parameters` attribute. This PR just tags the child mesh with the parent's `distribution_parameters`.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
