### PR TITLE
Refactor test parameterization for some IO tests

### DIFF
--- a/scripts/firedrake-check
+++ b/scripts/firedrake-check
@@ -26,7 +26,7 @@ TESTS = {
     ),
     2: (
         # HDF5/checkpointing
-        "tests/firedrake/output/test_io_function.py::test_io_function_base[cell_family_degree2]",
+        "tests/firedrake/output/test_io_function.py::test_io_function_base[triangle_small-DP-0]",
     ),
     3: (
         "tests/firedrake/regression/test_dg_advection.py::test_dg_advection_icosahedral_sphere[nprocs=3]",

--- a/tests/firedrake/output/test_io_function.py
+++ b/tests/firedrake/output/test_io_function.py
@@ -154,7 +154,7 @@ def _load_check_save_functions(filename, func_name, comm, method, mesh_name, var
 
 
 @pytest.mark.parallel(2)
-@pytest.mark.parametrize('cell_family_degree', [
+@pytest.mark.parametrize('cell_type,family,degree', [
     ("triangle_small", "P", 1),
     ("triangle_small", "P", 6),
     ("triangle_small", "DP", 0),
@@ -192,9 +192,7 @@ def _load_check_save_functions(filename, func_name, comm, method, mesh_name, var
     ("triangle_3d", "BDMF", 4),
     ("quad_3d", "RTCF", 4)
 ])
-def test_io_function_base(cell_family_degree, tmpdir):
-    # Parameters
-    cell_type, family, degree = cell_family_degree
+def test_io_function_base(cell_type, family, degree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_base_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)
@@ -247,13 +245,12 @@ def test_io_function_real(cell_type, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_tuples', [("triangle", (("BDMF", 4), ("DP", 3))),
-                                                       ("tetrahedra", (("P", 2), ("DP", 1))),
-                                                       ("tetrahedra", (("N1E", 2), ("DP", 1))),
-                                                       ("quadrilateral", (("Q", 4), ("DQ", 3))),
-                                                       ("quadrilateral", (("RTCF", 3), ("DQ", 2)))])
-def test_io_function_mixed(cell_family_degree_tuples, tmpdir):
-    cell_type, family_degree_tuples = cell_family_degree_tuples
+@pytest.mark.parametrize('cell_type,family_degree_tuples', [("triangle", (("BDMF", 4), ("DP", 3))),
+                                                            ("tetrahedra", (("P", 2), ("DP", 1))),
+                                                            ("tetrahedra", (("N1E", 2), ("DP", 1))),
+                                                            ("quadrilateral", (("Q", 4), ("DQ", 3))),
+                                                            ("quadrilateral", (("RTCF", 3), ("DQ", 2)))])
+def test_io_function_mixed(cell_type, family_degree_tuples, tmpdir):
     filename = join(str(tmpdir), "test_io_function_mixed_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)
@@ -277,10 +274,9 @@ def test_io_function_mixed(cell_family_degree_tuples, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_tuples', [("triangle", (("BDME", 4), ("Real", 0))),
-                                                       ("quadrilateral", (("RTCF", 3), ("Real", 0)))])
-def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
-    cell_type, family_degree_tuples = cell_family_degree_tuples
+@pytest.mark.parametrize('cell_type,family_degree_tuples', [("triangle", (("BDME", 4), ("Real", 0))),
+                                                            ("quadrilateral", (("RTCF", 3), ("Real", 0)))])
+def test_io_function_mixed_real(cell_type, family_degree_tuples, tmpdir):
     filename = join(str(tmpdir), "test_io_function_mixed_real_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)
@@ -316,17 +312,16 @@ def test_io_function_mixed_real(cell_family_degree_tuples, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_dim', [("triangle", "RTE", 3, 3),
-                                                    ("triangle", "RTF", 3, 4),
-                                                    ("tetrahedra", "P", 2, 3),
-                                                    ("tetrahedra", "N1E", 4, 3),
-                                                    ("tetrahedra", "N1F", 3, 4),
-                                                    ("quadrilateral", "Q", 4, 5),
-                                                    ("quadrilateral", "RTCE", 3, 4),
-                                                    ("quadrilateral", "RTCF", 3, 3),
-                                                    ("quadrilateral", "DPC", 5, 3)])
-def test_io_function_vector(cell_family_degree_dim, tmpdir):
-    cell_type, family, degree, vector_dim = cell_family_degree_dim
+@pytest.mark.parametrize('cell_type,family,degree,vector_dim', [("triangle", "RTE", 3, 3),
+                                                                ("triangle", "RTF", 3, 4),
+                                                                ("tetrahedra", "P", 2, 3),
+                                                                ("tetrahedra", "N1E", 4, 3),
+                                                                ("tetrahedra", "N1F", 3, 4),
+                                                                ("quadrilateral", "Q", 4, 5),
+                                                                ("quadrilateral", "RTCE", 3, 4),
+                                                                ("quadrilateral", "RTCF", 3, 3),
+                                                                ("quadrilateral", "DPC", 5, 3)])
+def test_io_function_vector(cell_type, family, degree, vector_dim, tmpdir):
     filename = join(str(tmpdir), "test_io_function_vector_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)
@@ -347,12 +342,11 @@ def test_io_function_vector(cell_family_degree_dim, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_shape_symmetry', [("triangle", "P", 3, (3, 4), None),
-                                                               ("tetrahedra", "P", 4, (3, 4), None),
-                                                               ("quadrilateral", "Q", 4, (2, 4), None),
-                                                               ("quadrilateral", "Q", 3, (3, 3), True)])
-def test_io_function_tensor(cell_family_degree_shape_symmetry, tmpdir):
-    cell_type, family, degree, shape, symmetry = cell_family_degree_shape_symmetry
+@pytest.mark.parametrize('cell_type,family,degree,shape,symmetry', [("triangle", "P", 3, (3, 4), None),
+                                                                    ("tetrahedra", "P", 4, (3, 4), None),
+                                                                    ("quadrilateral", "Q", 4, (2, 4), None),
+                                                                    ("quadrilateral", "Q", 3, (3, 3), True)])
+def test_io_function_tensor(cell_type, family, degree, shape, symmetry, tmpdir):
     filename = join(str(tmpdir), "test_io_function_tensor_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)
@@ -409,10 +403,9 @@ def test_io_function_mixed_vector(cell_type, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_vfamily_vdegree', [("triangle", "BDMF", 2, "DG", 1),
-                                                                ("quadrilateral", "RTCF", 2, "DG", 1)])
-def test_io_function_extrusion(cell_family_degree_vfamily_vdegree, tmpdir):
-    cell_type, family, degree, vfamily, vdegree = cell_family_degree_vfamily_vdegree
+@pytest.mark.parametrize('cell_type,family,degree,vfamily,vdegree', [("triangle", "BDMF", 2, "DG", 1),
+                                                                     ("quadrilateral", "RTCF", 2, "DG", 1)])
+def test_io_function_extrusion(cell_type, family, degree, vfamily, vdegree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_extrusion_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     mesh = _get_mesh(cell_type, COMM_WORLD)
@@ -437,10 +430,9 @@ def test_io_function_extrusion(cell_family_degree_vfamily_vdegree, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree', [("triangle", "P", 4),
-                                                ("quadrilateral", "Q", 4)])
-def test_io_function_extrusion_real(cell_family_degree, tmpdir):
-    cell_type, family, degree = cell_family_degree
+@pytest.mark.parametrize('cell_type,family,degree', [("triangle", "P", 4),
+                                                     ("quadrilateral", "Q", 4)])
+def test_io_function_extrusion_real(cell_type, family, degree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_extrusion_real_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     mesh = _get_mesh(cell_type, COMM_WORLD)
@@ -462,10 +454,9 @@ def test_io_function_extrusion_real(cell_family_degree, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_dim', [("triangle", "P", 4, 5),
-                                                    ("quadrilateral", "Q", 4, 7)])
-def test_io_function_vector_extrusion_real(cell_family_degree_dim, tmpdir):
-    cell_type, family, degree, dim = cell_family_degree_dim
+@pytest.mark.parametrize('cell_type,family,degree,dim', [("triangle", "P", 4, 5),
+                                                         ("quadrilateral", "Q", 4, 7)])
+def test_io_function_vector_extrusion_real(cell_type, family, degree, dim, tmpdir):
     filename = join(str(tmpdir), "test_io_function_vector_extrusion_real_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     mesh = _get_mesh(cell_type, COMM_WORLD)
@@ -487,12 +478,11 @@ def test_io_function_vector_extrusion_real(cell_family_degree_dim, tmpdir):
 
 
 @pytest.mark.parallel(nprocs=3)
-@pytest.mark.parametrize('cell_family_degree_dim', [
+@pytest.mark.parametrize('cell_type,family0,degree0,dim0,family1,degree1,vfamily1,vdegree1,dim1', [
     ("triangle", "P", 1, 2, "BDMF", 2, "DG", 2, 2),
     ("quadrilateral", "Q", 1, 2, "RTCF", 2, "DG", 0, 2)
 ])
-def test_io_function_mixed_vector_extrusion_real(cell_family_degree_dim, tmpdir):
-    cell_type, family0, degree0, dim0, family1, degree1, vfamily1, vdegree1, dim1 = cell_family_degree_dim
+def test_io_function_mixed_vector_extrusion_real(cell_type, family0, degree0, dim0, family1, degree1, vfamily1, vdegree1, dim1, tmpdir):
     filename = join(str(tmpdir), "test_io_function_mixed_vector_extrusion_real_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     mesh = _get_mesh(cell_type, COMM_WORLD)
@@ -535,10 +525,9 @@ def _compute_random_layers(base):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize('cell_family_degree_vfamily_vdegree', [("triangle", "DP", 7, "DG", 3),
-                                                                ("quadrilateral", "DQ", 6, "DG", 3)])
-def test_io_function_extrusion_variable_layer1(cell_family_degree_vfamily_vdegree, tmpdir):
-    cell_type, family, degree, vfamily, vdegree = cell_family_degree_vfamily_vdegree
+@pytest.mark.parametrize('cell_type,family,degree,vfamily,vdegree', [("triangle", "DP", 7, "DG", 3),
+                                                                     ("quadrilateral", "DQ", 6, "DG", 3)])
+def test_io_function_extrusion_variable_layer1(cell_type, family, degree, vfamily, vdegree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_extrusion_variable_layer_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     mesh = _get_mesh(cell_type, COMM_WORLD)
@@ -565,10 +554,9 @@ def test_io_function_extrusion_variable_layer1(cell_family_degree_vfamily_vdegre
 
 # -- Unable to test in parallel due to potential bug with variable layers extrusion + project in parallel (Issue #2169)
 
-@pytest.mark.parametrize('cell_family_degree_vfamily_vdegree', [("triangle", "BDMF", 2, "DG", 3),
-                                                                ("quadrilateral", "RTCF", 2, "DG", 3)])
-def test_io_function_extrusion_variable_layer(cell_family_degree_vfamily_vdegree, tmpdir):
-    cell_type, family, degree, vfamily, vdegree = cell_family_degree_vfamily_vdegree
+@pytest.mark.parametrize('cell_type,family,degree,vfamily,vdegree', [("triangle", "BDMF", 2, "DG", 3),
+                                                                     ("quadrilateral", "RTCF", 2, "DG", 3)])
+def test_io_function_extrusion_variable_layer(cell_type, family, degree, vfamily, vdegree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_extrusion_variable_layer_dump.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     method = "project"
@@ -624,10 +612,9 @@ def test_io_function_extrusion_periodic(tmpdir):
 
 
 @pytest.mark.parallel(nprocs=2)
-@pytest.mark.parametrize("cell_family_degree", [("triangle", "P", 1),
-                                                ("quadrilateral", "Q", 1)])
-def test_io_function_naming(cell_family_degree, tmpdir):
-    cell_type, family, degree = cell_family_degree
+@pytest.mark.parametrize("cell_type,family,degree", [("triangle", "P", 1),
+                                                     ("quadrilateral", "Q", 1)])
+def test_io_function_naming(cell_type, family, degree, tmpdir):
     filename = join(str(tmpdir), "test_io_function_naming.h5")
     filename = COMM_WORLD.bcast(filename, root=0)
     meshA = _get_mesh(cell_type, COMM_WORLD)


### PR DESCRIPTION
This means that we see things like
```
          <Function test_io_function_base[triangle_small-P-1]>
          <Function test_io_function_base[triangle_small-P-6]>
          <Function test_io_function_base[triangle_small-DP-0]>
```
instead of
```
          <Function test_io_function_base[cell_family_degree0]>
          <Function test_io_function_base[cell_family_degree1]>
          <Function test_io_function_base[cell_family_degree2]>
```

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
