### PR TITLE
Try to handle solver caching for linear forms (-> #4638)

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -48,7 +48,6 @@ class CachedSolverBlock(Block):
         self.tangent_cache = tangent_cache
         self.adjoint_cache = adjoint_cache
         self.hessian_cache = hessian_cache
-        self.is_linear = forward_cache.is_linear
 
         # The adj_sol in the cached forms is shared by all blocks.
         # This adj_sol belongs to this block specifically so we can
@@ -93,7 +92,7 @@ class CachedSolverBlock(Block):
         """
         for replaced_dep, dep in zip(self.tangent_cache.replaced_tlms,
                                      self._coefficient_dependencies()):
-            if dep.output == self.forward_cache.func and not self.is_linear:
+            if dep.output == self.forward_cache.func:
                 continue
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
@@ -150,7 +149,7 @@ class CachedSolverBlock(Block):
         for dFdm, dep in zip(self.tangent_cache.dFdm_forms, self.get_dependencies()):
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
-            if dep.output is self.forward_cache.func and not self.is_linear:  # Can't compute dependence on initial guess
+            if dep.output is self.forward_cache.func:  # Can't compute dependence on initial guess
                 continue
             tlm_rhs += firedrake.assemble(dFdm)
 
@@ -205,7 +204,7 @@ class CachedSolverBlock(Block):
         return prepared
 
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
-        if block_variable.output == self.forward_cache.func and not self.is_linear:
+        if block_variable.output == self.forward_cache.func:
             return None
 
         if isinstance(block_variable.output, firedrake.DirichletBC):
@@ -246,7 +245,7 @@ class CachedSolverBlock(Block):
                                 self._coefficient_dependencies()):
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
-            if dep.output is self.forward_cache.func and not self.is_linear:  # Can't compute dependence on initial guess
+            if dep.output is self.forward_cache.func:  # Can't compute dependence on initial guess
                 continue
             if len(d2Fdmdu.integrals()) > 0:
                 hessian_rhs -= firedrake.assemble(d2Fdmdu)
@@ -267,7 +266,7 @@ class CachedSolverBlock(Block):
     def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None):
         m = block_variable.output
 
-        if m is self.forward_cache.func and not self.is_linear:
+        if m is self.forward_cache.func:
             return None
 
         if isinstance(m, firedrake.DirichletBC):
@@ -283,7 +282,7 @@ class CachedSolverBlock(Block):
                 continue
             if dep.tlm_value is None:
                 continue
-            if dep.output is self.forward_cache.func and not self.is_linear:
+            if dep.output is self.forward_cache.func:
                 continue
             relevant_d2Fdm2_forms.append(self.hessian_cache.d2Fdm2_adj_forms[idx][i])
 

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -238,7 +238,8 @@ class CachedSolverBlock(Block):
 
         # tlm_output contribution
         self.hessian_cache.tlm_output.assign(tlm_output)
-        hessian_rhs -= firedrake.assemble(self.hessian_cache.d2Fdu2_form)
+        if not self.hessian_cache.d2Fdu2_form.empty():
+            hessian_rhs -= firedrake.assemble(self.hessian_cache.d2Fdu2_form)
 
         # tlm_input contribution
         for d2Fdmdu, dep in zip(self.hessian_cache.d2Fdmdu_forms,

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -148,11 +148,10 @@ class NonlinearVariationalSolverMixin:
         Fnew = replace(F, replace_map)
         unew = replace_map[problem.u]
 
-        # for linear problems, we should provide the Jacobian
-        # since we know it
-        Jnew = None
-        if problem.is_linear:
-            Jnew = replace(problem.J, replace_map)
+        Jnew = replace(problem.J, replace_map)
+        Jpnew = None
+        if problem.Jp is not problem.J:
+            Jpnew = replace(problem.Jp, replace_map)
 
         # We also need to "replace" all the bcs in
         # the new NLVS so we can modify those values
@@ -171,7 +170,7 @@ class NonlinearVariationalSolverMixin:
 
         # This NLVS will be used to recompute the solve.
         # TODO: solver_parameters
-        nlvp = NonlinearVariationalProblem(Fnew, unew, J=Jnew, bcs=bcs_new)
+        nlvp = NonlinearVariationalProblem(Fnew, unew, J=Jnew, Jp=Jpnew, bcs=bcs_new)
         nlvs = NonlinearVariationalSolver(
             nlvp,
             *self._ad_args_kwargs.forward_args,

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -148,6 +148,12 @@ class NonlinearVariationalSolverMixin:
         Fnew = replace(F, replace_map)
         unew = replace_map[problem.u]
 
+        # for linear problems, we should provide the Jacobian
+        # since we know it
+        Jnew = None
+        if problem.is_linear:
+            Jnew = replace(problem.J, replace_map)
+
         # We also need to "replace" all the bcs in
         # the new NLVS so we can modify those values
         # without affecting user code.
@@ -165,7 +171,7 @@ class NonlinearVariationalSolverMixin:
 
         # This NLVS will be used to recompute the solve.
         # TODO: solver_parameters
-        nlvp = NonlinearVariationalProblem(Fnew, unew, bcs=bcs_new)
+        nlvp = NonlinearVariationalProblem(Fnew, unew, J=Jnew, bcs=bcs_new)
         nlvs = NonlinearVariationalSolver(
             nlvp,
             *self._ad_args_kwargs.forward_args,

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -188,7 +188,7 @@ class NonlinearVariationalSolverMixin:
     @no_annotations
     def _ad_tangent_cache(self):
         from firedrake import (
-            Function, Cofunction, derivative, TrialFunction,
+            Function, Cofunction, derivative,
             LinearVariationalProblem, LinearVariationalSolver)
 
         # If we build the TLM form from the cached
@@ -205,7 +205,7 @@ class NonlinearVariationalSolverMixin:
         # Then for the _partial_ derivatives:
         # (dF/du)*(du/dm) + dF/dm = 0 so we calculate:
         # (dF/du)*(du/dm) = -dF/dm
-        dFdu = derivative(F, u, TrialFunction(V))
+        dFdu = expand_derivatives(derivative(F, u))
         dFdm = Cofunction(V.dual())
         dudm = Function(V)
 
@@ -229,8 +229,6 @@ class NonlinearVariationalSolverMixin:
             replaced_tlms.append(mtlm)
 
             dFdm = derivative(-F, m, mtlm)
-            # TODO: Do we need expand_derivatives here? If so, why?
-            dFdm = expand_derivatives(dFdm)
             dFdm_tlm_forms.append(dFdm)
 
         tlm_val = Function(V)
@@ -334,34 +332,33 @@ class NonlinearVariationalSolverMixin:
     @no_annotations
     def _ad_hessian_cache(self):
         from firedrake import (
-            Function, TestFunction)
+            Function, TrialFunction)
 
         nlvp = self._ad_forward_cache.solver._problem
         F = nlvp.F
         u = nlvp.u
         V = u.function_space()
 
-        # 1. Forms to calculate rhs of Hessian solve
+        # Solution of the adjoint equation, requires evaluate_adj to
+        # have been called
+        adj_sol = Function(V)
+        # Solution of the TLM equation, requires evaluate_tlm to
+        # have been called (which is handled by the driver)
+        tlm_output = Function(V)
+        # Solution of the second-order adjoint equation,
+        # this is computed during prepare_evaluate_hessian
+        adj2_sol = Function(V)
 
-        # Calculate d^2F/du^2 * du/dm * dm
+        # 1. Forms to calculate rhs of Hessian solve
+        # Calculate d^2F*/du^2 * du/dm * dm
         # where dm is direction for tlm action so du/dm * dm is tlm output
         dFdu = self._ad_tangent_cache.dFdu
-        tlm_output = Function(V)
-        d2Fdu2 = derivative(dFdu, u, tlm_output)
-        # print()
-        # print(f"{dFdu = }")
-        # print()
-        # print(f"{d2Fdu2 = }")
-        # print()
-        d2Fdu2 = expand_derivatives(d2Fdu2)
+        dFdu_adj = action(adjoint(dFdu), adj_sol)
 
-        adj_sol = Function(V)
-
-        # Contribution from tlm_output
-        if len(d2Fdu2.integrals()) > 0:
-            d2Fdu2_form = action(adjoint(d2Fdu2), adj_sol)
-        else:
-            d2Fdu2_form = d2Fdu2
+        d2Fdu2 = derivative(dFdu_adj, u, tlm_output)
+        # expand_derivatives will simplify down to an empty
+        # form if required
+        d2Fdu2_form = expand_derivatives(d2Fdu2)
 
         # Contributions from each tlm_input
         dFdu_adj = action(self._ad_adjoint_cache.dFdu_adj, adj_sol)
@@ -374,27 +371,21 @@ class NonlinearVariationalSolverMixin:
             d2Fdmdu_forms.append(d2Fdmdu)
 
         # 2. Forms to calculate contribution from each control
-        adj2_sol = Function(V)
-
-        Fadj = action(F, adj_sol)
-        Fadj2 = action(F, adj2_sol)
-
         dFdm_adj2_forms = []
         d2Fdm2_adj_forms = []
         d2Fdudm_forms = []
         for m in self._ad_forward_cache.replaced_deps:
-            dm = TestFunction(m.function_space())
-            dFdm_adj2 = expand_derivatives(
-                derivative(Fadj2, m, dm))
+            dm = TrialFunction(m.function_space())
+            dFdm = derivative(F, m, dm)
 
+            dFdm_adj2 = action(adjoint(dFdm), adj2_sol)
             dFdm_adj2_forms.append(dFdm_adj2)
 
-            dFdm_adj = derivative(Fadj, m, dm)
-
-            d2Fdudm = expand_derivatives(
-                derivative(dFdm_adj, u, tlm_output))
-
-            d2Fdudm_forms.append(d2Fdudm)
+            # we need to expand derivatives before taking
+            # the second derivative
+            dFdm_adj = expand_derivatives(action(adjoint(dFdm), adj_sol))
+            d2Fdudm = derivative(dFdm_adj, u, tlm_output)
+            d2Fdudm_forms.append(expand_derivatives(d2Fdudm))
 
             d2Fdm2_adj_forms_k = []
             for m2, dm2 in zip(self._ad_forward_cache.replaced_deps,

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -150,7 +150,7 @@ class NonlinearVariationalSolverMixin:
 
         Jnew = replace(problem.J, replace_map)
         Jpnew = None
-        if problem.Jp is not problem.J:
+        if problem.Jp and problem.Jp is not problem.J:
             Jpnew = replace(problem.Jp, replace_map)
 
         # We also need to "replace" all the bcs in

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -17,7 +17,6 @@ ForwardSolveRecomputeCache = namedtuple(
         "func",
         "bcs",
         "solver",
-        "is_linear",
         "replaced_deps",
     ]
 )
@@ -182,7 +181,6 @@ class NonlinearVariationalSolverMixin:
             func=self._ad_problem.u,
             bcs=bcs_new,
             solver=nlvs,
-            is_linear=self._ad_problem.is_linear,
             replaced_deps=tuple(replace_map.values()),
         )
 


### PR DESCRIPTION
When we try to cache the Hessian and TLM solvers for a linear form (the L2 Riesz representation), there are a few assumptions about the resulting derivative forms that fail:

- expand_derivatives(d2Fdu2) breaks when it tries to expand a ZeroBaseForm, so we just skip that step (with a try/except that needs to be fixed!)
- taking derivative(action(F, v), L) doesn't work, so we switch to action(derivative(F, L), v)
- for a linear problem, d2Fdudm is zero, but derivative(dFdm_adj) fails, so we simply ~skip adding to the Hessian forms~ add explicit zero forms in that case
- the TLM solver fails unless we explicitly expand derivative(F, u) from the linear form