### PR TITLE
Add AMD compatibility for OffloadPC

### DIFF
--- a/firedrake/preconditioners/offload.py
+++ b/firedrake/preconditioners/offload.py
@@ -10,7 +10,10 @@ __all__ = ("OffloadPC",)
 _device_vector_impls = {
     "CUDA": {
         "createWithArrays": "createCUDAWithArrays",
-    }
+    },
+    "HIP": {
+        "createWithArrays": "createHIPWithArrays",
+    },
 }
 
 

--- a/firedrake/utils.py
+++ b/firedrake/utils.py
@@ -78,7 +78,7 @@ def device_matrix_type(*, warn: bool = True) -> str | None:
         this system or None
 
     """
-    _device_mat_type_map = {"HOST": None, "CUDA": "aijcusparse"}
+    _device_mat_type_map = {"HOST": None, "CUDA": "aijcusparse", "HIP": "aijhipsparse"}
     dev_type = get_device_type()
     if dev_type is None:
         if warn:

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -243,6 +243,7 @@ class ScalarType(enum.Enum):
 class GPUPlatform(enum.Enum):
     NO_GPU = "none"
     CUDA = "cuda"
+    HIP = "hip"
 
 
 class InvalidConfigurationError(Exception):
@@ -1146,6 +1147,95 @@ COMMUNITY_ARCHS: Mapping[ArchKey, CommunityArch] = {
         library_dirs=[
             "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
+    ),
+
+    (OS.UBUNTU_2404_X86_64, ScalarType.DEFAULT, GPUPlatform.HIP): CommunityArch(
+        name="default-hip",
+        maintainer="the G-ADOPT team",
+        contact="at help@gadopt.org",
+        last_modified="2026-07-07",
+        system_packages=[
+            "bison",
+            "build-essential",
+            "cmake",
+            "flex",
+            "gfortran",
+            "git",
+            "ninja-build",
+            "pkg-config",
+            "python3-dev",
+            "python3-pip",
+
+            # PETSc external packages
+            "libfftw3-dev",
+            "libfftw3-mpi-dev",
+            "libhwloc-dev",
+            "libhdf5-mpi-dev",
+            "libmumps-ptscotch-dev",
+            "libmetis-dev",
+            "libnetcdf-dev",
+            "libopenblas-dev",
+            "libopenmpi-dev",
+            "libpnetcdf-dev",
+            "libptscotch-dev",
+            "libscalapack-openmpi-dev",
+
+            # HIP packages
+            "rocm-hip-libraries",
+            "rocm-hip-runtime",
+            "rocm-language-runtime",
+            "rocm-ml-libraries",
+            "rocm-opencl-runtime",
+            "rocm-developer-tools",
+            "rocm-hip-runtime-dev",
+            "rocm-hip-sdk",
+            "rocm-opencl-sdk",
+            "rocm-openmp-sdk"
+        ],
+        extra_petsc_configure_options=[
+            "--with-bison",
+            "--with-fftw",
+            "--with-hdf5",
+            "--with-hwloc",
+            "--with-metis",
+            "--with-mumps",
+            "--with-netcdf",
+            "--with-pnetcdf",
+            "--with-ptscotch",
+            "--with-scalapack-lib=-lscalapack-openmpi",
+            "--with-zlib",
+            "--download-hypre",
+            "--download-suitesparse",
+            "--download-superlu_dist",
+
+            # HIP options
+            "--with-hip=1",
+            "--with-hip-dir=/opt/rocm",
+            "--with-hip-arch=gfx90a",
+            "--with-openmp=1",
+            "--with-cxx-dialect=c++17",
+            "--download-umpire",
+        ],
+        cflags=["-O3", "-march=native", "-mtune=native"],
+        cxxflags=["-O3", "-march=native", "-mtune=native"],
+        fflags=["-O3", "-march=native", "-mtune=native"],
+        include_dirs=[
+            "/usr/include/hdf5/openmpi",
+            "/usr/include/scotch",
+            "/usr/include/superlu",
+            "/usr/include/superlu-dist",
+        ],
+        library_dirs=[
+            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
+        ],
+        # Note - must be set before PETSc install
+        extra_env_vars={
+            "CMAKE_PREFIX_PATH": "/opt/rocm/lib/cmake/hip:/opt/rocm/lib/cmake/hipblas:/opt/rocm/lib/cmake/hipblas-common:/opt/rocm/lib/cmake/rocsolver:/opt/rocm/lib/cmake/rocblas",
+        },
+        # See https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html for latest
+        # installer package URL.
+        # Must be installed with apt (not dpkg).
+        extra_url="https://repo.radeon.com/amdgpu-install/7.2.4/ubuntu/noble/amdgpu-install_7.2.4.70204-1_all.deb",
     ),
 }
 


### PR DESCRIPTION
## Add AMD GPU compatibility for `OffloadPC`

PETSc supports AMD GPUs through its CUPM abstraction layer, so extending `OffloadPC` support to AMD GPUs is a matter of associating the HIP matrix/vector types with the PETSc `HIP` device type. Also include an Ubuntu 24.04 HIP/ROCm `CommunityArch` in `firedrake-configure`.