### PR TITLE
Fix for quadrature rule with mixed dimension macroelements

### DIFF
--- a/tests/firedrake/submesh/test_submesh_assemble.py
+++ b/tests/firedrake/submesh/test_submesh_assemble.py
@@ -567,3 +567,33 @@ def test_assemble_parent_coefficient():
 
     A_ref.petscmat.axpy(-1, A.petscmat)
     assert np.isclose(A_ref.petscmat.norm(PETSc.NormType.NORM_FROBENIUS), 0)
+
+
+def test_submesh_assemble_facet_macroelement():
+    # Test that the macro quadrature rule is correctly selected
+    # for macroelements whose restriction is also a macroelement
+    rg = RandomGenerator(PCG64(seed=0))
+    mesh = UnitSquareMesh(4, 4)
+    DGT = FunctionSpace(mesh, "DGT", 0)
+    marker = Function(DGT)
+    DirichletBC(DGT, 1, "on_boundary").apply(marker)
+    label = 111
+    mesh = RelabeledMesh(mesh, [marker], [label])
+    submesh = Submesh(mesh, mesh.topological_dimension-1, label)
+
+    V = FunctionSpace(mesh, "CG", 1, variant="iso")
+    Vsub = FunctionSpace(submesh, "CG", 1)
+    Z = V * Vsub
+    z = rg.uniform(Z, -1, 1)
+    u, usub = split(z)
+    v, vsub = TestFunctions(Z)
+
+    ds_sub = Measure("ds", domain=mesh, intersect_measures=[dx(submesh)])
+
+    a1 = assemble(inner(1-u, vsub)*ds_sub(degree=2))
+    a2 = assemble(inner(u, vsub)*ds_sub(degree=4))
+    a = Function(a1.function_space()).assign(a1+a2)
+
+    vsub = TestFunction(Vsub)
+    aref = assemble(inner(1, vsub)*dx(submesh))
+    assert np.allclose(a.dat[1].data_ro, aref.dat.data_ro)

--- a/tsfc/kernel_interface/common.py
+++ b/tsfc/kernel_interface/common.py
@@ -346,6 +346,10 @@ def set_quad_rule(params, cell, integral_type, functions):
         finat_elements = set(create_element(e) for e in elements if e.family() != "Real")
         fiat_cells = [fiat_cell] + [finat_el.complex for finat_el in finat_elements]
         if any(c.is_macrocell() for c in fiat_cells):
+            if len(set(c.get_spatial_dimension() for c in fiat_cells)) > 1:
+                dimension = fiat_cell.get_dimension()
+                fiat_cells = [c if c.get_dimension() == dimension else
+                              c.construct_subcomplex(dimension) for c in fiat_cells]
             fiat_cell = max_complex(fiat_cells)
         integration_dim, _ = lower_integral_type(fiat_cell, integral_type)
         quad_rule = fem.get_quadrature_rule(fiat_cell, integration_dim, quadrature_degree, scheme)


### PR DESCRIPTION
# Description
Codim-1 submesh assembly with macroelements was failing to get the right cell to build the quadrature rule.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
