### PR TITLE
Drop support for python 3.10

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -49,7 +49,7 @@ Prerequisites
 -------------
 
 On Linux the only prerequisite needed to install Firedrake is a suitable version
-of Python (3.10 or greater). On macOS it is important that homebrew_ and Xcode_
+of Python (3.11 or greater). On macOS it is important that homebrew_ and Xcode_
 are installed and up to date and that the homebrew-installed Python is used
 instead of the system one.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
   {name = "Josh Hope-Collins"},
   {name = "Connor J. Ward", email = "c.ward20@imperial.ac.uk"},
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "cachetools",
   "decorator<=4.4.2",
@@ -49,7 +49,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -45,7 +45,7 @@ def warn(msg: str):
 
 # Start by checking the Python version, older Pythons may not be able to run
 # this script.
-MINIMUM_PYTHON_VERSION = "3.10"
+MINIMUM_PYTHON_VERSION = "3.11"
 if sys.version < MINIMUM_PYTHON_VERSION:
     error(f"Firedrake requires Python {MINIMUM_PYTHON_VERSION} or greater")
 


### PR DESCRIPTION
... since it has effectively been dropped already by https://github.com/FEniCS/ufl/pull/485, which gets pulled in with `"fenics-ufl @ git+https://github.com/FEniCS/ufl.git@main"`