### PR TITLE
bugfixes to ensemble_function adjoint util

### DIFF
--- a/firedrake/adjoint_utils/ensemble_function.py
+++ b/firedrake/adjoint_utils/ensemble_function.py
@@ -13,7 +13,7 @@ class EnsembleFunctionMixin(OverloadedType):
     Enables EnsembleFunction to do the following:
     - Be a Control for a NumpyReducedFunctional (_ad_to_list and _ad_assign_numpy)
     - Be used with pyadjoint TAO solver (_ad_{to,from}_petsc)
-    - Be used as a Control for Taylor tests (_ad_dot)
+    - Be used as a Control for Taylor tests (_ad_dot, _ad_add, _ad_mul)
     """
 
     @staticmethod
@@ -32,10 +32,8 @@ class EnsembleFunctionMixin(OverloadedType):
     @staticmethod
     def _ad_to_list(m):
         with m.vec_ro() as gvec:
-            lvec = PETSc.Vec().createSeq(gvec.size,
-                                         comm=PETSc.COMM_SELF)
-            PETSc.Scatter().toAll(gvec).scatter(
-                gvec, lvec, addv=PETSc.InsertMode.INSERT_VALUES)
+            scatter, lvec = PETSc.Scatter().toAll(gvec)
+            scatter.scatter(gvec, lvec, addv=PETSc.InsertMode.INSERT_VALUES)
         return lvec.array_r.tolist()
 
     @staticmethod
@@ -50,22 +48,22 @@ class EnsembleFunctionMixin(OverloadedType):
         local_dot = sum(uself._ad_dot(uother, options=options)
                         for uself, uother in zip(self.subfunctions,
                                                  other.subfunctions))
-        return self.ensemble.ensemble_comm.allreduce(local_dot)
-
-    def _ad_convert_riesz(self, value, options=None):
-        raise NotImplementedError
+        return self.function_space().ensemble.allreduce(local_dot)
 
     def _ad_init_zero(self, dual=False):
-        from firedrake import EnsembleFunction, EnsembleCofunction
+        from firedrake import EnsembleFunction
+        space = self.function_space()
         if dual:
-            return EnsembleCofunction(self.function_space().dual())
-        else:
-            return EnsembleFunction(self.function_space())
+            space = space.dual()
+        return EnsembleFunction(space)
+
+    def _ad_convert_riesz(self, value, riesz_map=None):
+        return value.riesz_representation(riesz_map=riesz_map or "L2")
 
     def _ad_create_checkpoint(self):
         if disk_checkpointing():
             raise NotImplementedError(
-                "Disk checkpointing not implemented for EnsembleFunctions")
+                f"Disk checkpointing not implemented for {type(self).__name__}")
         else:
             return self.copy()
 
@@ -73,12 +71,12 @@ class EnsembleFunctionMixin(OverloadedType):
         if type(checkpoint) is type(self):
             return checkpoint
         raise NotImplementedError(
-            "Disk checkpointing not implemented for EnsembleFunctions")
+            f"Disk checkpointing not implemented for {type(self).__name__}")
 
     def _ad_from_petsc(self, vec):
-        with self.vec_wo as self_v:
+        with self.vec_wo() as self_v:
             vec.copy(self_v)
 
     def _ad_to_petsc(self, vec=None):
-        with self.vec_ro as self_v:
+        with self.vec_ro() as self_v:
             return self_v.copy(vec or self._vec.duplicate())

--- a/firedrake/ensemble/ensemble_function.py
+++ b/firedrake/ensemble/ensemble_function.py
@@ -192,9 +192,20 @@ class EnsembleFunctionBase(EnsembleFunctionMixin):
         return self
 
     @PETSc.Log.EventDecorator()
+    def __isub__(self, other):
+        self += -1*other
+        return self
+
+    @PETSc.Log.EventDecorator()
     def __add__(self, other):
         new = self.copy()
         new += other
+        return new
+
+    @PETSc.Log.EventDecorator()
+    def __sub__(self, other):
+        new = self.copy()
+        new -= other
         return new
 
     @PETSc.Log.EventDecorator()
@@ -205,13 +216,18 @@ class EnsembleFunctionBase(EnsembleFunctionMixin):
 
     @PETSc.Log.EventDecorator()
     def __rmul__(self, other):
+        new = self.copy()
         if type(other) is type(self):
-            for us, uo in zip(self.subfunctions, other.subfunctions):
-                us.assign(us*uo)
+            for un, uo in zip(new.subfunctions, other.subfunctions):
+                un.assign(uo*un)
         else:
-            for us in self.subfunctions:
-                us *= other
-        return self
+            for un in new.subfunctions:
+                un.assign(other*un)
+        return new
+
+    @PETSc.Log.EventDecorator()
+    def __neg__(self):
+        return (-1)*self
 
     @contextmanager
     def vec(self):


### PR DESCRIPTION
EnsembleFunction adjoint_utils mixin:
1. `_ad_to_list`: simplify PETSc.Scatter.
2. `_ad_convert_riesz`: implementation
3. `_to/from_petsc`: missing braces. 

EnsembleFunction:
1. `__rmul__`: return new object rather than modifying self.
2. `__sub__` impl.