### PR TITLE
Bugfix with deflation: only deflate successful solves

### DIFF
--- a/firedrake/deflation.py
+++ b/firedrake/deflation.py
@@ -94,7 +94,8 @@ class DeflatedSNES(SNESBase):
         snes.reason = self.inner.reason
 
         # Record the solution we've just found
-        self.deflation.append(Function(self.problem.u))
+        if snes.reason > 0:
+            self.deflation.append(Function(self.problem.u))
 
         return out
 


### PR DESCRIPTION
There is a small bug in the implementation of deflation. Right now it deflates the final state of the inner solver when it terminates, whether the solve was successful or not. This changes it so that only successful solves are deflated.