### PR TITLE
Move CovariancePC to top level namespace

### DIFF
--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -88,7 +88,8 @@ from firedrake.preconditioners import (  # noqa: F401
     ASMLinesmoothPC, ASMExtrudedStarPC, AssembledPC, AuxiliaryOperatorPC,
     MassInvPC, PCDPC, PatchPC, PlaneSmoother, PatchSNES, P1PC, P1SNES,
     LORPC, GTMGPC, PMGPC, PMGSNES, HypreAMS, HypreADS, FDMPC,
-    PoissonFDMPC, TwoLevelPC, HiptmairPC, FacetSplitPC, BDDCPC
+    PoissonFDMPC, TwoLevelPC, HiptmairPC, FacetSplitPC, BDDCPC,
+    CovariancePC
 )
 from firedrake.mesh import (  # noqa: F401
     Mesh, ExtrudedMesh, VertexOnlyMesh, RelabeledMesh,

--- a/firedrake/adjoint/__init__.py
+++ b/firedrake/adjoint/__init__.py
@@ -35,9 +35,8 @@ from firedrake.adjoint.ufl_constraints import (  # noqa: F401
 from firedrake.adjoint.ensemble_reduced_functional import EnsembleReducedFunctional  # noqa F401
 from firedrake.adjoint.transformed_functional import L2RieszMap, L2TransformedFunctional  # noqa: F401
 from firedrake.adjoint.covariance_operator import (  # noqa F401
-    WhiteNoiseGenerator, AutoregressiveCovariance,
-    PyOP2NoiseBackend, PetscNoiseBackend, VOMNoiseBackend,
-    CovarianceMat, CovariancePC)
+    WhiteNoiseGenerator, AutoregressiveCovariance, CovarianceMat,
+    PyOP2NoiseBackend, PetscNoiseBackend, VOMNoiseBackend)
 import numpy_adjoint  # noqa F401
 import firedrake.ufl_expr
 import types

--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -1014,16 +1014,19 @@ class CovarianceMatCtx:
             viewer.printfASCII(f"    correlation lengthscale: {self.covariance.lengthscale}\n")
             viewer.printfASCII(f"    standard deviation: {self.covariance.stddev}\n")
 
-            if self.operation == self.Operation.ACTION:
-                viewer.printfASCII("  Information for the diffusion solver for applying the action:\n")
-                ksp = self.covariance.solver.snes.ksp
-            elif self.operation == self.Operation.INVERSE:
-                viewer.printfASCII("  Information for the mass solver for applying the inverse:\n")
-                ksp = self.covariance.mass_solver.snes.ksp
-            level = ksp.getTabLevel()
-            ksp.setTabLevel(mat.getTabLevel() + 1)
-            ksp.view(viewer)
-            ksp.setTabLevel(level)
+            if viewer.getFormat() == PETSc.Viewer.Format.ASCII_INFO_DETAIL:
+                if self.operation == self.Operation.ACTION:
+                    viewer.printfASCII("  Information for the diffusion solver for applying the action:\n")
+                    ksp = self.covariance.solver.snes.ksp
+                elif self.operation == self.Operation.INVERSE:
+                    viewer.printfASCII("  Information for the mass solver for applying the inverse:\n")
+                    ksp = self.covariance.mass_solver.snes.ksp
+                viewer.pushASCIITab()
+                ksp.view(viewer)
+                viewer.popASCIITab()
+            else:
+                prefix = mat.getOptionsPrefix() or ""
+                viewer.printfASCII(f"  Use -{prefix}ksp_view ::ascii_info_detail to display information for diffusion or mass solver.\n")
 
 
 def CovarianceMat(covariance: CovarianceOperatorBase,
@@ -1071,109 +1074,3 @@ def CovarianceMat(covariance: CovarianceOperatorBase,
 
 
 CovarianceMat.Operation = CovarianceMatCtx.Operation
-
-
-class CovariancePC(petsctools.PCBase):
-    r"""
-    A python PC context for a covariance operator.
-    Will apply either the action or inverse of the covariance,
-    whichever is the opposite of the Mat operator.
-
-    .. math::
-
-        B: V^{*} \to V
-
-        B^{-1}: V \to V^{*}
-
-    Available options:
-
-    * ``-pc_use_amat`` - use Amat to apply the covariance operator.
-
-    See Also
-    --------
-    CovarianceOperatorBase
-    AutoregressiveCovariance
-    CovarianceMatCtx
-    CovarianceMat
-    """
-    needs_python_pmat = True
-    prefix = "covariance"
-
-    def initialize(self, pc):
-        A, P = pc.getOperators()
-
-        use_amat_prefix = self.parent_prefix + "pc_use_amat"
-        self.use_amat = PETSc.Options().getBool(use_amat_prefix, False)
-        mat = (A if self.use_amat else P).getPythonContext()
-
-        if not isinstance(mat, CovarianceMatCtx):
-            raise TypeError(
-                "CovariancePC needs a CovarianceMatCtx")
-        covariance = mat.covariance
-
-        self.covariance = covariance
-        self.mat = mat
-
-        V = covariance.function_space()
-        primal = Function(V)
-        dual = Function(V.dual())
-
-        # PC does the opposite of the Mat
-        if mat.operation == CovarianceMatCtx.Operation.ACTION:
-            self.operation = CovarianceMatCtx.Operation.INVERSE
-            self.x = primal
-            self.y = dual
-            self._apply_op = covariance.apply_inverse
-        elif mat.operation == CovarianceMatCtx.Operation.INVERSE:
-            self.operation = CovarianceMatCtx.Operation.ACTION
-            self.x = dual
-            self.y = primal
-            self._apply_op = covariance.apply_action
-
-    def apply(self, pc, x, y):
-        """Apply the action or inverse of the covariance operator
-        to x, putting the result in y.
-
-        y is not guaranteed to be zero on entry.
-
-        Parameters
-        ----------
-        pc : PETSc.PC
-            The PETSc preconditioner that self is the python context of.
-        x : PETSc.Vec
-            The vector acted on by the pc.
-        y : PETSc.Vec
-            The result of the pc application.
-        """
-        with self.x.dat.vec_wo as xvec:
-            x.copy(result=xvec)
-
-        self._apply_op(self.x, tensor=self.y)
-
-        with self.y.dat.vec_ro as yvec:
-            yvec.copy(result=y)
-
-    def update(self, pc):
-        pass
-
-    def view(self, pc, viewer=None):
-        """View object. Method usually called by PETSc with e.g. -ksp_view.
-        """
-        if viewer is None:
-            return
-        if viewer.getType() != PETSc.Viewer.Type.ASCII:
-            return
-
-        viewer.printfASCII(f"  firedrake covariance operator preconditioner: {type(self).__name__}\n")
-        viewer.printfASCII(f"  Applying the {str(self.operation)} of the covariance operator {type(self.covariance).__name__}\n")
-
-        if self.use_amat:
-            viewer.printfASCII("  using Amat matrix\n")
-
-        if (type(self.covariance) is AutoregressiveCovariance) and (self.covariance.iterations > 0):
-            if self.operation == CovarianceMatCtx.Operation.ACTION:
-                viewer.printfASCII("  Information for the diffusion solver for applying the action:\n")
-                self.covariance.solver.snes.ksp.view(viewer)
-            elif self.operation == CovarianceMatCtx.Operation.INVERSE:
-                viewer.printfASCII("  Information for the mass solver for applying the inverse:\n")
-                self.covariance.mass_solver.snes.ksp.view(viewer)

--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -517,7 +517,7 @@ class CovarianceOperatorBase:
     AutoregressiveCovariance
     CovarianceMatCtx
     CovarianceMat
-    CovariancePC
+    ~firedrake.preconditioners.covariance.CovariancePC
     """
 
     @abc.abstractmethod
@@ -696,7 +696,7 @@ class AutoregressiveCovariance(CovarianceOperatorBase):
     WhiteNoiseGenerator
     CovarianceOperatorBase
     CovarianceMat
-    CovariancePC
+    ~firedrake.preconditioners.covariance.CovariancePC
     diffusion_form
     """
 
@@ -934,7 +934,7 @@ class CovarianceMatCtx:
     CovarianceOperatorBase
     AutoregressiveCovariance
     CovarianceMat
-    CovariancePC
+    ~firedrake.preconditioners.covariance.CovariancePC
     """
     class Operation(Enum):
         """
@@ -945,7 +945,7 @@ class CovarianceMatCtx:
         CovarianceOperatorBase
         AutoregressiveCovariance
         CovarianceMat
-        CovariancePC
+        ~firedrake.preconditioners.covariance.CovariancePC
         """
         ACTION = 'action'
         INVERSE = 'inverse'
@@ -1060,7 +1060,7 @@ def CovarianceMat(covariance: CovarianceOperatorBase,
     AutoregressiveCovariance
     CovarianceMatCtx
     CovarianceMatCtx.Operation
-    CovariancePC
+    ~firedrake.preconditioners.covariance.CovariancePC
     """
     ctx = CovarianceMatCtx(covariance, operation=operation)
 

--- a/firedrake/preconditioners/__init__.py
+++ b/firedrake/preconditioners/__init__.py
@@ -24,3 +24,4 @@ from firedrake.preconditioners.fdm import FDMPC, PoissonFDMPC  # noqa: F401
 from firedrake.preconditioners.hiptmair import TwoLevelPC, HiptmairPC  # noqa: F401
 from firedrake.preconditioners.facet_split import FacetSplitPC  # noqa: F401
 from firedrake.preconditioners.bddc import BDDCPC  # noqa: F401
+from firedrake.preconditioners.covariance import CovariancePC  # noqa: F401

--- a/firedrake/preconditioners/covariance.py
+++ b/firedrake/preconditioners/covariance.py
@@ -21,10 +21,10 @@ class CovariancePC(petsctools.PCBase):
 
     See Also
     --------
-    ~firedrake.adjoint.CovarianceOperatorBase
-    ~firedrake.adjoint.AutoregressiveCovariance
-    ~firedrake.adjoint.CovarianceMatCtx
-    ~firedrake.adjoint.CovarianceMat
+    ~firedrake.adjoint.covariance_operator.CovarianceOperatorBase
+    ~firedrake.adjoint.covariance_operator.AutoregressiveCovariance
+    ~firedrake.adjoint.covariance_operator.CovarianceMatCtx
+    ~firedrake.adjoint.covariance_operator.CovarianceMat
     """
     needs_python_pmat = True
     prefix = "covariance"

--- a/firedrake/preconditioners/covariance.py
+++ b/firedrake/preconditioners/covariance.py
@@ -1,0 +1,119 @@
+import petsctools
+from firedrake.petsc import PETSc
+from firedrake.function import Function
+
+
+class CovariancePC(petsctools.PCBase):
+    r"""
+    A python PC context for a covariance operator.
+    Will apply either the action or inverse of the covariance,
+    whichever is the opposite of the Mat operator.
+
+    .. math::
+
+        B: V^{*} \to V
+
+        B^{-1}: V \to V^{*}
+
+    Available options:
+
+    * ``-pc_use_amat`` - use Amat to apply the covariance operator.
+
+    See Also
+    --------
+    ~firedrake.adjoint.CovarianceOperatorBase
+    ~firedrake.adjoint.AutoregressiveCovariance
+    ~firedrake.adjoint.CovarianceMatCtx
+    ~firedrake.adjoint.CovarianceMat
+    """
+    needs_python_pmat = True
+    prefix = "covariance"
+
+    def initialize(self, pc):
+        from firedrake.adjoint.covariance_operator import CovarianceMatCtx
+        A, P = pc.getOperators()
+
+        use_amat_prefix = self.parent_prefix + "pc_use_amat"
+        self.use_amat = PETSc.Options().getBool(use_amat_prefix, False)
+        mat = (A if self.use_amat else P).getPythonContext()
+
+        if not isinstance(mat, CovarianceMatCtx):
+            raise TypeError(
+                "CovariancePC needs a CovarianceMatCtx")
+        covariance = mat.covariance
+
+        self.covariance = covariance
+        self.mat = mat
+
+        V = covariance.function_space()
+        primal = Function(V)
+        dual = Function(V.dual())
+
+        # PC does the opposite of the Mat
+        if mat.operation == CovarianceMatCtx.Operation.ACTION:
+            self.operation = CovarianceMatCtx.Operation.INVERSE
+            self.x = primal
+            self.y = dual
+            self._apply_op = covariance.apply_inverse
+        elif mat.operation == CovarianceMatCtx.Operation.INVERSE:
+            self.operation = CovarianceMatCtx.Operation.ACTION
+            self.x = dual
+            self.y = primal
+            self._apply_op = covariance.apply_action
+
+    def apply(self, pc, x, y):
+        """Apply the action or inverse of the covariance operator
+        to x, putting the result in y.
+
+        y is not guaranteed to be zero on entry.
+
+        Parameters
+        ----------
+        pc : PETSc.PC
+            The PETSc preconditioner that self is the python context of.
+        x : PETSc.Vec
+            The vector acted on by the pc.
+        y : PETSc.Vec
+            The result of the pc application.
+        """
+        with self.x.dat.vec_wo as xvec:
+            x.copy(result=xvec)
+
+        self._apply_op(self.x, tensor=self.y)
+
+        with self.y.dat.vec_ro as yvec:
+            yvec.copy(result=y)
+
+    def update(self, pc):
+        pass
+
+    def view(self, pc, viewer=None):
+        """View object. Method usually called by PETSc with e.g. -ksp_view.
+        """
+        from firedrake.adjoint.covariance_operator import (
+            CovarianceMatCtx, AutoregressiveCovariance)
+        if viewer is None:
+            return
+        if viewer.getType() != PETSc.Viewer.Type.ASCII:
+            return
+
+        viewer.printfASCII(f"  firedrake covariance operator preconditioner: {type(self).__name__}\n")
+        viewer.printfASCII(f"  Applying the {str(self.operation)} of the covariance operator {type(self.covariance).__name__}\n")
+
+        if self.use_amat:
+            viewer.printfASCII("  using Amat matrix\n")
+
+        if (type(self.covariance) is AutoregressiveCovariance) and (self.covariance.iterations > 0):
+            if viewer.getFormat() == PETSc.Viewer.Format.ASCII_INFO_DETAIL:
+                if self.operation == CovarianceMatCtx.Operation.ACTION:
+                    viewer.printfASCII("  Information for the diffusion solver for applying the action:\n")
+                    ksp = self.covariance.solver.snes.ksp
+                elif self.operation == CovarianceMatCtx.Operation.INVERSE:
+                    viewer.printfASCII("  Information for the mass solver for applying the inverse:\n")
+                    ksp = self.covariance.mass_solver.snes.ksp
+                viewer.pushASCIITab()
+                ksp.view(viewer)
+                viewer.popASCIITab()
+            else:
+                prefix = pc.getOptionsPrefix() or ""
+                viewer.printfASCII(f"  Use -{prefix}ksp_view ::ascii_info_detail to display information for diffusion or mass solver.\n")

--- a/tests/firedrake/regression/test_covariance_operator.py
+++ b/tests/firedrake/regression/test_covariance_operator.py
@@ -302,7 +302,7 @@ def test_covariance_mat(m, family, operation):
             'ksp_max_it': 2,
             'ksp_rtol': tol,
             'pc_type': 'python',
-            'pc_python_type': 'firedrake.adjoint.CovariancePC',
+            'pc_python_type': 'firedrake.CovariancePC',
         }
     )
     x.zero()


### PR DESCRIPTION
This looks like a lot of lines but it's almost all just relocating the `CovariancePC`.


Previously, to use the `CovariancePC` you needed `"pc_python_type": "firedrake.adjoint.CovariancePC"`, which is quite verbose.
Moving it to the top level means you only need `"pc_python_type": "firedrake.CovariancePC"`, which is also consistent with all our other PCs.

The imports from `firedrake.adjoint` needed for the PC are moved inside the PC methods so that `firedrake.adjoint.__init__` is not accidentally run when firedrake is imported.

The view methods for the Covariance PC and Mat now only view the subsolvers if you ask for `ascii_info_detail` so the default output is much easier to parse.