### PR TITLE
Minor bugfixes to noise generators

### DIFF
--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -323,7 +323,7 @@ class VOMNoiseBackend(NoiseBackendBase):
 
         b = rng.standard_normal(self.function_space)
 
-        if apply_riesz:
+        if not apply_riesz:
             b = b.riesz_representation(self.riesz_map)
 
         if tensor:

--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -71,7 +71,7 @@ class NoiseBackendBase:
                  seed: int | None = None):
         self._V = V
         self._Vb = V.broken_space()
-        self._rng = rng or RandomGenerator(PCG64(seed=seed))
+        self._rng = rng or RandomGenerator(PCG64(seed=seed, comm=V.comm))
 
     @abc.abstractmethod
     def sample(self, *, rng=None,


### PR DESCRIPTION
1. The random function generator should have a comm.
2. The VOM noise generator was returning a Function when asked for a Cofunction and vice-versa.