### PR TITLE
Stop propagating log messages to root logger.

### DIFF
--- a/firedrake/logging.py
+++ b/firedrake/logging.py
@@ -72,6 +72,9 @@ def set_log_handlers(handlers=None, comm=COMM_WORLD):
 
     for package in packages:
         logger = logging.getLogger(package)
+        # Avoids duplicating messages if someone directly invokes logging.info:
+        logger.propagate = False
+
         for handler in logger.handlers:
             logger.removeHandler(handler)
 


### PR DESCRIPTION
Fixes #4753

Before when anyone (or any other external packages, such as pyadjoint, see #4753 ) directly uses the root logger of python's logging package, it automatically adds a handler on the root logger that will also display messages send to firedrake's logger, thus duplicating our messages (in particular in parallel on all cores).

Example:
```
from firedrake import *
import logging

logging.info("This message creates handler for root logger")

set_log_level(INFO)
info("This firedrake message is duplicated")
```

This PR stops these messages being propagated to the root logger.