### PR TITLE
Adjoint + submesh

### DIFF
--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -19,7 +19,7 @@ class AssembleBlock(Block):
         if meshes and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
             for mesh in meshes:  # add all meshes as dependency
-                self.add_dependency(mesh, no_duplicates=True)
+                self.add_dependency(mesh)
 
         for c in self.form.coefficients():
             self.add_dependency(c, no_duplicates=True)

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -4,7 +4,6 @@ from ufl.domain import extract_domains
 from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, AdjFloat, create_overloaded_object
 from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
-from .block_utils import isconstant
 
 
 class AssembleBlock(Block):
@@ -104,9 +103,7 @@ class AssembleBlock(Block):
 
         arity_form = len(form.arguments())
 
-        if isconstant(c):
-            space = c.function_space()
-        elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
+        if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             space = c.function_space()
         elif isinstance(c, firedrake.MeshGeometry):
             c_rep = firedrake.SpatialCoordinate(c_rep)
@@ -161,9 +158,7 @@ class AssembleBlock(Block):
         c1 = block_variable.output
         c1_rep = block_variable.saved_output
 
-        if isconstant(c1):
-            space = c1.function_space()
-        elif isinstance(c1, (firedrake.Function, firedrake.Cofunction)):
+        if isinstance(c1, (firedrake.Function, firedrake.Cofunction)):
             space = c1.function_space()
         elif isinstance(c1, firedrake.MeshGeometry):
             c1_rep = firedrake.SpatialCoordinate(c1)

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -19,7 +19,7 @@ class AssembleBlock(Block):
         if meshes and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
             for mesh in meshes:  # add all meshes as dependency
-                self.add_dependency(mesh)
+                self.add_dependency(mesh, no_duplicates=True)
 
         for c in self.form.coefficients():
             self.add_dependency(c, no_duplicates=True)

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -1,24 +1,38 @@
 import ufl
 import firedrake
-from ufl.domain import as_domain
+from ufl.domain import extract_domains
 from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, AdjFloat, create_overloaded_object
 from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
 from .block_utils import isconstant
 
 
+def _extract_meshes(expr):
+    try:
+        return tuple(extract_domains(expr))
+    except AttributeError:
+        return ()
+
+
+def _extract_unique_mesh_for_constant(expr):
+    meshes = _extract_meshes(expr)
+    if len(meshes) != 1:
+        raise NotImplementedError(
+            "Differentiating an assembled multi-domain/Submesh form with respect "
+            "to a Constant is not implemented yet: cannot choose a unique mesh "
+            "for the Constant adjoint function space."
+        )
+    return meshes[0]
+
+
 class AssembleBlock(Block):
     def __init__(self, form, ad_block_tag=None):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
         self.form = form
-        try:
-            mesh = as_domain(form)
-        except AttributeError:
-            mesh = None
-
-        if mesh and not isinstance(self.form, ufl.Interpolate):
+        if not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
-            self.add_dependency(mesh)
+            for mesh in _extract_meshes(form):
+                self.add_dependency(mesh, no_duplicates=True)
 
         for c in self.form.coefficients():
             self.add_dependency(c, no_duplicates=True)
@@ -104,7 +118,7 @@ class AssembleBlock(Block):
         arity_form = len(form.arguments())
 
         if isconstant(c):
-            mesh = as_domain(self.form)
+            mesh = _extract_unique_mesh_for_constant(self.form)
             space = c._ad_function_space(mesh)
         elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             space = c.function_space()
@@ -162,7 +176,7 @@ class AssembleBlock(Block):
         c1_rep = block_variable.saved_output
 
         if isconstant(c1):
-            mesh = as_domain(form)
+            mesh = _extract_unique_mesh_for_constant(form)
             space = c1._ad_function_space(mesh)
         elif isinstance(c1, (firedrake.Function, firedrake.Cofunction)):
             space = c1.function_space()

--- a/firedrake/adjoint_utils/blocks/assembly.py
+++ b/firedrake/adjoint_utils/blocks/assembly.py
@@ -7,31 +7,18 @@ from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
 from .block_utils import isconstant
 
 
-def _extract_meshes(expr):
-    try:
-        return tuple(extract_domains(expr))
-    except AttributeError:
-        return ()
-
-
-def _extract_unique_mesh_for_constant(expr):
-    meshes = _extract_meshes(expr)
-    if len(meshes) != 1:
-        raise NotImplementedError(
-            "Differentiating an assembled multi-domain/Submesh form with respect "
-            "to a Constant is not implemented yet: cannot choose a unique mesh "
-            "for the Constant adjoint function space."
-        )
-    return meshes[0]
-
-
 class AssembleBlock(Block):
     def __init__(self, form, ad_block_tag=None):
         super(AssembleBlock, self).__init__(ad_block_tag=ad_block_tag)
         self.form = form
-        if not isinstance(self.form, ufl.Interpolate):
+        try:  # form can have multiple meshes
+            meshes = tuple(extract_domains(form))
+        except AttributeError:
+            meshes = None
+
+        if meshes and not isinstance(self.form, ufl.Interpolate):
             # Interpolation differentiation wrt spatial coordinates is currently not supported.
-            for mesh in _extract_meshes(form):
+            for mesh in meshes:  # add all meshes as dependency
                 self.add_dependency(mesh, no_duplicates=True)
 
         for c in self.form.coefficients():
@@ -118,8 +105,7 @@ class AssembleBlock(Block):
         arity_form = len(form.arguments())
 
         if isconstant(c):
-            mesh = _extract_unique_mesh_for_constant(self.form)
-            space = c._ad_function_space(mesh)
+            space = c.function_space()
         elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             space = c.function_space()
         elif isinstance(c, firedrake.MeshGeometry):
@@ -176,8 +162,7 @@ class AssembleBlock(Block):
         c1_rep = block_variable.saved_output
 
         if isconstant(c1):
-            mesh = _extract_unique_mesh_for_constant(form)
-            space = c1._ad_function_space(mesh)
+            space = c1.function_space()
         elif isinstance(c1, (firedrake.Function, firedrake.Cofunction)):
             space = c1.function_space()
         elif isinstance(c1, firedrake.MeshGeometry):

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -1,5 +1,6 @@
 import numpy
 import ufl
+from ufl.domain import extract_domains
 from ufl import replace
 from ufl.formatting.ufl2unicode import ufl2unicode
 from enum import Enum
@@ -9,6 +10,24 @@ from pyadjoint.enlisting import Enlist
 import firedrake
 from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
 from .block_utils import isconstant
+
+
+def _extract_meshes(expr):
+    try:
+        return tuple(extract_domains(expr))
+    except AttributeError:
+        return ()
+
+
+def _extract_unique_mesh_for_constant(expr):
+    meshes = _extract_meshes(expr)
+    if len(meshes) != 1:
+        raise NotImplementedError(
+            "Differentiating a multi-domain/Submesh solve with respect to a "
+            "Constant is not implemented yet: cannot choose a unique mesh for "
+            "the Constant adjoint function space."
+        )
+    return meshes[0]
 
 
 def extract_subfunction(u, V):
@@ -74,8 +93,11 @@ class GenericSolveBlock(Block):
         for bc in self.bcs:
             self.add_dependency(bc, no_duplicates=True)
 
-        mesh = self.lhs.ufl_domain()
-        self.add_dependency(mesh)
+        for mesh in _extract_meshes(self.lhs):
+            self.add_dependency(mesh, no_duplicates=True)
+        if isinstance(self.rhs, ufl.Form):
+            for mesh in _extract_meshes(self.rhs):
+                self.add_dependency(mesh, no_duplicates=True)
         self._init_solver_parameters(args, kwargs)
 
     def _init_solver_parameters(self, args, kwargs):
@@ -243,7 +265,7 @@ class GenericSolveBlock(Block):
         c_rep = block_variable.saved_output
 
         if isconstant(c):
-            mesh = F_form.ufl_domain()
+            mesh = _extract_unique_mesh_for_constant(F_form)
             trial_function = firedrake.TrialFunction(
                 c._ad_function_space(mesh)
             )
@@ -455,7 +477,7 @@ class GenericSolveBlock(Block):
             return [tmp_bc]
 
         if isconstant(c_rep):
-            mesh = F_form.ufl_domain()
+            mesh = _extract_unique_mesh_for_constant(F_form)
             W = c._ad_function_space(mesh)
         elif isinstance(c, firedrake.MeshGeometry):
             X = firedrake.SpatialCoordinate(c)
@@ -759,7 +781,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
         elif isinstance(c, firedrake.Constant):
-            mesh = F_form.ufl_domain()
+            mesh = _extract_unique_mesh_for_constant(F_form)
             trial_function = firedrake.TrialFunction(
                 c._ad_function_space(mesh)
             )

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -12,24 +12,6 @@ from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
 from .block_utils import isconstant
 
 
-def _extract_meshes(expr):
-    try:
-        return tuple(extract_domains(expr))
-    except AttributeError:
-        return ()
-
-
-def _extract_unique_mesh_for_constant(expr):
-    meshes = _extract_meshes(expr)
-    if len(meshes) != 1:
-        raise NotImplementedError(
-            "Differentiating a multi-domain/Submesh solve with respect to a "
-            "Constant is not implemented yet: cannot choose a unique mesh for "
-            "the Constant adjoint function space."
-        )
-    return meshes[0]
-
-
 def extract_subfunction(u, V):
     """If V is a subspace of the function-space of u, return the component of u that is in that subspace."""
     if V.index is not None:
@@ -93,11 +75,17 @@ class GenericSolveBlock(Block):
         for bc in self.bcs:
             self.add_dependency(bc, no_duplicates=True)
 
-        for mesh in _extract_meshes(self.lhs):
-            self.add_dependency(mesh, no_duplicates=True)
-        if isinstance(self.rhs, ufl.Form):
-            for mesh in _extract_meshes(self.rhs):
+        try:  # add all meshes as dependency
+            for mesh in tuple(extract_domains(self.lhs)):
                 self.add_dependency(mesh, no_duplicates=True)
+        except AttributeError:
+            pass
+
+        if isinstance(self.rhs, (ufl.Form, ufl.Cofunction)):
+            # add all meshes as dependency
+            for mesh in tuple(extract_domains(self.rhs)):
+                self.add_dependency(mesh, no_duplicates=True)
+
         self._init_solver_parameters(args, kwargs)
 
     def _init_solver_parameters(self, args, kwargs):
@@ -265,9 +253,8 @@ class GenericSolveBlock(Block):
         c_rep = block_variable.saved_output
 
         if isconstant(c):
-            mesh = _extract_unique_mesh_for_constant(F_form)
             trial_function = firedrake.TrialFunction(
-                c._ad_function_space(mesh)
+                c.function_space()
             )
         elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
@@ -477,8 +464,7 @@ class GenericSolveBlock(Block):
             return [tmp_bc]
 
         if isconstant(c_rep):
-            mesh = _extract_unique_mesh_for_constant(F_form)
-            W = c._ad_function_space(mesh)
+            W = c_rep.function_space()
         elif isinstance(c, firedrake.MeshGeometry):
             X = firedrake.SpatialCoordinate(c)
             W = c._ad_function_space()
@@ -781,7 +767,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
         elif isinstance(c, firedrake.Constant):
-            mesh = _extract_unique_mesh_for_constant(F_form)
+            mesh = extract_domains(F_form)[0]  # I don't like this
             trial_function = firedrake.TrialFunction(
                 c._ad_function_space(mesh)
             )

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -81,7 +81,7 @@ class GenericSolveBlock(Block):
         except AttributeError:
             pass
 
-        if isinstance(self.rhs, (ufl.Form, ufl.Cofunction)):
+        if isinstance(self.rhs, ufl.BaseForm):
             # add all meshes as dependency
             for mesh in extract_domains(self.rhs):
                 self.add_dependency(mesh, no_duplicates=True)
@@ -252,11 +252,7 @@ class GenericSolveBlock(Block):
         c = block_variable.output
         c_rep = block_variable.saved_output
 
-        if isconstant(c):
-            trial_function = firedrake.TrialFunction(
-                c.function_space()
-            )
-        elif isinstance(c, (firedrake.Function, firedrake.Cofunction)):
+        if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
         elif isinstance(c, firedrake.DirichletBC):
             tmp_bc = c.reconstruct(
@@ -463,9 +459,7 @@ class GenericSolveBlock(Block):
             )
             return [tmp_bc]
 
-        if isconstant(c_rep):
-            W = c_rep.function_space()
-        elif isinstance(c, firedrake.MeshGeometry):
+        if isinstance(c, firedrake.MeshGeometry):
             X = firedrake.SpatialCoordinate(c)
             W = c._ad_function_space()
         else:

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -767,9 +767,8 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
         elif isinstance(c, firedrake.Constant):
-            mesh = extract_domains(F_form)[0]  # I don't like this
             trial_function = firedrake.TrialFunction(
-                c._ad_function_space(mesh)
+                c.function_space()
             )
         elif isinstance(c, firedrake.DirichletBC):
             tmp_bc = c.reconstruct(

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -1,6 +1,6 @@
 import numpy
 import ufl
-from ufl.domain import extract_domains
+from ufl.domain import extract_domains, extract_unique_domain
 from ufl import replace
 from ufl.formatting.ufl2unicode import ufl2unicode
 from enum import Enum
@@ -767,8 +767,12 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         if isinstance(c, (firedrake.Function, firedrake.Cofunction)):
             trial_function = firedrake.TrialFunction(c.function_space())
         elif isinstance(c, firedrake.Constant):
+            try:
+                mesh = extract_unique_domain(F_form)
+            except ValueError:
+                raise ValueError("Expecting a single mesh")
             trial_function = firedrake.TrialFunction(
-                c.function_space()
+                c._ad_function_space(mesh)
             )
         elif isinstance(c, firedrake.DirichletBC):
             tmp_bc = c.reconstruct(

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -9,7 +9,6 @@ from pyadjoint import Block, stop_annotating, get_working_tape
 from pyadjoint.enlisting import Enlist
 import firedrake
 from firedrake.adjoint_utils.checkpointing import maybe_disk_checkpoint
-from .block_utils import isconstant
 
 
 def extract_subfunction(u, V):

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -76,14 +76,14 @@ class GenericSolveBlock(Block):
             self.add_dependency(bc, no_duplicates=True)
 
         try:  # add all meshes as dependency
-            for mesh in tuple(extract_domains(self.lhs)):
+            for mesh in extract_domains(self.lhs):
                 self.add_dependency(mesh, no_duplicates=True)
         except AttributeError:
             pass
 
         if isinstance(self.rhs, (ufl.Form, ufl.Cofunction)):
             # add all meshes as dependency
-            for mesh in tuple(extract_domains(self.rhs)):
+            for mesh in extract_domains(self.rhs):
                 self.add_dependency(mesh, no_duplicates=True)
 
         self._init_solver_parameters(args, kwargs)

--- a/tests/firedrake/adjoint/test_solving.py
+++ b/tests/firedrake/adjoint/test_solving.py
@@ -314,6 +314,7 @@ def test_two_nonlinear_solves():
     assert rf.tape.recompute_count == 5
 
 
+@pytest.mark.skipcomplex
 def test_multiple_meshes(rg):
     mesh1 = UnitSquareMesh(4, 4)
     mesh2 = RectangleMesh(nx=4, ny=4, Lx=3, Ly=1, originX=2, originY=0)
@@ -345,6 +346,7 @@ def test_multiple_meshes(rg):
     assert taylor_test(rf, f, df) > 1.95
 
 
+@pytest.mark.skipcomplex
 def test_submesh(rg):
     mesh = UnitSquareMesh(4, 4)
     x, y = SpatialCoordinate(mesh)

--- a/tests/firedrake/adjoint/test_solving.py
+++ b/tests/firedrake/adjoint/test_solving.py
@@ -339,11 +339,15 @@ def test_multiple_meshes(rg):
 
     solve(a - L == 0, u, bcs)
 
-    J = assemble(u1**2*dx(mesh1) + u2**2*dx(mesh2))
+    J = assemble(u1**4*dx(mesh1) + u2**4*dx(mesh2))
     rf = ReducedFunctional(J, Control(f))
     df = rg.uniform(V)
 
-    assert taylor_test(rf, f, df) > 1.95
+    taylor = taylor_to_dict(rf, f, df)
+
+    assert min(taylor['R0']['Rate']) > 0.95, taylor['R0']
+    assert min(taylor['R1']['Rate']) > 1.95, taylor['R1']
+    assert min(taylor['R2']['Rate']) > 2.95, taylor['R2']
 
 
 @pytest.mark.skipcomplex
@@ -375,11 +379,15 @@ def test_submesh(rg):
 
     solve(a - L == 0, u, bcs)
 
-    J = assemble(u2**2*dx_sub)
+    J = assemble(u2**4*dx_sub)
     rf = ReducedFunctional(J, Control(f))
     df = rg.uniform(V1)
 
-    assert taylor_test(rf, f, df) > 1.95
+    taylor = taylor_to_dict(rf, f, df)
+
+    assert min(taylor['R0']['Rate']) > 0.95, taylor['R0']
+    assert min(taylor['R1']['Rate']) > 1.95, taylor['R1']
+    assert min(taylor['R2']['Rate']) > 2.95, taylor['R2']
 
 
 def convergence_rates(E_values, eps_values):

--- a/tests/firedrake/adjoint/test_solving.py
+++ b/tests/firedrake/adjoint/test_solving.py
@@ -347,10 +347,10 @@ def test_multiple_meshes(rg):
 
 def test_submesh(rg):
     mesh = UnitSquareMesh(4, 4)
-    x,y = SpatialCoordinate(mesh)
+    x, y = SpatialCoordinate(mesh)
 
     DG = FunctionSpace(mesh, "DG", 0)
-    ind = Function(DG).interpolate(conditional(y>0.5, 1, 0))
+    ind = Function(DG).interpolate(conditional(y > 0.5, 1, 0))
     relabeled_mesh = RelabeledMesh(mesh, [ind], [10])
     submesh = Submesh(relabeled_mesh, 2, 10)
     dx_sub = Measure("dx", domain=submesh, intersect_measures=(Measure("dx", relabeled_mesh),))
@@ -378,6 +378,7 @@ def test_submesh(rg):
     df = rg.uniform(V1)
 
     assert taylor_test(rf, f, df) > 1.95
+
 
 def convergence_rates(E_values, eps_values):
     from numpy import log

--- a/tests/firedrake/adjoint/test_solving.py
+++ b/tests/firedrake/adjoint/test_solving.py
@@ -314,6 +314,71 @@ def test_two_nonlinear_solves():
     assert rf.tape.recompute_count == 5
 
 
+def test_multiple_meshes(rg):
+    mesh1 = UnitSquareMesh(4, 4)
+    mesh2 = RectangleMesh(nx=4, ny=4, Lx=3, Ly=1, originX=2, originY=0)
+
+    V1 = FunctionSpace(mesh1, "CG", 1)
+    V2 = FunctionSpace(mesh2, "CG", 1)
+    V = V1*V2
+
+    u = Function(V)
+    u1, u2 = split(u)
+    v1, v2 = TestFunctions(V)
+
+    f = Function(V).assign(10.)
+    f1, f2 = split(f)
+
+    a = inner(grad(u1), grad(v1))*dx(mesh1) + inner(grad(u2), grad(v2))*dx(mesh2)
+    L = inner(f1, v1)*dx(mesh1) + inner(f2, v2)*dx(mesh2)
+
+    bc1 = DirichletBC(V.sub(0), 0, "on_boundary")
+    bc2 = DirichletBC(V.sub(1), 0, "on_boundary")
+    bcs = [bc1, bc2]
+
+    solve(a - L == 0, u, bcs)
+
+    J = assemble(u1**2*dx(mesh1) + u2**2*dx(mesh2))
+    rf = ReducedFunctional(J, Control(f))
+    df = rg.uniform(V)
+
+    assert taylor_test(rf, f, df) > 1.95
+
+
+def test_submesh(rg):
+    mesh = UnitSquareMesh(4, 4)
+    x,y = SpatialCoordinate(mesh)
+
+    DG = FunctionSpace(mesh, "DG", 0)
+    ind = Function(DG).interpolate(conditional(y>0.5, 1, 0))
+    relabeled_mesh = RelabeledMesh(mesh, [ind], [10])
+    submesh = Submesh(relabeled_mesh, 2, 10)
+    dx_sub = Measure("dx", domain=submesh, intersect_measures=(Measure("dx", relabeled_mesh),))
+
+    V1 = FunctionSpace(relabeled_mesh, "CG", 1)
+    V2 = FunctionSpace(submesh, "CG", 1)
+    V = V1*V2
+
+    u = Function(V)
+    u1, u2 = split(u)
+    v1, v2 = TestFunctions(V)
+
+    f = Function(V1).assign(10.)
+
+    a = inner(grad(u1), grad(v1))*dx(relabeled_mesh)
+    a += inner(u1 - u2, v2)*dx_sub
+    L = inner(f, v1)*dx(relabeled_mesh)
+
+    bcs = [DirichletBC(V.sub(0), 0, "on_boundary")]
+
+    solve(a - L == 0, u, bcs)
+
+    J = assemble(u2**2*dx_sub)
+    rf = ReducedFunctional(J, Control(f))
+    df = rg.uniform(V1)
+
+    assert taylor_test(rf, f, df) > 1.95
+
 def convergence_rates(E_values, eps_values):
     from numpy import log
     r = []


### PR DESCRIPTION
To make the adjoint compatible with `Submesh`, both the mesh and submesh are added as dependencies to an adjoint block. This is accomplished by replacing `ufl_domain` and `as_domain` with `extract_domains` in the appropriate files.

Perhaps this implementation is too naive and not all meshes need to be added as dependencies?
Does this account for all adjoint + submesh cases?

**To do:**
- answer questions above
- write tests

**Disclaimer:**
ChatGPT came up with the initial implementation which was restructured by me