### PR TITLE
Revert "Prevent Cython 3.2.6 from being installed in build"

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -124,9 +124,6 @@ runs:
         python3 -m venv venv
         . venv/bin/activate
 
-        echo 'Cython!=3.2.6' > constraints.txt
-        export PIP_CONSTRAINT=constraints.txt
-
         : # Empty the pip cache to ensure that everything is compiled from scratch
         pip cache purge
 


### PR DESCRIPTION
Reverts firedrakeproject/firedrake#5208

Closes https://github.com/firedrakeproject/firedrake/issues/5210

Thanks @indiamai for handling this originally