### PR TITLE
Fix multidomain form data

### DIFF
--- a/tsfc/ufl_utils.py
+++ b/tsfc/ufl_utils.py
@@ -25,7 +25,7 @@ from ufl.classes import (Abs, Argument, CellOrientation,
                          Product,
                          ScalarValue, Sqrt, Zero, CellVolume, FacetArea)
 from ufl.utils.sorting import sorted_by_count
-from ufl.domain import extract_unique_domain
+from ufl.domain import extract_domains, extract_unique_domain
 
 from gem.node import MemoizerArg
 
@@ -55,7 +55,7 @@ def compute_form_data(form,
     """
     # Multidomain problems require further index simplifications to ensure
     # that unwanted quantities do not appear inside single-domain integrals.
-    do_remove_component_tensors = len(form.ufl_domains()) > 1
+    do_remove_component_tensors = len(extract_domains(form)) > 1
     fd = ufl_compute_form_data(
         form,
         do_apply_function_pullbacks=do_apply_function_pullbacks,


### PR DESCRIPTION
# Description

`form.ufl_domains()` is not enough to detect a multidomain problem, it only returns the domain of the `Measure`. Here we actually need to grab all domains by traversing the DAG


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
