### PR TITLE
Add CC to extra_env_vars for OS.UNKNOWN

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -849,7 +849,10 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cflags=["-O3", "-march=native", "-mtune=native"],
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
-        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
+        extra_env_vars={
+            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
+            "CC": "mpicc",
+        },
     ),
 
     (OS.UNKNOWN, ScalarType.COMPLEX, GPUPlatform.NO_GPU): Arch(
@@ -874,7 +877,10 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cflags=["-O3", "-march=native", "-mtune=native"],
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
-        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
+        extra_env_vars={
+            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
+            "CC": "mpicc",
+        },
     ),
 }
 


### PR DESCRIPTION
I found that this is needed to build h5py if we are using a PETSc-built HDF5.

https://docs.h5py.org/en/stable/build.html#building-against-parallel-hdf5



<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
