### PR TITLE
Improve building compiled extensions using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ all: ext
 .PHONY: ext
 ext:
 	@echo "    Building extension modules"
-	@python setup.py build_ext --inplace > build.log 2>&1 || cat build.log
+	@python setup.py build_ext --inplace 2>&1 | tee cat build.log
 
 .PHONY: allext
 allext:
 	@echo "    Force building all extension modules"
-	@python setup.py build_ext --inplace --force > build.log 2>&1 || cat build.log
+	@python setup.py build_ext --inplace --force 2>&1 | tee cat build.log
 
 .PHONY: lint
 lint: srclint actionlint dockerlint

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 .PHONY: all
-all: modules
+all: ext
 
-.PHONY: modules
-modules:
+.PHONY: ext
+ext:
 	@echo "    Building extension modules"
 	@python setup.py build_ext --inplace > build.log 2>&1 || cat build.log
+
+.PHONY: allext
+allext:
+	@echo "    Force building all extension modules"
+	@python setup.py build_ext --inplace --force > build.log 2>&1 || cat build.log
 
 .PHONY: lint
 lint: srclint actionlint dockerlint
@@ -54,39 +59,6 @@ dockerlint:
 			< $$DOCKERFILE \
 			|| exit 1; \
 	done
-
-.PHONY: clean
-clean:
-	@echo "    Cleaning extension modules"
-	@python setup.py clean > /dev/null 2>&1
-	@echo "    RM firedrake/cython/dmplex.*.so"
-	-@rm -f firedrake/cython/dmplex.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/dmplex.c"
-	-@rm -f firedrake/cython/dmplex.c > /dev/null 2>&1
-	@echo "    RM firedrake/cython/extrusion_numbering.*.so"
-	-@rm -f firedrake/cython/extrusion_numbering.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/extrusion_numbering.c"
-	-@rm -f firedrake/cython/extrusion_numbering.c > /dev/null 2>&1
-	@echo "    RM firedrake/cython/hdf5interface.*.so"
-	-@rm -f firedrake/cython/hdf5interface.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/hdf5interface.c"
-	-@rm -f firedrake/cython/hdf5interface.c > /dev/null 2>&1
-	@echo "    RM firedrake/cython/spatialindex.*.so"
-	-@rm -f firedrake/cython/spatialindex.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/spatialindex.c"
-	-@rm -f firedrake/cython/spatialindex.c > /dev/null 2>&1
-	@echo "    RM firedrake/cython/supermeshimpl.*.so"
-	-@rm -f firedrake/cython/supermeshimpl.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/supermeshimpl.c"
-	-@rm -f firedrake/cython/supermeshimpl.c > /dev/null 2>&1
-	@echo "    RM firedrake/cython/mg/impl.*.so"
-	-@rm -f firedrake/cython/mg/impl.so > /dev/null 2>&1
-	@echo "    RM firedrake/cython/mg/impl.c"
-	-@rm -f firedrake/cython/mg/impl.c > /dev/null 2>&1
-	@echo "    RM pyop2/*.so"
-	-@rm -f pyop2/*.so > /dev/null 2>&1
-	@echo "    RM tinyasm/*.so"
-	-@rm -f tinyasm/*.so > /dev/null 2>&1
 
 # NOTE: It is recommended to run this command from inside the 'firedrake'
 # Docker image to reduce the likelihood of test failures.

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
-.PHONY: all
-all: ext
-
 .PHONY: ext
 ext:
 	@echo "    Building extension modules"
 	@python setup.py build_ext --inplace 2>&1 | tee cat build.log
 
-.PHONY: allext
-allext:
+.PHONY: extforce
+extforce:
 	@echo "    Force building all extension modules"
 	@python setup.py build_ext --inplace --force 2>&1 | tee cat build.log
 


### PR DESCRIPTION
setuptools doesn't provide a way to clean up compiled extensions if they are built inplace. make clean was therefore a best-guess, highly bitrotted removal of the inplace extensions. It was removing many files that no longer exist and failing to remove others.

Instead of this approach here we just provide a way to force a rebuild of all extensions. The end result is the same but robust to future file changes.




<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
