### PR TITLE
Fix #4961: declare pymbolic and platformdirs, drop pycparser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,11 @@ dependencies = [
   # "petsc4py==3.24.5",
   "petsctools @ git+https://github.com/firedrakeproject/petsctools.git@main",
   "pkgconfig",
+  "platformdirs",
   "progress",
+  "pymbolic",
   # TODO RELEASE
   "pyadjoint-ad @ git+https://github.com/dolfin-adjoint/pyadjoint@master",
-  "pycparser",
   "pytools[siphash]",
   "requests",
   "scipy",


### PR DESCRIPTION
> **⚠️ This PR was generated by an AI agent (Claude Opus 4.7).** All commits are attributed accordingly. A human should review before merging.

## Summary

Fixes #4961 — `uv sync` / `poetry` prune packages that Firedrake imports at runtime but does not declare in `[project.dependencies]`.

- **Add `pymbolic`** — imported at `firedrake/mg/kernels.py:14`, `firedrake/slate/slac/kernel_builder.py:10`, `pyop2/codegen/rep2loopy.py:9`, `tsfc/loopy.py:16`, and method-local sites in `pyop2/types/dat.py` and `pyop2/codegen/loopycompat.py`. Previously only transitive via `loopy`.
- **Add `platformdirs`** — imported at `firedrake/scripts/firedrake_clean.py:7`, which is the `firedrake-clean` console-script entrypoint. Previously only transitive via `pytools`.
- **Drop `pycparser`** — no `import pycparser` / `from pycparser` anywhere in `firedrake/`, `pyop2/`, or `tsfc/`. Stale.

## Intentionally out of scope

- **`petsc4py`** stays commented alongside the other `TODO RELEASE` entries. It will be declared when the next PETSc release pin is applied, consistent with existing practice.
- **`requests`** is kept — it is used by `firedrake/scripts/firedrake-zenodo` (listed under `[tool.setuptools].script-files`).
- No changes to `[project.optional-dependencies]` or `[build-system].requires` — the `uv sync` bug only affects the base `dependencies` list.

## Verification

- `python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); deps=d['project']['dependencies']; assert 'pymbolic' in deps and 'platformdirs' in deps and 'pycparser' not in deps"` → ok
- `uv pip compile pyproject.toml` resolves cleanly
- Metadata-only change, no code paths modified, so the existing test suite is unaffected.

## Test plan
- [ ] Reproduce the original failure: install Firedrake in a fresh env, run `uv sync`, confirm `pymbolic` and `platformdirs` are retained (currently they are removed)
- [ ] CI passes

---

Commit attribution: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)