### PR TITLE
Install build requirements in workflow now they aren't available by default

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -499,6 +499,7 @@ jobs:
       - name: Install Firedrake
         id: install
         run: |
+          pip install --verbose -r ./firedrake-repo/requirements-build.txt
           CC=mpicc CXX=mpicxx \
             pip install --verbose --no-build-isolation './firedrake-repo[docs]'
           firedrake-clean


### PR DESCRIPTION
https://github.com/firedrakeproject/firedrake/pull/4955 made it so that our build requirements are no longer available inside the `dev-release` Docker image by default. I don't think this is necessarily problematic but we now have to install them in our other workflows.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
