### PR TITLE
Record projection solver parameters on the tape

### DIFF
--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -1,10 +1,9 @@
 from functools import wraps
 from pyop2.mpi import temp_internal_comm
 import ufl
-from ufl.domain import extract_unique_domain
 from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
-from firedrake.adjoint_utils.blocks import FunctionAssignBlock, ProjectBlock, SubfunctionBlock, FunctionMergeBlock, SupermeshProjectBlock
+from firedrake.adjoint_utils.blocks import FunctionAssignBlock, SubfunctionBlock, FunctionMergeBlock
 import firedrake
 from .checkpointing import disk_checkpointing, CheckpointFunction, \
     CheckpointBase, checkpoint_init_data, DelegatedFunctionCheckpoint
@@ -25,32 +24,6 @@ class FunctionMixin(FloatingType):
                                   _ad_outputs=kwargs.pop("_ad_outputs", None),
                                   ad_block_tag=kwargs.pop("ad_block_tag", None), **kwargs)
             init(self, *args, **kwargs)
-        return wrapper
-
-    @staticmethod
-    def _ad_annotate_project(project):
-        @wraps(project)
-        def wrapper(self, b, *args, **kwargs):
-            ad_block_tag = kwargs.pop("ad_block_tag", None)
-            annotate = annotate_tape(kwargs)
-
-            if annotate:
-                bcs = kwargs.get("bcs", [])
-                if isinstance(b, firedrake.Function) and extract_unique_domain(b) != self.function_space().mesh():
-                    block = SupermeshProjectBlock(b, self.function_space(), self, bcs, ad_block_tag=ad_block_tag)
-                else:
-                    block = ProjectBlock(b, self.function_space(), self, bcs, ad_block_tag=ad_block_tag)
-
-                tape = get_working_tape()
-                tape.add_block(block)
-
-            with stop_annotating():
-                output = project(self, b, *args, **kwargs)
-
-            if annotate:
-                block.add_output(output.create_block_variable())
-
-            return output
         return wrapper
 
     @staticmethod

--- a/firedrake/adjoint_utils/projection.py
+++ b/firedrake/adjoint_utils/projection.py
@@ -5,6 +5,43 @@ from firedrake import function
 from ufl.domain import extract_unique_domain
 
 
+def _project_block(source, target, output, bcs, ad_block_tag, sb_kwargs,
+                   project_kwargs):
+    """Create the tape block recording a projection.
+
+    Mirrors the dispatch in :func:`firedrake.projection.Projector` so that
+    the tape records what the forward projection actually does, including
+    the solver parameters the projection solves with. The solver parameters
+    are resolved through the same code path as the Projector, so the
+    projection defaults (rather than the global firedrake solver defaults)
+    are what replay and adjoint solves use.
+    """
+    from firedrake.projection import resolve_projection_solver_parameters
+
+    V = target.function_space() if isinstance(target, function.Function) else target
+    solver_parameters = project_kwargs.get("solver_parameters")
+    form_compiler_parameters = project_kwargs.get("form_compiler_parameters")
+    if isinstance(source, function.Function) and extract_unique_domain(source) != V.mesh():
+        return SupermeshProjectBlock(
+            source, V, output, bcs, ad_block_tag=ad_block_tag,
+            solver_parameters=solver_parameters,
+            form_compiler_parameters=form_compiler_parameters,
+            **sb_kwargs)
+
+    solver_parameters = resolve_projection_solver_parameters(solver_parameters)
+    forward_kwargs = {"solver_parameters": solver_parameters}
+    if form_compiler_parameters is not None:
+        forward_kwargs["form_compiler_parameters"] = form_compiler_parameters
+    sb_kwargs = dict(sb_kwargs)
+    sb_kwargs.setdefault("forward_kwargs", forward_kwargs)
+    # The mass matrix is self-adjoint, so the adjoint solve reuses the
+    # forward solver parameters. The adjoint solve takes an assembled
+    # matrix, which accepts no form compiler parameters.
+    sb_kwargs.setdefault("adj_kwargs", {"solver_parameters": solver_parameters})
+    return ProjectBlock(source, V, output, bcs, ad_block_tag=ad_block_tag,
+                        solver_parameters=solver_parameters, **sb_kwargs)
+
+
 def annotate_project(project):
     @wraps(project)
     def wrapper(*args, **kwargs):
@@ -18,28 +55,23 @@ def annotate_project(project):
 
         ad_block_tag = kwargs.pop("ad_block_tag", None)
         annotate = annotate_tape(kwargs)
+        block = None
         if annotate:
             bcs = kwargs.get("bcs", [])
             sb_kwargs = ProjectBlock.pop_kwargs(kwargs)
             if isinstance(args[1], function.Function):
                 # block should be created before project because output might also be an input that needs checkpointing
-                output = args[1]
-                V = output.function_space()
-                if isinstance(args[0], function.Function) and extract_unique_domain(args[0]) != V.mesh():
-                    block = SupermeshProjectBlock(args[0], V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
-                else:
-                    block = ProjectBlock(args[0], V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
+                block = _project_block(args[0], args[1], args[1], bcs,
+                                       ad_block_tag, sb_kwargs, kwargs)
 
         with stop_annotating():
             output = project(*args, **kwargs)
 
         if annotate:
+            if block is None:
+                block = _project_block(args[0], args[1], output, bcs,
+                                       ad_block_tag, sb_kwargs, kwargs)
             tape = get_working_tape()
-            if not isinstance(args[1], function.Function):
-                if isinstance(args[0], function.Function) and extract_unique_domain(args[0]) != args[1].mesh():
-                    block = SupermeshProjectBlock(args[0], args[1], output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
-                else:
-                    block = ProjectBlock(args[0], args[1], output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
             tape.add_block(block)
             block.add_output(output.create_block_variable())
 

--- a/firedrake/adjoint_utils/projection.py
+++ b/firedrake/adjoint_utils/projection.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
-from firedrake.adjoint_utils.blocks import ProjectBlock, SupermeshProjectBlock
+from firedrake.adjoint_utils.blocks import (
+    FunctionAssignBlock, ProjectBlock, SupermeshProjectBlock
+)
 from firedrake import function
 from ufl.domain import extract_unique_domain
 
@@ -27,6 +29,12 @@ def _project_block(source, target, output, bcs, ad_block_tag, sb_kwargs,
             solver_parameters=solver_parameters,
             form_compiler_parameters=form_compiler_parameters,
             **sb_kwargs)
+
+    if isinstance(source, function.Function) and not bcs \
+            and source.function_space() == V:
+        # The forward projection shortcuts to an assignment and performs
+        # no solve, so record an assignment rather than a mass solve.
+        return FunctionAssignBlock(output, source, ad_block_tag=ad_block_tag)
 
     solver_parameters = resolve_projection_solver_parameters(solver_parameters)
     forward_kwargs = {"solver_parameters": solver_parameters}

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -340,7 +340,6 @@ class Function(ufl.Coefficient, FunctionMixin):
         return data[i]
 
     @PETSc.Log.EventDecorator()
-    @FunctionMixin._ad_annotate_project
     def project(self, b, *args, **kwargs):
         r"""Project ``b`` onto ``self``. ``b`` must be a :class:`Function` or a
         UFL expression.
@@ -348,6 +347,9 @@ class Function(ufl.Coefficient, FunctionMixin):
         This is equivalent to ``project(b, self)``.
         Any of the additional arguments to :func:`~firedrake.projection.project`
         may also be passed, and they will have their usual effect.
+
+        The annotation of this call on the pyadjoint tape is handled by
+        :func:`~firedrake.projection.project`, to which this delegates.
         """
         from firedrake import projection
         return projection.project(b, self, *args, **kwargs)

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -19,6 +19,34 @@ from firedrake.adjoint_utils import annotate_project
 __all__ = ['project', 'Projector']
 
 
+def resolve_projection_solver_parameters(solver_parameters: Optional[dict]) -> dict:
+    """Return the solver parameters a projection will actually solve with.
+
+    Fills in the projection defaults (CG with a preconditioner chosen
+    according to the matrix type) on top of any user-supplied parameters,
+    without mutating the input dictionary. This is used both by the
+    :class:`ProjectorBase` constructor and by the adjoint annotation, so
+    that the tape records the parameters of the forward solve.
+    """
+    if solver_parameters is None:
+        solver_parameters = {}
+    else:
+        solver_parameters = solver_parameters.copy()
+    solver_parameters.setdefault("ksp_type", "cg")
+    solver_parameters.setdefault("ksp_rtol", 1e-8)
+    mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
+    if mat_type == "nest":
+        solver_parameters.setdefault("pc_type", "fieldsplit")
+        solver_parameters.setdefault("fieldsplit_pc_type", "bjacobi")
+        solver_parameters.setdefault("fieldsplit_sub_pc_type", "icc")
+    elif mat_type == "matfree":
+        solver_parameters.setdefault("pc_type", "jacobi")
+    else:
+        solver_parameters.setdefault("pc_type", "bjacobi")
+        solver_parameters.setdefault("sub_pc_type", "icc")
+    return solver_parameters
+
+
 def sanitise_input(v, V):
     if isinstance(v, function.Function):
         return v
@@ -143,22 +171,7 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
             else:
                 form_compiler_parameters = {}
             form_compiler_parameters["quadrature_degree"] = quadrature_degree
-        if solver_parameters is None:
-            solver_parameters = {}
-        else:
-            solver_parameters = solver_parameters.copy()
-        solver_parameters.setdefault("ksp_type", "cg")
-        solver_parameters.setdefault("ksp_rtol", 1e-8)
-        mat_type = solver_parameters.get("mat_type", firedrake.parameters["default_matrix_type"])
-        if mat_type == "nest":
-            solver_parameters.setdefault("pc_type", "fieldsplit")
-            solver_parameters.setdefault("fieldsplit_pc_type", "bjacobi")
-            solver_parameters.setdefault("fieldsplit_sub_pc_type", "icc")
-        elif mat_type == "matfree":
-            solver_parameters.setdefault("pc_type", "jacobi")
-        else:
-            solver_parameters.setdefault("pc_type", "bjacobi")
-            solver_parameters.setdefault("sub_pc_type", "icc")
+        solver_parameters = resolve_projection_solver_parameters(solver_parameters)
         self.source = source
         self.target = target
         self.solver_parameters = solver_parameters

--- a/tests/firedrake/adjoint/test_projection.py
+++ b/tests/firedrake/adjoint/test_projection.py
@@ -166,6 +166,64 @@ def test_self_project_function():
 
 
 @pytest.mark.skipcomplex
+@pytest.mark.parametrize("project_via_method", [False, True])
+def test_project_solver_parameters_recorded(project_via_method):
+    # A deliberately unconverged solve, so that the forward result is
+    # distinguishable from a converged one: the replay only matches the
+    # taped functional if it uses the recorded solver parameters.
+    sp = {
+        "ksp_type": "richardson",
+        "pc_type": "none",
+        "ksp_max_it": 1,
+        "ksp_convergence_test": "skip",
+    }
+
+    mesh = UnitSquareMesh(4, 4)
+    W = FunctionSpace(mesh, "CG", 2)
+    V = FunctionSpace(mesh, "CG", 1)
+    x, y = SpatialCoordinate(mesh)
+    f = Function(W).interpolate(sin(2 * pi * x) * cos(2 * pi * y))
+
+    if project_via_method:
+        u = Function(V).project(f, solver_parameters=sp)
+    else:
+        u = project(f, V, solver_parameters=sp)
+    J = assemble(u**2 * dx)
+
+    from firedrake.adjoint_utils.blocks import ProjectBlock
+    block, = (b for b in get_working_tape().get_blocks()
+              if isinstance(b, ProjectBlock))
+    recorded = block.forward_kwargs["solver_parameters"]
+    assert all(recorded[key] == value for key, value in sp.items())
+    assert block.adj_kwargs["solver_parameters"] == recorded
+
+    rf = ReducedFunctional(J, Control(f))
+    assert rf(f) == pytest.approx(float(J), rel=1e-12)
+
+
+@pytest.mark.skipcomplex
+def test_project_default_solver_parameters_recorded():
+    # The Projector's default solver parameters must end up on the tape,
+    # so that replay does not fall back to the global firedrake defaults.
+    mesh = UnitSquareMesh(4, 4)
+    W = FunctionSpace(mesh, "CG", 2)
+    V = FunctionSpace(mesh, "CG", 1)
+    x, y = SpatialCoordinate(mesh)
+    f = Function(W).interpolate(x * y)
+
+    u = project(f, V)
+    assemble(u**2 * dx)
+
+    from firedrake.adjoint_utils.blocks import ProjectBlock
+    from firedrake.projection import resolve_projection_solver_parameters
+    block, = (b for b in get_working_tape().get_blocks()
+              if isinstance(b, ProjectBlock))
+    expected = resolve_projection_solver_parameters(None)
+    assert block.forward_kwargs["solver_parameters"] == expected
+    assert block.adj_kwargs["solver_parameters"] == expected
+
+
+@pytest.mark.skipcomplex
 def test_project_to_function_space():
     mesh = UnitSquareMesh(1, 1)
     V = FunctionSpace(mesh, "CG", 1)

--- a/tests/firedrake/adjoint/test_projection.py
+++ b/tests/firedrake/adjoint/test_projection.py
@@ -224,6 +224,34 @@ def test_project_default_solver_parameters_recorded():
 
 
 @pytest.mark.skipcomplex
+def test_same_space_project_records_assignment(rg):
+    # Projecting a Function onto its own space shortcuts to an assignment
+    # in the forward model, so the tape must record an assignment rather
+    # than a mass solve.
+    from firedrake.adjoint_utils.blocks import (
+        FunctionAssignBlock, GenericSolveBlock
+    )
+    mesh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(mesh, "CG", 1)
+    x, y = SpatialCoordinate(mesh)
+    f = Function(V).interpolate(x * y)
+
+    u = Function(V)
+    u.project(f)
+    J = assemble(u**2 * dx)
+
+    blocks = get_working_tape().get_blocks()
+    assert not any(isinstance(b, GenericSolveBlock) for b in blocks)
+    assert sum(isinstance(b, FunctionAssignBlock) for b in blocks) == 1
+
+    rf = ReducedFunctional(J, Control(f))
+    assert rf(f) == pytest.approx(float(J), rel=1e-12)
+
+    h = rg.uniform(V)
+    assert taylor_test(rf, f, h) > 1.9
+
+
+@pytest.mark.skipcomplex
 def test_project_to_function_space():
     mesh = UnitSquareMesh(1, 1)
     V = FunctionSpace(mesh, "CG", 1)


### PR DESCRIPTION
Fixes #5172.

When a `project` call was annotated, the resulting `ProjectBlock` recorded no solver configuration at all: `annotate_project` forwarded only the adjoint callback kwargs, the `Function.project` path forwarded nothing, and the Projector's own cg/icc defaults are applied after annotation has already happened. As a result every taped projection was replayed and adjointed with the global firedrake defaults, i.e. a direct solve with mumps, regardless of what the forward projection actually did. The issue has a small example where the replayed functional differs from the taped one by three orders of magnitude.

The first commit extracts the Projector's parameter defaulting into `resolve_projection_solver_parameters` and has the annotation record the effective parameters of the forward solve on the block. The forward kwargs carry the solver and form compiler parameters, while the adjoint kwargs carry only the solver parameters, since the adjoint solve goes through the assembled-matrix path which accepts no form compiler parameters; the mass matrix is self-adjoint so reusing the forward parameters is the right thing. The duplicated annotation wrapper on `Function.project` is removed in favour of the annotation on `projection.project`, to which it delegates, so both entry points now record the same block. Supermesh projections pass the parameters through to the `Projector` the block already holds.

Note this deliberately changes replay behaviour: an un-parameterised taped projection now replays with the cg/icc mass solve it actually performed forward (to `ksp_rtol` 1e-8) instead of an exact direct solve. That is the point of the fix, but it may shift replayed values within solver tolerance for tests that relied on the old behaviour.

The second commit addresses the second inconsistency noted in the issue: projecting a Function onto its own space shortcuts to an assignment in the forward model, with no solve at all, while the tape recorded a `ProjectBlock` that performed a mass solve on every replay. The tape now records a `FunctionAssignBlock`, matching the forward model.

This touches `firedrake/adjoint_utils/blocks/solving.py` territory adjacent to the CachedSolverBlock work in #4638; I have left a note there. A more structural follow-up, where the block holds the `Projector` itself so that replay reuses its cached solver (as `SupermeshProjectBlock` already does), is left for after #4638 settles.
