### PR TITLE
Assemble interpolates with Indexed arguments

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -1667,11 +1667,13 @@ class MixedInterpolator(Interpolator):
             sub_mat_type: Literal["aij", "baij"],
     ) -> PETSc.Mat:
         """Return a PETSc nested matrix built from sub-interpolator matrices."""
-        shape = tuple(len(a.function_space()) for a in self.interpolate_args)
+        spaces = tuple(a.function_space() for a in self.interpolate_args)
+        shape = tuple(len(V) for V in spaces)
         blocks = numpy.full(shape, PETSc.Mat(), dtype=object)
         for indices, (interp, sub_bcs) in Isub.items():
             blocks[indices] = interp._get_callable(bcs=sub_bcs, mat_type=sub_mat_type)()
-        return PETSc.Mat().createNest(blocks)
+        isrows, iscols = (V.dof_dset.field_ises for V in spaces)
+        return PETSc.Mat().createNest(blocks, isrows=isrows, iscols=iscols, comm=self.target_space.comm)
 
     def _build_aij(
             self,

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -755,3 +755,19 @@ def test_interpolation_cell_subset():
     u = Function(FunctionSpace(mesh, "DG", 0)).interpolate(-a*-a, subset=mesh.cell_subset(100))
 
     assert assemble((u-a/2)*dx) < 1e-14
+
+
+def test_interpolate_indexed():
+    mesh = UnitSquareMesh(2, 2)
+    V = FunctionSpace(mesh, "CG", 1)
+    U = FunctionSpace(mesh, "CG", 2)
+    W = V * U
+
+    u1, u2 = TrialFunctions(W)
+    I = assemble(interpolate(u1, U), mat_type="nest")
+    I_block = assemble(interpolate(TrialFunction(V), U))
+    assert np.allclose(I.petscmat.getNestSubMatrix(0, 0)[:, :], I_block.petscmat[:, :])
+
+    I1 = assemble(interpolate(u2, U), mat_type="nest")
+    I1_block = assemble(interpolate(TrialFunction(U), U))
+    assert np.allclose(I1.petscmat.getNestSubMatrix(0, 1)[:, :], I1_block.petscmat[:, :])


### PR DESCRIPTION
If we don't pass the ISes to `createNest`, PETSc complains with errors like `[0] No nonzero submatrix in column 1`.