### PR TITLE
Fixes for multidomain form preprocessing

### DIFF
--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -52,6 +52,9 @@ def compute_form_data(form,
     kwargs overriden in the way TSFC needs it and is provided for
     other form compilers based on TSFC.
     """
+    # Multidomain problems require further index simplifications to ensure
+    # that unwanted quantities do not appear inside single-domain integrals.
+    do_remove_component_tensors = len(form.ufl_domains()) > 1
     fd = ufl_compute_form_data(
         form,
         do_apply_function_pullbacks=do_apply_function_pullbacks,
@@ -63,7 +66,8 @@ def compute_form_data(form,
         do_estimate_degrees=do_estimate_degrees,
         do_replace_functions=True,
         coefficients_to_split=coefficients_to_split,
-        complex_mode=complex_mode
+        complex_mode=complex_mode,
+        do_remove_component_tensors=do_remove_component_tensors,
     )
     constants = extract_firedrake_constants(form)
     fd.constants = constants


### PR DESCRIPTION
# Description
Applies more agressive index simplifications to ensure that quantities defined on other domains do not appear in integrals with single-domain `Measures`. 

This is an alternative solution to the issue addressed in https://github.com/firedrakeproject/Irksome/pull/225

> Suppose `u = (u0, u1) in V0 * V1` is the unknown for a mixed formulation where the function spaces `V0` and `V1` are defined on different meshes. At stage `i` we replace `u -> (A*k)[i]`, where `k[i] = (k[0][i], k[1][i])` is the component of the stage vector for stage i.
>
> For a single-domain integral like `inner(u[0], v[0]) * dx(mesh0)`, we run into an issue when we replace `u[0] -> (A*k)[i][0]` inside the integral as `k` is defined on both `mesh0` and `mesh1`.

This PR fixes this by removing component tensors for multidomain problems. This is an optional step in `compute_form_data` that we were skipping because it has a GEM equivalent that we were already using. 

The index simplification effectively introduces the replacement `u[0] -> (A*k[0])[i]`, removing `k[1]` from the integral with `dx(mesh0)`.

It is still unclear whether we should set `do_remove_component_tensors=True` as the default.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
