### PR TITLE
Deprecate variable layer extrusion

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -20,6 +20,7 @@ import rtree
 from textwrap import dedent
 from pathlib import Path
 import typing
+import warnings
 
 from pyop2 import op2
 from pyop2.mpi import (
@@ -3387,7 +3388,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
     :arg layers:         number of extruded cell layers in the "vertical"
                          direction.  One may also pass an array of
                          shape (cells, 2) to specify a variable number
-                         of layers.  In this case, each entry is a pair
+                         of layers (deprecated).  In this case, each entry is a pair
                          ``[a, b]`` where ``a`` indicates the starting
                          cell layer of the column and ``b`` the number
                          of cell layers in that column.
@@ -3451,6 +3452,13 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
     name = name if name is not None else mesh.name + "_extruded"
     layers = np.asarray(layers, dtype=IntType)
     if layers.shape:
+        warnings.warn(
+            "Variable layer extrusion is deprecated and will be removed "
+            "in the 2026.10.0 release. If possible we recommend using "
+            "Submesh instead. Please get in touch if this is a critical ",
+            "issue for you.",
+            FutureWarning,
+        )
         if periodic:
             raise ValueError("Must provide constant layer for periodic extrusion")
         if layers.shape != (mesh.cell_set.total_size, 2):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3455,7 +3455,7 @@ def ExtrudedMesh(mesh, layers, layer_height=None, extrusion_type='uniform', peri
         warnings.warn(
             "Variable layer extrusion is deprecated and will be removed "
             "in the 2026.10.0 release. If possible we recommend using "
-            "Submesh instead. Please get in touch if this is a critical ",
+            "Submesh instead. Please get in touch if this is a critical "
             "issue for you.",
             FutureWarning,
         )


### PR DESCRIPTION
This is going away in pyop3.

I am optimistic that one day we can recover the functionality using `Submesh` but definitely not immediately.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
