### PR TITLE
Add particle code as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "particles"]
+	path = particles
+	url = git@github.com:achanbour/firedrake-particles.git


### PR DESCRIPTION
Adding the **experimental** particle code as a submodule for public usage and testing. This currently only works with the `achanbour/dev` branch of Firedrake as some of the additional functionality developed does not yet exist in `main`.
