### PR TITLE
Enable SingleMemoryStorageSchedule in test_checkpointing_validity

### DIFF
--- a/tests/firedrake/adjoint/test_burgers_newton.py
+++ b/tests/firedrake/adjoint/test_burgers_newton.py
@@ -264,6 +264,8 @@ def test_checkpointing_validity(solve_type, checkpointing, basics):
     tape.progress_bar = ProgressBar
     if checkpointing == "Revolve":
         tape.enable_checkpointing(Revolve(steps, steps//3))
+    elif checkpointing == "SingleMemory":
+        tape.enable_checkpointing(SingleMemoryStorageSchedule())
     elif checkpointing == "Mixed":
         enable_disk_checkpointing()
         tape.enable_checkpointing(MixedCheckpointSchedule(steps, steps//3, storage=StorageType.DISK))


### PR DESCRIPTION
`test_checkpointing_validity` is parametrised over `"Revolve"`, `"SingleMemory"`,
`"NoneAdjoint"`, `"Mixed"` and `None`, but the body only enables the Revolve and Mixed
schedules, so the SingleMemory case silently compared two unscheduled tapes. This adds the
missing `elif` so that parametrisation does what its test id promises. Nothing new is caught
by this — the case passes against the released pyadjoint pin and against
dolfin-adjoint/pyadjoint#248 — it simply makes the test consistent with what it advertises.
`"NoneAdjoint"` is left unwired since `NoneCheckpointSchedule` does not support the adjoint
sweep this test performs.
