### PR TITLE
Fix IndexError in _pic_swarm_in_mesh on MPI ranks with empty cell partition

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3937,8 +3937,13 @@ def _pic_swarm_in_mesh(
         base_parent_cell_nums_visible = base_parent_cell_nums[visible_idxs]
         extrusion_heights_visible = extrusion_heights[visible_idxs]
     else:
-        plex_parent_cell_nums = parent_mesh.topology.cell_closure[
-            parent_cell_nums_local, -1
+        # Fancy-index only the visible rows: parent_cell_nums_local has
+        # -1 sentinels for query points with no owning cell on this rank,
+        # which crash the indexing on ranks whose cell_closure is shape
+        # (0, k). Sentinel rows are discarded by [visible_idxs] below.
+        plex_parent_cell_nums = np.full_like(parent_cell_nums_local, -1)
+        plex_parent_cell_nums[visible_idxs] = parent_mesh.topology.cell_closure[
+            parent_cell_nums_local[visible_idxs], -1
         ]
         base_parent_cell_nums_visible = None
         extrusion_heights_visible = None

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -3929,18 +3929,16 @@ def _pic_swarm_in_mesh(
         base_parent_cell_nums, extrusion_heights = _parent_extrusion_numbering(
             parent_cell_nums_local, parent_mesh.layers
         )
-        # mesh.topology.cell_closure[:, -1] maps Firedrake cell numbers to plex
-        # numbers.
-        plex_parent_cell_nums = parent_mesh.topology.cell_closure[
-            base_parent_cell_nums, -1
+        # cell_closure[:, -1] maps Firedrake cell numbers to plex numbers.
+        # Index only visible rows: -1 sentinels crash on empty-rank arrays.
+        plex_parent_cell_nums = np.full_like(base_parent_cell_nums, -1)
+        plex_parent_cell_nums[visible_idxs] = parent_mesh.topology.cell_closure[
+            base_parent_cell_nums[visible_idxs], -1
         ]
         base_parent_cell_nums_visible = base_parent_cell_nums[visible_idxs]
         extrusion_heights_visible = extrusion_heights[visible_idxs]
     else:
-        # Fancy-index only the visible rows: parent_cell_nums_local has
-        # -1 sentinels for query points with no owning cell on this rank,
-        # which crash the indexing on ranks whose cell_closure is shape
-        # (0, k). Sentinel rows are discarded by [visible_idxs] below.
+        # Index only visible rows: -1 sentinels crash on empty-rank arrays.
         plex_parent_cell_nums = np.full_like(parent_cell_nums_local, -1)
         plex_parent_cell_nums[visible_idxs] = parent_mesh.topology.cell_closure[
             parent_cell_nums_local[visible_idxs], -1

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -349,13 +349,9 @@ def test_submesh_interpolate_adjoint(fe_fesub):
 
 
 @pytest.mark.parallel(nprocs=8)
-def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
-    # Regression test for an IndexError in firedrake.mesh._pic_swarm_in_mesh
-    # when interpolating a function defined on a Submesh of an exterior facet
-    # onto its parent mesh in parallel: ranks that own zero cells of the
-    # Submesh hit ``IndexError: index -1 is out of bounds for axis 0 with
-    # size 0`` because parent_cell_nums_local contains -1 sentinels and
-    # cell_closure has shape (0, k) on those ranks.
+def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_8_processes():
+    # Regression test: ranks with zero Submesh cells crashed with IndexError
+    # in _pic_swarm_in_mesh (-1 sentinels invalid on empty-rank cell_closure).
     mesh = UnitCubeMesh(2, 2, 2)
     x, y, z = SpatialCoordinate(mesh)
     V_marker = FunctionSpace(mesh, "HDiv Trace", 0)
@@ -379,3 +375,22 @@ def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
     assert np.allclose(
         f_parent.dat.data_with_halos, expected.dat.data_with_halos
     )
+
+
+@pytest.mark.parallel(nprocs=8)
+def test_submesh_interpolate_3Dcell_extruded_empty_rank_8_processes():
+    # Regression test for the same IndexError in the extruded branch of
+    # _pic_swarm_in_mesh: ExtrudedMesh(UnitSquareMesh(1,1), layers=3) has 6
+    # cells, so with nprocs=8 at least two ranks own zero extruded cells.
+    base = UnitSquareMesh(1, 1)
+    ext = ExtrudedMesh(base, layers=3)
+    xe, ye, ze = SpatialCoordinate(ext)
+    V_ext = FunctionSpace(ext, "CG", 1)
+    f_ext = Function(V_ext).interpolate(xe + ye + ze)
+    mesh = UnitCubeMesh(2, 2, 2)
+    xt, yt, zt = SpatialCoordinate(mesh)
+    V = FunctionSpace(mesh, "CG", 1)
+    f = Function(V)
+    f.interpolate(f_ext, allow_missing_dofs=True)
+    expected = Function(V).interpolate(xt + yt + zt)
+    assert np.allclose(f.dat.data_with_halos, expected.dat.data_with_halos)

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -365,6 +365,7 @@ def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
     facet_value = 999
     mesh = RelabeledMesh(mesh, [facet_indicator], [facet_value])
     subm = Submesh(mesh, mesh.topological_dimension - 1, facet_value)
+    subm.tolerance = 0.1
     x, y, z = SpatialCoordinate(mesh)
     xs, ys, zs = SpatialCoordinate(subm)
     V_sub = FunctionSpace(subm, "CG", 1)

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -346,3 +346,35 @@ def test_submesh_interpolate_adjoint(fe_fesub):
     # Test 0-form
     result_0 = assemble(interpolate(u1, ustar2, allow_missing_dofs=True))
     assert np.isclose(result_0, expected)
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
+    # Regression test for an IndexError in firedrake.mesh._pic_swarm_in_mesh
+    # when interpolating a function defined on a Submesh of an exterior facet
+    # onto its parent mesh in parallel: ranks that own zero cells of the
+    # Submesh hit ``IndexError: index -1 is out of bounds for axis 0 with
+    # size 0`` because parent_cell_nums_local contains -1 sentinels and
+    # cell_closure has shape (0, k) on those ranks.
+    mesh = UnitCubeMesh(8, 8, 8)
+    x, y, z = SpatialCoordinate(mesh)
+    V_marker = FunctionSpace(mesh, "HDiv Trace", 0)
+    facet_indicator = Function(V_marker).interpolate(
+        conditional(x > 0.999, 1.0, 0.0)
+    )
+    facet_value = 999
+    mesh = RelabeledMesh(mesh, [facet_indicator], [facet_value])
+    subm = Submesh(mesh, mesh.topological_dimension - 1, facet_value)
+    x, y, z = SpatialCoordinate(mesh)
+    xs, ys, zs = SpatialCoordinate(subm)
+    V_sub = FunctionSpace(subm, "CG", 1)
+    V_parent = FunctionSpace(mesh, "CG", 1)
+    f_sub = Function(V_sub).interpolate(ys + zs)
+    f_parent = Function(V_parent)
+    f_parent.interpolate(f_sub, allow_missing_dofs=True)
+    expected = Function(V_parent).interpolate(
+        conditional(x > 0.999, y + z, 0.0)
+    )
+    assert np.allclose(
+        f_parent.dat.data_with_halos, expected.dat.data_with_halos
+    )

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -356,7 +356,7 @@ def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
     # Submesh hit ``IndexError: index -1 is out of bounds for axis 0 with
     # size 0`` because parent_cell_nums_local contains -1 sentinels and
     # cell_closure has shape (0, k) on those ranks.
-    mesh = UnitCubeMesh(8, 8, 8)
+    mesh = UnitCubeMesh(2, 2, 2)
     x, y, z = SpatialCoordinate(mesh)
     V_marker = FunctionSpace(mesh, "HDiv Trace", 0)
     facet_indicator = Function(V_marker).interpolate(

--- a/tests/firedrake/submesh/test_submesh_interpolate.py
+++ b/tests/firedrake/submesh/test_submesh_interpolate.py
@@ -348,7 +348,7 @@ def test_submesh_interpolate_adjoint(fe_fesub):
     assert np.isclose(result_0, expected)
 
 
-@pytest.mark.parallel(nprocs=2)
+@pytest.mark.parallel(nprocs=8)
 def test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_2_processes():
     # Regression test for an IndexError in firedrake.mesh._pic_swarm_in_mesh
     # when interpolating a function defined on a Submesh of an exterior facet


### PR DESCRIPTION
# Description

Fixes #5077.

In `_pic_swarm_in_mesh`, `parent_cell_nums_local` contains `-1` sentinels for points not
owned by the current rank. On ranks with an empty cell partition, `cell_closure` has shape
`(0, k)` and NumPy rejects `-1` as an axis-0 index, causing an `IndexError` when
interpolating from a `Submesh` onto its parent mesh in parallel.

Fix: index `cell_closure` only on `visible_idxs` (the non-sentinel entries), pre-filling
the rest with `-1`. The same issue exists in the extruded branch: `_parent_extrusion_numbering`
floor-divides `parent_cell_nums_local`, and `-1 // N == -1` in Python, so sentinels pass
through into `base_parent_cell_nums` and cause the same crash. Both branches are fixed.

Two regression tests added in `tests/firedrake/submesh/test_submesh_interpolate.py` using
8 MPI ranks:

- `test_submesh_interpolate_3Dcell_2Dfacet_empty_rank_8_processes`: interpolates from a
  `Submesh` of the x=1 face of `UnitCubeMesh(2, 2, 2)` onto the parent mesh.
- `test_submesh_interpolate_3Dcell_extruded_empty_rank_8_processes`: interpolates from
  `ExtrudedMesh(UnitSquareMesh(1, 1), layers=3)` (6 cells) onto a `UnitCubeMesh(2, 2, 2)`,
  guaranteeing at least two ranks own zero extruded cells.