### PR TITLE
Tighten tao tolerances in adjoint tests

### DIFF
--- a/tests/firedrake/adjoint/test_optimisation.py
+++ b/tests/firedrake/adjoint/test_optimisation.py
@@ -62,7 +62,7 @@ def minimize_tao_lmvm(rf):
                                  "tao_converged_reason": None,
                                  "tao_gatol": 1.0e-5,
                                  "tao_grtol": 0.0,
-                                 "tao_gttol": 1.0e-6,
+                                 "tao_gttol": 1.0e-7,
                                  "tao_monitor": None})
     return solver.solve()
 
@@ -74,7 +74,7 @@ def minimize_tao_nls(rf):
                                  "tao_converged_reason": None,
                                  "tao_gatol": 1.0e-5,
                                  "tao_grtol": 0.0,
-                                 "tao_gttol": 1.0e-6,
+                                 "tao_gttol": 1.0e-7,
                                  "tao_monitor": None})
     return solver.solve()
 


### PR DESCRIPTION
Replaces #5042 

One of the TAO optimisation tests started failing recently because it is now just missed the error tolerance on the optimised solution. Presumably something has changed in the solver stack so it is getting a slightly different solution.

Tightening up the tolerance makes the solution pass again. I looked at some of the other tests that use these parameter sets and some of them were also only just passing with the previous tolerance, so I don't think we mind the slight increase in the test durations.