### PR TITLE
Use embedded transfer for HDiv/HCurl on manifolds

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1026,7 +1026,7 @@ def _build_interpolation_callables(
         parloop_args.append(tensor(access, (rows_map, columns_map), lgmaps=lgmaps))
 
     if oriented:
-        co = target_mesh.cell_orientations()
+        co = source_mesh.cell_orientations()
         parloop_args.append(co.dat(op2.READ, co.cell_node_map()))
 
     if needs_cell_sizes:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3098,13 +3098,16 @@ def make_mesh_from_coordinates(coordinates, name, tolerance=0.5):
     element = coordinates.ufl_element()
     if V.rank != 1 or len(element.reference_value_shape) != 1:
         raise ValueError("Coordinates must be from a rank-1 FunctionSpace with rank-1 value_shape.")
-    assert V.mesh().ufl_cell().topological_dimension <= V.value_size
+    orig_mesh = V.mesh()
+    assert orig_mesh.ufl_cell().topological_dimension <= V.value_size
 
     mesh = MeshGeometry(coordinates)
     mesh.name = name
     # Mark mesh as being made from coordinates
     mesh._made_from_coordinates = True
     mesh._tolerance = tolerance
+    mesh._did_reordering = orig_mesh._did_reordering
+    mesh._distribution_parameters = orig_mesh._distribution_parameters
     return mesh
 
 

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -51,7 +51,6 @@ class TransferManager(object):
     def is_native(self, element, gdim, op):
         if element in self.native_transfers:
             return self.native_transfers[element][op] is not None
-
         if isinstance(element.cell, ufl.TensorProductCell):
             if isinstance(element, finat.ufl.TensorProductElement):
                 return all(self.is_native(e, gdim, op) for e in element.factor_elements)
@@ -59,18 +58,20 @@ class TransferManager(object):
                 return all(self.is_native(e, gdim, op) for e in element.sub_elements)
 
         # Can we interpolate into this element?
+        # Piola-mapped elements on manifolds
+        # have degrees of freedom evaluating to
+        # different values on either side of a facet
+        tdim = element.cell.topological_dimension
+        if tdim != gdim and element.mapping() != "identity":
+            return False
+
         finat_element = create_element(element)
         try:
             finat_element.dual_basis
         except NotImplementedError:
             return False
         else:
-            # We can only interpolate into CG/DG spaces on manifold meshes
-            tdim = element.cell.topological_dimension
-            if tdim != gdim and (element.sobolev_space not in {ufl.H1, ufl.L2}):
-                return False
-            else:
-                return True
+            return True
 
     def _native_transfer(self, element, gdim, op):
         try:

--- a/firedrake/mg/embedded.py
+++ b/firedrake/mg/embedded.py
@@ -48,28 +48,35 @@ class TransferManager(object):
         self.use_averaging = use_averaging
         self.caches = {}
 
-    def is_native(self, element, op):
+    def is_native(self, element, gdim, op):
         if element in self.native_transfers:
             return self.native_transfers[element][op] is not None
+
         if isinstance(element.cell, ufl.TensorProductCell):
             if isinstance(element, finat.ufl.TensorProductElement):
-                return all(self.is_native(e, op) for e in element.factor_elements)
+                return all(self.is_native(e, gdim, op) for e in element.factor_elements)
             elif isinstance(element, finat.ufl.MixedElement):
-                return all(self.is_native(e, op) for e in element.sub_elements)
+                return all(self.is_native(e, gdim, op) for e in element.sub_elements)
 
         # Can we interpolate into this element?
         finat_element = create_element(element)
         try:
             finat_element.dual_basis
-            return True
         except NotImplementedError:
             return False
+        else:
+            # We can only interpolate into CG/DG spaces on manifold meshes
+            tdim = element.cell.topological_dimension
+            if tdim != gdim and (element.sobolev_space not in {ufl.H1, ufl.L2}):
+                return False
+            else:
+                return True
 
-    def _native_transfer(self, element, op):
+    def _native_transfer(self, element, gdim, op):
         try:
             return self.native_transfers[element][op]
         except KeyError:
-            if self.is_native(element, op):
+            if self.is_native(element, gdim, op):
                 ops = firedrake.prolong, firedrake.restrict, firedrake.inject
                 return self.native_transfers.setdefault(element, ops)[op]
         return None
@@ -241,8 +248,9 @@ class TransferManager(object):
         if not self.requires_transfer(Vs, transfer_op, source, target):
             return
 
-        if self.is_native(target_element, transfer_op):
-            self._native_transfer(target_element, transfer_op)(source, target)
+        gdim = Vt.mesh().geometric_dimension
+        if self.is_native(target_element, gdim, transfer_op):
+            self._native_transfer(target_element, gdim, transfer_op)(source, target)
         elif type(source_element) is finat.ufl.MixedElement:
             assert type(target_element) is finat.ufl.MixedElement
             for source_, target_ in zip(source.subfunctions, target.subfunctions):
@@ -306,8 +314,9 @@ class TransferManager(object):
         if not self.requires_transfer(Vs_star, Op.RESTRICT, source, target):
             return
 
-        if self.is_native(source_element, Op.RESTRICT):
-            self._native_transfer(source_element, Op.RESTRICT)(source, target)
+        gdim = Vs_star.mesh().geometric_dimension
+        if self.is_native(source_element, gdim, Op.RESTRICT):
+            self._native_transfer(source_element, gdim, Op.RESTRICT)(source, target)
         elif type(source_element) is finat.ufl.MixedElement:
             assert type(target_element) is finat.ufl.MixedElement
             for source_, target_ in zip(source.subfunctions, target.subfunctions):

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -75,25 +75,34 @@ def prolong(coarse, fine):
         Vf = fine.function_space()
         Vc = coarse.function_space()
 
-        coarse_coords = get_coordinates(Vc)
+        coarse_coords = Vc.mesh().coordinates
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
         kernel = kernels.prolong_kernel(coarse, Vf)
-
         # XXX: Should be able to figure out locations by pushing forward
         # reference cell node locations to physical space.
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf)
+        kernel_args = [
+            fine.dat(op2.WRITE),
+            coarse.dat(op2.READ, fine_to_coarse),
+            node_locations.dat(op2.READ),
+            coarse_coords.dat(op2.READ, fine_to_coarse_coords),
+        ]
+        if kernel.oriented:
+            co = Vc.mesh().cell_orientations()
+            m = utils.fine_node_to_coarse_node_map(Vf, co.function_space())
+            kernel_args.append(co.dat(op2.READ, m))
+        if kernel.needs_cell_sizes:
+            coarse_cell_sizes = Vc.mesh().cell_sizes
+            m = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
+            kernel_args.append(coarse_cell_sizes.dat(op2.READ, m))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse, coarse_coords]:
             d.dat.global_to_local_begin(op2.READ)
             d.dat.global_to_local_end(op2.READ)
-        op2.par_loop(kernel, fine.node_set,
-                     fine.dat(op2.WRITE),
-                     coarse.dat(op2.READ, fine_to_coarse),
-                     node_locations.dat(op2.READ),
-                     coarse_coords.dat(op2.READ, fine_to_coarse_coords))
+        op2.par_loop(kernel, fine.node_set, *kernel_args)
 
         if needs_quadrature:
             # Transfer to the actual target space
@@ -153,20 +162,30 @@ def restrict(fine_dual, coarse_dual):
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf.dual())
 
-        coarse_coords = get_coordinates(Vc.dual())
+        coarse_coords = Vc.mesh().coordinates
         fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
         fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
+        kernel = kernels.restrict_kernel(Vf, Vc)
+        kernel_args = [
+            coarse_dual.dat(op2.INC, fine_to_coarse),
+            fine_dual.dat(op2.READ),
+            node_locations.dat(op2.READ),
+            coarse_coords.dat(op2.READ, fine_to_coarse_coords)
+        ]
+        if kernel.oriented:
+            co = Vc.mesh().cell_orientations()
+            m = utils.fine_node_to_coarse_node_map(Vf, co.function_space())
+            kernel_args.append(co.dat(op2.READ, m))
+        if kernel.needs_cell_sizes:
+            coarse_cell_sizes = Vc.mesh().cell_sizes
+            m = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
+            kernel_args.append(coarse_cell_sizes.dat(op2.READ, m))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse_coords]:
             d.dat.global_to_local_begin(op2.READ)
             d.dat.global_to_local_end(op2.READ)
-        kernel = kernels.restrict_kernel(Vf, Vc)
-        op2.par_loop(kernel, fine_dual.node_set,
-                     coarse_dual.dat(op2.INC, fine_to_coarse),
-                     fine_dual.dat(op2.READ),
-                     node_locations.dat(op2.READ),
-                     coarse_coords.dat(op2.READ, fine_to_coarse_coords))
+        op2.par_loop(kernel, fine_dual.node_set, *kernel_args)
         fine_dual = coarse_dual
     return coarse_dual
 
@@ -228,24 +247,33 @@ def inject(fine, coarse):
         Vc = coarse.function_space()
         Vf = fine.function_space()
         if not dg:
-            fine_coords = get_coordinates(Vf)
+            fine_coords = Vf.mesh().coordinates
             coarse_to_fine = utils.coarse_node_to_fine_node_map(Vc, Vf)
             coarse_to_fine_coords = utils.coarse_node_to_fine_node_map(Vc, fine_coords.function_space())
-
             node_locations = utils.physical_node_locations(Vc)
+            kernel_args = [
+                coarse.dat(op2.WRITE),
+                fine.dat(op2.READ, coarse_to_fine),
+                node_locations.dat(op2.READ),
+                fine_coords.dat(op2.READ, coarse_to_fine_coords)
+            ]
+            if kernel.oriented:
+                fine_orient = Vf.mesh().cell_orientations()
+                m = utils.coarse_node_to_fine_node_map(Vc, fine_orient.function_space())
+                kernel_args.append(fine_orient.dat(op2.READ, m))
+            if kernel.needs_cell_sizes:
+                fine_cell_sizes = Vf.mesh().cell_sizes
+                m = utils.coarse_node_to_fine_node_map(Vc, fine_cell_sizes.function_space())
+                kernel_args.append(fine_cell_sizes.dat(op2.READ, m))
             # Have to do this, because the node set core size is not right for
             # this expanded stencil
             for d in [fine, fine_coords]:
                 d.dat.global_to_local_begin(op2.READ)
                 d.dat.global_to_local_end(op2.READ)
-            op2.par_loop(kernel, coarse.node_set,
-                         coarse.dat(op2.WRITE),
-                         fine.dat(op2.READ, coarse_to_fine),
-                         node_locations.dat(op2.READ),
-                         fine_coords.dat(op2.READ, coarse_to_fine_coords))
+            op2.par_loop(kernel, coarse.node_set, *kernel_args)
         else:
-            coarse_coords = get_coordinates(Vc)
-            fine_coords = get_coordinates(Vf)
+            coarse_coords = Vc.mesh().coordinates
+            fine_coords = Vf.mesh().coordinates
             coarse_cell_to_fine_nodes = utils.coarse_cell_to_fine_node_map(Vc, Vf)
             coarse_cell_to_fine_coords = utils.coarse_cell_to_fine_node_map(Vc, fine_coords.function_space())
             # Have to do this, because the node set core size is not right for
@@ -265,11 +293,3 @@ def inject(fine, coarse):
             coarse = new_coarse.interpolate(coarse)
         fine = coarse
     return coarse
-
-
-def get_coordinates(V):
-    coords = V.mesh().coordinates
-    if V.boundary_set:
-        W = V.reconstruct(element=coords.function_space().ufl_element())
-        coords = Function(W).interpolate(coords)
-    return coords

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -75,11 +75,13 @@ def prolong(coarse, fine):
         Vf = fine.function_space()
         Vc = coarse.function_space()
         compose_map = lambda u: utils.fine_node_to_coarse_node_map(Vf, u.function_space())
-        kernel = kernels.prolong_kernel(coarse, Vf)
+
         # XXX: Should be able to figure out locations by pushing forward
         # reference cell node locations to physical space.
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf)
+
+        kernel = kernels.prolong_kernel(coarse, Vf)
         kernel_args = [
             fine.dat(op2.WRITE),
             coarse.dat(op2.READ, compose_map(coarse)),
@@ -243,9 +245,9 @@ def inject(fine, coarse):
             coarse = Function(Vc.reconstruct(mesh=meshes[next_level]))
         Vc = coarse.function_space()
         Vf = fine.function_space()
-        compose_map = lambda u: utils.coarse_node_to_fine_node_map(Vc, u.function_space())
 
         if not dg:
+            compose_map = lambda u: utils.coarse_node_to_fine_node_map(Vc, u.function_space())
             node_locations = utils.physical_node_locations(Vc)
             kernel_args = [
                 coarse.dat(op2.WRITE),
@@ -269,6 +271,7 @@ def inject(fine, coarse):
                 d.dat.global_to_local_end(op2.READ)
             op2.par_loop(kernel, coarse.node_set, *kernel_args)
         else:
+            compose_map = lambda u: utils.coarse_cell_to_fine_node_map(Vc, u.function_space())
             coarse_coords = Vc.mesh().coordinates
             fine_coords = Vf.mesh().coordinates
             # Have to do this, because the node set core size is not right for

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -245,7 +245,6 @@ def inject(fine, coarse):
             coarse = Function(Vc.reconstruct(mesh=meshes[next_level]))
         Vc = coarse.function_space()
         Vf = fine.function_space()
-
         if not dg:
             compose_map = lambda u: utils.coarse_node_to_fine_node_map(Vc, u.function_space())
             node_locations = utils.physical_node_locations(Vc)

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -74,10 +74,7 @@ def prolong(coarse, fine):
             fine = Function(Vf.reconstruct(mesh=meshes[next_level]))
         Vf = fine.function_space()
         Vc = coarse.function_space()
-
-        coarse_coords = Vc.mesh().coordinates
-        fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
-        fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
+        compose_map = lambda u: utils.fine_node_to_coarse_node_map(Vf, u.function_space())
         kernel = kernels.prolong_kernel(coarse, Vf)
         # XXX: Should be able to figure out locations by pushing forward
         # reference cell node locations to physical space.
@@ -85,18 +82,19 @@ def prolong(coarse, fine):
         node_locations = utils.physical_node_locations(Vf)
         kernel_args = [
             fine.dat(op2.WRITE),
-            coarse.dat(op2.READ, fine_to_coarse),
+            coarse.dat(op2.READ, compose_map(coarse)),
             node_locations.dat(op2.READ),
-            coarse_coords.dat(op2.READ, fine_to_coarse_coords),
         ]
+        # source mesh quantities
+        source_mesh = Vc.mesh()
+        coarse_coords = source_mesh.coordinates
+        kernel_args.append(coarse_coords.dat(op2.READ, compose_map(coarse_coords)))
         if kernel.oriented:
-            co = Vc.mesh().cell_orientations()
-            m = utils.fine_node_to_coarse_node_map(Vf, co.function_space())
-            kernel_args.append(co.dat(op2.READ, m))
+            co = source_mesh.cell_orientations()
+            kernel_args.append(co.dat(op2.READ, compose_map(co)))
         if kernel.needs_cell_sizes:
-            coarse_cell_sizes = Vc.mesh().cell_sizes
-            m = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
-            kernel_args.append(coarse_cell_sizes.dat(op2.READ, m))
+            cs = source_mesh.cell_sizes
+            kernel_args.append(cs.dat(op2.READ, compose_map(cs)))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse, coarse_coords]:
@@ -156,30 +154,29 @@ def restrict(fine_dual, coarse_dual):
             coarse_dual = Function(Vc.reconstruct(mesh=meshes[next_level]))
         Vf = fine_dual.function_space()
         Vc = coarse_dual.function_space()
+        compose_map = lambda u: utils.fine_node_to_coarse_node_map(Vf, u.function_space())
 
         # XXX: Should be able to figure out locations by pushing forward
         # reference cell node locations to physical space.
         # x = \sum_i c_i \phi_i(x_hat)
         node_locations = utils.physical_node_locations(Vf.dual())
 
-        coarse_coords = Vc.mesh().coordinates
-        fine_to_coarse = utils.fine_node_to_coarse_node_map(Vf, Vc)
-        fine_to_coarse_coords = utils.fine_node_to_coarse_node_map(Vf, coarse_coords.function_space())
         kernel = kernels.restrict_kernel(Vf, Vc)
         kernel_args = [
-            coarse_dual.dat(op2.INC, fine_to_coarse),
+            coarse_dual.dat(op2.INC, compose_map(coarse_dual)),
             fine_dual.dat(op2.READ),
             node_locations.dat(op2.READ),
-            coarse_coords.dat(op2.READ, fine_to_coarse_coords)
         ]
+        # source mesh quantities
+        source_mesh = Vc.mesh()
+        coarse_coords = source_mesh.coordinates
+        kernel_args.append(coarse_coords.dat(op2.READ, compose_map(coarse_coords)))
         if kernel.oriented:
-            co = Vc.mesh().cell_orientations()
-            m = utils.fine_node_to_coarse_node_map(Vf, co.function_space())
-            kernel_args.append(co.dat(op2.READ, m))
+            co = source_mesh.cell_orientations()
+            kernel_args.append(co.dat(op2.READ, compose_map(co)))
         if kernel.needs_cell_sizes:
-            coarse_cell_sizes = Vc.mesh().cell_sizes
-            m = utils.fine_node_to_coarse_node_map(Vf, coarse_cell_sizes.function_space())
-            kernel_args.append(coarse_cell_sizes.dat(op2.READ, m))
+            cs = source_mesh.cell_sizes
+            kernel_args.append(cs.dat(op2.READ, compose_map(cs)))
         # Have to do this, because the node set core size is not right for
         # this expanded stencil
         for d in [coarse_coords]:
@@ -246,25 +243,25 @@ def inject(fine, coarse):
             coarse = Function(Vc.reconstruct(mesh=meshes[next_level]))
         Vc = coarse.function_space()
         Vf = fine.function_space()
+        compose_map = lambda u: utils.coarse_node_to_fine_node_map(Vc, u.function_space())
+
         if not dg:
-            fine_coords = Vf.mesh().coordinates
-            coarse_to_fine = utils.coarse_node_to_fine_node_map(Vc, Vf)
-            coarse_to_fine_coords = utils.coarse_node_to_fine_node_map(Vc, fine_coords.function_space())
             node_locations = utils.physical_node_locations(Vc)
             kernel_args = [
                 coarse.dat(op2.WRITE),
-                fine.dat(op2.READ, coarse_to_fine),
+                fine.dat(op2.READ, compose_map(fine)),
                 node_locations.dat(op2.READ),
-                fine_coords.dat(op2.READ, coarse_to_fine_coords)
             ]
+            # source mesh quantities
+            source_mesh = Vf.mesh()
+            fine_coords = source_mesh.coordinates
+            kernel_args.append(fine_coords.dat(op2.READ, compose_map(fine_coords)))
             if kernel.oriented:
-                fine_orient = Vf.mesh().cell_orientations()
-                m = utils.coarse_node_to_fine_node_map(Vc, fine_orient.function_space())
-                kernel_args.append(fine_orient.dat(op2.READ, m))
+                co = source_mesh.cell_orientations()
+                kernel_args.append(co.dat(op2.READ, compose_map(co)))
             if kernel.needs_cell_sizes:
-                fine_cell_sizes = Vf.mesh().cell_sizes
-                m = utils.coarse_node_to_fine_node_map(Vc, fine_cell_sizes.function_space())
-                kernel_args.append(fine_cell_sizes.dat(op2.READ, m))
+                cs = source_mesh.cell_sizes
+                kernel_args.append(cs.dat(op2.READ, compose_map(cs)))
             # Have to do this, because the node set core size is not right for
             # this expanded stencil
             for d in [fine, fine_coords]:
@@ -274,8 +271,6 @@ def inject(fine, coarse):
         else:
             coarse_coords = Vc.mesh().coordinates
             fine_coords = Vf.mesh().coordinates
-            coarse_cell_to_fine_nodes = utils.coarse_cell_to_fine_node_map(Vc, Vf)
-            coarse_cell_to_fine_coords = utils.coarse_cell_to_fine_node_map(Vc, fine_coords.function_space())
             # Have to do this, because the node set core size is not right for
             # this expanded stencil
             for d in [fine, fine_coords]:
@@ -283,8 +278,8 @@ def inject(fine, coarse):
                 d.dat.global_to_local_end(op2.READ)
             op2.par_loop(kernel, Vc.mesh().cell_set,
                          coarse.dat(op2.INC, coarse.cell_node_map()),
-                         fine.dat(op2.READ, coarse_cell_to_fine_nodes),
-                         fine_coords.dat(op2.READ, coarse_cell_to_fine_coords),
+                         fine.dat(op2.READ, compose_map(fine)),
+                         fine_coords.dat(op2.READ, compose_map(fine_coords)),
                          coarse_coords.dat(op2.READ, coarse_coords.cell_node_map()))
 
         if needs_quadrature:

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -92,9 +92,9 @@ static inline void to_reference_coords_kernel(PetscScalar *X, const PetscScalar 
     return evaluate_template_c % code
 
 
-def compile_element(operand, dual_arg, parameters=None,
-                    name="evaluate"):
-    """Generate code for point evaluations.
+def dual_evaluation_kernel(operand, dual_arg, parameters=None,
+                           name="evaluate"):
+    """Generate kernel for dual evaluation.
 
     Parameters
     ----------
@@ -105,8 +105,8 @@ def compile_element(operand, dual_arg, parameters=None,
 
     Returns
     -------
-    str
-        The generated code
+    pyop2.op2.Kernel
+        The kernel
     """
     source_mesh = extract_unique_domain(operand)
     target_space = dual_arg.arguments()[0].ufl_function_space()
@@ -126,20 +126,21 @@ def compile_element(operand, dual_arg, parameters=None,
                                                 ufl_element,
                                                 parameters=parameters,
                                                 name="pyop2_kernel_"+name)
-    return lp.generate_code_v2(kernel.ast).device_code()
+    return kernel
 
 
-def _make_kernel_args(element, *args):
+def _make_kernel_args(kernel, element, *args):
     """Returns a string of argument names to call the kernel.
        Discards coordinate arguments if they do not appear in the kernel."""
     # NOTE: TSFC will sometimes drop run-time arguments in generated
     # kernels if they are deemed not-necessary.
     # For further information, see the same note in interpolation.py.
     mask = [True] * len(args)
-    # Drop the source coordinates if the element is affinely-mapped.
-    needs_coordinates = element.mapping != "affine"
-    mask[1] = needs_coordinates
-    # Drop the target location if the element is constant.
+    # Drop source mesh quantities if they do not appear in the kernel.
+    mask[1] = kernel.oriented
+    mask[2] = kernel.needs_cell_sizes
+    mask[3] = kernel.needs_external_coords
+    # Drop the target coordinates if the element is constant.
     is_constant = sum(as_tuple(element.degree)) == 0 and not element.complex.is_macrocell()
     mask[-1] = not is_constant
     kernel_args = ", ".join(arg for arg, include in zip(args, mask) if include)
@@ -177,16 +178,19 @@ def prolong_kernel(expression, Vf):
     try:
         return cache[key]
     except KeyError:
-        evaluate_code = compile_element(expression, ufl.TestFunction(Vf.dual()))
+        kernel = dual_evaluation_kernel(expression, ufl.TestFunction(Vf.dual()))
+        evaluate_code = lp.generate_code_v2(kernel.ast).device_code()
         to_reference_kernel = to_reference_coordinates(coordinates.ufl_element())
         coords_element = create_element(coordinates.ufl_element())
         element = create_element(expression.ufl_element())
+        num_verts = len(element.cell.get_vertices())
 
-        my_kernel = """#include <petsc.h>
+        kernel_code = """#include <petsc.h>
         %(to_reference)s
         %(evaluate)s
         __attribute__((noinline)) /* Clang bug */
-        static void pyop2_kernel_prolong(PetscScalar *R, PetscScalar *f, const PetscScalar *X, const PetscScalar *Xc)
+        static void pyop2_kernel_prolong(PetscScalar *R, PetscScalar *f, const PetscScalar *X, const PetscScalar *Xc
+                                         %(cell_orient)s%(cell_sizes)s)
         {
             PetscScalar Xref[%(tdim)d];
             int cell = -1;
@@ -232,7 +236,9 @@ def prolong_kernel(expression, Vf):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": evaluate_code,
-               "kernel_args": _make_kernel_args(element, "R", "Xci", "fi", "Xref"),
+               "cell_orient": ", const PetscScalar *co" if kernel.oriented else "",
+               "cell_sizes": ", const PetscScalar *cs" if kernel.needs_cell_sizes else "",
+               "kernel_args": _make_kernel_args(kernel, element, "R", "co+cell", f"cs+cell*{num_verts}", "Xci", "fi", "Xref"),
                "ncandidate": ncandidate,
                "Rdim": Vf.block_size,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
@@ -241,7 +247,10 @@ def prolong_kernel(expression, Vf):
                "coarse_cell_inc": element.space_dimension(),
                "tdim": element.cell.get_spatial_dimension()}
 
-        return cache.setdefault(key, op2.Kernel(my_kernel, name="pyop2_kernel_prolong"))
+        transfer_kernel = op2.Kernel(kernel_code, name="pyop2_kernel_prolong")
+        transfer_kernel.oriented = kernel.oriented
+        transfer_kernel.needs_cell_sizes = kernel.needs_cell_sizes
+        return cache.setdefault(key, transfer_kernel)
 
 
 def restrict_kernel(Vf, Vc):
@@ -260,17 +269,20 @@ def restrict_kernel(Vf, Vc):
         return cache[key]
     except KeyError:
         assert isinstance(Vc, FiredrakeDualSpace) and isinstance(Vf, FiredrakeDualSpace)
-        evaluate_code = compile_element(ufl.TestFunction(Vc.dual()), ufl.Cofunction(Vf))
+        kernel = dual_evaluation_kernel(ufl.TestFunction(Vc.dual()), ufl.Cofunction(Vf))
+        evaluate_code = lp.generate_code_v2(kernel.ast).device_code()
         to_reference_kernel = to_reference_coordinates(coordinates.ufl_element())
         coords_element = create_element(coordinates.ufl_element())
         element = create_element(Vc.ufl_element())
+        num_verts = len(element.cell.get_vertices())
 
-        my_kernel = """#include <petsc.h>
+        kernel_code = """#include <petsc.h>
         %(to_reference)s
         %(evaluate)s
 
         __attribute__((noinline)) /* Clang bug */
-        static void pyop2_kernel_restrict(PetscScalar *R, PetscScalar *b, const PetscScalar *X, const PetscScalar *Xc)
+        static void pyop2_kernel_restrict(PetscScalar *R, PetscScalar *b, const PetscScalar *X, const PetscScalar *Xc
+                                          %(cell_orient)s%(cell_sizes)s)
         {
             PetscScalar Xref[%(tdim)d];
             int cell = -1;
@@ -316,7 +328,9 @@ def restrict_kernel(Vf, Vc):
         }
         """ % {"to_reference": str(to_reference_kernel),
                "evaluate": evaluate_code,
-               "kernel_args": _make_kernel_args(element, "Ri", "Xc", "b", "Xref"),
+               "cell_orient": ", const PetscScalar *co" if kernel.oriented else "",
+               "cell_sizes": ", const PetscScalar *cs" if kernel.needs_cell_sizes else "",
+               "kernel_args": _make_kernel_args(kernel, element, "Ri", "co+cell", f"cs+cell*{num_verts}", "Xc", "b", "Xref"),
                "ncandidate": ncandidate,
                "inside_cell": inside_check(element.cell, eps=1e-8, X="Xref"),
                "celldist_l1_c_expr": celldist_l1_c_expr(element.cell, X="Xref"),
@@ -324,7 +338,10 @@ def restrict_kernel(Vf, Vc):
                "coarse_cell_inc": element.space_dimension(),
                "tdim": element.cell.get_spatial_dimension()}
 
-        return cache.setdefault(key, op2.Kernel(my_kernel, name="pyop2_kernel_restrict"))
+        transfer_kernel = op2.Kernel(kernel_code, name="pyop2_kernel_restrict")
+        transfer_kernel.oriented = kernel.oriented
+        transfer_kernel.needs_cell_sizes = kernel.needs_cell_sizes
+        return cache.setdefault(key, transfer_kernel)
 
 
 def inject_kernel(Vf, Vc):

--- a/firedrake/supermeshing.py
+++ b/firedrake/supermeshing.py
@@ -218,6 +218,7 @@ each supermesh cell.
     kernel_A = dual_evaluation_kernel(ufl.Coefficient(V_A), ufl.TestFunction(V_S_A.dual()), name="evaluate_kernel_A")
     kernel_B = dual_evaluation_kernel(ufl.Coefficient(V_B), ufl.TestFunction(V_S_B.dual()), name="evaluate_kernel_B")
     kernel_S = dual_evaluation_kernel(ufl.Coefficient(V_S), ufl.TestFunction(V_S.dual()), name="evaluate_kernel_S")
+    dummy_args = ["dummy_place_holder"] * 3
 
     M_SS = assemble(inner(TrialFunction(V_S_A), TestFunction(V_S_B)) * dx)
     M_SS = M_SS.petscmat[:, :]
@@ -447,9 +448,9 @@ each supermesh cell.
         "evaluate_S": generate_code_v2(kernel_S.ast).device_code(),
         "evaluate_A": generate_code_v2(kernel_A.ast).device_code(),
         "evaluate_B": generate_code_v2(kernel_B.ast).device_code(),
-        "kernel_args_S": _make_kernel_args(kernel_S, V_S.finat_element, "physical_node_location", "BARF", "BARF", "simplex_S", "reference_node_location"),
-        "kernel_args_A": _make_kernel_args(kernel_A, V_A.finat_element, "&R_AS[i][j]", "BARF", "BARF", "coeffs_A", "reference_nodes_A[j]"),
-        "kernel_args_B": _make_kernel_args(kernel_B, V_B.finat_element, "&R_BS[i][j]", "BARF", "BARF", "coeffs_B", "reference_nodes_B[j]"),
+        "kernel_args_S": _make_kernel_args(kernel_S, V_S.finat_element, "physical_node_location", *dummy_args, "simplex_S", "reference_node_location"),
+        "kernel_args_A": _make_kernel_args(kernel_A, V_A.finat_element, "&R_AS[i][j]", *dummy_args, "coeffs_A", "reference_nodes_A[j]"),
+        "kernel_args_B": _make_kernel_args(kernel_B, V_B.finat_element, "&R_BS[i][j]", *dummy_args, "coeffs_B", "reference_nodes_B[j]"),
         "to_reference": str(to_reference_kernel),
         "num_nodes_A": num_nodes_A,
         "num_nodes_B": num_nodes_B,

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -2142,6 +2142,8 @@ def IcosahedralSphereMesh(
         comm=comm,
     )
     if degree > 1:
+        dparams = m._distribution_parameters
+        did_reordering = m._did_reordering
         new_coords = Function(VectorFunctionSpace(m, "CG", degree))
         new_coords.interpolate(ufl.SpatialCoordinate(m))
         # "push out" to sphere
@@ -2155,6 +2157,8 @@ def IcosahedralSphereMesh(
             permutation_name=permutation_name,
             comm=comm,
         )
+        m._distribution_parameters = dparams
+        m._did_reordering = did_reordering
     m._radius = radius
     return m
 
@@ -2193,6 +2197,7 @@ def UnitIcosahedralSphereMesh(
         refinement_level=refinement_level,
         degree=degree,
         reorder=reorder,
+        distribution_parameters=distribution_parameters,
         comm=comm,
         name=name,
         distribution_name=distribution_name,

--- a/firedrake/utility_meshes.py
+++ b/firedrake/utility_meshes.py
@@ -2142,8 +2142,6 @@ def IcosahedralSphereMesh(
         comm=comm,
     )
     if degree > 1:
-        dparams = m._distribution_parameters
-        did_reordering = m._did_reordering
         new_coords = Function(VectorFunctionSpace(m, "CG", degree))
         new_coords.interpolate(ufl.SpatialCoordinate(m))
         # "push out" to sphere
@@ -2157,8 +2155,6 @@ def IcosahedralSphereMesh(
             permutation_name=permutation_name,
             comm=comm,
         )
-        m._distribution_parameters = dparams
-        m._did_reordering = did_reordering
     m._radius = radius
     return m
 

--- a/tests/firedrake/multigrid/test_embedded_transfer.py
+++ b/tests/firedrake/multigrid/test_embedded_transfer.py
@@ -180,7 +180,6 @@ def manifold():
     distribution_parameters = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
     base = UnitIcosahedralSphereMesh(refinement_level=0, degree=1,
                                      distribution_parameters=distribution_parameters)
-
     mh = MeshHierarchy(base, refinement_levels=3)
     for m in mh:
         m.init_cell_orientations(SpatialCoordinate(m))

--- a/tests/firedrake/multigrid/test_embedded_transfer.py
+++ b/tests/firedrake/multigrid/test_embedded_transfer.py
@@ -187,7 +187,8 @@ def manifold():
     return mh[-1]
 
 
-@pytest.mark.parallel([1])
+@pytest.mark.skipcomplexnoslate
+@pytest.mark.parallel([1, 3])
 def test_riesz_manifold(manifold, solver_parameters):
     V = FunctionSpace(manifold, "RT", 1)
     solver = make_solver(V, solver_parameters)

--- a/tests/firedrake/multigrid/test_embedded_transfer.py
+++ b/tests/firedrake/multigrid/test_embedded_transfer.py
@@ -40,23 +40,44 @@ def V(mesh, space, degree):
         return FunctionSpace(mesh, space, degree, variant="integral")
 
 
-@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
-def test_transfer(op, V):
+def expr(V):
+    mesh = V.mesh()
+    x = SpatialCoordinate(mesh)
+    rank = len(V.value_shape)
+    if rank == 0:
+        return sum(x)
+    elif rank == 1:
+        if mesh.topological_dimension != mesh.geometric_dimension:
+            return cross(CellNormal(mesh), Constant([1]*len(x)))
+        elif V.ufl_element().sobolev_space == HCurl and len(x) == 2:
+            return perp(x)
+        else:
+            return x
+    elif rank == 2:
+        return sym(outer(x, Constant([1]*len(x))))
+    else:
+        raise ValueError("Unexpected value shape")
 
-    def expr(V):
-        x = SpatialCoordinate(V.mesh())
-        return {H1: x, HCurl: perp(x), HDiv: x}[V.ufl_element().sobolev_space]
 
+def check_transfer(op, V):
     mh, _ = get_level(V.mesh())
     Vf = V
     Vc = V.reconstruct(mh[0])
+
+    def error(x, y):
+        mesh = y.function_space().mesh()
+        if mesh.topological_dimension == mesh.geometric_dimension:
+            return errornorm(x, y)
+        else:
+            n = CellNormal(mesh)
+            return norm((x-y) - outer(n, n)*(x-y))
 
     if op == "prolong":
         uf = Function(Vf)
         uc = Function(Vc)
         uc.interpolate(expr(Vc))
         prolong(uc, uf)
-        assert errornorm(expr(Vf), uf) < 1E-13
+        assert error(expr(Vf), uf) < 1E-13
 
     elif op == "restrict":
         rf = assemble(inner(expr(Vf), TestFunction(Vf))*dx)
@@ -84,11 +105,43 @@ def test_transfer(op, V):
         uc.interpolate(expr(Vc))
         uf.interpolate(expr(Vf))
         inject(uf, uc)
-        assert errornorm(expr(Vc), uc) < 1E-13
+        assert error(expr(Vc), uc) < 1E-13
+
+
+@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
+def test_transfer(op, V):
+    check_transfer(op, V)
+
+
+@pytest.mark.parametrize("family,degree", [("AWc", 3)])
+@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
+def test_transfer_zany(op, mesh, family, degree):
+    V = FunctionSpace(mesh, family, degree)
+    check_transfer(op, V)
 
 
 @pytest.fixture
-def solver_parameters(V):
+def manifold():
+    distribution_parameters = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+    base = UnitIcosahedralSphereMesh(refinement_level=0, degree=1,
+                                     distribution_parameters=distribution_parameters)
+
+    del base._radius
+    mh = MeshHierarchy(base, refinement_levels=3)
+    for m in mh:
+        m.init_cell_orientations(SpatialCoordinate(m))
+    return mh[-1]
+
+
+@pytest.mark.parametrize("family,degree", [("RT", 1)])
+@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
+def test_transfer_manifold(op, manifold, family, degree):
+    V = FunctionSpace(manifold, family, degree)
+    check_transfer(op, V)
+
+
+@pytest.fixture
+def solver_parameters():
     solver_parameters = {
         "mat_type": "aij",
         "snes_type": "ksponly",
@@ -116,22 +169,28 @@ def solver_parameters(V):
     return solver_parameters
 
 
-@pytest.fixture
-def solver(V, space, solver_parameters):
+def make_solver(V, solver_parameters):
     u = Function(V)
     v = TestFunction(V)
-    (x, y) = SpatialCoordinate(V.mesh())
-    f = as_vector([2*y*(1-x**2),
-                   -2*x*(1-y**2)])
+
+    coords = SpatialCoordinate(V.mesh())
+    if len(coords) == 2:
+        (x, y) = coords
+        f = as_vector([2*y*(1-x**2),
+                       -2*x*(1-y**2)])
+    else:
+        x = coords
+        f = x*sum(x)
     if u.ufl_shape == ():
         f = sum(f)
     a = Constant(1)
     b = Constant(100)
-    if space == "RT":
+    space = V.ufl_element().sobolev_space
+    if space == HDiv:
         F = a*inner(u, v)*dx + b*inner(div(u), div(v))*dx - inner(f, v)*dx
-    elif space == "N1curl":
+    elif space == HCurl:
         F = a*inner(u, v)*dx + b*inner(curl(u), curl(v))*dx - inner(f, v)*dx
-    elif space == "CG":
+    elif space == H1:
         F = a*inner(u, v)*dx + b*inner(grad(u), grad(v))*dx - inner(f, v)*dx
     problem = NonlinearVariationalProblem(F, u)
     solver = NonlinearVariationalSolver(problem, solver_parameters=solver_parameters,
@@ -140,6 +199,15 @@ def solver(V, space, solver_parameters):
 
 
 @pytest.mark.parallel([1, 3])
-def test_riesz(V, solver):
+def test_riesz(V, solver_parameters):
+    solver = make_solver(V, solver_parameters)
+    solver.solve()
+    assert solver.snes.ksp.getIterationNumber() < 15
+
+
+@pytest.mark.parallel([1])
+def test_riesz_manifold(manifold, solver_parameters):
+    V = FunctionSpace(manifold, "RT", 1)
+    solver = make_solver(V, solver_parameters)
     solver.solve()
     assert solver.snes.ksp.getIterationNumber() < 15

--- a/tests/firedrake/multigrid/test_embedded_transfer.py
+++ b/tests/firedrake/multigrid/test_embedded_transfer.py
@@ -47,9 +47,7 @@ def expr(V):
     if rank == 0:
         return sum(x)
     elif rank == 1:
-        if mesh.topological_dimension != mesh.geometric_dimension:
-            return cross(CellNormal(mesh), Constant([1]*len(x)))
-        elif V.ufl_element().sobolev_space == HCurl and len(x) == 2:
+        if V.ufl_element().sobolev_space == HCurl and len(x) == 2:
             return perp(x)
         else:
             return x
@@ -64,20 +62,12 @@ def check_transfer(op, V):
     Vf = V
     Vc = V.reconstruct(mh[0])
 
-    def error(x, y):
-        mesh = y.function_space().mesh()
-        if mesh.topological_dimension == mesh.geometric_dimension:
-            return errornorm(x, y)
-        else:
-            n = CellNormal(mesh)
-            return norm((x-y) - outer(n, n)*(x-y))
-
     if op == "prolong":
         uf = Function(Vf)
         uc = Function(Vc)
         uc.interpolate(expr(Vc))
         prolong(uc, uf)
-        assert error(expr(Vf), uf) < 1E-13
+        assert errornorm(expr(Vf), uf) < 1E-13
 
     elif op == "restrict":
         rf = assemble(inner(expr(Vf), TestFunction(Vf))*dx)
@@ -105,7 +95,7 @@ def check_transfer(op, V):
         uc.interpolate(expr(Vc))
         uf.interpolate(expr(Vf))
         inject(uf, uc)
-        assert error(expr(Vc), uc) < 1E-13
+        assert errornorm(expr(Vc), uc) < 1E-13
 
 
 @pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
@@ -117,26 +107,6 @@ def test_transfer(op, V):
 @pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
 def test_transfer_zany(op, mesh, family, degree):
     V = FunctionSpace(mesh, family, degree)
-    check_transfer(op, V)
-
-
-@pytest.fixture
-def manifold():
-    distribution_parameters = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
-    base = UnitIcosahedralSphereMesh(refinement_level=0, degree=1,
-                                     distribution_parameters=distribution_parameters)
-
-    del base._radius
-    mh = MeshHierarchy(base, refinement_levels=3)
-    for m in mh:
-        m.init_cell_orientations(SpatialCoordinate(m))
-    return mh[-1]
-
-
-@pytest.mark.parametrize("family,degree", [("RT", 1)])
-@pytest.mark.parametrize("op", ["prolong", "restrict", "inject"])
-def test_transfer_manifold(op, manifold, family, degree):
-    V = FunctionSpace(manifold, family, degree)
     check_transfer(op, V)
 
 
@@ -203,6 +173,18 @@ def test_riesz(V, solver_parameters):
     solver = make_solver(V, solver_parameters)
     solver.solve()
     assert solver.snes.ksp.getIterationNumber() < 15
+
+
+@pytest.fixture
+def manifold():
+    distribution_parameters = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+    base = UnitIcosahedralSphereMesh(refinement_level=0, degree=1,
+                                     distribution_parameters=distribution_parameters)
+
+    mh = MeshHierarchy(base, refinement_levels=3)
+    for m in mh:
+        m.init_cell_orientations(SpatialCoordinate(m))
+    return mh[-1]
 
 
 @pytest.mark.parallel([1])


### PR DESCRIPTION
# Description
Fixes https://github.com/firedrakeproject/firedrake/issues/5045

Interpolation into H(div) on a manifold is not a well-defined operation. Because the edge normals are not necessarily aligned, the degrees of freedom mean different things for the two cells on either side of the edge. 

This PR adds support for cannonical prolongation and restriction by evaluating degrees of freedom, by providing `cell_orientations` to the kernels that require them. However, this results in prolongation and restriction kernels that fail to be the adjoint of each other, presumably because dofs are not evaluting to the same value on different cells.

The solution here is to fall back to the embedded DG L2 projection transfer kernels for non-CG/DG elements on manifolds.


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
