### PR TITLE
Fix MG transfers for elements that need cell sizes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,6 +143,7 @@ nitpick_ignore_regex = [
     (r'py:.*', r'progress\..*'),
     # Ignore undocumented PyOP2
     ('py:class', 'pyop2.caching.Cached'),
+    ('py:class', 'pyop2.op2.Kernel'),
     # Ignore mission docs from Firedrake internal "private" code
     # Any "Base" class eg:
     #   firedrake.adjoint.checkpointing.CheckpointBase

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -283,8 +283,14 @@ def inject(fine, coarse):
     return coarse
 
 
-def _topology_permutation(f, V):
-    """Permute the Function f with the same entity ordering as the FunctionSpace V."""
+def apply_entity_permutation(f, V):
+    """Permute the Function f with the same entity ordering as the FunctionSpace V.
+    
+    The multigrid transfer kernels require geometric quantities of the source mesh
+    to have the same entity ordering as the source Function being transfered.
+    We need to permute f if V is a RestrictedFunctionSpace, because the
+    geometric quantities will live on an unrestricted FunctionSpace.
+    """
     if V.boundary_set:
         W = V.reconstruct(element=f.function_space().ufl_element())
         f = Function(W).assign(f)
@@ -293,9 +299,9 @@ def _topology_permutation(f, V):
 
 def get_coordinates(V):
     """Return mesh coordinates with the same entity ordering as V."""
-    return _topology_permutation(V.mesh().coordinates, V)
+    return apply_entity_permutation(V.mesh().coordinates, V)
 
 
 def get_cell_sizes(V):
     """Return cell sizes with the same entity ordering as V."""
-    return _topology_permutation(V.mesh().cell_sizes, V)
+    return apply_entity_permutation(V.mesh().cell_sizes, V)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -285,7 +285,6 @@ def inject(fine, coarse):
 
 def apply_entity_permutation(f, V):
     """Permute the Function f with the same entity ordering as the FunctionSpace V.
-    
     The multigrid transfer kernels require geometric quantities of the source mesh
     to have the same entity ordering as the source Function being transfered.
     We need to permute f if V is a RestrictedFunctionSpace, because the

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -285,6 +285,7 @@ def inject(fine, coarse):
 
 def apply_entity_permutation(f, V):
     """Permute the Function f with the same entity ordering as the FunctionSpace V.
+    
     The multigrid transfer kernels require geometric quantities of the source mesh
     to have the same entity ordering as the source Function being transfered.
     We need to permute f if V is a RestrictedFunctionSpace, because the

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -79,21 +79,26 @@ def prolong(coarse, fine):
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
         kernel = kernels.prolong_kernel(coarse, Vf)
-
         # XXX: Should be able to figure out locations by pushing forward
         # reference cell node locations to physical space.
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf)
+        kernel_args = [
+            fine.dat(op2.WRITE),
+            coarse.dat(op2.READ, fine_to_coarse),
+            node_locations.dat(op2.READ),
+            coarse_coords.dat(op2.READ, fine_to_coarse_coords),
+        ]
+        if kernel.needs_cell_sizes:
+            coarse_cell_sizes = get_cell_sizes(Vc)
+            fine_to_coarse_sizes = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
+            kernel_args.append(coarse_cell_sizes.dat(op2.READ, fine_to_coarse_sizes))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse, coarse_coords]:
             d.dat.global_to_local_begin(op2.READ)
             d.dat.global_to_local_end(op2.READ)
-        op2.par_loop(kernel, fine.node_set,
-                     fine.dat(op2.WRITE),
-                     coarse.dat(op2.READ, fine_to_coarse),
-                     node_locations.dat(op2.READ),
-                     coarse_coords.dat(op2.READ, fine_to_coarse_coords))
+        op2.par_loop(kernel, fine.node_set, *kernel_args)
 
         if needs_quadrature:
             # Transfer to the actual target space
@@ -156,17 +161,23 @@ def restrict(fine_dual, coarse_dual):
         coarse_coords = get_coordinates(Vc.dual())
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
+        kernel = kernels.restrict_kernel(Vf, Vc)
+        kernel_args = [
+            coarse_dual.dat(op2.INC, fine_to_coarse),
+            fine_dual.dat(op2.READ),
+            node_locations.dat(op2.READ),
+            coarse_coords.dat(op2.READ, fine_to_coarse_coords)
+        ]
+        if kernel.needs_cell_sizes:
+            coarse_cell_sizes = get_cell_sizes(Vc)
+            fine_to_coarse_sizes = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
+            kernel_args.append(coarse_cell_sizes.dat(op2.READ, fine_to_coarse_sizes))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse_coords]:
             d.dat.global_to_local_begin(op2.READ)
             d.dat.global_to_local_end(op2.READ)
-        kernel = kernels.restrict_kernel(Vf, Vc)
-        op2.par_loop(kernel, fine_dual.node_set,
-                     coarse_dual.dat(op2.INC, fine_to_coarse),
-                     fine_dual.dat(op2.READ),
-                     node_locations.dat(op2.READ),
-                     coarse_coords.dat(op2.READ, fine_to_coarse_coords))
+        op2.par_loop(kernel, fine_dual.node_set, *kernel_args)
         fine_dual = coarse_dual
     return coarse_dual
 
@@ -231,18 +242,23 @@ def inject(fine, coarse):
             fine_coords = get_coordinates(Vf)
             coarse_to_fine = utils.coarse_node_to_fine_node_map(Vc, Vf)
             coarse_to_fine_coords = utils.coarse_node_to_fine_node_map(Vc, fine_coords.function_space())
-
             node_locations = utils.physical_node_locations(Vc)
+            kernel_args = [
+                coarse.dat(op2.WRITE),
+                fine.dat(op2.READ, coarse_to_fine),
+                node_locations.dat(op2.READ),
+                fine_coords.dat(op2.READ, coarse_to_fine_coords)
+            ]
+            if kernel.needs_cell_sizes:
+                fine_cell_sizes = get_cell_sizes(Vf)
+                coarse_to_fine_sizes = utils.coarse_node_to_fine_node_map(Vc, fine_cell_sizes.function_space())
+                kernel_args.append(fine_cell_sizes.dat(op2.READ, coarse_to_fine_sizes))
             # Have to do this, because the node set core size is not right for
             # this expanded stencil
             for d in [fine, fine_coords]:
                 d.dat.global_to_local_begin(op2.READ)
                 d.dat.global_to_local_end(op2.READ)
-            op2.par_loop(kernel, coarse.node_set,
-                         coarse.dat(op2.WRITE),
-                         fine.dat(op2.READ, coarse_to_fine),
-                         node_locations.dat(op2.READ),
-                         fine_coords.dat(op2.READ, coarse_to_fine_coords))
+            op2.par_loop(kernel, coarse.node_set, *kernel_args)
         else:
             coarse_coords = get_coordinates(Vc)
             fine_coords = get_coordinates(Vf)
@@ -267,9 +283,19 @@ def inject(fine, coarse):
     return coarse
 
 
-def get_coordinates(V):
-    coords = V.mesh().coordinates
+def _topology_permutation(f, V):
+    """Permute the Function f with the same entity ordering as the FunctionSpace V."""
     if V.boundary_set:
-        W = V.reconstruct(element=coords.function_space().ufl_element())
-        coords = Function(W).interpolate(coords)
-    return coords
+        W = V.reconstruct(element=f.function_space().ufl_element())
+        f = Function(W).assign(f)
+    return f
+
+
+def get_coordinates(V):
+    """Return mesh coordinates with the same entity ordering as V."""
+    return _topology_permutation(V.mesh().coordinates, V)
+
+
+def get_cell_sizes(V):
+    """Return cell sizes with the same entity ordering as V."""
+    return _topology_permutation(V.mesh().cell_sizes, V)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -75,7 +75,7 @@ def prolong(coarse, fine):
         Vf = fine.function_space()
         Vc = coarse.function_space()
 
-        coarse_coords = get_coordinates(Vc)
+        coarse_coords = Vc.mesh().coordinates
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
         kernel = kernels.prolong_kernel(coarse, Vf)
@@ -90,7 +90,7 @@ def prolong(coarse, fine):
             coarse_coords.dat(op2.READ, fine_to_coarse_coords),
         ]
         if kernel.needs_cell_sizes:
-            coarse_cell_sizes = get_cell_sizes(Vc)
+            coarse_cell_sizes = Vc.mesh().cell_sizes
             fine_to_coarse_sizes = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
             kernel_args.append(coarse_cell_sizes.dat(op2.READ, fine_to_coarse_sizes))
         # Have to do this, because the node set core size is not right for
@@ -158,7 +158,7 @@ def restrict(fine_dual, coarse_dual):
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf.dual())
 
-        coarse_coords = get_coordinates(Vc.dual())
+        coarse_coords = Vc.mesh().coordinates
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
         kernel = kernels.restrict_kernel(Vf, Vc)
@@ -169,7 +169,7 @@ def restrict(fine_dual, coarse_dual):
             coarse_coords.dat(op2.READ, fine_to_coarse_coords)
         ]
         if kernel.needs_cell_sizes:
-            coarse_cell_sizes = get_cell_sizes(Vc)
+            coarse_cell_sizes = Vc.mesh().cell_sizes
             fine_to_coarse_sizes = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
             kernel_args.append(coarse_cell_sizes.dat(op2.READ, fine_to_coarse_sizes))
         # Have to do this, because the node set core size is not right for
@@ -239,7 +239,7 @@ def inject(fine, coarse):
         Vc = coarse.function_space()
         Vf = fine.function_space()
         if not dg:
-            fine_coords = get_coordinates(Vf)
+            fine_coords = Vf.mesh().coordinates
             coarse_to_fine = utils.coarse_node_to_fine_node_map(Vc, Vf)
             coarse_to_fine_coords = utils.coarse_node_to_fine_node_map(Vc, fine_coords.function_space())
             node_locations = utils.physical_node_locations(Vc)
@@ -250,7 +250,7 @@ def inject(fine, coarse):
                 fine_coords.dat(op2.READ, coarse_to_fine_coords)
             ]
             if kernel.needs_cell_sizes:
-                fine_cell_sizes = get_cell_sizes(Vf)
+                fine_cell_sizes = Vf.mesh().cell_sizes
                 coarse_to_fine_sizes = utils.coarse_node_to_fine_node_map(Vc, fine_cell_sizes.function_space())
                 kernel_args.append(fine_cell_sizes.dat(op2.READ, coarse_to_fine_sizes))
             # Have to do this, because the node set core size is not right for
@@ -260,8 +260,8 @@ def inject(fine, coarse):
                 d.dat.global_to_local_end(op2.READ)
             op2.par_loop(kernel, coarse.node_set, *kernel_args)
         else:
-            coarse_coords = get_coordinates(Vc)
-            fine_coords = get_coordinates(Vf)
+            coarse_coords = Vc.mesh().coordinates
+            fine_coords = Vf.mesh().coordinates
             coarse_cell_to_fine_nodes = utils.coarse_cell_to_fine_node_map(Vc, Vf)
             coarse_cell_to_fine_coords = utils.coarse_cell_to_fine_node_map(Vc, fine_coords.function_space())
             # Have to do this, because the node set core size is not right for
@@ -281,27 +281,3 @@ def inject(fine, coarse):
             coarse = new_coarse.interpolate(coarse)
         fine = coarse
     return coarse
-
-
-def apply_entity_permutation(f, V):
-    """Permute the Function f with the same entity ordering as the FunctionSpace V.
-    
-    The multigrid transfer kernels require geometric quantities of the source mesh
-    to have the same entity ordering as the source Function being transfered.
-    We need to permute f if V is a RestrictedFunctionSpace, because the
-    geometric quantities will live on an unrestricted FunctionSpace.
-    """
-    if V.boundary_set:
-        W = V.reconstruct(element=f.function_space().ufl_element())
-        f = Function(W).assign(f)
-    return f
-
-
-def get_coordinates(V):
-    """Return mesh coordinates with the same entity ordering as V."""
-    return apply_entity_permutation(V.mesh().coordinates, V)
-
-
-def get_cell_sizes(V):
-    """Return cell sizes with the same entity ordering as V."""
-    return apply_entity_permutation(V.mesh().cell_sizes, V)

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -92,9 +92,9 @@ static inline void to_reference_coords_kernel(PetscScalar *X, const PetscScalar 
     return evaluate_template_c % code
 
 
-def compile_element(operand, dual_arg, parameters=None,
-                    name="evaluate"):
-    """Generate code for point evaluations.
+def dual_evaluation_kernel(operand, dual_arg, parameters=None,
+                           name="evaluate"):
+    """Generate kernel for dual evaluation.
 
     Parameters
     ----------
@@ -105,8 +105,8 @@ def compile_element(operand, dual_arg, parameters=None,
 
     Returns
     -------
-    str
-        The generated code
+    op2.Kernel
+        The kernel
     """
     source_mesh = extract_unique_domain(operand)
     target_space = dual_arg.arguments()[0].ufl_function_space()
@@ -126,10 +126,30 @@ def compile_element(operand, dual_arg, parameters=None,
                                                 ufl_element,
                                                 parameters=parameters,
                                                 name="pyop2_kernel_"+name)
+    return kernel
+
+
+def compile_element(operand, dual_arg, parameters=None,
+                    name="evaluate"):
+    """Generate code for point evaluations.
+
+    Parameters
+    ----------
+    operand: ufl.Expr
+        A primal expression
+    dual_arg: ufl.Coargument | ufl.Cofunction
+        A dual argument or coefficient
+
+    Returns
+    -------
+    str
+        The generated code
+    """
+    kernel = dual_evaluation_kernel(operand, dual_arg, parameters=parameters, name=name)
     return lp.generate_code_v2(kernel.ast).device_code()
 
 
-def _make_kernel_args(element, *args):
+def _make_kernel_args(kernel, element, *args):
     """Returns a string of argument names to call the kernel.
        Discards coordinate arguments if they do not appear in the kernel."""
     # NOTE: TSFC will sometimes drop run-time arguments in generated
@@ -137,8 +157,8 @@ def _make_kernel_args(element, *args):
     # For further information, see the same note in interpolation.py.
     mask = [True] * len(args)
     # Drop the source coordinates if the element is affinely-mapped.
-    needs_coordinates = element.mapping != "affine"
-    mask[1] = needs_coordinates
+    mask[1] = kernel.needs_cell_sizes
+    mask[2] = kernel.needs_external_coords
     # Drop the target location if the element is constant.
     is_constant = sum(as_tuple(element.degree)) == 0 and not element.complex.is_macrocell()
     mask[-1] = not is_constant
@@ -177,16 +197,18 @@ def prolong_kernel(expression, Vf):
     try:
         return cache[key]
     except KeyError:
-        evaluate_code = compile_element(expression, ufl.TestFunction(Vf.dual()))
+        kernel = dual_evaluation_kernel(expression, ufl.TestFunction(Vf.dual()))
+        evaluate_code = lp.generate_code_v2(kernel.ast).device_code()
         to_reference_kernel = to_reference_coordinates(coordinates.ufl_element())
         coords_element = create_element(coordinates.ufl_element())
         element = create_element(expression.ufl_element())
+        num_verts = len(element.cell.get_vertices())
 
-        my_kernel = """#include <petsc.h>
+        kernel_code = """#include <petsc.h>
         %(to_reference)s
         %(evaluate)s
         __attribute__((noinline)) /* Clang bug */
-        static void pyop2_kernel_prolong(PetscScalar *R, PetscScalar *f, const PetscScalar *X, const PetscScalar *Xc)
+        static void pyop2_kernel_prolong(PetscScalar *R, PetscScalar *f, const PetscScalar *X, const PetscScalar *Xc%(cell_sizes)s)
         {
             PetscScalar Xref[%(tdim)d];
             int cell = -1;
@@ -232,7 +254,8 @@ def prolong_kernel(expression, Vf):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": evaluate_code,
-               "kernel_args": _make_kernel_args(element, "R", "Xci", "fi", "Xref"),
+               "cell_sizes": ", const PetscScalar *cs" if kernel.needs_cell_sizes else "",
+               "kernel_args": _make_kernel_args(kernel, element, "R", f"cs+cell*{num_verts}", "Xci", "fi", "Xref"),
                "ncandidate": ncandidate,
                "Rdim": Vf.block_size,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
@@ -241,7 +264,9 @@ def prolong_kernel(expression, Vf):
                "coarse_cell_inc": element.space_dimension(),
                "tdim": element.cell.get_spatial_dimension()}
 
-        return cache.setdefault(key, op2.Kernel(my_kernel, name="pyop2_kernel_prolong"))
+        transfer_kernel = op2.Kernel(kernel_code, name="pyop2_kernel_prolong")
+        transfer_kernel.needs_cell_sizes = kernel.needs_cell_sizes
+        return cache.setdefault(key, transfer_kernel)
 
 
 def restrict_kernel(Vf, Vc):
@@ -260,17 +285,19 @@ def restrict_kernel(Vf, Vc):
         return cache[key]
     except KeyError:
         assert isinstance(Vc, FiredrakeDualSpace) and isinstance(Vf, FiredrakeDualSpace)
-        evaluate_code = compile_element(ufl.TestFunction(Vc.dual()), ufl.Cofunction(Vf))
+        kernel = dual_evaluation_kernel(ufl.TestFunction(Vc.dual()), ufl.Cofunction(Vf))
+        evaluate_code = lp.generate_code_v2(kernel.ast).device_code()
         to_reference_kernel = to_reference_coordinates(coordinates.ufl_element())
         coords_element = create_element(coordinates.ufl_element())
         element = create_element(Vc.ufl_element())
+        num_verts = len(element.cell.get_vertices())
 
-        my_kernel = """#include <petsc.h>
+        kernel_code = """#include <petsc.h>
         %(to_reference)s
         %(evaluate)s
 
         __attribute__((noinline)) /* Clang bug */
-        static void pyop2_kernel_restrict(PetscScalar *R, PetscScalar *b, const PetscScalar *X, const PetscScalar *Xc)
+        static void pyop2_kernel_restrict(PetscScalar *R, PetscScalar *b, const PetscScalar *X, const PetscScalar *Xc%(cell_sizes)s)
         {
             PetscScalar Xref[%(tdim)d];
             int cell = -1;
@@ -316,7 +343,8 @@ def restrict_kernel(Vf, Vc):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": evaluate_code,
-               "kernel_args": _make_kernel_args(element, "Ri", "Xc", "b", "Xref"),
+               "cell_sizes": ", const PetscScalar *cs" if kernel.needs_cell_sizes else "",
+               "kernel_args": _make_kernel_args(kernel, element, "Ri", f"cs+cell*{num_verts}", "Xc", "b", "Xref"),
                "ncandidate": ncandidate,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
@@ -324,7 +352,9 @@ def restrict_kernel(Vf, Vc):
                "coarse_cell_inc": element.space_dimension(),
                "tdim": element.cell.get_spatial_dimension()}
 
-        return cache.setdefault(key, op2.Kernel(my_kernel, name="pyop2_kernel_restrict"))
+        transfer_kernel = op2.Kernel(kernel_code, name="pyop2_kernel_restrict")
+        transfer_kernel.needs_cell_sizes = kernel.needs_cell_sizes
+        return cache.setdefault(key, transfer_kernel)
 
 
 def inject_kernel(Vf, Vc):

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -18,6 +18,7 @@ import gem.impero_utils as impero_utils
 
 import ufl
 import tsfc
+import pyop2
 
 import tsfc.kernel_interface.firedrake_loopy as firedrake_interface
 
@@ -105,7 +106,7 @@ def dual_evaluation_kernel(operand, dual_arg, parameters=None,
 
     Returns
     -------
-    op2.Kernel
+    pyop2.op2.Kernel
         The kernel
     """
     source_mesh = extract_unique_domain(operand)

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -129,26 +129,6 @@ def dual_evaluation_kernel(operand, dual_arg, parameters=None,
     return kernel
 
 
-def compile_element(operand, dual_arg, parameters=None,
-                    name="evaluate"):
-    """Generate code for point evaluations.
-
-    Parameters
-    ----------
-    operand: ufl.Expr
-        A primal expression
-    dual_arg: ufl.Coargument | ufl.Cofunction
-        A dual argument or coefficient
-
-    Returns
-    -------
-    str
-        The generated code
-    """
-    kernel = dual_evaluation_kernel(operand, dual_arg, parameters=parameters, name=name)
-    return lp.generate_code_v2(kernel.ast).device_code()
-
-
 def _make_kernel_args(kernel, element, *args):
     """Returns a string of argument names to call the kernel.
        Discards coordinate arguments if they do not appear in the kernel."""

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -136,10 +136,10 @@ def _make_kernel_args(kernel, element, *args):
     # kernels if they are deemed not-necessary.
     # For further information, see the same note in interpolation.py.
     mask = [True] * len(args)
-    # Drop the source coordinates if the element is affinely-mapped.
+    # Drop source mesh quantities if they do not appear in the kernel.
     mask[1] = kernel.needs_cell_sizes
     mask[2] = kernel.needs_external_coords
-    # Drop the target location if the element is constant.
+    # Drop the target coordinates if the element is constant.
     is_constant = sum(as_tuple(element.degree)) == 0 and not element.complex.is_macrocell()
     mask[-1] = not is_constant
     kernel_args = ", ".join(arg for arg, include in zip(args, mask) if include)

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -18,7 +18,6 @@ import gem.impero_utils as impero_utils
 
 import ufl
 import tsfc
-import pyop2
 
 import tsfc.kernel_interface.firedrake_loopy as firedrake_interface
 

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -4,10 +4,11 @@ import ctypes
 import pathlib
 import libsupermesh
 import petsctools
+
 from firedrake.cython.supermeshimpl import assemble_mixed_mass_matrix as ammm, intersection_finder
 from firedrake.mg.utils import get_level
 from firedrake.petsc import PETSc
-from firedrake.mg.kernels import to_reference_coordinates, compile_element, _make_kernel_args
+from firedrake.mg.kernels import to_reference_coordinates, dual_evaluation_kernel, _make_kernel_args
 from firedrake.utility_meshes import UnitTriangleMesh, UnitTetrahedronMesh
 from firedrake.functionspace import FunctionSpace
 from firedrake.assemble import assemble
@@ -21,6 +22,7 @@ from pyop2.sparsity import get_preallocation
 from pyop2.compilation import load
 from pyop2.mpi import COMM_SELF
 from collections import defaultdict
+from loopy import generate_code_v2
 
 
 __all__ = ["assemble_mixed_mass_matrix", "intersection_finder"]
@@ -213,9 +215,9 @@ each supermesh cell.
     V_S_A = FunctionSpace(reference_mesh, V_A.ufl_element())
     V_S_B = FunctionSpace(reference_mesh, V_B.ufl_element())
 
-    evaluate_kernel_A = compile_element(ufl.Coefficient(V_A), ufl.TestFunction(V_S_A.dual()), name="evaluate_kernel_A")
-    evaluate_kernel_B = compile_element(ufl.Coefficient(V_B), ufl.TestFunction(V_S_B.dual()), name="evaluate_kernel_B")
-    evaluate_kernel_S = compile_element(ufl.Coefficient(V_S), ufl.TestFunction(V_S.dual()), name="evaluate_kernel_S")
+    kernel_A = dual_evaluation_kernel(ufl.Coefficient(V_A), ufl.TestFunction(V_S_A.dual()), name="evaluate_kernel_A")
+    kernel_B = dual_evaluation_kernel(ufl.Coefficient(V_B), ufl.TestFunction(V_S_B.dual()), name="evaluate_kernel_B")
+    kernel_S = dual_evaluation_kernel(ufl.Coefficient(V_S), ufl.TestFunction(V_S.dual()), name="evaluate_kernel_S")
 
     M_SS = assemble(inner(TrialFunction(V_S_A), TestFunction(V_S_B)) * dx)
     M_SS = M_SS.petscmat[:, :]
@@ -442,12 +444,12 @@ each supermesh cell.
         return num_elements;
     }
     """ % {
-        "evaluate_S": str(evaluate_kernel_S),
-        "evaluate_A": str(evaluate_kernel_A),
-        "evaluate_B": str(evaluate_kernel_B),
-        "kernel_args_S": _make_kernel_args(V_S.finat_element, "physical_node_location", "BARF", "simplex_S", "reference_node_location"),
-        "kernel_args_A": _make_kernel_args(V_A.finat_element, "&R_AS[i][j]", "BARF", "coeffs_A", "reference_nodes_A[j]"),
-        "kernel_args_B": _make_kernel_args(V_B.finat_element, "&R_BS[i][j]", "BARF", "coeffs_B", "reference_nodes_B[j]"),
+        "evaluate_S": generate_code_v2(kernel_S.ast).device_code(),
+        "evaluate_A": generate_code_v2(kernel_A.ast).device_code(),
+        "evaluate_B": generate_code_v2(kernel_B.ast).device_code(),
+        "kernel_args_S": _make_kernel_args(kernel_S, V_S.finat_element, "physical_node_location", "BARF", "BARF", "simplex_S", "reference_node_location"),
+        "kernel_args_A": _make_kernel_args(kernel_A, V_A.finat_element, "&R_AS[i][j]", "BARF", "BARF", "coeffs_A", "reference_nodes_A[j]"),
+        "kernel_args_B": _make_kernel_args(kernel_B, V_B.finat_element, "&R_BS[i][j]", "BARF", "BARF", "coeffs_B", "reference_nodes_B[j]"),
         "to_reference": str(to_reference_kernel),
         "num_nodes_A": num_nodes_A,
         "num_nodes_B": num_nodes_B,

--- a/tests/firedrake/multigrid/test_embedded_transfer.py
+++ b/tests/firedrake/multigrid/test_embedded_transfer.py
@@ -40,13 +40,20 @@ def V(mesh, space, degree):
         return FunctionSpace(mesh, space, degree, variant="integral")
 
 
-@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
-def test_transfer(op, V):
-
-    def expr(V):
-        x = SpatialCoordinate(V.mesh())
+def expr(V):
+    x = SpatialCoordinate(V.mesh())
+    rank = len(V.value_shape)
+    if rank == 0:
+        return sum(x)
+    elif rank == 1:
         return {H1: x, HCurl: perp(x), HDiv: x}[V.ufl_element().sobolev_space]
+    elif rank == 2:
+        return sym(outer(x, Constant([1]*len(x))))
+    else:
+        raise ValueError("Unexpected value shape")
 
+
+def run_transfer(op, V):
     mh, _ = get_level(V.mesh())
     Vf = V
     Vc = V.reconstruct(mh[0])
@@ -85,6 +92,18 @@ def test_transfer(op, V):
         uf.interpolate(expr(Vf))
         inject(uf, uc)
         assert errornorm(expr(Vc), uc) < 1E-13
+
+
+@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
+def test_transfer(op, V):
+    run_transfer(op, V)
+
+
+@pytest.mark.parametrize("family,degree", [("AWc", 3)])
+@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
+def test_transfer_zany(op, mesh, family, degree):
+    V = FunctionSpace(mesh, family, degree)
+    run_transfer(op, V)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description
For zany elements that are mapped with a rescaling by `mesh.cell_sizes` (such as AWc and HZ), MG will trigger a compile error. This PR adds the missing support for `cell_sizes` in the MG transfer codegen.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
