### PR TITLE
firedrake-configure: scope apt HDF5 to --with-hdf5-* and declare zlib1g-dev

### DIFF
--- a/scripts/check-config
+++ b/scripts/check-config
@@ -97,8 +97,8 @@ def check_zlib_declared() -> None:
         for arch_key, arch in all_archs.items()
         if "--with-zlib" in arch.extra_petsc_configure_options
         and (arch.system_packages is None
-             or arch.system_packages is not None
-             and "zlib1g-dev" not in arch.system_packages)
+             or (arch.system_packages is not None
+             and "zlib1g-dev" not in arch.system_packages))
     ]
     if offenders:
         raise InvalidConfigurationException(

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -27,6 +27,7 @@ def main():
     check_slepc_version()
     check_petsc_version_spec()
     check_zlib_declared()
+    check_hdf5_scoped()
 
 
 def check_min_python_version() -> None:
@@ -101,6 +102,33 @@ def check_zlib_declared() -> None:
         raise InvalidConfigurationException(
             "The following archs request '--with-zlib' but do not declare "
             f"'zlib1g-dev' in their system packages: {offenders}"
+        )
+
+
+def check_hdf5_scoped() -> None:
+    """Check that HDF5's location is expressed via a scoped selector.
+
+    An arch's HDF5 location must be with a ``--with-hdf5-*`` option, not as
+    raw ``-I``/``-L`` entries in ``include_dirs``/``library_dirs``. The latter
+    end up in the shared OPTFLAGS, where they cannot be removed by a consumer that overrides HDF5 to
+    ``--download-hdf5``.
+
+    """
+    firedrake_configure = _load_firedrake_configure()
+    all_archs = {
+        **firedrake_configure.OFFICIAL_ARCHS,
+        **firedrake_configure.RETIRED_ARCHS,
+        **firedrake_configure.COMMUNITY_ARCHS,
+    }
+    offenders = [
+        ", ".join(key_part.value for key_part in arch_key)
+        for arch_key, arch in all_archs.items()
+        if any("hdf5" in dir_ for dir_ in (*arch.include_dirs, *arch.library_dirs))
+    ]
+    if offenders:
+        raise InvalidConfigurationException(
+            "The following archs put an HDF5 path in include_dirs/library_dirs "
+            f"instead of a '--with-hdf5-*' selector: {offenders}"
         )
 
 

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -8,8 +8,10 @@ of hardcoded values (via CI).
 
 """
 
+import importlib.util
 import pathlib
 import re
+from importlib.machinery import SourceFileLoader
 
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -24,6 +26,7 @@ def main():
     check_petsc_version()
     check_slepc_version()
     check_petsc_version_spec()
+    check_zlib_declared()
 
 
 def check_min_python_version() -> None:
@@ -70,6 +73,50 @@ def check_petsc_version_spec() -> None:
         REPO_ROOT / "setup.py",
         f"petsctools.init\\(version_spec=\"{petsc_version_spec}\"\\)",
     )
+
+
+def check_zlib_declared() -> None:
+    """Check that archs linking the system zlib also declare its package.
+
+    If an arch passes ``--with-zlib`` to PETSc configure then it links against
+    the system zlib, so that library must appear in ``system_packages`` (as
+    ``zlib1g-dev``). Otherwise zlib is an undeclared dependency that only works
+    by being pulled in transitively by another package.
+
+    """
+    firedrake_configure = _load_firedrake_configure()
+    all_archs = {
+        **firedrake_configure.OFFICIAL_ARCHS,
+        **firedrake_configure.RETIRED_ARCHS,
+        **firedrake_configure.COMMUNITY_ARCHS,
+    }
+    offenders = [
+        ", ".join(key_part.value for key_part in arch_key)
+        for arch_key, arch in all_archs.items()
+        if "--with-zlib" in arch.extra_petsc_configure_options
+        and arch.system_packages is not None
+        and "zlib1g-dev" not in arch.system_packages
+    ]
+    if offenders:
+        raise InvalidConfigurationException(
+            "The following archs request '--with-zlib' but do not declare "
+            f"'zlib1g-dev' in their system packages: {offenders}"
+        )
+
+
+def _load_firedrake_configure():
+    """Import the 'firedrake-configure' script as a module.
+
+    The hyphen in the filename means it cannot be imported normally, so load it
+    directly from its path.
+
+    """
+    script_path = REPO_ROOT / "scripts" / "firedrake-configure"
+    loader = SourceFileLoader("firedrake_configure", str(script_path))
+    spec = importlib.util.spec_from_loader("firedrake_configure", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
 
 
 def check_file_contains_pattern(

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
 
-"""Sanity checks for hardcoded configuration in the Firedrake repository.
+"""Script that makes sure that hardcoded version numbers are consistent.
 
-Run in CI to catch configuration that has drifted out of sync: version numbers
-duplicated across files, and arch definitions in ``firedrake-configure`` that
-link a system library without declaring its package or that point at HDF5 with
-raw ``-I``/``-L`` flags instead of a scoped ``--with-hdf5-*`` selector.
+It looks at files in the Firedrake repository and makes sure that everywhere a
+version number is hardcoded that it matches. This allows for single-source-of-truth
+of hardcoded values (via CI).
 
 """
 
-import importlib.util
 import pathlib
 import re
-from importlib.machinery import SourceFileLoader
 
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -27,8 +24,6 @@ def main():
     check_petsc_version()
     check_slepc_version()
     check_petsc_version_spec()
-    check_zlib_declared()
-    check_hdf5_scoped()
 
 
 def check_min_python_version() -> None:
@@ -75,78 +70,6 @@ def check_petsc_version_spec() -> None:
         REPO_ROOT / "setup.py",
         f"petsctools.init\\(version_spec=\"{petsc_version_spec}\"\\)",
     )
-
-
-def check_zlib_declared() -> None:
-    """Check that archs linking the system zlib also declare its package.
-
-    If an arch passes ``--with-zlib`` to PETSc configure then it links against
-    the system zlib, so that library must appear in ``system_packages`` (as
-    ``zlib1g-dev``). Otherwise zlib is an undeclared dependency that only works
-    by being pulled in transitively by another package.
-
-    """
-    firedrake_configure = _load_firedrake_configure()
-    all_archs = {
-        **firedrake_configure.OFFICIAL_ARCHS,
-        **firedrake_configure.RETIRED_ARCHS,
-        **firedrake_configure.COMMUNITY_ARCHS,
-    }
-    offenders = [
-        ", ".join(key_part.value for key_part in arch_key)
-        for arch_key, arch in all_archs.items()
-        if "--with-zlib" in arch.extra_petsc_configure_options
-        and (arch.system_packages is None
-             or (arch.system_packages is not None
-             and "zlib1g-dev" not in arch.system_packages))
-    ]
-    if offenders:
-        raise InvalidConfigurationException(
-            "The following archs request '--with-zlib' but do not declare "
-            f"'zlib1g-dev' in their system packages: {offenders}"
-        )
-
-
-def check_hdf5_scoped() -> None:
-    """Check that HDF5's location is expressed via a scoped selector.
-
-    An arch's HDF5 location must be with a ``--with-hdf5-*`` option, not as
-    raw ``-I``/``-L`` entries in ``include_dirs``/``library_dirs``. The latter
-    end up in the shared OPTFLAGS, where they cannot be removed by a consumer that overrides HDF5 to
-    ``--download-hdf5``.
-
-    """
-    firedrake_configure = _load_firedrake_configure()
-    all_archs = {
-        **firedrake_configure.OFFICIAL_ARCHS,
-        **firedrake_configure.RETIRED_ARCHS,
-        **firedrake_configure.COMMUNITY_ARCHS,
-    }
-    offenders = [
-        ", ".join(key_part.value for key_part in arch_key)
-        for arch_key, arch in all_archs.items()
-        if any("hdf5" in dir_ for dir_ in (*arch.include_dirs, *arch.library_dirs))
-    ]
-    if offenders:
-        raise InvalidConfigurationException(
-            "The following archs put an HDF5 path in include_dirs/library_dirs "
-            f"instead of a '--with-hdf5-*' selector: {offenders}"
-        )
-
-
-def _load_firedrake_configure():
-    """Import the 'firedrake-configure' script as a module.
-
-    The hyphen in the filename means it cannot be imported normally, so load it
-    directly from its path.
-
-    """
-    script_path = REPO_ROOT / "scripts" / "firedrake-configure"
-    loader = SourceFileLoader("firedrake_configure", str(script_path))
-    spec = importlib.util.spec_from_loader("firedrake_configure", loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
 
 
 def check_file_contains_pattern(

--- a/scripts/check-config
+++ b/scripts/check-config
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-"""Script that makes sure that hardcoded version numbers are consistent.
+"""Sanity checks for hardcoded configuration in the Firedrake repository.
 
-It looks at files in the Firedrake repository and makes sure that everywhere a
-version number is hardcoded that it matches. This allows for single-source-of-truth
-of hardcoded values (via CI).
+Run in CI to catch configuration that has drifted out of sync: version numbers
+duplicated across files, and arch definitions in ``firedrake-configure`` that
+link a system library without declaring its package or that point at HDF5 with
+raw ``-I``/``-L`` flags instead of a scoped ``--with-hdf5-*`` selector.
 
 """
 
@@ -95,8 +96,9 @@ def check_zlib_declared() -> None:
         ", ".join(key_part.value for key_part in arch_key)
         for arch_key, arch in all_archs.items()
         if "--with-zlib" in arch.extra_petsc_configure_options
-        and arch.system_packages is not None
-        and "zlib1g-dev" not in arch.system_packages
+        and (arch.system_packages is None
+             or arch.system_packages is not None
+             and "zlib1g-dev" not in arch.system_packages)
     ]
     if offenders:
         raise InvalidConfigurationException(

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -444,7 +444,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-hypre",
             "--with-metis",
@@ -463,13 +464,9 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/hypre",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -509,7 +506,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -527,12 +525,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -574,7 +568,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -593,13 +588,9 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/hypre",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -639,7 +630,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -657,12 +649,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -712,7 +700,8 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -735,13 +724,9 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
         extra_env_vars={
             "PATH": "/usr/local/cuda/bin:$PATH",
@@ -959,7 +944,8 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -976,13 +962,9 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -1023,7 +1005,8 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1039,13 +1022,9 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -1087,7 +1066,8 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1104,13 +1084,9 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -1151,7 +1127,8 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5",
+            "--with-hdf5-include=/usr/include/hdf5/openmpi",
+            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1167,13 +1144,9 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
-            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
-        ],
-        library_dirs=[
-            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 }

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -922,7 +922,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
-            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -944,8 +943,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5-include=/usr/include/hdf5/openmpi",
-            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
+            "--with-hdf5",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -962,9 +960,13 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
+            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
+        ],
+        library_dirs=[
+            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -982,7 +984,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
-            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -1005,8 +1006,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5-include=/usr/include/hdf5/openmpi",
-            "--with-hdf5-lib=[/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
+            "--with-hdf5",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1022,9 +1022,13 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
+            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
+        ],
+        library_dirs=[
+            "/usr/lib/x86_64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -1044,7 +1048,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
-            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -1066,8 +1069,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         extra_petsc_configure_options=[
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5-include=/usr/include/hdf5/openmpi",
-            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
+            "--with-hdf5",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1084,9 +1086,13 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
+            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
+        ],
+        library_dirs=[
+            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 
@@ -1104,7 +1110,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
-            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -1127,8 +1132,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "--with-scalar-type=complex",
             "--with-bison",
             "--with-fftw",
-            "--with-hdf5-include=/usr/include/hdf5/openmpi",
-            "--with-hdf5-lib=[/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5.so,/usr/lib/aarch64-linux-gnu/hdf5/openmpi/libhdf5_hl.so]",
+            "--with-hdf5",
             "--with-hwloc",
             "--with-metis",
             "--with-mumps",
@@ -1144,9 +1148,13 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
         cxxflags=["-O3", "-march=native", "-mtune=native"],
         fflags=["-O3", "-march=native", "-mtune=native"],
         include_dirs=[
+            "/usr/include/hdf5/openmpi",
             "/usr/include/scotch",
             "/usr/include/superlu",
             "/usr/include/superlu-dist",
+        ],
+        library_dirs=[
+            "/usr/lib/aarch64-linux-gnu/hdf5/openmpi",
         ],
     ),
 }

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -439,6 +439,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -502,6 +503,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -567,6 +569,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -630,6 +633,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -691,6 +695,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libpnetcdf-dev",
             "libptscotch-dev",
             "libscalapack-openmpi-dev",
+            "zlib1g-dev",
 
             # CUDA packages
             "cuda-compat-13-0",
@@ -949,6 +954,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -1011,6 +1017,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -1075,6 +1082,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -1137,6 +1145,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
+            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -421,6 +421,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -439,7 +440,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -483,6 +483,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -500,7 +501,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -545,6 +545,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -563,7 +564,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -607,6 +607,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -624,7 +625,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -669,6 +669,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -683,7 +684,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "libpnetcdf-dev",
             "libptscotch-dev",
             "libscalapack-openmpi-dev",
-            "zlib1g-dev",
 
             # CUDA packages
             "cuda-compat-13-0",
@@ -922,6 +922,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -939,7 +940,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -982,6 +982,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -999,7 +1000,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",
@@ -1044,6 +1044,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -1061,7 +1062,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-bison",
@@ -1104,6 +1104,7 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "pkg-config",
             "python3-dev",
             "python3-pip",
+            "zlib1g-dev",
 
             # PETSc external packages
             "libfftw3-dev",
@@ -1121,7 +1122,6 @@ RETIRED_ARCHS: Mapping[ArchKey, RetiredArch] = {
             "libsuitesparse-dev",
             "libsuperlu-dev",
             "libsuperlu-dist-dev",
-            "zlib1g-dev",
         ],
         extra_petsc_configure_options=[
             "--with-scalar-type=complex",


### PR DESCRIPTION
# Description

This PR introduces two fixes to the setup configuration: 
1. Improvement: firedrake-configure represents the system HDF5 location inconsistently — unscoped OPTFLAGS -I/-L on the apt path, instead of a scoped --with-hdf5-* selector
2. Issue: firedrake-configure requests --with-zlib on apt but omits zlib from --show-system-packages

### Improvement 1 - Scope the apt HDF5 location via `--with-hdf5-*` instead of `OPTFLAGS` `-I/-L`
On the apt paths (`--package-manager apt-x86_64` and `apt-aarch64`), `--show-petsc-configure-options` expresses HDF5's system location as raw `-I`/`-L` baked into `--COPTFLAGS/--CXXOPTFLAGS/--FOPTFLAGS`:
```
--COPTFLAGS='… -I/usr/include/hdf5/openmpi … -L/usr/lib/<triplet>/hdf5/openmpi'
```
rather than through a package-scoped selector. This is inconsistent with how `firedrake-configure` handles the same concept elsewhere:
- **ScaLAPACK** on the same apt path uses a scoped selector: `--with-scalapack-lib=-lscalapack-openmpi`.
- **HDF5** on the brew path uses a scoped selector: `--with-hdf5-dir=/opt/homebrew`.
So only the **apt + HDF5** combination puts the location outside the `--with-X*` selector pattern. Because the path isn't tied to the HDF5 selector, a consumer that switches to `--download-hdf5` can drop the `--with-hdf5` selector but not the stray `-L`, so PETSc links the system HDF5 while h5py loads the downloaded one, giving two HDF5s in one process (`H5Iget_type` runtime error).
Improvement: use `--with-hdf5-include` / `--with-hdf5-lib` on the apt archs so the location travels with the selector.

### Fix 2 - Declare `zlib1g-dev` on the apt path
On apt, configure asks for `--with-zlib` but `--show-system-packages` never lists `zlib1g-dev`. It works today only because another `-dev` package pulls zlib in transitively. For a build that installs exactly the declared set, zlib becomes an undeclared dependency (missing from the SBOM) and breaks on a minimal image.
Fix: add `zlib1g-dev` to the apt archs' system packages, matching what brew already does.


## Changes

- `scripts/firedrake-configure`: for every apt-based arch, replace `--with-hdf5` + the HDF5 entries in `include_dirs`/`library_dirs` with explicit `--with-hdf5-include` / `--with-hdf5-lib` options; add `zlib1g-dev` to the apt archs' system packages.