### PR TITLE
`Ensemble.sequential` context manager

### DIFF
--- a/firedrake/ensemble/ensemble.py
+++ b/firedrake/ensemble/ensemble.py
@@ -588,24 +588,22 @@ class Ensemble:
         return requests
 
     @contextmanager
-    def sequential(self, *, synchronise: bool = False, **kwargs):
+    def sequential(self, *, synchronise: bool = False, reverse: bool = False, **kwargs):
         """
-        Context manager for executing code on each ensemble member
-        consecutively (ordered by increasing :attr:`~.Ensemble.ensemble_rank`).
+        Context manager for executing code on each ensemble
+        member consecutively (ordered by increasing
+        :attr:`~.Ensemble.ensemble_rank`).
 
-        Any data in ``kwargs`` will be made available in the returned context
-        and will be communicated forward after each ensemble member exits.
-        :class:`.Function` or :class:`.Cofunction` ``kwargs`` will be sent with
-        the ``Ensemble`` wrappers, and other types will be delegated to the
-        standard :class:`mpi4py.MPI.Comm` methods.
+        Any data in ``kwargs`` will be made available in the returned
+        context and will be communicated forward after each ensemble
+        member exits. :class:`.Function` or :class:`.Cofunction`
+        ``kwargs`` will be sent with the corresponding Ensemble methods.
 
         For example:
 
         .. code-block:: python3
 
-            index=0
-
-            with ensemble.sequential(index=index) as ctx:
+            with ensemble.sequential(index=0) as ctx:
                 print(ensemble.ensemble_rank, ctx.index)
                 ctx.index += 2
 
@@ -619,10 +617,9 @@ class Ensemble:
             3 6
             ...
 
-        Note that the `value` (but not presence) of each ``kwarg`` is
-        ignored on all ranks except rank ``0``. On subsequent ranks
-        the values in the returned ``ctx`` are those sent forward from
-        the previous rank.
+        If ``reverse is True`` then the ensemble ranks will be looped through
+        in decreasing order i.e. ``ensemble_rank == (ensemble_size - 1)`` will
+        run first, then ``ensemble_rank == (ensemble_size - 2)`` etc.
 
         Parameters
         ----------
@@ -630,46 +627,49 @@ class Ensemble:
             If True then MPI_Barrier will be called on the ``global_comm``
             at the beginning and end of this method.
 
+        reverse :
+            If True then will iterate through spatial comms in order of
+            decreasing ``ensemble_rank``.
+
         kwargs :
             Data to be passed forward by each rank and made available
             in the returned ``ctx``.
         """
         rank = self.ensemble_rank
-        first_rank = (rank == 0)
-        last_rank = (rank == self.ensemble_size - 1)
+        if reverse:  # send backwards
+            src = rank + 1
+            dst = rank - 1
+            first_rank = (rank == self.ensemble_size - 1)
+            last_rank = (rank == 0)
+        else:  # send forwards
+            src = rank - 1
+            dst = rank + 1
+            first_rank = (rank == 0)
+            last_rank = (rank == self.ensemble_size - 1)
 
         if synchronise:
             self.global_comm.Barrier()
 
-        # make sure we have unique tags for each message
-        tag_offset = len(kwargs.items()) + 1
-
         if not first_rank:
-            src = rank - 1
             for i, (k, v) in enumerate(kwargs.items()):
-                recv_kwargs = {'source': src, 'tag': tag_offset*rank+i}
                 if isinstance(v, (Function, Cofunction)):
-                    self.recv(kwargs[k], **recv_kwargs)
+                    # Functions are sent in-place, everything else is pickled
+                    recv_args = [kwargs[k]]
                 else:
-                    kwargs[k] = self.ensemble_comm.recv(
-                        **recv_kwargs)
+                    recv_args = []
+                kwargs[k] = self.recv(*recv_args, source=src, tag=rank+i*100)
 
         ctx = SimpleNamespace(**kwargs)
         yield ctx
 
         if not last_rank:
-            dst = rank + 1
             for i, v in enumerate((getattr(ctx, k)
                                    for k in kwargs.keys())):
-                send_kwargs = {'dest': dst, 'tag': tag_offset*dst+i}
                 try:
-                    if isinstance(v, (Function, Cofunction)):
-                        self.send(v, **send_kwargs)
-                    else:
-                        self.ensemble_comm.send(v, **send_kwargs)
+                    self.send(v, dest=dst, tag=dst+i*100)
                 except Exception as error:
                     raise TypeError(
-                        "Failed to send object of type {type(v)}. kwargs for"
+                        "Failed to send object of type {type(v)__name__}. kwargs for"
                         " Ensemble.sequential must be Functions, Cofunctions,"
                         " or acceptable arguments to mpi4py.MPI.Comm.send."
                     ) from error

--- a/tests/firedrake/ensemble/test_ensemble.py
+++ b/tests/firedrake/ensemble/test_ensemble.py
@@ -383,7 +383,8 @@ def test_ensemble_solvers(ensemble, W, urank, urank_sum):
 
 
 @pytest.mark.parallel(nprocs=6)
-def test_ensemble_sequential(ensemble):
+@pytest.mark.parametrize("direction", ["forward", "reverse"])
+def test_ensemble_sequential(ensemble, direction):
     """
     Test that the sequential context manager sends forward
     the correct values after each rank has executed, for both
@@ -394,18 +395,23 @@ def test_ensemble_sequential(ensemble):
     mesh = UnitIntervalMesh(1, comm=ensemble.comm)
     R = FunctionSpace(mesh, "R", 0)
 
+    reverse = direction == "reverse"
+
     idx_i = 0
     idx_f = Function(R).zero()
     two = Function(R).assign(2)
 
-    with ensemble.sequential(idx_i=idx_i, idx_f=idx_f) as ctx:
+    with ensemble.sequential(reverse=reverse, idx_i=idx_i, idx_f=idx_f) as ctx:
         recv_i = float(ctx.idx_i)
         recv_f = float(ctx.idx_f)
 
         ctx.idx_i += 2
         ctx.idx_f += two
 
-    expected = 2*rank
+    if reverse:
+        expected = 2*(ensemble.ensemble_size - 1 - rank)
+    else:
+        expected = 2*rank
 
     parallel_assert(
         recv_i == expected,


### PR DESCRIPTION
Parallelism is great and all, but sometimes you just want to run things sequentially.

The `Ensemble.sequential` context manager gives a simple way run some code on spatial comm `0`, then send some data to spatial comm `1`, run some code there, send some data to spatial comm `2`, etc.
Any ``kwargs`` passed to ``sequential`` will be sent forwards after each spatial comm has run its code, and made available on the next spatial comm on the ``ctx`` object.

A simple example of this is initialising a timeseries over the entire ensemble - you want to start from the initial condition on rank 0, integrate a few timesteps, then pass the state to rank 1, integrate a few more timesteps etc.

In the code below, spatial comm `1` blocks until it receives the `state` data from spatial comm `0`, which only happens once spatial comm `0` has finished `integrate_local_timesteps` and updated `ctx.state`.

```py
ensemble = Ensemble(comm=COMM_WORLD, 1)
mesh = UnitIntervalMesh(10, comm=ensemble.comm)
V = FunctionSpace(mesh, "CG", 1)

...

state = Function(V).assign(ic)
local_start = Function(V)
local_final = Function(V)

with ensemble.sequential(state=state) as ctx:
	# on spatial comm 0: ctx.state=ic
	# on subsequent spatial comms: ctx.state is received from previous spatial comm.
	local_start.assign(ctx.state)

	local_final = integrate_local_timeseries(local_start)

	# give back the data we want sending to the next spatial comm
	ctx.state.assign(local_final)
```