### PR TITLE
Clone appctx for adjoint replay solvers (release)

### DIFF
--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -574,10 +574,12 @@ def solve_init_params(self, args, kwargs, varform):
                 raise NotImplementedError(
                     "Annotation of adaptive solves not implemented."
                 )
-            # The legacy adjoint solve goes through ``firedrake.solve``
-            # with an assembled matrix, which does not accept appctx.
-            # The variational solver mixin reinstates it (suitably
-            # cloned) for the adjoint LinearVariationalSolver.
+            # adj_kwargs feeds the assembled-matrix adjoint solve
+            # ``firedrake.solve(A, x, b, ...)``, whose kwarg validation
+            # rejects a top-level ``appctx`` (on that path appctx is read
+            # from ``solver_parameters`` instead). Drop it here; for solves
+            # driven through the variational solver mixin it is reinstated,
+            # suitably cloned, on the adjoint LinearVariationalSolver.
             self.adj_kwargs.pop("appctx", None)
 
     solver_params = kwargs.get("solver_parameters", None)

--- a/firedrake/adjoint_utils/blocks/solving.py
+++ b/firedrake/adjoint_utils/blocks/solving.py
@@ -574,6 +574,10 @@ def solve_init_params(self, args, kwargs, varform):
                 raise NotImplementedError(
                     "Annotation of adaptive solves not implemented."
                 )
+            # The legacy adjoint solve goes through ``firedrake.solve``
+            # with an assembled matrix, which does not accept appctx.
+            # The variational solver mixin reinstates it (suitably
+            # cloned) for the adjoint LinearVariationalSolver.
             self.adj_kwargs.pop("appctx", None)
 
     solver_params = kwargs.get("solver_parameters", None)

--- a/firedrake/adjoint_utils/variational_solver.py
+++ b/firedrake/adjoint_utils/variational_solver.py
@@ -3,6 +3,7 @@ from functools import wraps
 from pyadjoint.tape import get_working_tape, stop_annotating, annotate_tape, no_annotations
 from firedrake.adjoint_utils.blocks import NonlinearVariationalSolveBlock
 from firedrake.ufl_expr import derivative, adjoint
+import ufl
 from ufl import replace
 
 
@@ -86,17 +87,30 @@ class NonlinearVariationalSolverMixin:
 
                 # Forward variational solver.
                 if not self._ad_solvers["forward_nlvs"]:
+                    cloned_problem, replace_map = self._ad_problem_clone(
+                        self._ad_problem, block.get_dependencies())
+                    fwd_kwargs = self._ad_clone_kwargs(
+                        self._ad_kwargs, replace_map)
                     self._ad_solvers["forward_nlvs"] = type(self)(
-                        self._ad_problem_clone(self._ad_problem, block.get_dependencies()),
-                        **self._ad_kwargs
+                        cloned_problem, **fwd_kwargs
                     )
 
                 # Adjoint variational solver.
                 if not self._ad_solvers["adjoint_lvs"]:
                     with stop_annotating():
+                        adj_problem, adj_replace_map = self._ad_adj_lvs_problem(
+                            block, problem._ad_adj_F)
+                        # solve_init_params drops appctx from
+                        # block.adj_kwargs (the legacy assembled-matrix
+                        # path cannot consume it), so fall back to the
+                        # forward solver's appctx, cloned with the
+                        # adjoint replace map.
+                        adj_kwargs = self._ad_clone_kwargs(
+                            block.adj_kwargs, adj_replace_map,
+                            default_appctx=self._ad_kwargs.get("appctx"))
                         self._ad_solvers["adjoint_lvs"] = LinearVariationalSolver(
-                            self._ad_adj_lvs_problem(block, problem._ad_adj_F),
-                            *block.adj_args, **block.adj_kwargs)
+                            adj_problem,
+                            *block.adj_args, **adj_kwargs)
                         if self._ad_problem._constant_jacobian:
                             self._ad_solvers["update_adjoint"] = False
 
@@ -121,6 +135,10 @@ class NonlinearVariationalSolverMixin:
         numerical values of the coefficients in the residual and jacobian, so in order not to
         affect the user-defined self._ad_problem.F, self._ad_problem.J and self._ad_problem.u
         expressions, we'll instead create clones of them.
+
+        Returns the cloned problem and the coefficient replace map used
+        for F (a superset of the J map).  The map is needed so that the
+        caller can apply the same replacement to ``appctx`` entries.
         """
         from firedrake import NonlinearVariationalProblem
         _ad_count_map, J_replace_map, F_replace_map = self._build_count_map(
@@ -132,11 +150,15 @@ class NonlinearVariationalSolverMixin:
         nlvp.is_linear = problem.is_linear
         nlvp._constant_jacobian = problem._constant_jacobian
         nlvp._ad_count_map_update(_ad_count_map)
-        return nlvp
+        return nlvp, F_replace_map
 
     @no_annotations
     def _ad_adj_lvs_problem(self, block, adj_F):
-        """Create the adjoint variational problem."""
+        """Create the adjoint variational problem.
+
+        Returns the cloned problem and the coefficient replace map, so
+        that the caller can apply the same replacement to ``appctx``.
+        """
         from firedrake import Function, Cofunction, LinearVariationalProblem
         # Homogeneous boundary conditions for the adjoint problem
         # when Dirichlet boundary conditions are applied.
@@ -157,7 +179,44 @@ class NonlinearVariationalSolverMixin:
             bcs=tmp_problem.bcs,
             constant_jacobian=self._ad_problem._constant_jacobian)
         lvp._ad_count_map_update(_ad_count_map)
-        return lvp
+        return lvp, J_replace_map
+
+    @staticmethod
+    def _ad_clone_kwargs(kwargs, replace_map, default_appctx=None):
+        """Return a shallow copy of *kwargs* with ``appctx`` entries cloned.
+
+        The ``appctx`` dict may contain UFL expressions (or plain
+        ``Function`` objects) that reference the *original* coefficients.
+        The clone solvers work on deep copies of those coefficients, so
+        the ``appctx`` must undergo the same replacement for
+        preconditioners reading from it (e.g. ``MassInvPC``) to see the
+        values that ``_ad_solver_replace_forms`` keeps in sync with the
+        tape.
+
+        If *kwargs* carries no ``appctx`` of its own, *default_appctx*
+        (the forward solver's) is cloned instead.  The adjoint operator
+        is a linearisation of the forward operator, so a preconditioner
+        that needs something from ``appctx`` for the forward solve
+        needs the same thing for the adjoint solve.
+
+        Note that ``ufl.replace`` only maps coefficients that appear in
+        the cloned form.  An ``appctx`` entry referencing a coefficient
+        that is not part of the form, or that is not a UFL expression
+        (containers, callables, ...), is passed through by reference
+        and will not be updated during recomputation.
+        """
+        appctx = kwargs.get("appctx", default_appctx)
+        if not appctx:
+            return kwargs
+        cloned_appctx = {}
+        for key, value in appctx.items():
+            if isinstance(value, ufl.core.expr.Expr):
+                cloned_appctx[key] = ufl.replace(value, replace_map)
+            else:
+                cloned_appctx[key] = value
+        cloned = dict(kwargs)
+        cloned["appctx"] = cloned_appctx
+        return cloned
 
     def _build_count_map(self, J, dependencies, F=None):
         from firedrake import Function

--- a/tests/firedrake/adjoint/test_appctx.py
+++ b/tests/firedrake/adjoint/test_appctx.py
@@ -1,0 +1,250 @@
+"""Tests that appctx is correctly cloned for forward and adjoint
+solver replays during tape evaluation.
+
+When a NonlinearVariationalSolver is created with an appctx dict,
+the adjoint machinery creates clone solvers for tape replay. The
+clone solvers' form coefficients (F, J) are deep-copied so they can
+be independently updated from the tape. The appctx dict must undergo
+the same replacement so that preconditioners reading from appctx
+(e.g. MassInvPC) see the cloned values that _ad_solver_replace_forms
+keeps in sync with the tape.
+"""
+import pytest
+
+from firedrake import *
+from firedrake.adjoint import *
+from firedrake.adjoint_utils.blocks import NonlinearVariationalSolveBlock
+from firedrake.preconditioners.base import PCBase
+
+
+@pytest.fixture(autouse=True)
+def autouse_set_test_tape(set_test_tape):
+    pass
+
+
+class MuRecorderPC(PCBase):
+    """Identity preconditioner that records the appctx 'mu' value at
+    every initialize/update. Used to verify appctx liveness during
+    replay."""
+    mu_log = []
+
+    def initialize(self, pc):
+        appctx = self.get_appctx(pc)
+        self._mu_ref = appctx["mu"]
+        self._record()
+
+    def update(self, pc):
+        self._record()
+
+    def _record(self):
+        mu = self._mu_ref
+        if isinstance(mu, Function):
+            val = float(mu.dat.data_ro[0])
+        elif isinstance(mu, Constant):
+            val = float(mu)
+        else:
+            val = None
+        MuRecorderPC.mu_log.append(val)
+
+    def apply(self, pc, x, y):
+        x.copy(y)
+
+    def applyTranspose(self, pc, x, y):
+        x.copy(y)
+
+
+def _setup_problem_with_appctx(solver_params=None):
+    """Build a Poisson-like problem where mu appears in both the form
+    and the appctx.  Two solves are performed with mu=1 and mu=10 so
+    that stale-appctx bugs are detectable.  The functional accumulates
+    a contribution after each solve so that both solve blocks carry an
+    adjoint input and neither adjoint solve is skipped."""
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    mu = Function(V, name="mu")
+    mu.assign(1.0)
+
+    u = Function(V, name="u")
+    v = TestFunction(V)
+
+    F = mu * inner(grad(u), grad(v)) * dx - Constant(1.0) * v * dx
+    bc = DirichletBC(V, 0.0, "on_boundary")
+
+    if solver_params is None:
+        solver_params = {"snes_type": "ksponly",
+                         "ksp_type": "cg", "pc_type": "sor"}
+
+    problem = NonlinearVariationalProblem(F, u, bcs=bc)
+    solver = NonlinearVariationalSolver(
+        problem, solver_parameters=solver_params, appctx={"mu": mu})
+
+    control = Function(V, name="control")
+    control.assign(1.0)
+
+    mu.assign(control)
+    solver.solve()
+    J = assemble(u * u * dx)
+    mu.assign(10.0 * control)
+    solver.solve()
+    J += assemble(u * u * dx)
+    return J, control, mu
+
+
+def _get_solve_blocks():
+    tape = get_working_tape()
+    return [b for b in tape.get_blocks()
+            if isinstance(b, NonlinearVariationalSolveBlock)]
+
+
+@pytest.mark.skipcomplex
+def test_appctx_forward_clone_identity():
+    """The forward clone solver's appctx['mu'] must be the same object
+    as the mu coefficient inside the clone's F form, so that
+    _ad_solver_replace_forms keeps them in sync during replay."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    solve_blocks = _get_solve_blocks()
+    assert len(solve_blocks) >= 2
+
+    clone = solve_blocks[0]._ad_solvers["forward_nlvs"]
+    assert clone is not None
+
+    appctx_mu = clone._ad_kwargs["appctx"]["mu"]
+    assert appctx_mu is not mu
+
+    clone_F_coeffs = clone._problem.F.coefficients()
+    clone_mu_candidates = [c for c in clone_F_coeffs if c.name() == "mu"]
+    assert len(clone_mu_candidates) == 1
+    clone_mu = clone_mu_candidates[0]
+    assert clone_mu is not mu
+    assert appctx_mu is clone_mu
+
+
+@pytest.mark.skipcomplex
+def test_appctx_adjoint_clone_identity():
+    """The adjoint clone solver's appctx['mu'] must be the same object
+    as the mu coefficient inside the adjoint's J form (= adjoint of
+    dF/du). It must be distinct from both the original and the forward
+    clone, since the forward and adjoint clones have independent
+    replace maps that _ad_solver_replace_forms updates separately."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat.derivative()
+
+    solve_blocks = _get_solve_blocks()
+    assert len(solve_blocks) >= 2
+
+    adj_lvs = solve_blocks[0]._ad_solvers["adjoint_lvs"]
+    assert adj_lvs is not None
+
+    fwd_clone = solve_blocks[0]._ad_solvers["forward_nlvs"]
+    fwd_appctx_mu = fwd_clone._ad_kwargs["appctx"]["mu"]
+
+    adj_appctx = adj_lvs._ctx.appctx
+    assert "mu" in adj_appctx
+    adj_appctx_mu = adj_appctx["mu"]
+
+    assert adj_appctx_mu is not mu
+    assert adj_appctx_mu is not fwd_appctx_mu
+
+    adj_J_coeffs = adj_lvs._problem.J.coefficients()
+    adj_mu_candidates = [c for c in adj_J_coeffs if c.name() == "mu"]
+    assert len(adj_mu_candidates) == 1
+    assert adj_appctx_mu is adj_mu_candidates[0]
+
+
+@pytest.mark.skipcomplex
+def test_appctx_forward_replay():
+    """During forward tape replay the preconditioner must see the same
+    mu values as the original forward run, not the stale end-of-run
+    value."""
+    MuRecorderPC.mu_log.clear()
+
+    solver_params = {
+        "snes_type": "ksponly",
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": __name__ + ".MuRecorderPC",
+    }
+    J, control, mu = _setup_problem_with_appctx(solver_params)
+    fwd_log = list(MuRecorderPC.mu_log)
+
+    MuRecorderPC.mu_log.clear()
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat(control)
+
+    replay_log = list(MuRecorderPC.mu_log)
+    assert fwd_log == replay_log
+
+
+@pytest.mark.skipcomplex
+def test_appctx_adjoint_replay():
+    """During the adjoint pass the preconditioner must see the correct
+    per-step mu from the forward trajectory, not the stale end-of-run
+    value. The adjoint traverses the tape backward, so both mu=1 and
+    mu=10 must appear in the log."""
+    MuRecorderPC.mu_log.clear()
+
+    solver_params = {
+        "snes_type": "ksponly",
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": __name__ + ".MuRecorderPC",
+    }
+    J, control, mu = _setup_problem_with_appctx(solver_params)
+
+    MuRecorderPC.mu_log.clear()
+    Jhat = ReducedFunctional(J, Control(control))
+    Jhat.derivative()
+
+    adj_log = list(MuRecorderPC.mu_log)
+    adj_values = set(round(v, 1) for v in adj_log if v is not None)
+    assert 1.0 in adj_values, (
+        f"adjoint PC never saw mu=1.0 (log: {adj_log})")
+    assert 10.0 in adj_values, (
+        f"adjoint PC never saw mu=10.0 (log: {adj_log})")
+
+
+@pytest.mark.skipcomplex
+def test_appctx_taylor_test():
+    """Taylor test with a mu-weighted Poisson problem and appctx.
+    A converged Krylov solve does not depend on the preconditioner, so
+    this cannot detect a stale appctx; it is a sanity check that the
+    appctx cloning machinery does not break the gradient."""
+    J, control, mu = _setup_problem_with_appctx()
+
+    Jhat = ReducedFunctional(J, Control(control))
+    h = Function(control.function_space())
+    h.assign(1.0)
+    assert taylor_test(Jhat, control, h) > 1.9
+
+
+@pytest.mark.skipcomplex
+def test_appctx_legacy_solve_path():
+    """An annotated ``solve(F == 0, u, ..., appctx=...)`` goes through
+    GenericSolveBlock, whose adjoint solve uses an assembled matrix and
+    cannot consume appctx. It must be dropped there (not passed
+    through), otherwise computing the derivative raises."""
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    mu = Function(V, name="mu")
+    mu.assign(1.0)
+
+    u = Function(V, name="u")
+    v = TestFunction(V)
+
+    F = mu * inner(grad(u), grad(v)) * dx - Constant(1.0) * v * dx
+    bc = DirichletBC(V, 0.0, "on_boundary")
+
+    solve(F == 0, u, bcs=bc,
+          solver_parameters={"snes_type": "ksponly",
+                             "ksp_type": "cg", "pc_type": "sor"},
+          appctx={"mu": mu})
+
+    J = assemble(u * u * dx)
+    Jhat = ReducedFunctional(J, Control(mu))
+    dJ = Jhat.derivative()
+    assert dJ.dat.data_ro.size > 0


### PR DESCRIPTION
During tape replay of an annotated `NonlinearVariationalSolver`, the appctx is passed to the clone solvers still pointing at the user's original coefficients (forward) or dropped (adjoint), so preconditioners reading UFL expressions from it, e.g. MassInvPC, see stale values instead of the tape-synced clones. This clones the appctx with the same coefficient replace maps used for the forms. Same fix as #5170, which addresses this for `main` on top of the #4638 refactor; this is the equivalent for the current release. Carrying appctx into the adjoint solver is safe since the adjoint equation uses J^T (https://firedrakeproject.slack.com/archives/C1Q0Y6H8A/p1776171359074139).

Disclosure: parts of this change were prepared with the help of Claude Code (Opus 4.8).