### PR TITLE
Manually clean up memory for some tests that don't call solve

### DIFF
--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -9,6 +9,7 @@ import sys
 os.environ["FIREDRAKE_DISABLE_OPTIONS_LEFT"] = "1"
 
 import pytest
+from mpi4py import MPI
 from petsctools import get_external_packages
 from pyadjoint.tape import (
     annotate_tape, get_working_tape, set_working_tape,
@@ -256,3 +257,10 @@ class _petsc_raises:
 def petsc_raises():
     # This function is needed because pytest does not support classes as fixtures.
     return _petsc_raises
+
+
+@pytest.fixture
+def garbage_cleanup():
+    """Fixture that runs the parallel garbage collector."""
+    yield
+    PETSc.garbage_cleanup(MPI.COMM_WORLD)

--- a/tests/firedrake/output/test_io_function.py
+++ b/tests/firedrake/output/test_io_function.py
@@ -16,6 +16,11 @@ extruded_mesh_name = "m_extruded"
 func_name = "f"
 
 
+@pytest.fixture(autouse=True)
+def autouse_garbage_cleanup(garbage_cleanup):
+    pass
+
+
 def _initialise_function(f, _f, method):
     if method == "project":
         getattr(f, method)(_f, solver_parameters={"ksp_type": "cg", "pc_type": "sor", "ksp_rtol": 1.e-16})

--- a/tests/firedrake/regression/test_covariance_operator.py
+++ b/tests/firedrake/regression/test_covariance_operator.py
@@ -39,7 +39,7 @@ def rng():
 @pytest.mark.parametrize("family", ("CG", "DG"))
 @pytest.mark.parametrize("mesh_type", ("interval", "square"))
 @pytest.mark.parametrize("backend_type", (PyOP2NoiseBackend, PetscNoiseBackend), ids=("pyop2", "petsc"))
-def test_white_noise(family, degree, mesh_type, dim, backend_type, rng):
+def test_white_noise(family, degree, mesh_type, dim, backend_type, rng, garbage_cleanup):
     """Test that white noise generator converges to a mass matrix covariance.
     """
 


### PR DESCRIPTION
We only call `PETSc.garbage_cleanup` when we call `solve`. This means that if we run lots of parallel tests that don't do this then we can end up consuming a lot of memory. I suspect that this was causing the concerning performance behaviour that I was observing last week.

These fixes should go into `main` because the covariance operator work isn't in `release` yet.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
