### PR TITLE
Support string subdomain_id in ufl.Measure, DirichletBC and Submesh

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -152,6 +152,7 @@ runs:
           --extra-index-url https://download.pytorch.org/whl/cpu \
           "./firedrake-repo[${{ inputs.deps }}]"
 
+        pip install -v --no-deps --ignore-installed git+https://github.com/firedrakeproject/ufl.git@pbrubeck/string-subdomain-id
         firedrake-clean
         pip list
 

--- a/demos/boussinesq/boussinesq.py.rst
+++ b/demos/boussinesq/boussinesq.py.rst
@@ -83,9 +83,6 @@ to prevent hydrostatic equilibrium and allow for a non-trivial velocity solution
 
     ngmesh = ngocc.OCCGeometry(shape, dim=2).GenerateMesh(maxh=0.1)
 
-    left_id = [i+1 for i, name in enumerate(ngmesh.GetRegionNames(dim=1)) if name == "left"]
-    right_id = [i+1 for i, name in enumerate(ngmesh.GetRegionNames(dim=1)) if name == "right"]
-
     mesh = Mesh(ngmesh)
     x, y = SpatialCoordinate(mesh)
 
@@ -133,8 +130,8 @@ The nonlinear form for the problem is::
      - inner(div(u), q) * dx                            # Incompressibility constraint
      + inner(dot(u, grad(T)), w) * dx                   # Temperature advection term
      + inner(grad(T), grad(w)) * dx                     # Temperature diffusion term
-     - inner(g_left, w) * ds(tuple(left_id))            # Weakly imposed Neumann BC terms
-     - inner(g_right, w) * ds(tuple(right_id))          # Weakly imposed Neumann BC terms
+     - inner(g_left, w) * ds("left")                    # Weakly imposed Neumann BC terms
+     - inner(g_right, w) * ds("right")                  # Weakly imposed Neumann BC terms
      + inner(T - T0, s) * dx                            # Integral constraint on T
      )
 

--- a/demos/netgen/netgen_mesh.py.rst
+++ b/demos/netgen/netgen_mesh.py.rst
@@ -89,7 +89,7 @@ Example: Poisson Problem
 -------------------------
 Let's now have a look at some features that can be useful when solving a variational problem using a Netgen mesh.
 We will consider as example the Poisson problem with constant source data and homogeneous boundary conditions on the boundary of the PacMan.
-The only method new to the reader should be the ``GetRegionNames`` which allows to find the IDs of the boundary we have labeled in Netgen. As usual we begin defining the ``FunctionSpace`` that will be used in our discretisation, defining trial and test functions and the source data::
+As usual we begin defining the ``FunctionSpace`` that will be used in our discretisation, defining trial and test functions and the source data::
 
    V = FunctionSpace(msh, "CG", 1)
    u = TrialFunction(V)
@@ -110,10 +110,9 @@ In code this becomes: ::
    a = inner(grad(u), grad(v))*dx
    L = inner(f, v) * dx
 
-Now we are ready to assemble the stiffness matrix for the problem. Since we want to enforce Dirichlet boundary conditions we construct a ``DirichletBC`` object and we use the ``GetRegionNames`` method from the Netgen mesh in order to map the label we have given when describing the geometry to the PETSc ``DMPLEX`` IDs. In particular if we look for the IDs of boundary element labeled either "line" or "curve" we would get::
+Now we are ready to assemble the stiffness matrix for the problem. Since we want to enforce Dirichlet boundary conditions we construct a ``DirichletBC`` object with the same string labels from the Netgen mesh. Here we specify homogenous boundary conditions on boundary elements labeled as ``"line"`` or ``"curve"``::
 
-   labels = [i+1 for i, name in enumerate(ngmsh.GetRegionNames(codim=1)) if name in ["line", "curve"]]
-   bc = DirichletBC(V, 0, labels)
+   bc = DirichletBC(V, 0, ["line", "curve"])
    print(labels)
 
 We then proceed to solve the problem::

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -47,7 +47,6 @@ del petsc
 
 from ufl import *  # noqa: F401
 from finat.ufl import *  # noqa: F401
-from firedrake.ufl_measure import *  # noqa: F401,F403
 
 from pyop2 import op2                        # noqa: F401
 from pyop2.mpi import COMM_WORLD, COMM_SELF  # noqa: F401

--- a/firedrake/__init__.py
+++ b/firedrake/__init__.py
@@ -47,6 +47,7 @@ del petsc
 
 from ufl import *  # noqa: F401
 from finat.ufl import *  # noqa: F401
+from firedrake.ufl_measure import *  # noqa: F401,F403
 
 from pyop2 import op2                        # noqa: F401
 from pyop2.mpi import COMM_WORLD, COMM_SELF  # noqa: F401

--- a/firedrake/bcs.py
+++ b/firedrake/bcs.py
@@ -43,6 +43,9 @@ class BCBase(object):
     def __init__(self, V, sub_domain):
 
         self._function_space = V
+        mesh = V.mesh()
+        if hasattr(mesh, "parse_subdomain_id"):
+            sub_domain = mesh.parse_subdomain_id(mesh.topological_dimension - 1, sub_domain)
         self.sub_domain = (sub_domain, ) if isinstance(sub_domain, str) else as_tuple(sub_domain)
         # If this BC is defined on a subspace (IndexedFunctionSpace or
         # ComponentFunctionSpace, possibly recursively), pull out the appropriate

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -347,9 +347,7 @@ def RestrictedFunctionSpace(function_space, boundary_set=[], name=None):
     if function_space.boundary_set:
         boundary_set = frozenset(boundary_set) | function_space.boundary_set
         function_space = function_space.function_space
-    if hasattr(mesh, "parse_subdomain_id"):
-        boundary_set = mesh.parse_subdomain_id(mesh.topological_dimension - 1, boundary_set)
-
+    boundary_set = mesh.parse_subdomain_id(mesh.topological_dimension - 1, boundary_set)
     return make_space(impl.RestrictedFunctionSpace(function_space.topological,
                                                    boundary_set=boundary_set,
                                                    name=name),

--- a/firedrake/functionspace.py
+++ b/firedrake/functionspace.py
@@ -342,9 +342,13 @@ def RestrictedFunctionSpace(function_space, boundary_set=[], name=None):
     make_space = type(function_space)
     mesh = function_space.mesh()
 
+    if isinstance(boundary_set, str):
+        boundary_set = (boundary_set,)
     if function_space.boundary_set:
         boundary_set = frozenset(boundary_set) | function_space.boundary_set
         function_space = function_space.function_space
+    if hasattr(mesh, "parse_subdomain_id"):
+        boundary_set = mesh.parse_subdomain_id(mesh.topological_dimension - 1, boundary_set)
 
     return make_space(impl.RestrictedFunctionSpace(function_space.topological,
                                                    boundary_set=boundary_set,

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -163,6 +163,89 @@ def _generate_default_mesh_topology_permutation_name(reorder):
     return "_".join(["firedrake", "default", str(reorder)])
 
 
+def _as_subdomain_id_list(subdomain_id):
+    if isinstance(subdomain_id, str) or not isinstance(subdomain_id, (list, tuple, set, frozenset, np.ndarray)):
+        subdomain_ids = (subdomain_id,)
+    else:
+        subdomain_ids = subdomain_id
+
+    ids = []
+    for sid in subdomain_ids:
+        if not isinstance(sid, numbers.Integral):
+            raise TypeError(f"Expected integer subdomain id, got {sid!r}")
+        ids.append(int(sid))
+    return ids
+
+
+def _parse_gmsh_physical_names(filename):
+    """Parse the ``$PhysicalNames`` block from a Gmsh ``.msh`` file."""
+    region_names = []
+    try:
+        with open(filename, encoding="utf-8", errors="replace") as f:
+            in_physical_names = False
+            for line in f:
+                line = line.strip()
+                if line == "$PhysicalNames":
+                    in_physical_names = True
+                    continue
+                if line == "$EndPhysicalNames":
+                    break
+                if not in_physical_names:
+                    continue
+                parts = line.split(maxsplit=2)
+                if len(parts) < 3:
+                    continue
+                try:
+                    dim = int(parts[0])
+                    tag = int(parts[1])
+                except ValueError:
+                    continue
+                name = parts[2].strip().strip('"')
+                if name:
+                    region_names.append((dim, tag, name))
+    except OSError:
+        pass
+    return region_names
+
+
+def _extract_netgen_region_names(ngmesh, mesh_dim):
+    """Extract region names from Netgen, converting codimension to dimension."""
+    get_names = getattr(ngmesh, "GetRegionNames", None)
+    if get_names is None:
+        get_names = getattr(ngmesh, "getRegionNames", None)
+    if get_names is None:
+        return []
+
+    region_names = []
+    for codim in range(mesh_dim + 1):
+        target_dim = mesh_dim - codim
+        try:
+            names = get_names(codim=codim)
+        except TypeError:
+            try:
+                names = get_names(dim=target_dim)
+            except TypeError:
+                continue
+        except RuntimeError:
+            continue
+        for tag, name in enumerate(names, start=1):
+            if name:
+                region_names.append((target_dim, tag, name))
+    return region_names
+
+
+def _register_region_names(mesh, region_names):
+    all_region_names = mesh.comm.allgather(region_names)
+    seen = set()
+    for rank_region_names in all_region_names:
+        for dim, tag, name in rank_region_names:
+            key = (dim, tag, name)
+            if key in seen:
+                continue
+            seen.add(key)
+            mesh.rename_subdomain(dim, tag, name)
+
+
 class _Facets(object):
     """Wrapper class for facet interation information on a :func:`Mesh`
 
@@ -599,6 +682,8 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         self._shared_data_cache = defaultdict(dict)
         # Cell subsets for integration over subregions
         self._subsets = {}
+        # Human-readable region names, keyed by topological entity dimension.
+        self.region_names = {d: {} for d in range(tdim + 1)}
         # A set of weakrefs to meshes that are explicitly labelled as being
         # parallel-compatible for interpolation/projection/supermeshing
         # To set, do e.g.
@@ -2876,6 +2961,80 @@ values from f.)"""
         current = super(MeshGeometry, self).__dir__()
         return list(OrderedDict.fromkeys(dir(self.topology) + current))
 
+
+    _reserved_subdomain_names = frozenset({"on_boundary", "everywhere", "otherwise", "top", "bottom"})
+
+    def rename_subdomain(self, dim, subdomain_id, subdomain_name):
+        """Bind a string name to one or more integer subdomain ids."""
+        if not isinstance(subdomain_name, str):
+            raise TypeError("subdomain_name must be a string")
+        dim = int(dim)
+        mesh_dim = self.topological_dimension
+        if not 0 <= dim <= mesh_dim:
+            raise ValueError(f"Invalid entity dimension {dim} for mesh of dimension {mesh_dim}")
+
+        region_names = getattr(self.topology, "region_names", None)
+        if region_names is None:
+            region_names = self.topology.region_names = {d: {} for d in range(mesh_dim + 1)}
+        dim_region_names = region_names.setdefault(dim, {})
+        dim_region_names.setdefault(subdomain_name, []).extend(_as_subdomain_id_list(subdomain_id))
+
+    def parse_subdomain_id(self, dim, subdomain_id):
+        """Resolve string region names to integer subdomain ids for an entity dimension."""
+        dim = int(dim)
+        mesh_dim = self.topological_dimension
+        if not 0 <= dim <= mesh_dim:
+            raise ValueError(f"Invalid entity dimension {dim} for mesh of dimension {mesh_dim}")
+
+        dim_region_names = getattr(self.topology, "region_names", {}).get(dim, {})
+        collection_types = (list, tuple, set, frozenset, np.ndarray)
+
+        def is_collection(value):
+            return not isinstance(value, str) and isinstance(value, collection_types)
+
+        def resolve_string(value):
+            if value in self._reserved_subdomain_names:
+                return (value,)
+            try:
+                return tuple(dim_region_names[value])
+            except KeyError:
+                available = sorted(dim_region_names)
+                raise ValueError(
+                    f"Subdomain region {value!r} not found in dimension {dim}. "
+                    f"Available names: {available}"
+                )
+
+        def resolve(value, flatten_named):
+            if isinstance(value, str):
+                resolved = resolve_string(value)
+                if flatten_named:
+                    return list(resolved)
+                if len(resolved) == 1:
+                    return resolved[0]
+                return resolved
+            if is_collection(value):
+                resolved = []
+                for entry in value:
+                    if is_collection(entry):
+                        resolved.append(resolve(entry, flatten_named=False))
+                    else:
+                        entry_resolved = resolve(entry, flatten_named=flatten_named)
+                        if flatten_named and isinstance(entry_resolved, list):
+                            resolved.extend(entry_resolved)
+                        else:
+                            resolved.append(entry_resolved)
+                return tuple(resolved)
+            return value
+
+        if isinstance(subdomain_id, str):
+            resolved = resolve_string(subdomain_id)
+            if resolved == (subdomain_id,):
+                return subdomain_id
+            return resolved
+        if is_collection(subdomain_id):
+            return resolve(subdomain_id, flatten_named=True)
+        return subdomain_id
+
     def mark_entities(self, f, label_value, label_name=None):
         """Mark selected entities.
 
@@ -3429,6 +3588,13 @@ def Mesh(meshfile, **kwargs):
             temp._distribution_parameters = mesh._distribution_parameters
             temp._did_reordering = mesh._did_reordering
             mesh = temp
+
+    if from_netgen:
+        region_names = _extract_netgen_region_names(meshfile, mesh.topological_dimension)
+        _register_region_names(mesh, region_names)
+    elif isinstance(meshfile, str) and meshfile.lower().endswith(".msh"):
+        region_names = _parse_gmsh_physical_names(meshfile)
+        _register_region_names(mesh, region_names)
 
     mesh.submesh_parent = submesh_parent
     mesh._tolerance = tolerance
@@ -4985,6 +5151,8 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     dim = plex.getDimension()
     if subdim not in {dim, dim - 1}:
         raise NotImplementedError(f"Found submesh dim ({subdim}) and parent dim ({dim})")
+    if subdomain_id is not None:
+        subdomain_id = mesh.parse_subdomain_id(subdim, subdomain_id)
     if subdomain_id is None:
         if label_name is not None:
             raise ValueError("subdomain_id=None requires label_name=None.")

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -210,27 +210,12 @@ def _parse_gmsh_physical_names(filename):
 
 def _extract_netgen_region_names(ngmesh, mesh_dim):
     """Extract region names from Netgen, converting codimension to dimension."""
-    get_names = getattr(ngmesh, "GetRegionNames", None)
-    if get_names is None:
-        get_names = getattr(ngmesh, "getRegionNames", None)
-    if get_names is None:
-        return []
-
     region_names = []
-    for codim in range(mesh_dim + 1):
-        target_dim = mesh_dim - codim
-        try:
-            names = get_names(codim=codim)
-        except TypeError:
-            try:
-                names = get_names(dim=target_dim)
-            except TypeError:
-                continue
-        except RuntimeError:
-            continue
-        for tag, name in enumerate(names, start=1):
-            if name:
-                region_names.append((target_dim, tag, name))
+    for dim in range(mesh_dim + 1):
+        names = ngmesh.GetRegionNames(dim=dim)
+        for subdomain_id, name in enumerate(names, start=1):
+            if name != "":
+                region_names.append((dim, subdomain_id, name))
     return region_names
 
 
@@ -238,12 +223,12 @@ def _register_region_names(mesh, region_names):
     all_region_names = mesh.comm.allgather(region_names)
     seen = set()
     for rank_region_names in all_region_names:
-        for dim, tag, name in rank_region_names:
-            key = (dim, tag, name)
+        for dim, subdomain_id, name in rank_region_names:
+            key = (dim, subdomain_id, name)
             if key in seen:
                 continue
             seen.add(key)
-            mesh.rename_subdomain(dim, tag, name)
+            mesh.rename_subdomain(dim, subdomain_id, name)
 
 
 class _Facets(object):
@@ -683,7 +668,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         # Cell subsets for integration over subregions
         self._subsets = {}
         # Human-readable region names, keyed by topological entity dimension.
-        self.region_names = {d: {} for d in range(tdim + 1)}
+        self.region_names = defaultdict(dict)
         # A set of weakrefs to meshes that are explicitly labelled as being
         # parallel-compatible for interpolation/projection/supermeshing
         # To set, do e.g.
@@ -2961,7 +2946,6 @@ values from f.)"""
         current = super(MeshGeometry, self).__dir__()
         return list(OrderedDict.fromkeys(dir(self.topology) + current))
 
-
     _reserved_subdomain_names = frozenset({"on_boundary", "everywhere", "otherwise", "top", "bottom"})
 
     def rename_subdomain(self, dim, subdomain_id, subdomain_name):
@@ -2973,10 +2957,7 @@ values from f.)"""
         if not 0 <= dim <= mesh_dim:
             raise ValueError(f"Invalid entity dimension {dim} for mesh of dimension {mesh_dim}")
 
-        region_names = getattr(self.topology, "region_names", None)
-        if region_names is None:
-            region_names = self.topology.region_names = {d: {} for d in range(mesh_dim + 1)}
-        dim_region_names = region_names.setdefault(dim, {})
+        dim_region_names = self.topology.region_names[dim]
         dim_region_names.setdefault(subdomain_name, []).extend(_as_subdomain_id_list(subdomain_id))
 
     def parse_subdomain_id(self, dim, subdomain_id):
@@ -2986,11 +2967,10 @@ values from f.)"""
         if not 0 <= dim <= mesh_dim:
             raise ValueError(f"Invalid entity dimension {dim} for mesh of dimension {mesh_dim}")
 
-        dim_region_names = getattr(self.topology, "region_names", {}).get(dim, {})
-        collection_types = (list, tuple, set, frozenset, np.ndarray)
+        dim_region_names = self.topology.region_names[dim]
 
         def is_collection(value):
-            return not isinstance(value, str) and isinstance(value, collection_types)
+            return not isinstance(value, str) and isinstance(value, Sequence)
 
         def resolve_string(value):
             if value in self._reserved_subdomain_names:
@@ -3008,7 +2988,7 @@ values from f.)"""
             if isinstance(value, str):
                 resolved = resolve_string(value)
                 if flatten_named:
-                    return list(resolved)
+                    return resolved
                 if len(resolved) == 1:
                     return resolved[0]
                 return resolved
@@ -3019,7 +2999,7 @@ values from f.)"""
                         resolved.append(resolve(entry, flatten_named=False))
                     else:
                         entry_resolved = resolve(entry, flatten_named=flatten_named)
-                        if flatten_named and isinstance(entry_resolved, list):
+                        if flatten_named and isinstance(entry_resolved, Sequence):
                             resolved.extend(entry_resolved)
                         else:
                             resolved.append(entry_resolved)

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -26,6 +26,7 @@ from firedrake.formmanipulation import split_form
 from firedrake.parameters import parameters as default_parameters
 from firedrake.petsc import PETSc
 from firedrake import utils
+from firedrake.ufl_measure import entity_dimension_from_integral_type
 
 # Set TSFC default scalar type at load time
 tsfc_default_parameters["scalar_type"] = utils.ScalarType
@@ -150,7 +151,30 @@ class TSFCKernel:
 SplitKernel = collections.namedtuple("SplitKernel", ["indices", "kinfo"])
 
 
+def _resolve_region_names(form):
+    if not isinstance(form, Form):
+        return form
+
+    integrals = []
+    changed = False
+    for integral in form.integrals():
+        domain = integral.ufl_domain()
+        parse_subdomain_id = getattr(domain, "parse_subdomain_id", None)
+        if parse_subdomain_id is None:
+            integrals.append(integral)
+            continue
+        dim = entity_dimension_from_integral_type(domain, integral.integral_type())
+        subdomain_id = integral.subdomain_id()
+        new_subdomain_id = parse_subdomain_id(dim, subdomain_id)
+        if new_subdomain_id != subdomain_id:
+            integral = integral.reconstruct(subdomain_id=new_subdomain_id)
+            changed = True
+        integrals.append(integral)
+    return Form(integrals) if changed else form
+
+
 def _compile_form_hashkey(form, name, parameters=None, split=True, dont_split=(), diagonal=False):
+    form = _resolve_region_names(form)
     return (
         form.signature(),
         name,
@@ -209,6 +233,8 @@ def compile_form(form, name, parameters=None, split=True, dont_split=(), diagona
     # Check that we get a Form
     if not isinstance(form, Form):
         raise RuntimeError("Unable to convert object to a UFL form: %s" % repr(form))
+
+    form = _resolve_region_names(form)
 
     if parameters is None:
         parameters = default_parameters["form_compiler"].copy()

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -11,6 +11,7 @@ import collections
 import ufl
 import finat.ufl
 from ufl import conj, Form, ZeroBaseForm
+from ufl.measure import as_integral_type
 from .ufl_expr import TestFunction, extract_domains
 
 from tsfc import compile_form as original_tsfc_compile_form
@@ -26,7 +27,6 @@ from firedrake.formmanipulation import split_form
 from firedrake.parameters import parameters as default_parameters
 from firedrake.petsc import PETSc
 from firedrake import utils
-from firedrake.ufl_measure import entity_dimension_from_integral_type
 
 # Set TSFC default scalar type at load time
 tsfc_default_parameters["scalar_type"] = utils.ScalarType
@@ -151,6 +151,20 @@ class TSFCKernel:
 SplitKernel = collections.namedtuple("SplitKernel", ["indices", "kinfo"])
 
 
+def entity_dimension_from_integral_type(domain, integral_type):
+    integral_type = as_integral_type(integral_type)
+    topological_dimension = domain.topological_dimension
+    if integral_type == "cell":
+        return topological_dimension
+    if integral_type.startswith("exterior_facet") or integral_type.startswith("interior_facet"):
+        return topological_dimension - 1
+    if integral_type == "ridge":
+        return topological_dimension - 2
+    if integral_type == "vertex":
+        return 0
+    return topological_dimension
+
+
 def _resolve_region_names(form):
     if not isinstance(form, Form):
         return form
@@ -160,15 +174,13 @@ def _resolve_region_names(form):
     for integral in form.integrals():
         domain = integral.ufl_domain()
         parse_subdomain_id = getattr(domain, "parse_subdomain_id", None)
-        if parse_subdomain_id is None:
-            integrals.append(integral)
-            continue
-        dim = entity_dimension_from_integral_type(domain, integral.integral_type())
-        subdomain_id = integral.subdomain_id()
-        new_subdomain_id = parse_subdomain_id(dim, subdomain_id)
-        if new_subdomain_id != subdomain_id:
-            integral = integral.reconstruct(subdomain_id=new_subdomain_id)
-            changed = True
+        if parse_subdomain_id is not None:
+            dim = entity_dimension_from_integral_type(domain, integral.integral_type())
+            subdomain_id = integral.subdomain_id()
+            new_subdomain_id = parse_subdomain_id(dim, subdomain_id)
+            if new_subdomain_id != subdomain_id:
+                integral = integral.reconstruct(subdomain_id=new_subdomain_id)
+                changed = True
         integrals.append(integral)
     return Form(integrals) if changed else form
 

--- a/tests/firedrake/regression/test_region_names.py
+++ b/tests/firedrake/regression/test_region_names.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import ufl
+
+from firedrake import *
+from firedrake.mesh import _parse_gmsh_physical_names
+
+
+def test_rename_subdomain_appends_and_parse():
+    mesh = UnitSquareMesh(1, 1)
+    mesh.rename_subdomain(1, 1, "walls")
+    mesh.rename_subdomain(1, [2, 3], "walls")
+
+    assert mesh.topology.region_names[1]["walls"] == [1, 2, 3]
+    assert mesh.parse_subdomain_id(1, "walls") == (1, 2, 3)
+    assert mesh.parse_subdomain_id(1, ["walls", 4]) == (1, 2, 3, 4)
+    assert mesh.parse_subdomain_id(1, "on_boundary") == "on_boundary"
+
+    with pytest.raises(ValueError, match="Subdomain region 'missing'"):
+        mesh.parse_subdomain_id(1, "missing")
+
+
+def test_dirichletbc_accepts_region_name():
+    mesh = UnitSquareMesh(2, 2)
+    mesh.rename_subdomain(1, [1, 2], "vertical")
+    V = FunctionSpace(mesh, "CG", 1)
+
+    named = DirichletBC(V, 0, "vertical")
+    numeric = DirichletBC(V, 0, [1, 2])
+
+    assert np.array_equal(np.sort(named.nodes), np.sort(numeric.nodes))
+
+
+def test_submesh_accepts_region_name():
+    mesh = UnitSquareMesh(2, 2)
+    mesh.rename_subdomain(1, [1, 2], "vertical")
+
+    submesh = Submesh(mesh, subdim=1, subdomain_id="vertical")
+    target = assemble(Constant(1) * ds(1, domain=mesh)) + assemble(Constant(1) * ds(2, domain=mesh))
+
+    assert assemble(Constant(1) * dx(domain=submesh)) == pytest.approx(target)
+
+
+def test_measure_accepts_region_name_with_domain():
+    mesh = UnitSquareMesh(2, 2)
+    mesh.rename_subdomain(1, [1, 2], "vertical")
+
+    named = assemble(Constant(1) * Measure("ds", domain=mesh, subdomain_id="vertical"))
+    ufl_named = assemble(Constant(1) * ufl.Measure("ds", domain=mesh, subdomain_id="vertical"))
+    target = assemble(Constant(1) * ds(1, domain=mesh)) + assemble(Constant(1) * ds(2, domain=mesh))
+
+    assert named == pytest.approx(target)
+    assert ufl_named == pytest.approx(target)
+
+
+def test_measure_accepts_region_name_with_inferred_domain():
+    mesh = UnitSquareMesh(2, 2)
+    mesh.rename_subdomain(1, [1, 2], "vertical")
+    V = FunctionSpace(mesh, "CG", 1)
+    f = Function(V)
+    f.assign(1)
+
+    named = assemble(f * ds("vertical"))
+    target = assemble(f * ds(1)) + assemble(f * ds(2))
+
+    assert named == pytest.approx(target)
+
+
+def test_gmsh_physical_names_parser(tmp_path):
+    filename = tmp_path / "named.msh"
+    filename.write_text(
+        "$MeshFormat\n2.2 0 8\n$EndMeshFormat\n"
+        "$PhysicalNames\n2\n1 5 \"left wall\"\n2 7 \"fluid\"\n$EndPhysicalNames\n"
+    )
+
+    assert _parse_gmsh_physical_names(str(filename)) == [(1, 5, "left wall"), (2, 7, "fluid")]
+
+
+@pytest.mark.skipnetgen
+def test_netgen_region_names_are_loaded():
+    from netgen.geom2d import SplineGeometry
+
+    geo = SplineGeometry()
+    geo.AddRectangle((0, 0), (1, 1), bc="rect")
+    ngmesh = geo.GenerateMesh(maxh=0.5)
+
+    mesh = Mesh(ngmesh)
+    labels = [1, 2, 3, 4]
+
+    assert mesh.topology.region_names[1]["rect"] == labels
+
+    V = FunctionSpace(mesh, "CG", 1)
+    named = DirichletBC(V, 0, "rect")
+    numeric = DirichletBC(V, 0, labels)
+
+    assert np.array_equal(np.sort(named.nodes), np.sort(numeric.nodes))
+
+
+def test_gmsh_region_names_are_loaded(tmp_path):
+    source = Path("tests/firedrake/meshes/square.msh").read_text()
+    physical_names = (
+        "$PhysicalNames\n2\n"
+        "1 1 \"left\"\n"
+        "2 1 \"cells\"\n"
+        "$EndPhysicalNames\n"
+    )
+    filename = tmp_path / "named_square.msh"
+    filename.write_text(source.replace("$EndMeshFormat\n", "$EndMeshFormat\n" + physical_names))
+
+    mesh = Mesh(str(filename))
+
+    assert mesh.topology.region_names[1]["left"] == [1]
+    assert mesh.topology.region_names[2]["cells"] == [1]
+    assert assemble(Constant(1) * ds("left", domain=mesh)) == pytest.approx(
+        assemble(Constant(1) * ds(1, domain=mesh))
+    )
+    assert assemble(Constant(1) * dx("cells", domain=mesh)) == pytest.approx(1.0)

--- a/tests/firedrake/regression/test_region_names.py
+++ b/tests/firedrake/regression/test_region_names.py
@@ -47,7 +47,7 @@ def test_measure_accepts_region_name_with_domain():
     mesh = UnitSquareMesh(2, 2)
     mesh.rename_subdomain(1, [1, 2], "vertical")
 
-    named = assemble(Constant(1) * Measure("ds", domain=mesh, subdomain_id="vertical"))
+    named = assemble(Constant(1) * ds(domain=mesh, subdomain_id="vertical"))
     ufl_named = assemble(Constant(1) * ufl.Measure("ds", domain=mesh, subdomain_id="vertical"))
     target = assemble(Constant(1) * ds(1, domain=mesh)) + assemble(Constant(1) * ds(2, domain=mesh))
 


### PR DESCRIPTION
# Description
> **Disclaimer:** This PR was implemented with Codex

Introduces native, human-readable region naming capabilities across Firedrake. By allowing users to seamlessly use string identifiers preserved from external mesh generators or explicitly assign custom semantic names to subdomains at runtime, it eliminates the cognitive overhead of tracking opaque numerical tags when defining boundary conditions, extracting submeshes, or specifying UFL variational forms.
```python
from firedrake import *
import netgen.occ as ngocc

# 1. Generate geometry & name boundaries natively in Netgen
wp = ngocc.WorkPlane()
box = wp.Rectangle(1, 1).Face()
box.edges.Max(ngocc.Y).name = "inlet"
box.faces.name = "fluid_domain"
ngmesh = ngocc.OCCGeometry(box, dim=2).GenerateMesh(maxh=0.1)

# 2. Native Firedrake Mesh captures the names automatically
mesh = Mesh(ngmesh)

# 3. Explicitly map a single string name to multiple disjoint entity IDs

# 4. Clean, human-readable API usage
V = FunctionSpace(mesh, "CG", 1)

# DirichletBC automatically maps "inlet" to the correct face ID
bc = DirichletBC(V, 0.0, "inlet")  

# SubMesh automatically maps "fluid_domain" using the correct keyword argument
submesh = Submesh(mesh, subdomain_id="fluid_domain")

# Form language integration: UFL Measures accept string region names directly
f = Function(V)
L = f * dx(subdomain_id="fluid_domain")
```