### PR TITLE
SLATE: Fix codegen for elimination of 1x1 block

### DIFF
--- a/firedrake/slate/slate.py
+++ b/firedrake/slate/slate.py
@@ -669,7 +669,8 @@ class Block(TensorBase):
         """Constructor for the Block class."""
         super(Block, self).__init__()
         self.operands = (tensor,)
-        self._blocks = dict(enumerate(map(as_tuple, indices)))
+        indices = tuple(map(as_tuple, indices))
+        self._blocks = dict(enumerate(indices))
         self._indices = indices
 
     @cached_property

--- a/tests/firedrake/slate/test_assemble_tensors.py
+++ b/tests/firedrake/slate/test_assemble_tensors.py
@@ -340,3 +340,30 @@ def test_reciprocal(mesh):
     ref = [1./d for d in assemble(mass + mass, diagonal=True).dat.data]
     for r, d in zip(res, np.diag(ref)):
         assert np.allclose(r, d, rtol=1e-14)
+
+
+@pytest.mark.parametrize("degree", (0, 1))
+def test_nested_block(mesh, degree):
+    V = FunctionSpace(mesh, "CG", degree+1)
+    Q = FunctionSpace(mesh, "DG", degree, variant="integral")
+    Z = V * Q
+
+    v0, q0 = TestFunctions(Z)
+    v1, q1 = TrialFunctions(Z)
+    a = (inner(grad(v1), grad(v0)) * dx
+         + inner(q1, v0) * dx
+         + inner(v1, q0) * dx
+         - inner(q1, q0) * dx
+         )
+
+    b = inner(q1, v0) * dx
+    J = Tensor(a)
+    D = Block(J, (1, 1))
+    B = Block(Tensor(b), ((0, 1), 1))
+    Jp = J - B * Inverse(D) * B.T
+
+    expect = assemble(Jp, mat_type="nest").petscmat.getNestSubMatrix(0, 0)
+
+    result = assemble(Block(Jp, (0, 0))).petscmat
+
+    assert np.allclose(result[:, :], expect[:, :])

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -362,7 +362,7 @@ def statement_evaluate(leaf, ctx):
     elif isinstance(expr, gem.ComponentTensor):
         idx = ctx.gem_to_pym_multiindex(expr.multiindex)
         var, sub_idx = ctx.pymbolic_variable_and_destruct(expr)
-        lhs = p.Subscript(var, idx + sub_idx)
+        lhs = p.Subscript(var, sub_idx + idx)
         with active_indices(dict(zip(expr.multiindex, idx)), ctx) as ctx_active:
             return [lp.Assignment(lhs, expression(expr.children[0], ctx_active), within_inames=ctx_active.active_inames())]
     elif isinstance(expr, gem.Inverse):


### PR DESCRIPTION
# Description
Fix a codegen index mismatch error when using SLATE for elimination of a 1x1 block, elimination of larger blocks was not previously affected.

- The fix has effect on `ComponentTensor` in general (not only for slate expressions)
- Improve SLATE API to allow `Block(T, (i, j))` as a shorthand for `Block(T, ((i, ), (j, )))`

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
