### PR TITLE
Clone appctx for the cached adjoint replay solvers

### DIFF
--- a/firedrake/adjoint_utils/blocks/__init__.py
+++ b/firedrake/adjoint_utils/blocks/__init__.py
@@ -1,7 +1,7 @@
 from firedrake.adjoint_utils.blocks.assembly import AssembleBlock  # noqa F401
 from firedrake.adjoint_utils.blocks.solving import (  # noqa F401
-    GenericSolveBlock, SolveLinearSystemBlock, ProjectBlock,
-    SupermeshProjectBlock, SolveVarFormBlock,
+    CachedSolverBlock, GenericSolveBlock, SolveLinearSystemBlock,
+    ProjectBlock, SupermeshProjectBlock, SolveVarFormBlock,
     NonlinearVariationalSolveBlock
 )
 from firedrake.adjoint_utils.blocks.function import (  # noqa F401

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -66,7 +66,6 @@ class CachedSolverBlock(Block):
         self.adj_residual = adj_residual
 
         self.adj_sol = adj_sol
-        self.adj_sol_buf = adj_sol.copy(deepcopy=True)
         self.adj2_sol = adj2_sol
         self.tlm_output = tlm_output
         self.d2Fdu2_form = d2Fdu2_form
@@ -190,7 +189,6 @@ class CachedSolverBlock(Block):
         solver.solve()
 
         self.adj_sol.assign(adj_sol)
-        self.adj_sol_buf.assign(adj_sol)
 
         if compute_boundary:
             adj_sol_bc = firedrake.assemble(self.adj_residual)
@@ -214,7 +212,7 @@ class CachedSolverBlock(Block):
         # self.adj_sol is shared between all blocks that this NLVS
         # generates so we can't store it there. Instead store it
         # in self.adj_sol_buf which is owned by this block only.
-        self.adj_sol_buf.assign(adj_sol)
+        self.adj_sol.assign(adj_sol)
 
         prepared = {
             "adj_sol": adj_sol.copy(deepcopy=True),
@@ -239,7 +237,6 @@ class CachedSolverBlock(Block):
         return dFdm
 
     def prepare_evaluate_hessian(self, inputs, hessian_inputs, adj_inputs, relevant_dependencies):
-        self.adj_sol.assign(self.adj_sol_buf)
         self.update_dependencies(use_output=True)
         self.update_hessian_dependencies()
 

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -40,48 +40,29 @@ HESSIAN = SolverType.HESSIAN
 
 
 class CachedSolverBlock(Block):
-    def __init__(self, func, bcs, cached_solvers,
-                 is_linear, replaced_dependencies,
-                 tlm_rhs, replaced_tlms, tlm_dFdm_forms,
-                 adj_rhs, adj_dFdm_forms, adj_residual,
-                 adj_sol, adj2_sol, tlm_output,
-                 d2Fdu2_form, d2Fdmdu_forms,
-                 dFdm_adj2_forms, d2Fdm2_adj_forms,
-                 d2Fdudm_forms,
+    def __init__(self, forward_cache, tangent_cache, adjoint_cache, hessian_cache,
                  ad_block_tag=None):
         super().__init__(ad_block_tag=ad_block_tag)
 
-        self.func = func
-        self.bcs = bcs
-        self.cached_solvers = cached_solvers
-        self.replaced_dependencies = replaced_dependencies
-        self.is_linear = is_linear
+        self.forward_cache = forward_cache
+        self.tangent_cache = tangent_cache
+        self.adjoint_cache = adjoint_cache
+        self.hessian_cache = hessian_cache
+        self.is_linear = forward_cache.is_linear
 
-        self.tlm_rhs = tlm_rhs
-        self.replaced_tlms = replaced_tlms
-        self.tlm_dFdm_forms = tlm_dFdm_forms
-
-        self.adj_rhs = adj_rhs
-        self.adj_dFdm_forms = adj_dFdm_forms
-        self.adj_residual = adj_residual
-
-        self.adj_sol = adj_sol
-        self.adj2_sol = adj2_sol
-        self.tlm_output = tlm_output
-        self.d2Fdu2_form = d2Fdu2_form
-        self.d2Fdmdu_forms = d2Fdmdu_forms
-        self.dFdm_adj2_forms = dFdm_adj2_forms
-        self.d2Fdm2_adj_forms = d2Fdm2_adj_forms
-        self.d2Fdudm_forms = d2Fdudm_forms
+        # The adj_sol in the cached forms is shared by all blocks.
+        # This adj_sol belongs to this block specifically so we can
+        # stash the adjoint solution for the hessian calculation.
+        self.adj_sol = adjoint_cache.adj_sol.copy(deepcopy=True, annotate=False)
 
     def _coefficient_dependencies(self, dependencies=None):
         dependencies = dependencies or self.get_dependencies()
-        return dependencies[:len(self.replaced_dependencies)]
+        return dependencies[:len(self.forward_cache.replaced_deps)]
 
     def _bc_dependencies(self, dependencies=None):
         dependencies = dependencies or self.get_dependencies()
-        if len(self.bcs) > 0:
-            return dependencies[-len(self.bcs):]
+        if len(self.forward_cache.bcs) > 0:
+            return dependencies[-len(self.forward_cache.bcs):]
         else:
             return []
 
@@ -90,7 +71,7 @@ class CachedSolverBlock(Block):
         """
         # Update the coefficients in the form.
         # Use the fact that zip will use the shorter length.
-        for replaced_dep, dep in zip(self.replaced_dependencies,
+        for replaced_dep, dep in zip(self.forward_cache.replaced_deps,
                                      self._coefficient_dependencies()):
             replaced_dep.assign(dep.saved_output)
 
@@ -101,24 +82,24 @@ class CachedSolverBlock(Block):
         # Jacobian is correct.
         if use_output:
             output = self.get_outputs()[0].saved_output
-            self.cached_solvers[FORWARD]._problem.u.assign(output)
+            self.forward_cache.solver._problem.u.assign(output)
 
         # Update the boundary conditions
-        for replaced_dep, dep in zip(self.bcs, self._bc_dependencies()):
+        for replaced_dep, dep in zip(self.forward_cache.bcs, self._bc_dependencies()):
             replaced_dep.set_value(dep.saved_output.function_arg)
 
     def update_tlm_dependencies(self):
         """Update all dependencies of the tlm solve.
         """
-        for replaced_dep, dep in zip(self.replaced_tlms,
+        for replaced_dep, dep in zip(self.tangent_cache.replaced_tlms,
                                      self._coefficient_dependencies()):
-            if dep.output == self.func and not self.is_linear:
+            if dep.output == self.forward_cache.func and not self.is_linear:
                 continue
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
             replaced_dep.assign(dep.tlm_value)
 
-        for replaced_dep, dep in zip(self.bcs, self._bc_dependencies()):
+        for replaced_dep, dep in zip(self.forward_cache.bcs, self._bc_dependencies()):
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 bc_val = 0
             else:
@@ -132,6 +113,9 @@ class CachedSolverBlock(Block):
     def update_hessian_dependencies(self):
         # TODO: Anything else to do here?
         self.update_tlm_dependencies()
+        # update the adj_sol in the cached forms with
+        # the adj_sol value owned by this block.
+        self.hessian_cache.adj_sol.assign(self.adj_sol)
 
     def _compute_boundary(self, relevant_dependencies):
         return any(isinstance(dep.output, firedrake.DirichletBC)
@@ -143,7 +127,7 @@ class CachedSolverBlock(Block):
     def recompute_component(self, inputs, block_variable, idx, prepared):
         self.update_dependencies(use_output=False)
 
-        solver = self.cached_solvers[FORWARD]
+        solver = self.forward_cache.solver
         solver.solve()
         result = solver._problem.u.copy(deepcopy=True)
 
@@ -161,42 +145,40 @@ class CachedSolverBlock(Block):
         self.update_tlm_dependencies()
 
         # Assemble the rhs of (dF/du)(du/dm) = -dF/dm
-        self.tlm_rhs.zero()
-        for dFdm, dep in zip(self.tlm_dFdm_forms, self.get_dependencies()):
+        tlm_rhs = self.tangent_cache.rhs
+        tlm_rhs.zero()
+        for dFdm, dep in zip(self.tangent_cache.dFdm_forms, self.get_dependencies()):
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
-            if dep.output is self.func and not self.is_linear:  # Can't compute dependence on initial guess
+            if dep.output is self.forward_cache.func and not self.is_linear:  # Can't compute dependence on initial guess
                 continue
-            self.tlm_rhs += firedrake.assemble(dFdm)
+            tlm_rhs += firedrake.assemble(dFdm)
 
         # Solve for dudm
-        solver = self.cached_solvers[TLM]
+        solver = self.tangent_cache.solver
         solver._problem.u.zero()
         solver.solve()
         result = solver._problem.u.copy(deepcopy=True)
         return result
 
     def solve_adj_equation(self, rhs, compute_boundary):
-        for bc in self.bcs:
+        for bc in self.forward_cache.bcs:
             bc.homogenize()
 
-        solver = self.cached_solvers[ADJOINT]
-        adj_sol = solver._problem.u
+        adj_rhs = self.adjoint_cache.rhs
+        adj_sol = self.adjoint_cache.adj_sol
 
-        self.adj_rhs.assign(rhs)
+        adj_rhs.assign(rhs)
         adj_sol.zero()
-
-        solver.solve()
-
-        self.adj_sol.assign(adj_sol)
+        self.adjoint_cache.solver.solve()
 
         if compute_boundary:
-            adj_sol_bc = firedrake.assemble(self.adj_residual)
+            adj_sol_bc = firedrake.assemble(self.adjoint_cache.residual)
             adj_sol_bc = adj_sol_bc.riesz_representation("l2")
         else:
             adj_sol_bc = None
 
-        return adj_sol, adj_sol_bc
+        return adj_sol.copy(deepcopy=True), adj_sol_bc
 
     def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
         self.update_dependencies(use_output=True)
@@ -208,20 +190,22 @@ class CachedSolverBlock(Block):
 
         adj_sol, adj_sol_bc = self.solve_adj_equation(dJdu, compute_boundary)
 
-        # store adj_sol for Hessian computation later.
-        # self.adj_sol is shared between all blocks that this NLVS
-        # generates so we can't store it there. Instead store it
-        # in self.adj_sol_buf which is owned by this block only.
+        # store adj_sol for Hessian computation later, or for inspecting
+        # adjoint sensitivities etc.
+        # self.adj_sol is owned by this block, whereas self.hessian_cache.adj_sol
+        # is shared between all blocks that the NLVS generates because it is the
+        # one in the cached forms, so we will update it as necessary if/when each
+        # block calculates the Hessian action.
         self.adj_sol.assign(adj_sol)
 
         prepared = {
-            "adj_sol": adj_sol.copy(deepcopy=True),
+            "adj_sol": adj_sol,
             "adj_sol_bc": adj_sol_bc
         }
         return prepared
 
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
-        if block_variable.output == self.func and not self.is_linear:
+        if block_variable.output == self.forward_cache.func and not self.is_linear:
             return None
 
         if isinstance(block_variable.output, firedrake.DirichletBC):
@@ -232,7 +216,7 @@ class CachedSolverBlock(Block):
             )
 
         # assemble sensititivy comment
-        dFdm = firedrake.assemble(self.adj_dFdm_forms[idx])
+        dFdm = firedrake.assemble(self.adjoint_cache.dFdm_forms[idx])
 
         return dFdm
 
@@ -254,15 +238,15 @@ class CachedSolverBlock(Block):
         hessian_rhs = hessian_input.copy(deepcopy=True)
 
         # tlm_output contribution
-        self.tlm_output.assign(tlm_output)
-        hessian_rhs -= firedrake.assemble(self.d2Fdu2_form)
+        self.hessian_cache.tlm_output.assign(tlm_output)
+        hessian_rhs -= firedrake.assemble(self.hessian_cache.d2Fdu2_form)
 
         # tlm_input contribution
-        for d2Fdmdu, dep in zip(self.d2Fdmdu_forms,
+        for d2Fdmdu, dep in zip(self.hessian_cache.d2Fdmdu_forms,
                                 self._coefficient_dependencies()):
             if dep.tlm_value is None:  # This dependency doesn't depend on the controls
                 continue
-            if dep.output is self.func and not self.is_linear:  # Can't compute dependence on initial guess
+            if dep.output is self.forward_cache.func and not self.is_linear:  # Can't compute dependence on initial guess
                 continue
             if len(d2Fdmdu.integrals()) > 0:
                 hessian_rhs -= firedrake.assemble(d2Fdmdu)
@@ -271,10 +255,10 @@ class CachedSolverBlock(Block):
         compute_boundary = self._compute_boundary(relevant_dependencies)
         adj2_sol, adj2_sol_bc = self.solve_adj_equation(hessian_rhs, compute_boundary)
 
-        self.adj2_sol.assign(adj2_sol)
+        self.hessian_cache.adj2_sol.assign(adj2_sol)
 
         prepared = {
-            "adj2_sol": adj2_sol.copy(deepcopy=True),
+            "adj2_sol": adj2_sol,
             "adj2_sol_bc": adj2_sol_bc,
         }
 
@@ -283,7 +267,7 @@ class CachedSolverBlock(Block):
     def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None):
         m = block_variable.output
 
-        if m is self.func and not self.is_linear:
+        if m is self.forward_cache.func and not self.is_linear:
             return None
 
         if isinstance(m, firedrake.DirichletBC):
@@ -299,14 +283,14 @@ class CachedSolverBlock(Block):
                 continue
             if dep.tlm_value is None:
                 continue
-            if dep.output is self.func and not self.is_linear:
+            if dep.output is self.forward_cache.func and not self.is_linear:
                 continue
-            relevant_d2Fdm2_forms.append(self.d2Fdm2_adj_forms[idx][i])
+            relevant_d2Fdm2_forms.append(self.hessian_cache.d2Fdm2_adj_forms[idx][i])
 
         hessian_output = 0
 
-        for form in (self.d2Fdudm_forms[idx],
-                     self.dFdm_adj2_forms[idx],
+        for form in (self.hessian_cache.d2Fdudm_forms[idx],
+                     self.hessian_cache.dFdm_adj2_forms[idx],
                      *relevant_d2Fdm2_forms):
             if not form.empty():
                 hessian_output += firedrake.assemble(-form)

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -847,6 +847,10 @@ def solve_init_params(self, args, kwargs, varform):
                 raise NotImplementedError(
                     "Annotation of adaptive solves not implemented."
                 )
+            # The legacy adjoint solve goes through ``firedrake.solve``
+            # with an assembled matrix, which does not accept appctx.
+            # The cached variational solvers reinstate it (suitably
+            # cloned) from forward_kwargs.
             self.adj_kwargs.pop("appctx", None)
 
     if hasattr(self, "tlm_args") and len(self.tlm_args) <= 0:

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -25,10 +25,296 @@ def extract_subfunction(u, V):
         return u
 
 
-class Solver(Enum):
+class SolverType(Enum):
     """Enum for solver types."""
     FORWARD = 0
     ADJOINT = 1
+    TLM = 2
+    HESSIAN = 3
+
+
+FORWARD = SolverType.FORWARD
+ADJOINT = SolverType.ADJOINT
+TLM = SolverType.TLM
+HESSIAN = SolverType.HESSIAN
+
+
+class CachedSolverBlock(Block):
+    def __init__(self, func, bcs, cached_solvers,
+                 is_linear, replaced_dependencies,
+                 tlm_rhs, replaced_tlms, tlm_dFdm_forms,
+                 adj_rhs, adj_dFdm_forms, adj_residual,
+                 adj_sol, adj2_sol, tlm_output,
+                 d2Fdu2_form, d2Fdmdu_forms,
+                 dFdm_adj2_forms, d2Fdm2_adj_forms,
+                 d2Fdudm_forms,
+                 ad_block_tag=None):
+        super().__init__(ad_block_tag=ad_block_tag)
+
+        self.func = func
+        self.bcs = bcs
+        self.cached_solvers = cached_solvers
+        self.replaced_dependencies = replaced_dependencies
+        self.is_linear = is_linear
+
+        self.tlm_rhs = tlm_rhs
+        self.replaced_tlms = replaced_tlms
+        self.tlm_dFdm_forms = tlm_dFdm_forms
+
+        self.adj_rhs = adj_rhs
+        self.adj_dFdm_forms = adj_dFdm_forms
+        self.adj_residual = adj_residual
+
+        self.adj_sol = adj_sol
+        self.adj_sol_buf = adj_sol.copy(deepcopy=True)
+        self.adj2_sol = adj2_sol
+        self.tlm_output = tlm_output
+        self.d2Fdu2_form = d2Fdu2_form
+        self.d2Fdmdu_forms = d2Fdmdu_forms
+        self.dFdm_adj2_forms = dFdm_adj2_forms
+        self.d2Fdm2_adj_forms = d2Fdm2_adj_forms
+        self.d2Fdudm_forms = d2Fdudm_forms
+
+    def _coefficient_dependencies(self, dependencies=None):
+        dependencies = dependencies or self.get_dependencies()
+        return dependencies[:len(self.replaced_dependencies)]
+
+    def _bc_dependencies(self, dependencies=None):
+        dependencies = dependencies or self.get_dependencies()
+        if len(self.bcs) > 0:
+            return dependencies[-len(self.bcs):]
+        else:
+            return []
+
+    def update_dependencies(self, use_output=False):
+        """Update all dependencies of the forward solve.
+        """
+        # Update the coefficients in the form.
+        # Use the fact that zip will use the shorter length.
+        for replaced_dep, dep in zip(self.replaced_dependencies,
+                                     self._coefficient_dependencies()):
+            replaced_dep.assign(dep.saved_output)
+
+        # 1. For forward recomputation the unknown Function should use
+        # the incoming value of the dependency as the initial guess.
+        # 2. For the adjoint, TLM, and Hessian, the unknown Function
+        # should use the computed value so that the linearised
+        # Jacobian is correct.
+        if use_output:
+            output = self.get_outputs()[0].saved_output
+            self.cached_solvers[FORWARD]._problem.u.assign(output)
+
+        # Update the boundary conditions
+        for replaced_dep, dep in zip(self.bcs, self._bc_dependencies()):
+            replaced_dep.set_value(dep.saved_output.function_arg)
+
+    def update_tlm_dependencies(self):
+        """Update all dependencies of the tlm solve.
+        """
+        for replaced_dep, dep in zip(self.replaced_tlms,
+                                     self._coefficient_dependencies()):
+            if dep.output == self.func and not self.is_linear:
+                continue
+            if dep.tlm_value is None:  # This dependency doesn't depend on the controls
+                continue
+            replaced_dep.assign(dep.tlm_value)
+
+        for replaced_dep, dep in zip(self.bcs, self._bc_dependencies()):
+            if dep.tlm_value is None:  # This dependency doesn't depend on the controls
+                bc_val = 0
+            else:
+                bc_val = dep.tlm_value.function_arg
+            replaced_dep.set_value(bc_val)
+
+    def update_adj_dependencies(self):
+        # TODO: Anything to do here?
+        pass
+
+    def update_hessian_dependencies(self):
+        # TODO: Anything else to do here?
+        self.update_tlm_dependencies()
+
+    def _compute_boundary(self, relevant_dependencies):
+        return any(isinstance(dep.output, firedrake.DirichletBC)
+                   for _, dep in relevant_dependencies)
+
+    def prepare_recompute_component(self, inputs, relevant_outputs):
+        return
+
+    def recompute_component(self, inputs, block_variable, idx, prepared):
+        self.update_dependencies(use_output=False)
+
+        solver = self.cached_solvers[FORWARD]
+        solver.solve()
+        result = solver._problem.u.copy(deepcopy=True)
+
+        # Possibly checkpoint the result for the adjoint solve later.
+        if isinstance(block_variable.checkpoint, firedrake.Function):
+            result = block_variable.checkpoint.assign(result)
+
+        return maybe_disk_checkpoint(result)
+
+    def prepare_evaluate_tlm(self, inputs, tlm_inputs, relevant_outputs):
+        return
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
+        self.update_dependencies(use_output=True)
+        self.update_tlm_dependencies()
+
+        # Assemble the rhs of (dF/du)(du/dm) = -dF/dm
+        self.tlm_rhs.zero()
+        for dFdm, dep in zip(self.tlm_dFdm_forms, self.get_dependencies()):
+            if dep.tlm_value is None:  # This dependency doesn't depend on the controls
+                continue
+            if dep.output is self.func and not self.is_linear:  # Can't compute dependence on initial guess
+                continue
+            self.tlm_rhs += firedrake.assemble(dFdm)
+
+        # Solve for dudm
+        solver = self.cached_solvers[TLM]
+        solver._problem.u.zero()
+        solver.solve()
+        result = solver._problem.u.copy(deepcopy=True)
+        return result
+
+    def solve_adj_equation(self, rhs, compute_boundary):
+        for bc in self.bcs:
+            bc.homogenize()
+
+        solver = self.cached_solvers[ADJOINT]
+        adj_sol = solver._problem.u
+
+        self.adj_rhs.assign(rhs)
+        adj_sol.zero()
+
+        solver.solve()
+
+        self.adj_sol.assign(adj_sol)
+        self.adj_sol_buf.assign(adj_sol)
+
+        if compute_boundary:
+            adj_sol_bc = firedrake.assemble(self.adj_residual)
+            adj_sol_bc = adj_sol_bc.riesz_representation("l2")
+        else:
+            adj_sol_bc = None
+
+        return adj_sol, adj_sol_bc
+
+    def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
+        self.update_dependencies(use_output=True)
+        self.update_adj_dependencies()
+
+        dJdu = adj_inputs[0]
+
+        compute_boundary = self._compute_boundary(relevant_dependencies)
+
+        adj_sol, adj_sol_bc = self.solve_adj_equation(dJdu, compute_boundary)
+
+        # store adj_sol for Hessian computation later.
+        # self.adj_sol is shared between all blocks that this NLVS
+        # generates so we can't store it there. Instead store it
+        # in self.adj_sol_buf which is owned by this block only.
+        self.adj_sol_buf.assign(adj_sol)
+
+        prepared = {
+            "adj_sol": adj_sol.copy(deepcopy=True),
+            "adj_sol_bc": adj_sol_bc
+        }
+        return prepared
+
+    def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx, prepared=None):
+        if block_variable.output == self.func and not self.is_linear:
+            return None
+
+        if isinstance(block_variable.output, firedrake.DirichletBC):
+            bc = block_variable.output
+            adj_sol_bc = prepared["adj_sol_bc"]
+            return bc.reconstruct(
+                g=extract_subfunction(adj_sol_bc, bc.function_space())
+            )
+
+        # assemble sensititivy comment
+        dFdm = firedrake.assemble(self.adj_dFdm_forms[idx])
+
+        return dFdm
+
+    def prepare_evaluate_hessian(self, inputs, hessian_inputs, adj_inputs, relevant_dependencies):
+        self.adj_sol.assign(self.adj_sol_buf)
+        self.update_dependencies(use_output=True)
+        self.update_hessian_dependencies()
+
+        hessian_input = hessian_inputs[0]
+        tlm_output = self.get_outputs()[0].tlm_value
+
+        if hessian_input is None:
+            return
+        if tlm_output is None:
+            return
+
+        # 1. Assemble rhs
+
+        # hessian input contribution
+        hessian_rhs = hessian_input.copy(deepcopy=True)
+
+        # tlm_output contribution
+        self.tlm_output.assign(tlm_output)
+        hessian_rhs -= firedrake.assemble(self.d2Fdu2_form)
+
+        # tlm_input contribution
+        for d2Fdmdu, dep in zip(self.d2Fdmdu_forms,
+                                self._coefficient_dependencies()):
+            if dep.tlm_value is None:  # This dependency doesn't depend on the controls
+                continue
+            if dep.output is self.func and not self.is_linear:  # Can't compute dependence on initial guess
+                continue
+            if len(d2Fdmdu.integrals()) > 0:
+                hessian_rhs -= firedrake.assemble(d2Fdmdu)
+
+        # 2. Solve adjoint system
+        compute_boundary = self._compute_boundary(relevant_dependencies)
+        adj2_sol, adj2_sol_bc = self.solve_adj_equation(hessian_rhs, compute_boundary)
+
+        self.adj2_sol.assign(adj2_sol)
+
+        prepared = {
+            "adj2_sol": adj2_sol.copy(deepcopy=True),
+            "adj2_sol_bc": adj2_sol_bc,
+        }
+
+        return prepared
+
+    def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs, block_variable, idx, relevant_dependencies, prepared=None):
+        m = block_variable.output
+
+        if m is self.func and not self.is_linear:
+            return None
+
+        if isinstance(m, firedrake.DirichletBC):
+            bc = block_variable.output
+            adj2_sol_bc = prepared["adj2_sol_bc"]
+            return bc.reconstruct(
+                g=extract_subfunction(adj2_sol_bc, bc.function_space())
+            )
+
+        relevant_d2Fdm2_forms = []
+        for i, dep in relevant_dependencies:
+            if i >= len(self._coefficient_dependencies()):
+                continue
+            if dep.tlm_value is None:
+                continue
+            if dep.output is self.func and not self.is_linear:
+                continue
+            relevant_d2Fdm2_forms.append(self.d2Fdm2_adj_forms[idx][i])
+
+        hessian_output = 0
+
+        for form in (self.d2Fdudm_forms[idx],
+                     self.dFdm_adj2_forms[idx],
+                     *relevant_d2Fdm2_forms):
+            if not form.empty():
+                hessian_output += firedrake.assemble(-form)
+
+        return hessian_output
 
 
 class GenericSolveBlock(Block):
@@ -56,6 +342,8 @@ class GenericSolveBlock(Block):
         # Solution function
         self.func = func
         self.function_space = self.func.function_space()
+        # Storage for adjoint solution of this block
+        self.adj_state_buf = func.copy(deepcopy=True)
         # Boundary conditions
         self.bcs = []
         if bcs is not None:
@@ -204,6 +492,8 @@ class GenericSolveBlock(Block):
             dFdu_form, dJdu, compute_bdy
         )
         self.adj_sol = adj_sol
+        self.adj_state = adj_sol
+        self.adj_state_buf.assign(adj_sol)
         if self.adj_cb is not None:
             self.adj_cb(adj_sol)
         if self.adj_bdy_cb is not None and compute_bdy:
@@ -214,31 +504,6 @@ class GenericSolveBlock(Block):
         r["adj_sol"] = adj_sol
         r["adj_sol_bdy"] = adj_sol_bdy
         return r
-
-    def _assemble_dFdu_adj(self, dFdu_adj_form, **kwargs):
-        return firedrake.assemble(dFdu_adj_form, **kwargs)
-
-    def _assemble_and_solve_adj_eq(self, dFdu_adj_form, dJdu, compute_bdy):
-        dJdu_copy = dJdu.copy()
-        # Homogenize and apply boundary conditions on adj_dFdu.
-        bcs = self._homogenize_bcs()
-        dFdu = firedrake.assemble(dFdu_adj_form, bcs=bcs, **self.assemble_kwargs)
-
-        adj_sol = firedrake.Function(self.function_space)
-        firedrake.solve(
-            dFdu, adj_sol, dJdu, *self.adj_args, **self.adj_kwargs
-        )
-
-        adj_sol_bdy = None
-        if compute_bdy:
-            adj_sol_bdy = self._compute_adj_bdy(
-                adj_sol, adj_sol_bdy, dFdu_adj_form, dJdu_copy)
-
-        return adj_sol, adj_sol_bdy
-
-    def _compute_adj_bdy(self, adj_sol, adj_sol_bdy, dFdu_adj_form, dJdu):
-        adj_sol_bdy = firedrake.assemble(dJdu - firedrake.action(dFdu_adj_form, adj_sol))
-        return adj_sol_bdy.riesz_representation("l2")
 
     def evaluate_adj_component(self, inputs, adj_inputs, block_variable, idx,
                                prepared=None):
@@ -283,7 +548,36 @@ class GenericSolveBlock(Block):
         dFdm = firedrake.assemble(dFdm, **self.assemble_kwargs)
         return dFdm
 
+    def _assemble_dFdu_adj(self, dFdu_adj_form, **kwargs):
+        return firedrake.assemble(dFdu_adj_form, **kwargs)
+
+    def _assemble_and_solve_adj_eq(self, dFdu_adj_form, dJdu, compute_bdy):
+        dJdu_copy = dJdu.copy()
+        # Homogenize and apply boundary conditions on adj_dFdu.
+        bcs = self._homogenize_bcs()
+        dFdu = firedrake.assemble(dFdu_adj_form, bcs=bcs, **self.assemble_kwargs)
+
+        adj_sol = firedrake.Function(self.function_space)
+        firedrake.solve(
+            dFdu, adj_sol, dJdu, *self.adj_args, **self.adj_kwargs
+        )
+
+        adj_sol_bdy = None
+        if compute_bdy:
+            adj_sol_bdy = self._compute_adj_bdy(
+                adj_sol, adj_sol_bdy, dFdu_adj_form, dJdu_copy)
+
+        return adj_sol, adj_sol_bdy
+
+    def _compute_adj_bdy(self, adj_sol, adj_sol_bdy, dFdu_adj_form, dJdu):
+        adj_sol_bdy = firedrake.assemble(dJdu - firedrake.action(dFdu_adj_form, adj_sol))
+        return adj_sol_bdy.riesz_representation("l2")
+
     def prepare_evaluate_tlm(self, inputs, tlm_inputs, relevant_outputs):
+        pass
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx,
+                               prepared=None):
         fwd_block_variable = self.get_outputs()[0]
         u = fwd_block_variable.output
 
@@ -295,16 +589,6 @@ class GenericSolveBlock(Block):
             fwd_block_variable.saved_output,
             firedrake.TrialFunction(u.function_space())
         )
-
-        return {
-            "form": F_form,
-            "dFdu": dFdu
-        }
-
-    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx,
-                               prepared=None):
-        F_form = prepared["form"]
-        dFdu = prepared["dFdu"]
         V = self.get_outputs()[idx].output.function_space()
 
         bcs = []
@@ -341,10 +625,11 @@ class GenericSolveBlock(Block):
         dFdm = ufl.algorithms.expand_derivatives(dFdm)
         dFdm = firedrake.assemble(dFdm)
         dudm = firedrake.Function(V)
-        return self._assemble_and_solve_tlm_eq(
+        result = self._assemble_and_solve_tlm_eq(
             firedrake.assemble(dFdu, bcs=bcs, **self.assemble_kwargs),
             dFdm, dudm, bcs
         )
+        return result
 
     def _assemble_and_solve_tlm_eq(self, dFdu, dFdm, dudm, bcs):
         return self._assembled_solve(dFdu, dFdm, dudm, bcs)
@@ -376,7 +661,10 @@ class GenericSolveBlock(Block):
             elif not isinstance(c, firedrake.DirichletBC):
                 dFdu_adj = firedrake.action(firedrake.adjoint(dFdu_form),
                                             adj_sol)
-                b_form += firedrake.derivative(dFdu_adj, c_rep, tlm_input)
+                # b_form += firedrake.derivative(dFdu_adj, c_rep, tlm_input)
+                bo_form = ufl.algorithms.expand_derivatives(
+                    firedrake.derivative(dFdu_adj, c_rep, tlm_input))
+                b_form += bo_form
 
         b_form = ufl.algorithms.expand_derivatives(b_form)
         if len(b_form.integrals()) > 0:
@@ -403,6 +691,8 @@ class GenericSolveBlock(Block):
         fwd_block_variable = self.get_outputs()[0]
         hessian_input = hessian_inputs[0]
         tlm_output = fwd_block_variable.tlm_value
+
+        self.adj_state = self.adj_state_buf.copy(deepcopy=True)
 
         if hessian_input is None:
             return
@@ -432,6 +722,7 @@ class GenericSolveBlock(Block):
         r["adj_sol2_bdy"] = adj_sol2_bdy
         r["form"] = F_form
         r["adj_sol"] = adj_sol
+
         return r
 
     def evaluate_hessian_component(self, inputs, hessian_inputs, adj_inputs,
@@ -577,6 +868,12 @@ def solve_init_params(self, args, kwargs, varform):
                 )
             self.adj_kwargs.pop("appctx", None)
 
+    if hasattr(self, "tlm_args") and len(self.tlm_args) <= 0:
+        self.tlm_args = self.adj_args
+
+    if hasattr(self, "tlm_kwargs") and len(self.tlm_kwargs) <= 0:
+        self.tlm_kwargs = self.adj_kwargs.copy()
+
     solver_params = kwargs.get("solver_parameters", None)
     if solver_params is not None and "mat_type" in solver_params:
         self.assemble_kwargs["mat_type"] = solver_params["mat_type"]
@@ -627,6 +924,8 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         self.problem_J = problem_J
         self.solver_kwargs = solver_kwargs
 
+        self.adj_state_buf = func.copy(deepcopy=True)
+
         super().__init__(lhs, rhs, func, bcs, **{**solver_kwargs, **kwargs})
 
         if self.problem_J is not None:
@@ -664,12 +963,12 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
             and self._ad_solvers["update_adjoint"]
         ):
             # Update left hand side of the adjoint equation.
-            self._ad_solver_replace_forms(Solver.ADJOINT)
+            self._ad_solver_replace_forms(SolverType.ADJOINT)
             self._ad_solvers["adjoint_lvs"].invalidate_jacobian()
             self._ad_solvers["update_adjoint"] = False
         elif not self._ad_solvers["forward_nlvs"]._problem._constant_jacobian:
             # Update left hand side of the adjoint equation.
-            self._ad_solver_replace_forms(Solver.ADJOINT)
+            self._ad_solver_replace_forms(SolverType.ADJOINT)
 
         # Update the right hand side of the adjoint equation.
         # problem.F._component[1] is the right hand side of the adjoint.
@@ -687,7 +986,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         return u_sol, adj_sol_bdy
 
     def _ad_assign_map(self, form, solver):
-        if solver == Solver.FORWARD:
+        if solver == SolverType.FORWARD:
             count_map = self._ad_solvers["forward_nlvs"]._problem._ad_count_map
         else:
             count_map = self._ad_solvers["adjoint_lvs"]._problem._ad_count_map
@@ -705,7 +1004,7 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
                         block_variable.saved_output
 
         if (
-            solver == Solver.ADJOINT
+            solver == SolverType.ADJOINT
             and not self._ad_solvers["forward_nlvs"]._problem._constant_jacobian
         ):
             block_variable = self.get_outputs()[0]
@@ -720,8 +1019,8 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
         for coeff, value in assign_map.items():
             coeff.assign(value)
 
-    def _ad_solver_replace_forms(self, solver=Solver.FORWARD):
-        if solver == Solver.FORWARD:
+    def _ad_solver_replace_forms(self, solver=SolverType.FORWARD):
+        if solver == SolverType.FORWARD:
             problem = self._ad_solvers["forward_nlvs"]._problem
             self._ad_assign_coefficients(problem.F, solver)
             self._ad_assign_coefficients(problem.J, solver)
@@ -734,7 +1033,8 @@ class NonlinearVariationalSolveBlock(GenericSolveBlock):
             relevant_dependencies
         )
         adj_sol, adj_sol_bdy = self._adjoint_solve(adj_inputs[0], compute_bdy)
-        self.adj_sol = adj_sol
+        self.adj_state = adj_sol
+        self.adj_state_buf.assign(adj_sol)
         if self.adj_cb is not None:
             self.adj_cb(adj_sol)
         if self.adj_bdy_cb is not None and compute_bdy:

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -847,10 +847,12 @@ def solve_init_params(self, args, kwargs, varform):
                 raise NotImplementedError(
                     "Annotation of adaptive solves not implemented."
                 )
-            # The legacy adjoint solve goes through ``firedrake.solve``
-            # with an assembled matrix, which does not accept appctx.
-            # The cached variational solvers reinstate it (suitably
-            # cloned) from forward_kwargs.
+            # adj_kwargs feeds the assembled-matrix adjoint solve
+            # ``firedrake.solve(A, x, b, ...)``, whose kwarg validation
+            # rejects a top-level ``appctx`` (on that path appctx is read
+            # from ``solver_parameters`` instead). Drop it here; the cached
+            # variational solvers reinstate it, suitably cloned, from
+            # forward_kwargs.
             self.adj_kwargs.pop("appctx", None)
 
     if hasattr(self, "tlm_args") and len(self.tlm_args) <= 0:

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -5,6 +5,7 @@ from firedrake.adjoint_utils.blocks import (
     NonlinearVariationalSolveBlock, CachedSolverBlock)
 from firedrake.adjoint_utils.blocks.solving import solve_init_params
 from firedrake.ufl_expr import derivative, adjoint, action
+import ufl
 from ufl import replace, Action
 from ufl.algorithms import expand_derivatives
 from types import SimpleNamespace
@@ -19,6 +20,7 @@ ForwardSolveRecomputeCache = namedtuple(
         "solver",
         "is_linear",
         "replaced_deps",
+        "replace_map",
     ]
 )
 
@@ -124,6 +126,43 @@ class NonlinearVariationalSolverMixin:
 
         return wrapper
 
+    @staticmethod
+    def _ad_clone_kwargs(kwargs, replace_map, default_appctx=None):
+        """Return a shallow copy of *kwargs* with ``appctx`` entries cloned.
+
+        The ``appctx`` dict may contain UFL expressions (or plain
+        ``Function`` objects) that reference the *original* form
+        coefficients.  The cached solvers work on deep copies of those
+        coefficients, so the ``appctx`` must undergo the same
+        replacement for preconditioners reading from it (e.g.
+        ``MassInvPC``) to see the values that ``update_dependencies``
+        keeps in sync with the tape.
+
+        If *kwargs* carries no ``appctx`` of its own, *default_appctx*
+        (the forward solver's) is cloned instead.  The tangent and
+        adjoint operators are linearisations of the forward operator,
+        so a preconditioner that needs something from ``appctx`` for
+        the forward solve needs the same thing for them.
+
+        Note that ``ufl.replace`` only maps coefficients that appear in
+        the forward residual ``F``.  An ``appctx`` entry referencing a
+        coefficient that is not part of ``F``, or that is not a UFL
+        expression (containers, callables, ...), is passed through by
+        reference and will not be updated during recomputation.
+        """
+        appctx = kwargs.get("appctx", default_appctx)
+        if not appctx:
+            return kwargs
+        cloned_appctx = {}
+        for key, value in appctx.items():
+            if isinstance(value, ufl.core.expr.Expr):
+                cloned_appctx[key] = ufl.replace(value, replace_map)
+            else:
+                cloned_appctx[key] = value
+        cloned = dict(kwargs)
+        cloned["appctx"] = cloned_appctx
+        return cloned
+
     @cached_property
     @no_annotations
     def _ad_forward_cache(self):
@@ -164,13 +203,20 @@ class NonlinearVariationalSolverMixin:
             for bc in bcs
         ]
 
+        # Any UFL expressions in the appctx must reference the new
+        # coefficients, not the user's originals, so that
+        # preconditioners reading from the appctx (e.g. MassInvPC)
+        # see the values updated during recomputation.
+        forward_kwargs = self._ad_clone_kwargs(
+            self._ad_args_kwargs.forward_kwargs, replace_map)
+
         # This NLVS will be used to recompute the solve.
         # TODO: solver_parameters
         nlvp = NonlinearVariationalProblem(Fnew, unew, bcs=bcs_new)
         nlvs = NonlinearVariationalSolver(
             nlvp,
             *self._ad_args_kwargs.forward_args,
-            **self._ad_args_kwargs.forward_kwargs)
+            **forward_kwargs)
 
         # The original coefficients will be added as
         # dependencies to all solve blocks.
@@ -184,6 +230,7 @@ class NonlinearVariationalSolverMixin:
             solver=nlvs,
             is_linear=self._ad_problem.is_linear,
             replaced_deps=tuple(replace_map.values()),
+            replace_map=replace_map,
         )
 
     @cached_property
@@ -214,11 +261,18 @@ class NonlinearVariationalSolverMixin:
         # Reuse the same bcs as the forward problem.
         # TODO: Think about if we should use new bcs.
         # TODO: solver_parameters
+        # The TLM form is built from the cloned forward problem, so the
+        # appctx must be replaced with the same forward replace map.
+        tlm_kwargs = self._ad_clone_kwargs(
+            self._ad_args_kwargs.tlm_kwargs,
+            self._ad_forward_cache.replace_map,
+            default_appctx=self._ad_args_kwargs.forward_kwargs.get("appctx"))
+
         lvp = LinearVariationalProblem(dFdu, dFdm, dudm, bcs=self._ad_forward_cache.bcs)
         lvs = LinearVariationalSolver(
             lvp,
             *self._ad_args_kwargs.tlm_args,
-            **self._ad_args_kwargs.tlm_kwargs)
+            **tlm_kwargs)
 
         tlm_rhs = dFdm
 
@@ -283,11 +337,18 @@ class NonlinearVariationalSolverMixin:
         # Reuse the same bcs as the forward problem.
         # TODO: Think about if we should use new bcs.
         # TODO: solver_parameters
+        # The adjoint form is built from the cloned forward problem, so
+        # the appctx must be replaced with the same forward replace map.
+        adj_kwargs = self._ad_clone_kwargs(
+            self._ad_args_kwargs.adj_kwargs,
+            self._ad_forward_cache.replace_map,
+            default_appctx=self._ad_args_kwargs.forward_kwargs.get("appctx"))
+
         lvp = LinearVariationalProblem(dFdu_adj, dJdu, adj_sol, bcs=self._ad_forward_cache.bcs)
         lvs = LinearVariationalSolver(
             lvp,
             *self._ad_args_kwargs.adj_args,
-            **self._ad_args_kwargs.adj_kwargs)
+            **adj_kwargs)
 
         # We'll need to assemble these forms to calculate
         # the adj_component for each dependency.

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -1,5 +1,5 @@
 import copy
-from functools import wraps
+from functools import wraps, cached_property
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
 from firedrake.adjoint_utils.blocks import (
     NonlinearVariationalSolveBlock, CachedSolverBlock)
@@ -8,6 +8,57 @@ from firedrake.ufl_expr import derivative, adjoint, action
 from ufl import replace, Action
 from ufl.algorithms import expand_derivatives
 from types import SimpleNamespace
+from collections import namedtuple
+
+
+ForwardSolveRecomputeCache = namedtuple(
+    'ForwardSolveRecomputeCache',
+    field_names=[
+        "func",
+        "bcs",
+        "solver",
+        "is_linear",
+        "replaced_deps",
+    ]
+)
+
+AdjointSolveRecomputeCache = namedtuple(
+    'AdjointSolveRecomputeCache',
+    field_names=[
+        "adj_sol",
+        "rhs",
+        "dFdm_forms",
+        "residual",
+        "solver",
+        "dFdu_adj",
+    ]
+)
+
+TangentSolveRecomputeCache = namedtuple(
+    "TangentSolveRecomputeCache",
+    field_names=[
+        "tlm_val",
+        "rhs",
+        "dFdm_forms",
+        "solver",
+        "replaced_tlms",
+        "dFdu",
+    ]
+)
+
+HessianSolveRecomputeCache = namedtuple(
+    "HessianSolveRecomputeCache",
+    field_names=[
+        "adj_sol",
+        "adj2_sol",
+        "tlm_output",
+        "d2Fdu2_form",
+        "d2Fdmdu_forms",
+        "dFdm_adj2_forms",
+        "d2Fdm2_adj_forms",
+        "d2Fdudm_forms",
+    ]
+)
 
 
 class NonlinearVariationalProblemMixin:
@@ -73,12 +124,13 @@ class NonlinearVariationalSolverMixin:
 
         return wrapper
 
-    def _ad_cache_forward_solver(self):
+    @cached_property
+    @no_annotations
+    def _ad_forward_cache(self):
         from firedrake import (
             DirichletBC,
             NonlinearVariationalProblem,
             NonlinearVariationalSolver)
-        from firedrake.adjoint_utils.blocks.solving import FORWARD
 
         problem = self._ad_problem
 
@@ -125,20 +177,26 @@ class NonlinearVariationalSolverMixin:
         # The block need handles to the newly created
         # objects to update their values when recomputing.
         self._ad_dependencies_to_add = (*replace_map.keys(), *bcs)
-        self._ad_replaced_dependencies = tuple(replace_map.values())
-        self._ad_bcs = bcs_new
-        self._ad_solver_cache[FORWARD] = nlvs
 
-    def _ad_cache_tlm_solver(self):
+        return ForwardSolveRecomputeCache(
+            func=self._ad_problem.u,
+            bcs=bcs_new,
+            solver=nlvs,
+            is_linear=self._ad_problem.is_linear,
+            replaced_deps=tuple(replace_map.values()),
+        )
+
+    @cached_property
+    @no_annotations
+    def _ad_tangent_cache(self):
         from firedrake import (
             Function, Cofunction, derivative, TrialFunction,
             LinearVariationalProblem, LinearVariationalSolver)
-        from firedrake.adjoint_utils.blocks.solving import FORWARD, TLM
 
         # If we build the TLM form from the cached
         # forward solve form then we can update exactly
         # the same coefficients/boundary conditions.
-        nlvp = self._ad_solver_cache[FORWARD]._problem
+        nlvp = self._ad_forward_cache.solver._problem
 
         F = nlvp.F
         u = nlvp.u
@@ -153,25 +211,22 @@ class NonlinearVariationalSolverMixin:
         dFdm = Cofunction(V.dual())
         dudm = Function(V)
 
-        self._ad_dFdu = dFdu
-
         # Reuse the same bcs as the forward problem.
         # TODO: Think about if we should use new bcs.
         # TODO: solver_parameters
-        lvp = LinearVariationalProblem(dFdu, dFdm, dudm, bcs=self._ad_bcs)
+        lvp = LinearVariationalProblem(dFdu, dFdm, dudm, bcs=self._ad_forward_cache.bcs)
         lvs = LinearVariationalSolver(
             lvp,
             *self._ad_args_kwargs.tlm_args,
             **self._ad_args_kwargs.tlm_kwargs)
 
-        self._ad_solver_cache[TLM] = lvs
-        self._ad_tlm_rhs = dFdm
+        tlm_rhs = dFdm
 
         # Do all the symbolic work for calculating dF/dm up front
         # so we only pay for the numeric calculations at run time.
         replaced_tlms = []
         dFdm_tlm_forms = []
-        for m in self._ad_replaced_dependencies:
+        for m in self._ad_forward_cache.replaced_deps:
             mtlm = m.copy(deepcopy=True)
             replaced_tlms.append(mtlm)
 
@@ -180,21 +235,28 @@ class NonlinearVariationalSolverMixin:
             dFdm = expand_derivatives(dFdm)
             dFdm_tlm_forms.append(dFdm)
 
-        # We'll need to update the replaced_tlm
-        # values and assemble the dFdm forms
-        self._ad_tlm_dFdm_forms = dFdm_tlm_forms
-        self._ad_replaced_tlms = replaced_tlms
+        tlm_val = Function(V)
 
-    def _ad_cache_adj_solver(self):
+        return TangentSolveRecomputeCache(
+            tlm_val=tlm_val,
+            rhs=tlm_rhs,
+            dFdm_forms=dFdm_tlm_forms,
+            solver=lvs,
+            replaced_tlms=replaced_tlms,
+            dFdu=dFdu,
+        )
+
+    @cached_property
+    @no_annotations
+    def _ad_adjoint_cache(self):
         from firedrake import (
             Function, Cofunction, TrialFunction, Argument,
             LinearVariationalProblem, LinearVariationalSolver)
-        from firedrake.adjoint_utils.blocks.solving import FORWARD, ADJOINT
 
         # If we build the adjoint form from the cached
         # forward solve form then we can update exactly
         # the same coefficients/boundary conditions.
-        nlvp = self._ad_solver_cache[FORWARD]._problem
+        nlvp = self._ad_forward_cache.solver._problem
 
         F = nlvp.F
         u = nlvp.u
@@ -206,15 +268,13 @@ class NonlinearVariationalSolverMixin:
         # Then for the _partial_ derivatives:
         # (dF/du)*(du/dm) + dF/dm = 0 so we calculate:
         # (dF/du)*(du/dm) = -dF/dm
-        dFdu = self._ad_dFdu
+        dFdu = self._ad_tangent_cache.dFdu
         try:
             dFdu_adj = adjoint(dFdu)
         except ValueError:
             # Try again without expanding derivatives,
             # as dFdu might have been simplied to an empty Form
             dFdu_adj = adjoint(dFdu, derivatives_expanded=True)
-
-        self._ad_dFdu_adj = dFdu_adj
 
         # This will be the rhs of the adjoint problem
         dJdu = Cofunction(V.dual())
@@ -223,19 +283,18 @@ class NonlinearVariationalSolverMixin:
         # Reuse the same bcs as the forward problem.
         # TODO: Think about if we should use new bcs.
         # TODO: solver_parameters
-        lvp = LinearVariationalProblem(dFdu_adj, dJdu, adj_sol, bcs=self._ad_bcs)
+        lvp = LinearVariationalProblem(dFdu_adj, dJdu, adj_sol, bcs=self._ad_forward_cache.bcs)
         lvs = LinearVariationalSolver(
             lvp,
             *self._ad_args_kwargs.adj_args,
             **self._ad_args_kwargs.adj_kwargs)
 
-        self._ad_solver_cache[ADJOINT] = lvs
-        self._ad_adj_rhs = dJdu
-
+        # We'll need to assemble these forms to calculate
+        # the adj_component for each dependency.
         # Do all the symbolic work for calculating dJ/du up front
         # so we only pay for the numeric calculations at run time.
         dFdm_adj_forms = []
-        for m in self._ad_replaced_dependencies:
+        for m in self._ad_forward_cache.replaced_deps:
             # Action of adjoint solution on dFdm
             # TODO: Which of the two implementations should we use?
             dFdm = derivative(-F, m, TrialFunction(m.function_space()))
@@ -262,18 +321,24 @@ class NonlinearVariationalSolverMixin:
         # we'll need the residual of the adjoint equation without
         # any DirichletBC using the solution calculated with
         # homogeneous DirichletBCs.
-        self._ad_adj_residual = dJdu - action(dFdu_adj, adj_sol)
+        adj_residual = dJdu - action(dFdu_adj, adj_sol)
 
-        # We'll need to assemble these forms to calculate
-        # the adj_component for each dependency.
-        self._ad_adj_dFdm_forms = dFdm_adj_forms
+        return AdjointSolveRecomputeCache(
+            adj_sol=adj_sol,
+            rhs=dJdu,
+            dFdm_forms=dFdm_adj_forms,
+            residual=adj_residual,
+            solver=lvs,
+            dFdu_adj=dFdu_adj,
+        )
 
-    def _ad_cache_hessian_solver(self):
+    @cached_property
+    @no_annotations
+    def _ad_hessian_cache(self):
         from firedrake import (
             Function, TestFunction)
-        from firedrake.adjoint_utils.blocks.solving import FORWARD
 
-        nlvp = self._ad_solver_cache[FORWARD]._problem
+        nlvp = self._ad_forward_cache.solver._problem
         F = nlvp.F
         u = nlvp.u
         V = u.function_space()
@@ -282,7 +347,7 @@ class NonlinearVariationalSolverMixin:
 
         # Calculate d^2F/du^2 * du/dm * dm
         # where dm is direction for tlm action so du/dm * dm is tlm output
-        dFdu = self._ad_dFdu
+        dFdu = self._ad_tangent_cache.dFdu
         tlm_output = Function(V)
         d2Fdu2 = derivative(dFdu, u, tlm_output)
         # print()
@@ -292,33 +357,26 @@ class NonlinearVariationalSolverMixin:
         # print()
         d2Fdu2 = expand_derivatives(d2Fdu2)
 
-        self._ad_tlm_output = tlm_output
-
         adj_sol = Function(V)
-        self._ad_adj_sol = adj_sol
 
         # Contribution from tlm_output
         if len(d2Fdu2.integrals()) > 0:
             d2Fdu2_form = action(adjoint(d2Fdu2), adj_sol)
         else:
             d2Fdu2_form = d2Fdu2
-        self._ad_d2Fdu2_form = d2Fdu2_form
 
         # Contributions from each tlm_input
-        dFdu_adj = action(self._ad_dFdu_adj, adj_sol)
+        dFdu_adj = action(self._ad_adjoint_cache.dFdu_adj, adj_sol)
         d2Fdmdu_forms = []
-        for m, dm in zip(self._ad_replaced_dependencies,
-                         self._ad_replaced_tlms):
+        for m, dm in zip(self._ad_forward_cache.replaced_deps,
+                         self._ad_tangent_cache.replaced_tlms):
             d2Fdmdu = expand_derivatives(
                 derivative(dFdu_adj, m, dm))
 
             d2Fdmdu_forms.append(d2Fdmdu)
 
-        self._ad_d2Fdmdu_forms = d2Fdmdu_forms
-
         # 2. Forms to calculate contribution from each control
         adj2_sol = Function(V)
-        self._ad_adj2_sol = adj2_sol
 
         Fadj = action(F, adj_sol)
         Fadj2 = action(F, adj2_sol)
@@ -326,7 +384,7 @@ class NonlinearVariationalSolverMixin:
         dFdm_adj2_forms = []
         d2Fdm2_adj_forms = []
         d2Fdudm_forms = []
-        for m in self._ad_replaced_dependencies:
+        for m in self._ad_forward_cache.replaced_deps:
             dm = TestFunction(m.function_space())
             dFdm_adj2 = expand_derivatives(
                 derivative(Fadj2, m, dm))
@@ -341,17 +399,24 @@ class NonlinearVariationalSolverMixin:
             d2Fdudm_forms.append(d2Fdudm)
 
             d2Fdm2_adj_forms_k = []
-            for m2, dm2 in zip(self._ad_replaced_dependencies,
-                               self._ad_replaced_tlms):
+            for m2, dm2 in zip(self._ad_forward_cache.replaced_deps,
+                               self._ad_tangent_cache.replaced_tlms):
                 d2Fdm2_adj = expand_derivatives(
                     derivative(dFdm_adj, m2, dm2))
                 d2Fdm2_adj_forms_k.append(d2Fdm2_adj)
 
             d2Fdm2_adj_forms.append(d2Fdm2_adj_forms_k)
 
-        self._ad_dFdm_adj2_forms = dFdm_adj2_forms
-        self._ad_d2Fdm2_adj_forms = d2Fdm2_adj_forms
-        self._ad_d2Fdudm_forms = d2Fdudm_forms
+        return HessianSolveRecomputeCache(
+            adj_sol=adj_sol,
+            adj2_sol=adj2_sol,
+            tlm_output=tlm_output,
+            d2Fdu2_form=d2Fdu2_form,
+            d2Fdmdu_forms=d2Fdmdu_forms,
+            dFdm_adj2_forms=dFdm_adj2_forms,
+            d2Fdm2_adj_forms=d2Fdm2_adj_forms,
+            d2Fdudm_forms=d2Fdudm_forms,
+        )
 
     @staticmethod
     def _ad_annotate_solve(solve):
@@ -367,37 +432,12 @@ class NonlinearVariationalSolverMixin:
                     raise ValueError(
                         "MissingMathsError: we do not know how to differentiate through a variational inequality")
 
-                if len(self._ad_solver_cache) == 0:
-                    with stop_annotating():
-                        self._ad_cache_forward_solver()
-                        self._ad_cache_tlm_solver()
-                        self._ad_cache_adj_solver()
-                        self._ad_cache_hessian_solver()
-
-                block = CachedSolverBlock(self._ad_problem.u,
-                                          self._ad_bcs,
-                                          self._ad_solver_cache,
-                                          self._ad_problem.is_linear,
-                                          self._ad_replaced_dependencies,
-
-                                          self._ad_tlm_rhs,
-                                          self._ad_replaced_tlms,
-                                          self._ad_tlm_dFdm_forms,
-
-                                          self._ad_adj_rhs,
-                                          self._ad_adj_dFdm_forms,
-                                          self._ad_adj_residual,
-
-                                          self._ad_adj_sol,
-                                          self._ad_adj2_sol,
-                                          self._ad_tlm_output,
-                                          self._ad_d2Fdu2_form,
-                                          self._ad_d2Fdmdu_forms,
-                                          self._ad_dFdm_adj2_forms,
-                                          self._ad_d2Fdm2_adj_forms,
-                                          self._ad_d2Fdudm_forms,
-
-                                          ad_block_tag=self.ad_block_tag)
+                block = CachedSolverBlock(
+                    self._ad_forward_cache,
+                    self._ad_tangent_cache,
+                    self._ad_adjoint_cache,
+                    self._ad_hessian_cache,
+                    ad_block_tag=self.ad_block_tag)
 
                 for dep in self._ad_dependencies_to_add:
                     block.add_dependency(dep, no_duplicates=True)

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -368,10 +368,11 @@ class NonlinearVariationalSolverMixin:
                         "MissingMathsError: we do not know how to differentiate through a variational inequality")
 
                 if len(self._ad_solver_cache) == 0:
-                    self._ad_cache_forward_solver()
-                    self._ad_cache_tlm_solver()
-                    self._ad_cache_adj_solver()
-                    self._ad_cache_hessian_solver()
+                    with stop_annotating():
+                        self._ad_cache_forward_solver()
+                        self._ad_cache_tlm_solver()
+                        self._ad_cache_adj_solver()
+                        self._ad_cache_hessian_solver()
 
                 block = CachedSolverBlock(self._ad_problem.u,
                                           self._ad_bcs,

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -1,9 +1,13 @@
 import copy
 from functools import wraps
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
-from firedrake.adjoint_utils.blocks import NonlinearVariationalSolveBlock
-from firedrake.ufl_expr import derivative, adjoint
-from ufl import replace
+from firedrake.adjoint_utils.blocks import (
+    NonlinearVariationalSolveBlock, CachedSolverBlock)
+from firedrake.adjoint_utils.blocks.solving import solve_init_params
+from firedrake.ufl_expr import derivative, adjoint, action
+from ufl import replace, Action
+from ufl.algorithms import expand_derivatives
+from types import SimpleNamespace
 
 
 class NonlinearVariationalProblemMixin:
@@ -52,10 +56,367 @@ class NonlinearVariationalSolverMixin:
                                 "recompute_count": 0}
             self._ad_adj_cache = {}
 
+            self._ad_solver_cache = {}
+
+            # process args/kwargs for cached solvers
+            self._ad_args_kwargs = SimpleNamespace(
+                forward_args=kwargs.pop("forward_args", []),
+                forward_kwargs=kwargs.pop("forward_kwargs", {}),
+                adj_args=kwargs.pop("adj_args", []),
+                adj_kwargs=kwargs.pop("adj_kwargs", {}),
+                tlm_args=kwargs.pop("tlm_args", []),
+                tlm_kwargs=kwargs.pop("tlm_kwargs", {}),
+                assemble_kwargs={}
+            )
+            solve_init_params(self._ad_args_kwargs,
+                              args, kwargs, varform=True)
+
         return wrapper
+
+    def _ad_cache_forward_solver(self):
+        from firedrake import (
+            DirichletBC,
+            NonlinearVariationalProblem,
+            NonlinearVariationalSolver)
+        from firedrake.adjoint_utils.blocks.solving import FORWARD
+
+        problem = self._ad_problem
+
+        # Build a new form so that we can update the coefficient
+        # values without affecting user code.
+        # We do this by copying all coefficients in the form and
+        # symbolically replacing the old values with the new.
+        F = problem.F
+        replace_map = {}
+        for old_coeff in F.coefficients():
+            new_coeff = old_coeff.copy(deepcopy=True)
+            replace_map[old_coeff] = new_coeff
+
+        # We need a handle to the new Function being
+        # solved for so that we can create an NLVS.
+        Fnew = replace(F, replace_map)
+        unew = replace_map[problem.u]
+
+        # We also need to "replace" all the bcs in
+        # the new NLVS so we can modify those values
+        # without affecting user code.
+        # Note that ``DirichletBC.reconstruct`` will
+        # return ``self`` if V, g, and sub_domain are
+        # all unchanged, so we need to explicitly
+        # instantiate a new object.
+        bcs = problem.bcs
+        bcs_new = [
+            DirichletBC(V=bc.function_space(),
+                        g=bc.function_arg,
+                        sub_domain=bc.sub_domain)
+            for bc in bcs
+        ]
+
+        # This NLVS will be used to recompute the solve.
+        # TODO: solver_parameters
+        nlvp = NonlinearVariationalProblem(Fnew, unew, bcs=bcs_new)
+        nlvs = NonlinearVariationalSolver(
+            nlvp,
+            *self._ad_args_kwargs.forward_args,
+            **self._ad_args_kwargs.forward_kwargs)
+
+        # The original coefficients will be added as
+        # dependencies to all solve blocks.
+        # The block need handles to the newly created
+        # objects to update their values when recomputing.
+        self._ad_dependencies_to_add = (*replace_map.keys(), *bcs)
+        self._ad_replaced_dependencies = tuple(replace_map.values())
+        self._ad_bcs = bcs_new
+        self._ad_solver_cache[FORWARD] = nlvs
+
+    def _ad_cache_tlm_solver(self):
+        from firedrake import (
+            Function, Cofunction, derivative, TrialFunction,
+            LinearVariationalProblem, LinearVariationalSolver)
+        from firedrake.adjoint_utils.blocks.solving import FORWARD, TLM
+
+        # If we build the TLM form from the cached
+        # forward solve form then we can update exactly
+        # the same coefficients/boundary conditions.
+        nlvp = self._ad_solver_cache[FORWARD]._problem
+
+        F = nlvp.F
+        u = nlvp.u
+        V = u.function_space()
+
+        # We need gradient of output/input i.e. du/dm.
+        # We know F(u; m) = 0 and _total_ dF/dm = 0.
+        # Then for the _partial_ derivatives:
+        # (dF/du)*(du/dm) + dF/dm = 0 so we calculate:
+        # (dF/du)*(du/dm) = -dF/dm
+        dFdu = derivative(F, u, TrialFunction(V))
+        dFdm = Cofunction(V.dual())
+        dudm = Function(V)
+
+        self._ad_dFdu = dFdu
+
+        # Reuse the same bcs as the forward problem.
+        # TODO: Think about if we should use new bcs.
+        # TODO: solver_parameters
+        lvp = LinearVariationalProblem(dFdu, dFdm, dudm, bcs=self._ad_bcs)
+        lvs = LinearVariationalSolver(
+            lvp,
+            *self._ad_args_kwargs.tlm_args,
+            **self._ad_args_kwargs.tlm_kwargs)
+
+        self._ad_solver_cache[TLM] = lvs
+        self._ad_tlm_rhs = dFdm
+
+        # Do all the symbolic work for calculating dF/dm up front
+        # so we only pay for the numeric calculations at run time.
+        replaced_tlms = []
+        dFdm_tlm_forms = []
+        for m in self._ad_replaced_dependencies:
+            mtlm = m.copy(deepcopy=True)
+            replaced_tlms.append(mtlm)
+
+            dFdm = derivative(-F, m, mtlm)
+            # TODO: Do we need expand_derivatives here? If so, why?
+            dFdm = expand_derivatives(dFdm)
+            dFdm_tlm_forms.append(dFdm)
+
+        # We'll need to update the replaced_tlm
+        # values and assemble the dFdm forms
+        self._ad_tlm_dFdm_forms = dFdm_tlm_forms
+        self._ad_replaced_tlms = replaced_tlms
+
+    def _ad_cache_adj_solver(self):
+        from firedrake import (
+            Function, Cofunction, TrialFunction, Argument,
+            LinearVariationalProblem, LinearVariationalSolver)
+        from firedrake.adjoint_utils.blocks.solving import FORWARD, ADJOINT
+
+        # If we build the adjoint form from the cached
+        # forward solve form then we can update exactly
+        # the same coefficients/boundary conditions.
+        nlvp = self._ad_solver_cache[FORWARD]._problem
+
+        F = nlvp.F
+        u = nlvp.u
+        V = u.function_space()
+
+        # TODO: rewrite for adjoint not TLM
+        # We need gradient of output/input i.e. du/dm.
+        # We know F(u; m) = 0 and _total_ dF/dm = 0.
+        # Then for the _partial_ derivatives:
+        # (dF/du)*(du/dm) + dF/dm = 0 so we calculate:
+        # (dF/du)*(du/dm) = -dF/dm
+        dFdu = self._ad_dFdu
+        try:
+            dFdu_adj = adjoint(dFdu)
+        except ValueError:
+            # Try again without expanding derivatives,
+            # as dFdu might have been simplied to an empty Form
+            dFdu_adj = adjoint(dFdu, derivatives_expanded=True)
+
+        self._ad_dFdu_adj = dFdu_adj
+
+        # This will be the rhs of the adjoint problem
+        dJdu = Cofunction(V.dual())
+        adj_sol = Function(V)
+
+        # Reuse the same bcs as the forward problem.
+        # TODO: Think about if we should use new bcs.
+        # TODO: solver_parameters
+        lvp = LinearVariationalProblem(dFdu_adj, dJdu, adj_sol, bcs=self._ad_bcs)
+        lvs = LinearVariationalSolver(
+            lvp,
+            *self._ad_args_kwargs.adj_args,
+            **self._ad_args_kwargs.adj_kwargs)
+
+        self._ad_solver_cache[ADJOINT] = lvs
+        self._ad_adj_rhs = dJdu
+
+        # Do all the symbolic work for calculating dJ/du up front
+        # so we only pay for the numeric calculations at run time.
+        dFdm_adj_forms = []
+        for m in self._ad_replaced_dependencies:
+            # Action of adjoint solution on dFdm
+            # TODO: Which of the two implementations should we use?
+            dFdm = derivative(-F, m, TrialFunction(m.function_space()))
+
+            # 1. from previous cached implementation
+            dFdm = adjoint(dFdm)
+            if isinstance(dFdm, Argument):
+                #  Corner case. Should be fixed more permanently upstream in UFL.
+                #  See: https://github.com/FEniCS/ufl/issues/395
+                dFdm = Action(dFdm, adj_sol)
+            else:
+                dFdm = dFdm * adj_sol
+
+            # 2. from GenericSolveBlock
+            # if isinstance(dFdm, ufl.Form):
+            #     dFdm = adjoint(dFdm)
+            #     dFdm = action(dFdm, adj_sol)
+            # else:
+            #     dFdm = dFdm(adj_sol)
+
+            dFdm_adj_forms.append(dFdm)
+
+        # To calculate the adjoint component of each DirichletBC
+        # we'll need the residual of the adjoint equation without
+        # any DirichletBC using the solution calculated with
+        # homogeneous DirichletBCs.
+        self._ad_adj_residual = dJdu - action(dFdu_adj, adj_sol)
+
+        # We'll need to assemble these forms to calculate
+        # the adj_component for each dependency.
+        self._ad_adj_dFdm_forms = dFdm_adj_forms
+
+    def _ad_cache_hessian_solver(self):
+        from firedrake import (
+            Function, TestFunction)
+        from firedrake.adjoint_utils.blocks.solving import FORWARD
+
+        nlvp = self._ad_solver_cache[FORWARD]._problem
+        F = nlvp.F
+        u = nlvp.u
+        V = u.function_space()
+
+        # 1. Forms to calculate rhs of Hessian solve
+
+        # Calculate d^2F/du^2 * du/dm * dm
+        # where dm is direction for tlm action so du/dm * dm is tlm output
+        dFdu = self._ad_dFdu
+        tlm_output = Function(V)
+        d2Fdu2 = derivative(dFdu, u, tlm_output)
+        # print()
+        # print(f"{dFdu = }")
+        # print()
+        # print(f"{d2Fdu2 = }")
+        # print()
+        d2Fdu2 = expand_derivatives(d2Fdu2)
+
+        self._ad_tlm_output = tlm_output
+
+        adj_sol = Function(V)
+        self._ad_adj_sol = adj_sol
+
+        # Contribution from tlm_output
+        if len(d2Fdu2.integrals()) > 0:
+            d2Fdu2_form = action(adjoint(d2Fdu2), adj_sol)
+        else:
+            d2Fdu2_form = d2Fdu2
+        self._ad_d2Fdu2_form = d2Fdu2_form
+
+        # Contributions from each tlm_input
+        dFdu_adj = action(self._ad_dFdu_adj, adj_sol)
+        d2Fdmdu_forms = []
+        for m, dm in zip(self._ad_replaced_dependencies,
+                         self._ad_replaced_tlms):
+            d2Fdmdu = expand_derivatives(
+                derivative(dFdu_adj, m, dm))
+
+            d2Fdmdu_forms.append(d2Fdmdu)
+
+        self._ad_d2Fdmdu_forms = d2Fdmdu_forms
+
+        # 2. Forms to calculate contribution from each control
+        adj2_sol = Function(V)
+        self._ad_adj2_sol = adj2_sol
+
+        Fadj = action(F, adj_sol)
+        Fadj2 = action(F, adj2_sol)
+
+        dFdm_adj2_forms = []
+        d2Fdm2_adj_forms = []
+        d2Fdudm_forms = []
+        for m in self._ad_replaced_dependencies:
+            dm = TestFunction(m.function_space())
+            dFdm_adj2 = expand_derivatives(
+                derivative(Fadj2, m, dm))
+
+            dFdm_adj2_forms.append(dFdm_adj2)
+
+            dFdm_adj = derivative(Fadj, m, dm)
+
+            d2Fdudm = expand_derivatives(
+                derivative(dFdm_adj, u, tlm_output))
+
+            d2Fdudm_forms.append(d2Fdudm)
+
+            d2Fdm2_adj_forms_k = []
+            for m2, dm2 in zip(self._ad_replaced_dependencies,
+                               self._ad_replaced_tlms):
+                d2Fdm2_adj = expand_derivatives(
+                    derivative(dFdm_adj, m2, dm2))
+                d2Fdm2_adj_forms_k.append(d2Fdm2_adj)
+
+            d2Fdm2_adj_forms.append(d2Fdm2_adj_forms_k)
+
+        self._ad_dFdm_adj2_forms = dFdm_adj2_forms
+        self._ad_d2Fdm2_adj_forms = d2Fdm2_adj_forms
+        self._ad_d2Fdudm_forms = d2Fdudm_forms
 
     @staticmethod
     def _ad_annotate_solve(solve):
+        @wraps(solve)
+        def wrapper(self, **kwargs):
+            """To disable the annotation, just pass :py:data:`annotate=False` to this routine, and it acts exactly like the
+            Firedrake solve call. This is useful in cases where the solve is known to be irrelevant or diagnostic
+            for the purposes of the adjoint computation (such as projecting fields to other function spaces
+            for the purposes of visualisation)."""
+            annotate = annotate_tape(kwargs)
+            if annotate:
+                if kwargs.pop("bounds", None) is not None:
+                    raise ValueError(
+                        "MissingMathsError: we do not know how to differentiate through a variational inequality")
+
+                if len(self._ad_solver_cache) == 0:
+                    self._ad_cache_forward_solver()
+                    self._ad_cache_tlm_solver()
+                    self._ad_cache_adj_solver()
+                    self._ad_cache_hessian_solver()
+
+                block = CachedSolverBlock(self._ad_problem.u,
+                                          self._ad_bcs,
+                                          self._ad_solver_cache,
+                                          self._ad_problem.is_linear,
+                                          self._ad_replaced_dependencies,
+
+                                          self._ad_tlm_rhs,
+                                          self._ad_replaced_tlms,
+                                          self._ad_tlm_dFdm_forms,
+
+                                          self._ad_adj_rhs,
+                                          self._ad_adj_dFdm_forms,
+                                          self._ad_adj_residual,
+
+                                          self._ad_adj_sol,
+                                          self._ad_adj2_sol,
+                                          self._ad_tlm_output,
+                                          self._ad_d2Fdu2_form,
+                                          self._ad_d2Fdmdu_forms,
+                                          self._ad_dFdm_adj2_forms,
+                                          self._ad_d2Fdm2_adj_forms,
+                                          self._ad_d2Fdudm_forms,
+
+                                          ad_block_tag=self.ad_block_tag)
+
+                for dep in self._ad_dependencies_to_add:
+                    block.add_dependency(dep, no_duplicates=True)
+                # mesh = self._ad_problem.u.function_space().mesh()
+                # block.add_dependency(mesh, no_duplicates=True)
+
+                get_working_tape().add_block(block)
+
+            with stop_annotating():
+                out = solve(self, **kwargs)
+
+            if annotate:
+                block.add_output(self._ad_problem._ad_u.create_block_variable())
+
+            return out
+
+        return wrapper
+
+    @staticmethod
+    def _ad_annotate_solve_old(solve):
         @wraps(solve)
         def wrapper(self, **kwargs):
             """To disable the annotation, just pass :py:data:`annotate=False` to this routine, and it acts exactly like the

--- a/tests/firedrake/adjoint/test_appctx.py
+++ b/tests/firedrake/adjoint/test_appctx.py
@@ -1,0 +1,255 @@
+"""Tests that appctx is correctly cloned for forward and adjoint
+solver replays during tape evaluation.
+
+When a NonlinearVariationalSolver is created with an appctx dict,
+the adjoint machinery builds cached solvers for tape replay. The
+cached solvers' form coefficients (F, J) are deep-copied so they can
+be independently updated from the tape. The appctx dict must undergo
+the same replacement so that preconditioners reading from appctx
+(e.g. MassInvPC) see the cloned values that
+``CachedSolverBlock.update_dependencies`` keeps in sync with the
+tape.
+"""
+import pytest
+
+from firedrake import *
+from firedrake.adjoint import *
+from firedrake.adjoint_utils.blocks import CachedSolverBlock
+from firedrake.preconditioners.base import PCBase
+
+
+@pytest.fixture(autouse=True)
+def autouse_set_test_tape(set_test_tape):
+    pass
+
+
+class MuRecorderPC(PCBase):
+    """Identity preconditioner that records the appctx 'mu' value at
+    every initialize/update. Used to verify appctx liveness during
+    replay."""
+    mu_log = []
+
+    def initialize(self, pc):
+        appctx = self.get_appctx(pc)
+        self._mu_ref = appctx["mu"]
+        self._record()
+
+    def update(self, pc):
+        self._record()
+
+    def _record(self):
+        mu = self._mu_ref
+        if isinstance(mu, Function):
+            val = float(mu.dat.data_ro[0])
+        elif isinstance(mu, Constant):
+            val = float(mu)
+        else:
+            val = None
+        MuRecorderPC.mu_log.append(val)
+
+    def apply(self, pc, x, y):
+        x.copy(y)
+
+    def applyTranspose(self, pc, x, y):
+        x.copy(y)
+
+
+def _setup_problem_with_appctx(solver_params=None):
+    """Build a Poisson-like problem where mu appears in both the form
+    and the appctx.  Two solves are performed with mu=1 and mu=10 so
+    that stale-appctx bugs are detectable.  The functional accumulates
+    a contribution after each solve so that both solve blocks carry an
+    adjoint input and neither adjoint solve is skipped."""
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    mu = Function(V, name="mu")
+    mu.assign(1.0)
+
+    u = Function(V, name="u")
+    v = TestFunction(V)
+
+    F = mu * inner(grad(u), grad(v)) * dx - Constant(1.0) * v * dx
+    bc = DirichletBC(V, 0.0, "on_boundary")
+
+    if solver_params is None:
+        solver_params = {"snes_type": "ksponly",
+                         "ksp_type": "cg", "pc_type": "sor"}
+
+    problem = NonlinearVariationalProblem(F, u, bcs=bc)
+    solver = NonlinearVariationalSolver(
+        problem, solver_parameters=solver_params, appctx={"mu": mu})
+
+    control = Function(V, name="control")
+    control.assign(1.0)
+
+    mu.assign(control)
+    solver.solve()
+    J = assemble(u * u * dx)
+    mu.assign(10.0 * control)
+    solver.solve()
+    J += assemble(u * u * dx)
+    return J, control, mu
+
+
+def _get_solve_blocks():
+    tape = get_working_tape()
+    return [b for b in tape.get_blocks()
+            if isinstance(b, CachedSolverBlock)]
+
+
+@pytest.mark.skipcomplex
+def test_appctx_forward_clone_identity():
+    """The cached forward solver's appctx['mu'] must be the same object
+    as the mu coefficient inside the cached F form, so that
+    update_dependencies keeps them in sync during replay."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    solve_blocks = _get_solve_blocks()
+    assert len(solve_blocks) >= 2
+
+    fwd_solver = solve_blocks[0].forward_cache.solver
+    appctx_mu = fwd_solver._ctx.appctx["mu"]
+    assert appctx_mu is not mu
+
+    fwd_F_coeffs = fwd_solver._problem.F.coefficients()
+    fwd_mu_candidates = [c for c in fwd_F_coeffs if c.name() == "mu"]
+    assert len(fwd_mu_candidates) == 1
+    fwd_mu = fwd_mu_candidates[0]
+    assert fwd_mu is not mu
+    assert appctx_mu is fwd_mu
+
+
+@pytest.mark.skipcomplex
+def test_appctx_derived_solvers_identity():
+    """The cached adjoint and TLM solvers' appctx['mu'] must be the
+    same object as the mu coefficient inside their Jacobians. Both
+    forms are derived from the cached forward problem, so this is the
+    same cloned coefficient the forward solver uses, and
+    update_dependencies keeps it in sync."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat.derivative()
+
+    solve_blocks = _get_solve_blocks()
+    assert len(solve_blocks) >= 2
+
+    fwd_solver = solve_blocks[0].forward_cache.solver
+    fwd_appctx_mu = fwd_solver._ctx.appctx["mu"]
+
+    adj_lvs = solve_blocks[0].adjoint_cache.solver
+    adj_appctx = adj_lvs._ctx.appctx
+    assert "mu" in adj_appctx
+    adj_appctx_mu = adj_appctx["mu"]
+
+    assert adj_appctx_mu is not mu
+    # There is a single replace map shared by all the cached solvers,
+    # so the adjoint appctx references the forward clone's coefficient.
+    assert adj_appctx_mu is fwd_appctx_mu
+
+    adj_J_coeffs = adj_lvs._problem.J.coefficients()
+    adj_mu_candidates = [c for c in adj_J_coeffs if c.name() == "mu"]
+    assert len(adj_mu_candidates) == 1
+    assert adj_appctx_mu is adj_mu_candidates[0]
+
+    # The TLM solver shares the same forward clone.
+    tlm_lvs = solve_blocks[0].tangent_cache.solver
+    tlm_appctx = tlm_lvs._ctx.appctx
+    assert "mu" in tlm_appctx
+    assert tlm_appctx["mu"] is fwd_appctx_mu
+
+
+@pytest.mark.skipcomplex
+def test_appctx_forward_replay():
+    """During forward tape replay the preconditioner must see the same
+    mu values as the original forward run, not the stale end-of-run
+    value."""
+    MuRecorderPC.mu_log.clear()
+
+    solver_params = {
+        "snes_type": "ksponly",
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": __name__ + ".MuRecorderPC",
+    }
+    J, control, mu = _setup_problem_with_appctx(solver_params)
+    fwd_log = list(MuRecorderPC.mu_log)
+
+    MuRecorderPC.mu_log.clear()
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat(control)
+
+    replay_log = list(MuRecorderPC.mu_log)
+    assert fwd_log == replay_log
+
+
+@pytest.mark.skipcomplex
+def test_appctx_adjoint_replay():
+    """During the adjoint pass the preconditioner must see the correct
+    per-step mu from the forward trajectory, not the stale end-of-run
+    value. The adjoint traverses the tape backward, so both mu=1 and
+    mu=10 must appear in the log."""
+    MuRecorderPC.mu_log.clear()
+
+    solver_params = {
+        "snes_type": "ksponly",
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": __name__ + ".MuRecorderPC",
+    }
+    J, control, mu = _setup_problem_with_appctx(solver_params)
+
+    MuRecorderPC.mu_log.clear()
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat.derivative()
+
+    adj_log = list(MuRecorderPC.mu_log)
+    adj_values = set(round(v, 1) for v in adj_log if v is not None)
+    assert 1.0 in adj_values, (
+        f"adjoint PC never saw mu=1.0 (log: {adj_log})")
+    assert 10.0 in adj_values, (
+        f"adjoint PC never saw mu=10.0 (log: {adj_log})")
+
+
+@pytest.mark.skipcomplex
+def test_appctx_taylor_test():
+    """Taylor test with a mu-weighted Poisson problem and appctx.
+    A converged Krylov solve does not depend on the preconditioner, so
+    this cannot detect a stale appctx; it is a sanity check that the
+    appctx cloning machinery does not break the gradient."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    Jhat = ReducedFunctional(J, Control(control))
+    h = Function(control.function_space())
+    h.assign(1.0)
+    assert taylor_test(Jhat, control, h) > 1.9
+
+
+@pytest.mark.skipcomplex
+def test_appctx_legacy_solve_path():
+    """An annotated ``solve(F == 0, u, ..., appctx=...)`` goes through
+    GenericSolveBlock, whose adjoint solve uses an assembled matrix and
+    cannot consume appctx. It must be dropped there (not passed
+    through), otherwise computing the derivative raises."""
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    mu = Function(V, name="mu")
+    mu.assign(1.0)
+
+    u = Function(V, name="u")
+    v = TestFunction(V)
+
+    F = mu * inner(grad(u), grad(v)) * dx - Constant(1.0) * v * dx
+    bc = DirichletBC(V, 0.0, "on_boundary")
+
+    solve(F == 0, u, bcs=bc,
+          solver_parameters={"snes_type": "ksponly",
+                             "ksp_type": "cg", "pc_type": "sor"},
+          appctx={"mu": mu})
+
+    J = assemble(u * u * dx)
+    Jhat = ReducedFunctional(J, Control(mu))
+    dJ = Jhat.derivative()
+    assert dJ.dat.data_ro.size > 0

--- a/tests/firedrake/adjoint/test_assemble.py
+++ b/tests/firedrake/adjoint/test_assemble.py
@@ -89,9 +89,11 @@ def test_assemble_1_forms_tlm(rg):
 
     h = rg.uniform(V)
     g = f.copy(deepcopy=True)
-    f.block_variable.tlm_value = h
-    tape.evaluate_tlm()
-    assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
+    Jhat(g)
+    assert (taylor_test(Jhat, g, h, dJdm=Jhat.tlm(h)) > 1.9)
+    # f.block_variable.tlm_value = h
+    # tape.evaluate_tlm()
+    # assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
 
 @pytest.mark.skipcomplex

--- a/tests/firedrake/adjoint/test_hessian.py
+++ b/tests/firedrake/adjoint/test_hessian.py
@@ -124,7 +124,6 @@ def test_function(rg):
     J = assemble(c ** 2 * u ** 2 * dx)
 
     Jhat = ReducedFunctional(J, [control_c, control_f])
-    dJdc, dJdf = compute_derivative(J, [control_c, control_f], apply_riesz=True)
 
     # Step direction for derivatives and convergence test
     h_c = Function(R, val=1.0)
@@ -161,6 +160,7 @@ def test_nonlinear(rg):
     Jhat = ReducedFunctional(J, Control(f))
 
     h = rg.uniform(V, 0, 10)
+    g = f.copy(deepcopy=True)
 
     J.block_variable.adj_value = 1.0
     f.block_variable.tlm_value = h
@@ -170,8 +170,6 @@ def test_nonlinear(rg):
 
     J.block_variable.hessian_value = 0
     tape.evaluate_hessian()
-
-    g = f.copy(deepcopy=True)
 
     dJdm = J.block_variable.tlm_value
     Hm = f.block_variable.hessian_value.dat.inner(h.dat)
@@ -223,25 +221,24 @@ def test_dirichlet(rg):
 def test_burgers(solve_type, rg):
     tape = Tape()
     set_working_tape(tape)
-    n = 100
-    mesh = UnitIntervalMesh(n)
-    V = FunctionSpace(mesh, "CG", 2)
+    nx = 50
+    nt = 5
+    mesh = UnitIntervalMesh(nx)
+    V = FunctionSpace(mesh, "CG", 1)
 
-    def Dt(u, u_, timestep):
-        return (u - u_)/timestep
+    def Dt(u, u_, dt):
+        return (u - u_)/dt
 
     x, = SpatialCoordinate(mesh)
-    pr = project(sin(2*pi*x), V, annotate=False)
-    ic = Function(V).assign(pr)
+    ic = Function(V).project(sin(2*pi*x))
 
     u_ = Function(V).assign(ic)
     u = Function(V).assign(ic)
     v = TestFunction(V)
 
-    nu = Constant(0.0001)
+    nu = Constant(1/100)
 
-    dt = 0.01
-    nt = 20
+    dt = Constant(1/nx)
 
     params = {
         'snes_rtol': 1e-10,
@@ -266,12 +263,6 @@ def test_burgers(solve_type, rg):
             NonlinearVariationalProblem(F, u),
             solver_parameters=params)
 
-    if use_nlvs:
-        solver.solve()
-    else:
-        solve(F == 0, u, bc, solver_parameters=params)
-    u_.assign(u)
-
     for _ in range(nt):
         if use_nlvs:
             solver.solve()
@@ -282,16 +273,13 @@ def test_burgers(solve_type, rg):
     J = assemble(u_*u_*dx + ic*ic*dx)
 
     Jhat = ReducedFunctional(J, Control(ic))
+
     h = rg.uniform(V)
     g = ic.copy(deepcopy=True)
-    J.block_variable.adj_value = 1.0
-    ic.block_variable.tlm_value = h
-    tape.evaluate_adj()
-    tape.evaluate_tlm()
 
-    J.block_variable.hessian_value = 0
-    tape.evaluate_hessian()
-
-    dJdm = J.block_variable.tlm_value
-    Hm = ic.block_variable.hessian_value.dat.inner(h.dat)
-    assert taylor_test(Jhat, g, h, dJdm=dJdm, Hm=Hm) > 2.9
+    taylor = taylor_to_dict(Jhat, g, h)
+    from pprint import pprint
+    pprint(taylor)
+    assert min(taylor['R0']['Rate']) > 0.95, taylor['R0']
+    assert min(taylor['R1']['Rate']) > 1.95, taylor['R1']
+    assert min(taylor['R2']['Rate']) > 2.95, taylor['R2']

--- a/tests/firedrake/adjoint/test_nlvs.py
+++ b/tests/firedrake/adjoint/test_nlvs.py
@@ -1,0 +1,191 @@
+import pytest
+
+from firedrake import *
+from firedrake.adjoint import *
+
+
+@pytest.fixture(autouse=True)
+def handle_taping():
+    yield
+    tape = get_working_tape()
+    tape.clear_tape()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def handle_annotation():
+    if not annotate_tape():
+        continue_annotation()
+    yield
+    # Ensure annotation is paused when we finish.
+    if annotate_tape():
+        pause_annotation()
+
+
+def forward(ic, dt, nt, bc_arg=None):
+    """Burgers equation solver."""
+    V = ic.function_space()
+
+    if bc_arg:
+        bc_val = bc_arg.copy(deepcopy=True)
+        bcs = [DirichletBC(V, bc_val, 1),
+               DirichletBC(V, 0, 2)]
+    else:
+        bcs = None
+
+    nu = Function(dt.function_space()).assign(0.1)
+
+    u0 = Function(V)
+    u1 = Function(V)
+    v = TestFunction(V)
+
+    F = ((u1 - u0)*v
+         + dt*u1*u1.dx(0)*v
+         + dt*nu*u1.dx(0)*v.dx(0))*dx
+
+    problem = NonlinearVariationalProblem(F, u1, bcs=bcs)
+    solver = NonlinearVariationalSolver(problem)
+
+    u1.assign(ic)
+
+    for i in range(nt):
+        u0.assign(u1)
+        solver.solve()
+        nu += dt
+        # if bc_arg:
+        #     bc_val.assign(bc_val + dt/nt)
+
+    J = assemble(u1*u1*dx)
+    return J
+
+
+@pytest.mark.skipcomplex
+@pytest.mark.parametrize("control_type", ["ic_control",
+                                          "dt_control",
+                                          "bc_control"])
+@pytest.mark.parametrize("bc_type", ["neumann_bc",
+                                     "dirichlet_bc"])
+def test_nlvs_adjoint(control_type, bc_type):
+    if control_type == 'bc_control' and bc_type == 'neumann_bc':
+        pytest.skip("Cannot use Neumann BCs as control")
+
+    nx = 100000
+    nt = 50
+
+    mesh = UnitIntervalMesh(nx)
+    x, = SpatialCoordinate(mesh)
+
+    V = FunctionSpace(mesh, "CG", 1)
+    R = FunctionSpace(mesh, "R", 0)
+
+    dt = Function(R).assign(1/nx)
+    ic = Function(V).interpolate(cos(2*pi*x))
+
+    dt0 = dt.copy(deepcopy=True)
+    ic0 = ic.copy(deepcopy=True)
+
+    if bc_type == 'neumann_bc':
+        bc_arg = None
+        bc_arg0 = None
+    elif bc_type == 'dirichlet_bc':
+        bc_arg = Function(R).assign(1.)
+        bc_arg0 = bc_arg.copy(deepcopy=True)
+    else:
+        raise ValueError(f"Unrecognised {bc_type=}")
+
+    if control_type == 'ic_control':
+        control = ic0
+    elif control_type == 'dt_control':
+        control = dt0
+    elif control_type == 'bc_control':
+        control = bc_arg0
+    else:
+        raise ValueError(f"Unrecognised {control_type=}")
+
+    PETSc.Sys.Print("record tape")
+    continue_annotation()
+    with set_working_tape() as tape:
+        J = forward(ic0, dt0, nt, bc_arg=bc_arg0)
+        Jhat = ReducedFunctional(J, Control(control), tape=tape)
+    pause_annotation()
+
+    if control_type == 'ic_control':
+        m = Function(V).assign(0.5*ic)
+        h = Function(V).interpolate(-0.5*cos(4*pi*x))
+
+        ic2 = m.copy(deepcopy=True)
+        dt2 = dt
+        bc_arg2 = bc_arg
+
+    elif control_type == 'dt_control':
+        m = Function(R).assign(0.05)
+        h = Function(R).assign(0.01)
+
+        ic2 = ic
+        dt2 = m.copy(deepcopy=True)
+        bc_arg2 = bc_arg
+
+    elif control_type == 'bc_control':
+        m = Function(R).assign(0.5)
+        h = Function(R).assign(-0.1)
+
+        ic2 = ic
+        dt2 = dt
+        bc_arg2 = m.copy(deepcopy=True)
+
+    from mpi4py import MPI
+
+    # # recompute component
+    # PETSc.Sys.Print("recompute test")
+    # assert abs(Jhat(m) - forward(ic2, dt2, nt, bc_arg=bc_arg2)) < 1e-14
+
+    # # tlm
+    # PETSc.Sys.Print("tlm test")
+    # Jhat(m)
+    # assert taylor_test(Jhat, m, h, dJdm=Jhat.tlm(h)) > 1.95
+
+    # # adjoint
+    # PETSc.Sys.Print("adjoint test")
+    # Jhat(m)
+    # assert taylor_test(Jhat, m, h) > 1.95
+
+    # # hessian
+    # PETSc.Sys.Print("hessian test")
+    # Jhat(m)
+    # taylor = taylor_to_dict(Jhat, m, h)
+    # from pprint import pprint
+    # pprint(taylor)
+
+    # assert min(taylor['R0']['Rate']) > 0.95
+    # assert min(taylor['R1']['Rate']) > 1.95
+    # assert min(taylor['R2']['Rate']) > 2.95
+
+    for _ in range(3):
+        stime = MPI.Wtime()
+        Jhat(m)
+        etime = MPI.Wtime()
+        PETSc.Sys.Print(f"Recompute time: {etime - stime:.4f}")
+
+    for _ in range(3):
+        stime = MPI.Wtime()
+        Jhat.derivative()
+        etime = MPI.Wtime()
+        PETSc.Sys.Print(f"Derivative time: {etime - stime:.4f}")
+
+    for _ in range(3):
+        stime = MPI.Wtime()
+        Jhat.tlm(h)
+        etime = MPI.Wtime()
+        PETSc.Sys.Print(f"TLM time: {etime - stime:.4f}")
+
+    for _ in range(3):
+        stime = MPI.Wtime()
+        Jhat.hessian(h, evaluate_tlm=False)
+        etime = MPI.Wtime()
+        PETSc.Sys.Print(f"Hessian time: {etime - stime:.4f}")
+
+
+if __name__ == "__main__":
+    control_type = "ic_control"
+    bc_type = "neumann_bc"
+    PETSc.Sys.Print(f"{control_type=} | {bc_type=}")
+    test_nlvs_adjoint(control_type, bc_type)

--- a/tests/firedrake/adjoint/test_nlvs.py
+++ b/tests/firedrake/adjoint/test_nlvs.py
@@ -68,8 +68,8 @@ def test_nlvs_adjoint(control_type, bc_type):
     if control_type == 'bc_control' and bc_type == 'neumann_bc':
         pytest.skip("Cannot use Neumann BCs as control")
 
-    nx = 100000
-    nt = 50
+    nx = 100
+    nt = 5
 
     mesh = UnitIntervalMesh(nx)
     x, = SpatialCoordinate(mesh)
@@ -77,7 +77,7 @@ def test_nlvs_adjoint(control_type, bc_type):
     V = FunctionSpace(mesh, "CG", 1)
     R = FunctionSpace(mesh, "R", 0)
 
-    dt = Function(R).assign(1/nx)
+    dt = Function(R).assign(2/nx)
     ic = Function(V).interpolate(cos(2*pi*x))
 
     dt0 = dt.copy(deepcopy=True)
@@ -134,30 +134,32 @@ def test_nlvs_adjoint(control_type, bc_type):
 
     from mpi4py import MPI
 
-    # # recompute component
-    # PETSc.Sys.Print("recompute test")
-    # assert abs(Jhat(m) - forward(ic2, dt2, nt, bc_arg=bc_arg2)) < 1e-14
+    # recompute component
+    PETSc.Sys.Print("recompute test")
+    assert abs(Jhat(m) - forward(ic2, dt2, nt, bc_arg=bc_arg2)) < 1e-14
 
-    # # tlm
-    # PETSc.Sys.Print("tlm test")
-    # Jhat(m)
-    # assert taylor_test(Jhat, m, h, dJdm=Jhat.tlm(h)) > 1.95
+    # tlm
+    PETSc.Sys.Print("tlm test")
+    Jhat(m)
+    assert taylor_test(Jhat, m, h, dJdm=Jhat.tlm(h)) > 1.95
 
-    # # adjoint
-    # PETSc.Sys.Print("adjoint test")
-    # Jhat(m)
-    # assert taylor_test(Jhat, m, h) > 1.95
+    # adjoint
+    PETSc.Sys.Print("adjoint test")
+    Jhat(m)
+    assert taylor_test(Jhat, m, h) > 1.95
 
-    # # hessian
-    # PETSc.Sys.Print("hessian test")
-    # Jhat(m)
-    # taylor = taylor_to_dict(Jhat, m, h)
-    # from pprint import pprint
-    # pprint(taylor)
+    # hessian
+    PETSc.Sys.Print("hessian test")
+    Jhat(m)
+    taylor = taylor_to_dict(Jhat, m, h)
+    from pprint import pprint
+    pprint(taylor)
 
-    # assert min(taylor['R0']['Rate']) > 0.95
-    # assert min(taylor['R1']['Rate']) > 1.95
-    # assert min(taylor['R2']['Rate']) > 2.95
+    assert min(taylor['R0']['Rate']) > 0.95
+    assert min(taylor['R1']['Rate']) > 1.95
+    assert min(taylor['R2']['Rate']) > 2.95
+
+    return
 
     for _ in range(3):
         stime = MPI.Wtime()


### PR DESCRIPTION
When an annotated `NonlinearVariationalSolver` is created with an `appctx`, the replay machinery deep-copies the form coefficients but passes the appctx through untouched (forward solver) or drops it entirely (adjoint and TLM solvers). Any preconditioner that reads UFL expressions out of the appctx, MassInvPC being the obvious one for Schur complement Stokes, ends up looking at the user's original coefficients rather than the clones the tape keeps in sync, so during replay it builds the preconditioner from stale end-of-forward-run values.

This applies the forward coefficient replace map to UFL entries in the appctx when the cached solvers are built. Since the tangent and adjoint solvers derive their forms from the cloned forward problem, all three share the one map and so point at the same cloned coefficients that `update_dependencies` updates at replay time. The adjoint and TLM solvers fall back to the forward appctx when their own kwargs don't carry one; David confirmed this is always safe since the adjoint equation uses J^T (https://firedrakeproject.slack.com/archives/C1Q0Y6H8A/p1776171359074139). The `appctx` pop in `solve_init_params` stays, because the legacy `GenericSolveBlock` adjoint path solves with an assembled matrix and can't accept the kwarg; there's a regression test pinning that path too.

The new tests in `tests/firedrake/adjoint/test_appctx.py` check object identity between the appctx and the cached forms, and use a recording preconditioner to verify the values seen during forward and adjoint replay match the forward trajectory.

Note this targets the #4638 refactor branch, so it only reaches `main` when that merges. The same bug exists in the current release through the old `_ad_problem_clone` machinery, so we should probably do a separate PR basing the release branch to fix released Firedrake as well; I have that version of the fix ready on a separate branch.

Disclosure: parts of this change were prepared with the help of Claude Code (Opus 4.8).