### PR TITLE
Mesh tolerance of 0.0 caused points to be lost

### DIFF
--- a/firedrake/locate.c
+++ b/firedrake/locate.c
@@ -27,10 +27,9 @@ int locate_cell(struct Function *f,
     pointers refer to is updated as necessary. */
     double ref_cell_dist_l1 = DBL_MAX;
     double current_ref_cell_dist_l1 =  -0.5;
-    /* NOTE: `tolerance`, which is used throughout this funciton, is a static
-       variable defined outside this function when putting together all the C
-       code that needs to be compiled - see pointquery_utils.py */
-
+    /* NOTE: `user_tolerance` is a static variable defined in the
+    `compile_coordinate_element` function in pointquery_utils.py. */
+    PetscReal tolerance = PetscMax(user_tolerance, PETSC_MACHINE_EPSILON);
     size_t *ids = NULL;
     size_t nids = 0;
     err = rtree_locate_all_at_point((const struct RTreeH *)f->rtree, x, &ids, &nids);

--- a/firedrake/pointquery_utils.py
+++ b/firedrake/pointquery_utils.py
@@ -249,7 +249,7 @@ struct ReferenceCoords {
     %(ScalarType)s X[%(geometric_dimension)d];
 };
 
-static %(RealType)s tolerance = %(tolerance)s; /* used in locate_cell */
+static %(RealType)s user_tolerance = %(tolerance)s; /* used in locate_cell */
 
 %(to_reference_coords_newton_step)s
 


### PR DESCRIPTION
Creating a VertexOnlyMesh on a mesh with a tolerance of 0.0 can cause points to be lost. E.g.

```
mesh = UnitTriangleMesh(0)
point = [[0.17, 0.17]]
vom = VertexOnlyMesh(mesh, point, tolerance=0.0)
```

would raise an error for a missing point even though (0.17,0.17) is clearly in the mesh. This happened because we check `ref_cell_dist_l1 < tolerance` to determine if a point is in a cell, and `ref_cell_dist_l1` is often very small but non-zero for points inside the cell.

The fix in this PR is to not allow a user tolerance below machine epsilon.