### PR TITLE
Add zenodo to linkcheck ignore list

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,6 +161,7 @@ nitpick_ignore_regex = [
 
 # Dodgy links
 linkcheck_ignore = [
+    r'https://zenodo.org/.*',
     r'https://doi\.org/.*',
     r'https://epubs\.siam\.org/doi/.*',
     r'https://www\.apl\.washington\.edu/',


### PR DESCRIPTION
We have been seeing the following linkcheck failures for some time now ([example](https://github.com/firedrakeproject/firedrake/actions/runs/23256175313/job/67611644153?pr=4972)):

```
(          zenodo: line   74) broken    https://zenodo.org/record/1402622 - 403 Client Error: Forbidden for url: https://zenodo.org/record/1402622
```

The fact that the error message is "client forbidden" makes me wonder if we are failing bot checks, which I don't think we can do anything about.

I've therefore added zenodo to the list of websites we ignore when we linkcheck.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
