### PR TITLE
`MixedCovarianceOperator`

### DIFF
--- a/firedrake/adjoint/__init__.py
+++ b/firedrake/adjoint/__init__.py
@@ -36,7 +36,7 @@ from firedrake.adjoint.ensemble_reduced_functional import EnsembleReducedFunctio
 from firedrake.adjoint.transformed_functional import L2RieszMap, L2TransformedFunctional  # noqa: F401
 from firedrake.adjoint.covariance_operator import (  # noqa F401
     WhiteNoiseGenerator, AutoregressiveCovariance, CovarianceMat,
-    PyOP2NoiseBackend, PetscNoiseBackend, VOMNoiseBackend)
+    PyOP2NoiseBackend, PetscNoiseBackend, VOMNoiseBackend, MixedCovarianceOperator)
 import numpy_adjoint  # noqa F401
 import firedrake.ufl_expr
 import types

--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -638,7 +638,7 @@ class MixedCovarianceOperator(CovarianceOperatorBase):
     --------
     CovarianceOperatorBase
     CovarianceMat
-    CovariancePC
+    ~firedrake.preconditioners.covariance.CovariancePC
     """
     def __init__(self, W: WithGeometry, subcovariances: Iterable[CovarianceOperatorBase]):
         if len(subcovariances) != len(W.subspaces):

--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -620,6 +620,84 @@ class CovarianceOperatorBase:
             " also want to implement apply_inverse.")
 
 
+class MixedCovarianceOperator(CovarianceOperatorBase):
+    """
+    A block-diagonal covariance operator that acts component-wise on a mixed function space.
+
+    The norm, sample, action, and inverse methods of this covariance operator will
+    apply the corresponding methods of each subcovariance operator to each component of the mixed space.
+
+    Parameters
+    ----------
+    W :
+        The MixedFunctionSpace that this covariance operator acts on.
+    subcovariances :
+        The covariance operators for each component of W.
+
+    See Also
+    --------
+    CovarianceOperatorBase
+    CovarianceMat
+    CovariancePC
+    """
+    def __init__(self, W: WithGeometry, subcovariances: Iterable[CovarianceOperatorBase]):
+        if len(subcovariances) != len(W.subspaces):
+            raise ValueError(
+                "Need one covariance operator per component of mixed space")
+        if not all(isinstance(cov, CovarianceOperatorBase)
+                   for cov in subcovariances):
+            raise TypeError(
+                "All covariance operators must be a CovarianceOperatorBase")
+        if not all(cov.function_space() == Wsub
+                   for cov, Wsub in zip(subcovariances, W.subspaces)):
+            raise ValueError(
+                "Covariance function spaces must match W subspaces")
+
+        self._W = W
+        self._subcovariances = subcovariances
+        self._rngs = [cov.rng() for cov in self.subcovariances]
+
+    def function_space(self):
+        return self._W
+
+    @property
+    def subcovariances(self):
+        """The covariance operators for each component of the mixed space."""
+        return self._subcovariances
+
+    def rng(self):
+        return self._rngs
+
+    def sample(self, rng=None, tensor=None):
+        tensor = tensor or Function(self.function_space)
+        for cov, tsub, rsub in zip(self.subcovariances,
+                                   tensor.subfunctions,
+                                   rng or self.rng()):
+            cov.sample(rng=rsub, tensor=tsub)
+        return tensor
+
+    def norm(self, x):
+        return sum(cov.norm(xsub)
+                   for cov, xsub in zip(self.subcovariances,
+                                        x.subfunctions))
+
+    def apply_inverse(self, x, tensor=None):
+        tensor = tensor or Cofunction(self.function_space().dual())
+        for cov, xsub, tsub in zip(self.subcovariances,
+                                   x.subfunctions,
+                                   tensor.subfunctions):
+            cov.apply_inverse(xsub, tensor=tsub)
+        return tensor
+
+    def apply_action(self, x, tensor=None):
+        tensor = tensor or Function(self.function_space())
+        for cov, xsub, tsub in zip(self.subcovariances,
+                                   x.subfunctions,
+                                   tensor.subfunctions):
+            cov.apply_action(xsub, tensor=tsub)
+        return tensor
+
+
 class AutoregressiveCovariance(CovarianceOperatorBase):
     r"""
     An m-th order autoregressive covariance operator using an implicit diffusion operator.
@@ -852,7 +930,8 @@ class AutoregressiveCovariance(CovarianceOperatorBase):
 
 
 def diffusion_form(u, v, kappa: Constant | Function,
-                   formulation: AutoregressiveCovariance.DiffusionForm):
+                   formulation: AutoregressiveCovariance.DiffusionForm,
+                   cell_size=None):
     """
     Convenience function for common diffusion forms.
 
@@ -873,6 +952,9 @@ def diffusion_form(u, v, kappa: Constant | Function,
         The diffusion coefficient.
     formulation :
         The type of diffusion form.
+    cell_size :
+        The cell size used to calculate the interior penalty stabilisation.
+        Defaults to ``CellSize(mesh)``. Ignored if formulation is ``CG``.
 
     Returns
     -------
@@ -886,6 +968,7 @@ def diffusion_form(u, v, kappa: Constant | Function,
 
     See Also
     --------
+    AutoregressiveCovariance
     AutoregressiveCovariance.DiffusionForm
     """
     if formulation == AutoregressiveCovariance.DiffusionForm.CG:
@@ -894,7 +977,7 @@ def diffusion_form(u, v, kappa: Constant | Function,
     elif formulation == AutoregressiveCovariance.DiffusionForm.IP:
         mesh = v.function_space().mesh()
         n = FacetNormal(mesh)
-        h = CellSize(mesh)
+        h = cell_size or CellSize(mesh)
         h_avg = 0.5*(h('+') + h('-'))
         alpha_h = Constant(4.0)/h_avg
         return (

--- a/tests/firedrake/regression/test_covariance_operator.py
+++ b/tests/firedrake/regression/test_covariance_operator.py
@@ -336,38 +336,38 @@ def test_mixed_covariance(operation):
     coords, = SpatialCoordinate(mesh)
 
     V0 = FunctionSpace(mesh, "CG", 1)
-    V1 = FunctionSpace(mesh, "CG", 2)
+    V1 = FunctionSpace(mesh, "DG", 1)
     W = V0*V1
 
-    Bc = AutoregressiveCovariance(V0, L, sigma, m=2)
-    Bd = AutoregressiveCovariance(V1, L, sigma, m=2)
+    Bc = AutoregressiveCovariance(V0, L, sigma, m=2, form="CG")
+    Bd = AutoregressiveCovariance(V1, 2*L, 2*sigma, m=2, form="IP")
 
     B = MixedCovarianceOperator(W, [Bc, Bd])
 
     mat = CovarianceMat(B, operation=operation)
 
-    expr_c = 2*pi*coords
-    expr_d = 4*pi*coords
+    expr_c = sin(2*pi*coords)
+    expr_d = cos(1*pi*coords)
 
     if operation == 'action':
         x = Function(W)
         y = Function(W)
 
-        x.subfunctions[0].interpolate(expr_c)
-        x.subfunctions[1].interpolate(expr_d)
+        x.subfunctions[0].project(expr_c)
+        x.subfunctions[1].project(expr_d)
         x = x.riesz_representation()
 
         xcheck = x.copy(deepcopy=True)
         ycheck = y.copy(deepcopy=True)
 
-        B.apply_action(xcheck)
+        B.apply_action(xcheck, tensor=ycheck)
 
     elif operation == 'inverse':
         x = Function(W)
         y = Function(W.dual())
 
-        x.subfunctions[0].interpolate(expr_c)
-        x.subfunctions[1].interpolate(expr_d)
+        x.subfunctions[0].project(expr_c)
+        x.subfunctions[1].project(expr_d)
 
         xcheck = x.copy(deepcopy=True)
         ycheck = y.copy(deepcopy=True)

--- a/tests/firedrake/regression/test_covariance_operator.py
+++ b/tests/firedrake/regression/test_covariance_operator.py
@@ -5,7 +5,8 @@ import petsctools
 from firedrake import *
 from firedrake.adjoint import (
     WhiteNoiseGenerator, PyOP2NoiseBackend, PetscNoiseBackend,
-    VOMNoiseBackend, AutoregressiveCovariance, CovarianceMat)
+    VOMNoiseBackend, AutoregressiveCovariance, MixedCovarianceOperator,
+    CovarianceMat)
 
 
 def petsc2numpy_vec(petsc_vec):
@@ -270,6 +271,104 @@ def test_covariance_mat(m, family, operation):
     elif operation == 'inverse':
         x = Function(V).project(expr)
         y = Function(V.dual())
+        xcheck = x.copy(deepcopy=True)
+        ycheck = y.copy(deepcopy=True)
+
+        B.apply_inverse(xcheck, tensor=ycheck)
+
+    with x.dat.vec as xv, y.dat.vec as yv:
+        mat.mult(xv, yv)
+
+    # flip to primal space to calculate norms
+    if operation == 'inverse':
+        y = y.riesz_representation()
+        ycheck = ycheck.riesz_representation()
+
+    assert errornorm(ycheck, y)/norm(ycheck) < 1e-12
+
+    if operation == 'inverse':
+        y = y.riesz_representation()
+        ycheck = ycheck.riesz_representation()
+
+    ksp = PETSc.KSP().create()
+    ksp.setOperators(mat)
+
+    tol = 1e-8
+
+    petsctools.set_from_options(
+        ksp, options_prefix=str(operation),
+        parameters={
+            'ksp_monitor': None,
+            'ksp_type': 'richardson',
+            'ksp_max_it': 2,
+            'ksp_rtol': tol,
+            'pc_type': 'python',
+            'pc_python_type': 'firedrake.CovariancePC',
+        }
+    )
+    x.zero()
+
+    with x.dat.vec as xv, y.dat.vec as yv:
+        with petsctools.inserted_options(ksp):
+            ksp.solve(yv, xv)
+
+    # CovarianceOperator operations should
+    # be exact inverses of each other.
+    assert ksp.its == 1
+
+    if operation == 'action':
+        x = x.riesz_representation()
+        xcheck = xcheck.riesz_representation()
+
+    assert errornorm(xcheck, x)/norm(xcheck) < 10*tol
+
+
+@pytest.mark.skipcomplex
+@pytest.mark.parametrize("operation", ("action", "inverse"))
+def test_mixed_covariance(operation):
+    """Test that covariance mat and pc apply correct and opposite actions.
+    """
+    nx = 20
+    L = 0.2
+    sigma = 0.9
+
+    mesh = UnitIntervalMesh(nx)
+    coords, = SpatialCoordinate(mesh)
+
+    V0 = FunctionSpace(mesh, "CG", 1)
+    V1 = FunctionSpace(mesh, "CG", 2)
+    W = V0*V1
+
+    Bc = AutoregressiveCovariance(V0, L, sigma, m=2)
+    Bd = AutoregressiveCovariance(V1, L, sigma, m=2)
+
+    B = MixedCovarianceOperator(W, [Bc, Bd])
+
+    mat = CovarianceMat(B, operation=operation)
+
+    expr_c = 2*pi*coords
+    expr_d = 4*pi*coords
+
+    if operation == 'action':
+        x = Function(W)
+        y = Function(W)
+
+        x.subfunctions[0].interpolate(expr_c)
+        x.subfunctions[1].interpolate(expr_d)
+        x = x.riesz_representation()
+
+        xcheck = x.copy(deepcopy=True)
+        ycheck = y.copy(deepcopy=True)
+
+        B.apply_action(xcheck)
+
+    elif operation == 'inverse':
+        x = Function(W)
+        y = Function(W.dual())
+
+        x.subfunctions[0].interpolate(expr_c)
+        x.subfunctions[1].interpolate(expr_d)
+
         xcheck = x.copy(deepcopy=True)
         ycheck = y.copy(deepcopy=True)
 


### PR DESCRIPTION
For a mixed space it is unlikely you will want the same covariance operator on all components.
`MixedCovarianceOperator` is a lets you stitch together a covariance operator on each component into a simple block-diagonal covariance operator.

There is a small bugfix to the `diffusion_form` to let the covariance operators work with Gusto because `CellSize` doesn't work with immersed meshes (e.g. a sphere).