### PR TITLE
bugfix: MixedCovariance.function_space property

### DIFF
--- a/firedrake/adjoint/covariance_operator.py
+++ b/firedrake/adjoint/covariance_operator.py
@@ -669,7 +669,7 @@ class MixedCovarianceOperator(CovarianceOperatorBase):
         return self._rngs
 
     def sample(self, rng=None, tensor=None):
-        tensor = tensor or Function(self.function_space)
+        tensor = tensor or Function(self.function_space())
         for cov, tsub, rsub in zip(self.subcovariances,
                                    tensor.subfunctions,
                                    rng or self.rng()):


### PR DESCRIPTION
Originally `MixedCovariance.function_space` was a property, but this wasn't consistent with the other `CovarianceOperator` types where `function_space` is a method. I missed this line when I fixed it.