### PR TITLE
Replace CoarsenIntegrand MultiFunction with DAGTraverser

### DIFF
--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -1,10 +1,9 @@
 import ufl
-from ufl.corealg.map_dag import map_expr_dag
-from ufl.corealg.multifunction import MultiFunction
+from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.domain import extract_unique_domain
 from ufl.duals import is_dual
 
-from functools import singledispatch, partial
+from functools import singledispatch, singledispatchmethod, partial
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.solving_utils import _SNESContext
@@ -22,7 +21,7 @@ class CoarseningError(Exception):
     pass
 
 
-class CoarsenIntegrand(MultiFunction):
+class CoarsenIntegrand(DAGTraverser):
 
     """'Coarsen' a :class:`ufl.Expr` by replacing coefficients,
     arguments and domain data with coarse mesh equivalents."""
@@ -32,28 +31,41 @@ class CoarsenIntegrand(MultiFunction):
             coefficient_mapping = {}
         self.coefficient_mapping = coefficient_mapping
         self.coarsen = coarsen
-        super(CoarsenIntegrand, self).__init__()
+        super().__init__()
 
-    ufl_type = MultiFunction.reuse_if_untouched
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
 
-    def argument(self, o):
+    @process.register(ufl.classes.Expr)
+    @process.register(ufl.BaseForm)
+    def _(self, o):
+        return self.reuse_if_untouched(o)
+
+    @process.register(ufl.classes.Argument)
+    def _(self, o):
         V = self.coarsen(o.function_space(), self.coarsen)
         return o.reconstruct(V)
 
-    def coefficient(self, o):
+    @process.register(ufl.classes.Coefficient)
+    def _(self, o):
         return self.coarsen(o, self.coarsen, coefficient_mapping=self.coefficient_mapping)
 
-    def cofunction(self, o):
+    @process.register(ufl.classes.Cofunction)
+    def _(self, o):
         return self.coarsen(o, self.coarsen, coefficient_mapping=self.coefficient_mapping)
 
-    def geometric_quantity(self, o):
+    @process.register(ufl.classes.GeometricQuantity)
+    def _(self, o):
         return type(o)(self.coarsen(extract_unique_domain(o), self.coarsen))
 
-    def circumradius(self, o):
+    @process.register(ufl.classes.Circumradius)
+    def _(self, o):
         mesh = self.coarsen(extract_unique_domain(o), self.coarsen)
         return firedrake.Circumradius(mesh)
 
-    def facet_normal(self, o):
+    @process.register(ufl.classes.FacetNormal)
+    def _(self, o):
         mesh = self.coarsen(extract_unique_domain(o), self.coarsen)
         return firedrake.FacetNormal(mesh)
 
@@ -79,7 +91,7 @@ def coarse_expr(expr, self, coefficient_mapping=None):
     if expr is None:
         return None
     mapper = CoarsenIntegrand(self, coefficient_mapping)
-    return map_expr_dag(mapper, expr)
+    return mapper(expr)
 
 
 @coarsen.register(ufl.Form)
@@ -98,7 +110,7 @@ def coarsen_form(form, self, coefficient_mapping=None):
     mapper = CoarsenIntegrand(self, coefficient_mapping)
     integrals = []
     for it in form.integrals():
-        integrand = map_expr_dag(mapper, it.integrand())
+        integrand = mapper(it.integrand())
         mesh = it.ufl_domain()
         new_mesh = self(mesh, self)
         if isinstance(integrand, ufl.classes.Zero):

--- a/tests/firedrake/multigrid/test_non_nested.py
+++ b/tests/firedrake/multigrid/test_non_nested.py
@@ -2,6 +2,8 @@ from firedrake import *
 from firedrake.mg.ufl_utils import coarsen as symbolic_coarsen
 from firedrake.petsc import DEFAULT_DIRECT_SOLVER_PARAMETERS
 from functools import singledispatch
+import ufl
+from ufl.corealg.traversal import traverse_unique_terminals
 
 
 def test_coarsen_callback():
@@ -38,6 +40,37 @@ def test_coarsen_callback():
     Ac, _ = lvs.snes.ksp.pc.getMGCoarseSolve().getOperators()
 
     assert Ac.getSize() == (25, 25)
+
+
+def test_symbolic_coarsen_geometric_quantities():
+    base = UnitSquareMesh(2, 2)
+    hierarchy = MeshHierarchy(base, 1)
+    mesh = hierarchy[-1]
+    coarse_mesh = hierarchy[-2]
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    x = SpatialCoordinate(mesh)
+    n = FacetNormal(mesh)
+    h = Circumradius(mesh)
+    f = Function(V).interpolate(1 + x[0])
+
+    form = ((f + x[0] + h) * u * v * dx
+            + inner(n, n) * f * v * ds)
+    coarse_form = symbolic_coarsen(form, symbolic_coarsen)
+
+    assert all(arg.function_space().mesh() is coarse_mesh for arg in coarse_form.arguments())
+
+    coarse_coeffs = [coeff for coeff in coarse_form.coefficients() if isinstance(coeff, Function)]
+    assert coarse_coeffs and coarse_coeffs[0] is not f
+    assert all(coeff.function_space().mesh() is coarse_mesh for coeff in coarse_coeffs)
+
+    for integral in coarse_form.integrals():
+        assert integral.ufl_domain() is coarse_mesh
+        for terminal in traverse_unique_terminals(integral.integrand()):
+            if isinstance(terminal, ufl.classes.GeometricQuantity):
+                assert terminal.ufl_domain() is coarse_mesh
 
 
 def test_sphere_mg():


### PR DESCRIPTION
## Summary
- migrate `CoarsenIntegrand` in `firedrake/mg/ufl_utils.py` from `MultiFunction` to `DAGTraverser`
- replace `map_expr_dag(...)` call sites with direct traverser calls in `coarse_expr` and `coarsen_form`
- add `test_symbolic_coarsen_geometric_quantities` in `tests/firedrake/multigrid/test_non_nested.py`

## Test plan
- [x] `python -m py_compile firedrake/mg/ufl_utils.py tests/firedrake/multigrid/test_non_nested.py`
- [ ] `pytest tests/firedrake/multigrid/test_non_nested.py -k coarsen` (blocked locally: missing `mpi4py`)
- [ ] `pytest tests/firedrake/multigrid/test_transfer_manager.py -k inside_coarsen` (blocked locally: missing `mpi4py`)