### PR TITLE
Speed up CI setup and refactor PyPI publishing workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -117,7 +117,7 @@ runs:
           --gpu-arch ${{ inputs.gpu }} \
           --show-env)
         export SLEPC_DIR=$PETSC_DIR/$PETSC_ARCH
-        :# Disable compiler optimisation to speed up build (especially petsc4py)
+        : # Disable compiler optimisation to speed up build (especially petsc4py)
         export CFLAGS="-O0"
         env
 

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -24,7 +24,7 @@ inputs:
   deps:
     description: Optional dependencies to install along with Firedrake (e.g. 'check')
     type: string
-    required: true
+    default: check
 
 runs:
   using: composite
@@ -117,6 +117,8 @@ runs:
           --gpu-arch ${{ inputs.gpu }} \
           --show-env)
         export SLEPC_DIR=$PETSC_DIR/$PETSC_ARCH
+        :# Disable compiler optimisation to speed up build (especially petsc4py)
+        export CFLAGS="-O0"
         env
 
         python3 -m venv venv
@@ -137,24 +139,18 @@ runs:
           pip install --no-deps git+https://github.com/NGSolve/ngsPETSc.git netgen-mesher netgen-occt
 
           : # We have to pass '--no-build-isolation' to use a custom petsc4py
-          EXTRA_BUILD_ARGS='--no-isolation'
           EXTRA_PIP_FLAGS='--no-build-isolation'
         elif [ ${{ inputs.base_ref }} = 'release' ]; then
-          EXTRA_BUILD_ARGS=''
           EXTRA_PIP_FLAGS=''
         else
           echo "Unrecognised 'base_ref' input: '${{ inputs.base_ref }}"
           exit 1
         fi
 
-        : # Install from an sdist so we can make sure that it is not ill-formed
-        pip install build
-        python -m build ./firedrake-repo --sdist $EXTRA_BUILD_ARGS
-
         pip install --verbose $EXTRA_PIP_FLAGS \
           --no-binary h5py \
           --extra-index-url https://download.pytorch.org/whl/cpu \
-          "$(echo ./firedrake-repo/dist/firedrake-*.tar.gz)[${{ inputs.deps }}]"
+          "./firedrake-repo[${{ inputs.deps }}]"
 
         firedrake-clean
         pip list

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -537,24 +537,3 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
-
-  upload_pypi:
-    name: Upload to PyPI (optional)
-    needs: test_linux
-    if: |
-      always() &&
-      inputs.upload_pypi &&
-      inputs.target_branch == 'release' &&
-      needs.test_linux.outputs.sdist_conclusion == 'success'
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-      - name: Push to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -11,10 +11,6 @@ on:
         description: The target branch (usually 'main' or 'release')
         type: string
         required: true
-      run_tests:
-        description: Whether to run the test suite
-        type: boolean
-        default: true
       build_docs:
         description: Whether to build the documentation
         type: boolean
@@ -29,10 +25,6 @@ on:
         default: false
       deploy_website:
         description: Whether to deploy the website
-        type: boolean
-        default: false
-      upload_pypi:
-        description: Whether to upload an sdist to PyPI
         type: boolean
         default: false
 
@@ -46,10 +38,6 @@ on:
         description: The target branch (usually 'main' or 'release')
         type: string
         required: true
-      run_tests:
-        description: Whether to run the test suite
-        type: boolean
-        default: true
       build_docs:
         description: Whether to build the documentation
         type: boolean
@@ -64,10 +52,6 @@ on:
         default: false
       deploy_website:
         description: Whether to deploy the website
-        type: boolean
-        default: false
-      upload_pypi:
-        description: Whether to upload an sdist to PyPI
         type: boolean
         default: false
 
@@ -91,8 +75,6 @@ jobs:
     container:
       # TODO: set to 'ubuntu:latest'
       image: ubuntu:noble
-    outputs:
-      sdist_conclusion: ${{ steps.report_sdist.outputs.conclusion }}
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
@@ -133,20 +115,9 @@ jobs:
           scalar_type: ${{ matrix.arch }}
           deps: ci
 
-      - name: Upload sdist (default ARCH only)
-        if: matrix.arch == 'default'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: firedrake-repo/dist/*
-
-      - name: Report sdist build status
-        id: report_sdist
-        run: echo "conclusion=success" >> "$GITHUB_OUTPUT"
-
       - name: Run TSFC tests
         # Run even if earlier tests failed
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           : # Use pytest-xdist here so we can have a single collated output (not possible
@@ -155,7 +126,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Run PyOP2 tests
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           : # Use pytest-xdist here so we can have a single collated output (not possible
@@ -168,7 +139,7 @@ jobs:
 
 
       - name: Run Firedrake tests (nprocs = 1)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           : # Use pytest-xdist here so we can have a single collated output (not possible
@@ -177,49 +148,49 @@ jobs:
         timeout-minutes: 90
 
       - name: Run tests (nprocs = 2)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 2 4 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 3)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 3 2 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 4)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 4 2 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 5)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 5 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 6)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 6 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 7)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 7 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 8)
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 8 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
@@ -228,7 +199,6 @@ jobs:
       - name: Run Gusto smoke tests
         # Only test Gusto in real mode
         if: |
-          inputs.run_tests &&
           (success() || steps.install.conclusion == 'success') &&
           matrix.arch == 'default'
         run: |
@@ -248,7 +218,6 @@ jobs:
 
       - name: Run Thetis smoke tests
         if: |
-          inputs.run_tests &&
           (success() || steps.install.conclusion == 'success') &&
           matrix.arch == 'default'
         run: |
@@ -260,7 +229,6 @@ jobs:
 
       - name: Run spyro smoke tests
         if: |
-          inputs.run_tests &&
           (success() || steps.install.conclusion == 'success') &&
           matrix.arch == 'default'
         run: |
@@ -272,7 +240,6 @@ jobs:
 
       - name: Run G-ADOPT smoke tests
         if: |
-          inputs.run_tests &&
           (success() || steps.install.conclusion == 'success') &&
           matrix.arch == 'default'
         run: |
@@ -284,7 +251,7 @@ jobs:
 
       - name: Upload log files
         uses: actions/upload-artifact@v4
-        if: inputs.run_tests && (success() || steps.install.conclusion == 'success')
+        if: success() || steps.install.conclusion == 'success'
         with:
           name: firedrake-logs-${{ matrix.arch }}
           path: pytest_*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,41 @@ jobs:
           fi
 
   pypi:
-    uses: ./.github/workflows/core.yml
+    name: Make PyPI release
     needs: check
-    with:
-      source_ref: ${{ inputs.branch }}
-      target_branch: release
-      run_tests: false
-      build_docs: false
-      upload_pypi: true
-    secrets: inherit
+    runs-on: [self-hosted, Linux]
+    container:
+      # TODO: set to 'ubuntu:latest'
+      image: ubuntu:noble
+    environment:
+      name: pypi
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: firedrake-repo
+          ref: ${{ inputs.branch }}
+
+      - name: Install Firedrake
+        uses: ./firedrake-repo/.github/actions/install
+        with:
+          os: linux
+          source_ref: ${{ inputs.branch }}
+          base_ref: release
+
+      - name: Create sdist
+        run: |
+          . venv/bin/activate
+          export $(python3 ./firedrake-repo/scripts/firedrake-configure --show-env)
+          env
+          pip install build
+          python -m build ./firedrake-repo --sdist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: firedrake-repo/dist/
+          # TODO: Use trusted publishing
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github_release:
     name: Create GitHub release


### PR DESCRIPTION
* Compile petsc4py and Firedrake with -O0
* Only build the sdist when we publish, not every time (I think it meant we were building things twice)


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
