### PR TITLE
Prevent Cython 3.2.6 from being installed in build

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -124,6 +124,9 @@ runs:
         python3 -m venv venv
         . venv/bin/activate
 
+        echo 'Cython!=3.2.6' > constraints.txt
+        export PIP_CONSTRAINT=constraints.txt
+
         : # Empty the pip cache to ensure that everything is compiled from scratch
         pip cache purge
 


### PR DESCRIPTION
# Description
The Cython release 3.2.6 has a bug that is causing CI failures. [cython:7767](https://github.com/cython/cython/issues/7767)

Add constraint that ensures this release is not installed in the CI

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
