### PR TITLE
Increase docs build retention from 1 to 5 days

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -554,7 +554,7 @@ jobs:
         with:
           name: github-pages
           path: firedrake-repo/docs/build/html
-          retention-days: 1
+          retention-days: 5
 
       # Some files are automatically generated when we install or build the
       # docs (e.g. AUTHORS.rst). These files are committed to the repository


### PR DESCRIPTION
It is frustrating to try and review docs changes only for them to have expired. I think 5 days is probably an appropriate duration.




<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
