### PR TITLE
Add concept of 'retired' configs to firedrake-configure

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -3,12 +3,9 @@
 """Script for preparing an environment to install Firedrake into."""
 
 # To avoid the pitfalls inherent in having executable configuration files
-# this script is intentionally extremely dumb. All configure options are computed
-# 'statically' (at import) and the only run-time logic that happens is dispatching
-# on the right package manager and arch.
-
-# As a matter of policy, new package managers and archs should only be added to
-# this file if they are *tested in CI*.
+# this script is intentionally extremely dumb. All configure options are set
+# in advance and the only run-time logic that happens is dispatching on the
+# right package manager and arch.
 
 import sys
 import time
@@ -81,16 +78,29 @@ def main():
     arch_key_str = f"{{{', '.join(f'{k.__class__.__name__}: {k.value}' for k in arch_key)}}}"
     if arch_key in OFFICIAL_ARCHS:
         arch = OFFICIAL_ARCHS[arch_key]
+    elif arch_key in RETIRED_ARCHS:
+        arch = RETIRED_ARCHS[arch_key]
+        warn(f"""\
+You have selected an older configuration of Firedrake that we no longer test:
+
+  {arch_key_str} (last modified {arch.last_modified})
+
+If you encounter issues please get in touch with the Firedrake team on GitHub or Slack.""")
     elif arch_key in COMMUNITY_ARCHS:
         arch = COMMUNITY_ARCHS[arch_key]
         warn(f"""\
-You have selected an untested, community-maintained Firedrake configuration
-(last modified {arch.last_modified}), if you encounter issues please
-contact {arch.maintainer} {arch.contact}""")
+You have selected an untested, community-maintained Firedrake configuration:
+
+  {arch_key_str} (last modified {arch.last_modified})
+
+If you encounter issues please contact {arch.maintainer} {arch.contact}.""")
     else:
         error(f"""\
-Firedrake configuration not found for option set '{arch_key_str}',
-please consider passing '--os unknown' or building manually""")
+Firedrake configuration not found for option set:
+
+  {arch_key_str}
+
+Please consider passing '--os unknown' or building manually.""")
 
     if args.show_system_packages:
         try:
@@ -342,6 +352,23 @@ class Arch:
 
         env_str = " ".join(f"{name}={replace_vars(value)}" for name, value in env.items())
         print_and_stop(env_str)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RetiredArch(Arch):
+    """A configuration that Firedrake used to test but no longer does.
+
+    For example this includes older versions of Ubuntu.
+
+    """
+
+    last_modified: str
+    """Date the configuration was last modified (YYYY-MM-DD).
+
+    This is useful for judging the age, and hence likelihood to work, of
+    submitted configurations.
+
+    """
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -885,15 +912,14 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
 }
 
 
-# 'Best effort' configurations that are not tested in CI
-COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
+# Configurations that Firedrake used to support, these are considered
+# more reliable that community configs.
+RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
 
     # Ubuntu 24.04 x86
 
-    (OS.UBUNTU_2404_X86_64, ScalarType.DEFAULT, GPUPlatform.NO_GPU): CommunityArch(
+    (OS.UBUNTU_2404_X86_64, ScalarType.DEFAULT, GPUPlatform.NO_GPU): RetiredArch(
         name="default",
-        maintainer="the Firedrake team",
-        contact="on Slack",
         last_modified="2026-05-13",
         system_packages=[
             "bison",
@@ -954,10 +980,8 @@ COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
         ],
     ),
 
-    (OS.UBUNTU_2404_X86_64, ScalarType.COMPLEX, GPUPlatform.NO_GPU): CommunityArch(
+    (OS.UBUNTU_2404_X86_64, ScalarType.COMPLEX, GPUPlatform.NO_GPU): RetiredArch(
         name="complex",
-        maintainer="the Firedrake team",
-        contact="on Slack",
         last_modified="2026-05-13",
         system_packages=[
             "bison",
@@ -1020,10 +1044,8 @@ COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
 
     # Ubuntu 24.04 aarch64
 
-    (OS.UBUNTU_2404_AARCH64, ScalarType.DEFAULT, GPUPlatform.NO_GPU): CommunityArch(
+    (OS.UBUNTU_2404_AARCH64, ScalarType.DEFAULT, GPUPlatform.NO_GPU): RetiredArch(
         name="default",
-        maintainer="the Firedrake team",
-        contact="on Slack",
         last_modified="2026-05-13",
         system_packages=[
             "bison",
@@ -1084,10 +1106,8 @@ COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
         ],
     ),
 
-    (OS.UBUNTU_2404_AARCH64, ScalarType.COMPLEX, GPUPlatform.NO_GPU): CommunityArch(
+    (OS.UBUNTU_2404_AARCH64, ScalarType.COMPLEX, GPUPlatform.NO_GPU): RetiredArch(
         name="complex",
-        maintainer="the Firedrake team",
-        contact="on Slack",
         last_modified="2026-05-13",
         system_packages=[
             "bison",
@@ -1148,6 +1168,10 @@ COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
         ],
     ),
 }
+
+
+# 'Best effort' configurations that are not tested in CI
+COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Users will see a less scary warning message when they attempt to use old Firedrake configs on systems that we no longer test.



<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
