### PR TITLE
Fix interpolation cell subset

### DIFF
--- a/pyop2/types/set.py
+++ b/pyop2/types/set.py
@@ -1,3 +1,4 @@
+import copy
 import ctypes
 import numbers
 
@@ -437,6 +438,9 @@ class Subset(ExtrudedSet):
     @cached_property
     def _argtypes_(self):
         return self._superset._argtypes_ + (ctypes.c_voidp, )
+
+    def __deepcopy__(self, memo):
+        return type(self)(copy.deepcopy(self._superset, memo), self._indices.copy())
 
     # Look up any unspecified attributes on the _set.
     def __getattr__(self, name):

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -744,12 +744,14 @@ def test_interpolate_form_mixed():
 
 
 def test_interpolation_cell_subset():
-    mesh = UnitIntervalMesh(1)
+    mesh = UnitIntervalMesh(2)
+    x = SpatialCoordinate(mesh)
 
-    ind = Function(FunctionSpace(mesh, "DG", 0)).interpolate(1)
+    ind = Function(FunctionSpace(mesh, "DG", 0)).interpolate(conditional(x[0] > 0.5, 1, 0))
+
     mesh = RelabeledMesh(mesh, [ind], [100])
 
     a = Constant(1)
     u = Function(FunctionSpace(mesh, "DG", 0)).interpolate(-a*-a, subset=mesh.cell_subset(100))
 
-    assert assemble((u-a)*dx) < 1e-14
+    assert assemble((u-a/2)*dx) < 1e-14

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -741,3 +741,15 @@ def test_interpolate_form_mixed():
 
     res3 = assemble(inner(u, q) * dx)  # V x W -> R
     assert mat_equals(res1, res3)
+
+
+def test_interpolation_cell_subset():
+    mesh = UnitIntervalMesh(1)
+
+    ind = Function(FunctionSpace(mesh, "DG", 0)).interpolate(1)
+    mesh = RelabeledMesh(mesh, [ind], [100])
+
+    a = Constant(1)
+    u = Function(FunctionSpace(mesh, "DG", 0)).interpolate(-a*-a, subset=mesh.cell_subset(100))
+
+    assert assemble((u-a)*dx) < 1e-14


### PR DESCRIPTION
MFE:
```
from firedrake import *

mesh = UnitIntervalMesh(1)

ind = Function(FunctionSpace(mesh, "DG", 0)).interpolate(1)
mesh = RelabeledMesh(mesh, [ind], [100])

a = Constant(1)
u = Function(FunctionSpace(mesh, "DG", 0)).interpolate(-a*-a, subset=mesh.cell_subset(100))
```
produces the following error:
```
File "/Users/karsknook/Software/main/firedrake/pyop2/types/set.py", line 444, in __getattr__
    value = getattr(self._superset, name)
                    ^^^^^^^^^^^^^^
  File "/Users/karsknook/Software/main/firedrake/pyop2/types/set.py", line 444, in __getattr__
    value = getattr(self._superset, name)
                    ^^^^^^^^^^^^^^
  File "/Users/karsknook/Software/main/firedrake/pyop2/types/set.py", line 444, in __getattr__
    value = getattr(self._superset, name)
                    ^^^^^^^^^^^^^^
  [Previous line repeated 2978 more times]
RecursionError: maximum recursion depth exceeded
```

**Connor's analysis:**
`dataclasses.asdict` with a PyOP2 `Subset` was causing a recursion error when it attempted to deepcopy it. This is because PyOP2 `Subsets` define `__getattr__` that accesses the superset but things weren't fully initialised.

Fix and test are included in PR

