### PR TITLE
Mutable FunctionSpaces

### DIFF
--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -330,12 +330,7 @@ class WithGeometryBase:
         return MixedFunctionSpace((self, other))
 
     def __getattr__(self, name):
-        # Fetch attributes from the underlying topological FS.
         val = getattr(self.topological, name)
-        # Avoid caching on the WG FS if the topological FS is defined on a mutable mesh as we expect these FS to change
-        # and want to be able to detect staleness in such cases
-        if not getattr(self.topological.mesh(), "_topology_is_mutable", False):
-            setattr(self, name, val)
         return val
 
     def __dir__(self):
@@ -565,9 +560,6 @@ class FunctionSpace:
         self._ufl_function_space = ufl.FunctionSpace(mesh.ufl_mesh(), element, label=self._label)
         self._mesh = mesh
 
-        self._mesh_topology_version = self._mesh._topology_version
-        r"""The topology version of the mesh on which this :class:`FunctionSpace` is defined."""
-
         self.value_size = self._ufl_function_space.value_size
         r"""The number of scalar components of this :class:`FunctionSpace`."""
 
@@ -587,48 +579,39 @@ class FunctionSpace:
 
         self.set_shared_data()
 
-        self.dof_dset = self.make_dof_dset()
+    @cached_property_until(lambda self: self._mesh._topology_version)
+    def _shared_data(self):
+        return get_shared_data(self._mesh, self.ufl_element())
+
+    @cached_property_until(lambda self: self._mesh._topology_version)
+    def dof_dset(self):
         r"""A :class:`pyop2.types.dataset.DataSet` representing the function space
         degrees of freedom."""
-        self.node_set = self.dof_dset.set
-        r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
+        return self.make_dof_dset()
 
     @property
-    def _shared_data(self):
-        # I have deliberately NOT set @cached_property_until here, although the version check is the
-        # same pattern: on staleness this property must refresh the whole shared data object -- based on which
-        # several properties like which dof_dset, global_numbering etc. get re-assigned as a side effect --
-        # while the caching decorator can only memoise a single return value.
-        if self._mesh_topology_version != self._mesh._topology_version:
-            self.refresh_shared_data()  # owns the refresh
-        return self._shared_data_private
+    def global_numbering(self):
+        return self._shared_data.global_numbering
 
-    def refresh_shared_data(self):
-        if self._mesh_topology_version == self._mesh._topology_version:
-            return
-        sdata = get_shared_data(self._mesh, self.ufl_element())
-        self._shared_data_private = sdata
-        self._mesh_topology_version = self._mesh._topology_version
-        self.global_numbering = sdata.global_numbering
-        self.dof_dset = self.make_dof_dset()
-        self.node_set = self.dof_dset.set
+    @property
+    def node_set(self):
+        r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
+        return self.dof_dset.set
 
     def set_shared_data(self):
         element = self.ufl_element()
-        sdata = get_shared_data(self._mesh, element)
+        sdata = self._shared_data
         # Need to create finat element again as sdata does not
         # want to carry finat_element.
         self.finat_element = create_element(element)
         # Used for reconstruction of mixed/component spaces.
         # sdata carries real_tensorproduct.
-        self._shared_data_private = sdata
         self.real_tensorproduct = sdata.real_tensorproduct
         self.extruded = sdata.extruded
         self.offset = sdata.offset
         self.offset_quotient = sdata.offset_quotient
         self.cell_boundary_masks = sdata.cell_boundary_masks
         self.interior_facet_boundary_masks = sdata.interior_facet_boundary_masks
-        self.global_numbering = sdata.global_numbering
 
     def make_dof_dset(self):
         return op2.DataSet(self._shared_data.node_set, self.shape or 1,
@@ -660,7 +643,8 @@ class FunctionSpace:
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash((self.mesh(), self.dof_dset, self.ufl_element()))
+        # Given that dof_dset is now re-created when the FS mutates, we remove it from the hash
+        return hash((self.mesh(), self.ufl_element()))
 
     @cached_property
     def _ad_parent_space(self):
@@ -669,12 +653,7 @@ class FunctionSpace:
     @cached_property_until(lambda self: self._mesh._topology_version)
     def dm(self):
         r"""A PETSc DM describing the data layout for this FunctionSpace."""
-        try:
-            _ = self._shared_data  # trigger refresh
-        except AttributeError:
-            pass  # RealFunctionSpace has no shared data
         dm = self._dm()
-        dmhooks.set_function_space(dm, self)
         return dm
 
     def _dm(self):
@@ -690,13 +669,12 @@ class FunctionSpace:
 
     @cached_property_until(lambda self: self._mesh._topology_version)
     def _ises(self):
-        _ = self._shared_data  # trigger refresh
         return self.dof_dset.field_ises
 
     @cached_property_until(lambda self: self._mesh._topology_version)
     def cell_node_list(self):
         r"""A numpy array mapping mesh cells to function space nodes."""
-        self._shared_data.entity_node_lists[self.mesh().cell_set]
+        return self._shared_data.entity_node_lists[self.mesh().cell_set]
 
     @cached_property
     def topological(self):
@@ -766,7 +744,6 @@ class FunctionSpace:
         this process.  If the :class:`FunctionSpace` has :attr:`FunctionSpace.rank` 0, this
         is equal to the :attr:`FunctionSpace.dof_count`, otherwise the :attr:`FunctionSpace.dof_count` is
         :attr:`dim` times the :attr:`node_count`."""
-        _ = self._shared_data
         constrained_node_set = set()
         for sub_domain in self.boundary_set:
             constrained_node_set.update(self._shared_data.boundary_nodes(self, sub_domain))
@@ -1016,21 +993,19 @@ class RestrictedFunctionSpace(FunctionSpace):
         self.topological = self
         self.name = name or function_space.name
 
-    def set_shared_data(self):
-        sdata = get_shared_data(self._mesh, self.ufl_element(), self.boundary_set)
-        self._shared_data = sdata
-        self.node_set = sdata.node_set
-        r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
-        self.dof_dset = op2.DataSet(self.node_set, self.shape or 1,
-                                    name="%s_nodes_dset" % self.name,
-                                    apply_local_global_filter=sdata.extruded)
-        r"""A :class:`pyop2.types.dataset.DataSet` representing the function space
-        degrees of freedom."""
+    @cached_property_until(lambda self: self._mesh._topology_version)
+    def _shared_data(self):
+        return get_shared_data(self._mesh, self.ufl_element(), self.boundary_set)
 
-        # check not all degrees of freedom are constrained
-        unconstrained_dofs = self.dof_dset.size - self.dof_dset.constrained_size
-        if self.comm.allreduce(unconstrained_dofs) == 0:
-            raise ValueError("All degrees of freedom are constrained.")
+    @cached_property_until(lambda self: self._mesh._topology_version)
+    def dof_dset(self):
+        r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
+        self.dof_dset = op2.DataSet(self._shared_data.node_set, self.shape or 1,
+                                    name="%s_nodes_dset" % self.name,
+                                    apply_local_global_filter=self._shared_data.extruded)
+
+    def set_shared_data(self):
+        sdata = self._shared_data
         self.finat_element = create_element(self.ufl_element())
         # Used for reconstruction of mixed/component spaces.
         # sdata carries real_tensorproduct.
@@ -1040,7 +1015,10 @@ class RestrictedFunctionSpace(FunctionSpace):
         self.offset_quotient = sdata.offset_quotient
         self.cell_boundary_masks = sdata.cell_boundary_masks
         self.interior_facet_boundary_masks = sdata.interior_facet_boundary_masks
-        self.global_numbering = sdata.global_numbering
+        # check not all degrees of freedom are constrained
+        unconstrained_dofs = self.dof_dset.size - self.dof_dset.constrained_size
+        if self.comm.allreduce(unconstrained_dofs) == 0:
+            raise ValueError("All degrees of freedom are constrained.")
 
     def __eq__(self, other):
         if not isinstance(other, RestrictedFunctionSpace):
@@ -1053,7 +1031,7 @@ class RestrictedFunctionSpace(FunctionSpace):
             str(self.function_space), self.name, self.boundary_set)
 
     def __hash__(self):
-        return hash((self.mesh(), self.dof_dset, self.ufl_element(),
+        return hash((self.mesh(), self.ufl_element(),
                      self.boundary_set))
 
     def local_to_global_map(self, bcs, lgmap=None, mat_type=None):
@@ -1455,6 +1433,10 @@ class RealFunctionSpace(FunctionSpace):
 
     finat_element = None
     global_numbering = None
+
+    @property
+    def _shared_data(self):
+        raise AttributeError("RealFunctionSpace has no shared data")
 
     def __eq__(self, other):
         if not isinstance(other, RealFunctionSpace):

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -19,9 +19,10 @@ from pyop2 import op2
 from pyop2.utils import as_tuple
 
 from firedrake import dmhooks
-from firedrake.mesh import MeshGeometry, MeshSequenceTopology, MeshSequenceGeometry, VertexOnlyMeshTopology
+from firedrake.mesh import MeshGeometry, MeshSequenceTopology, MeshSequenceGeometry
 from firedrake.functionspacedata import get_shared_data, create_element
 from firedrake.petsc import PETSc
+from firedrake.utils import cached_property_until
 from functools import cached_property
 
 
@@ -186,28 +187,11 @@ class WithGeometryBase:
         data = self.subspaces if mixed else self._components
         return data[i]
 
-    # @cached_property
-    # def dm(self):
-    #     dm = self._dm()
-    #     dmhooks.set_function_space(dm, self)
-    #     return dm
-    
     @property
     def dm(self):
-        current_version = getattr(self.topological.mesh(), "_topology_version", None)
-        try:
-            if self._wg_dm_version == current_version:
-                # always returns for meshes that are not VOMs
-                return self._wg_dm_cache
-        except AttributeError:
-            pass
-        # For VOMs: trigger a rebuild when the versions don't match
         dm = self.topological.dm
         dmhooks.set_function_space(dm, self)
-        self._wg_dm_version = current_version
-        self._wg_dm_cache = dm
         return dm
-
 
     @property
     def num_work_functions(self):
@@ -346,11 +330,12 @@ class WithGeometryBase:
         return MixedFunctionSpace((self, other))
 
     def __getattr__(self, name):
-        # Always fetch attributes from the topological FS
+        # Fetch attributes from the underlying topological FS.
         val = getattr(self.topological, name)
-        # Avoid caching if the topological FS is a VOM as we expect it to be changing
-        if not hasattr(self.topological, "_vom_topology_version"):
-            setattr(self, name, val)
+        # Avoid caching on the WG FS if the topological FS is defined on a mutable mesh as we expect these FS to change
+        # and want to be able to detect staleness in such cases
+        if not getattr(self.topological.mesh(), "_topology_is_mutable", False):
+            setattr(self, name, val)            
         return val
 
     def __dir__(self):
@@ -580,9 +565,8 @@ class FunctionSpace:
         self._ufl_function_space = ufl.FunctionSpace(mesh.ufl_mesh(), element, label=self._label)
         self._mesh = mesh
 
-        if isinstance(self._mesh, VertexOnlyMeshTopology):
-            # Store the topology version of the VOM the FS was built against
-            self._vom_topology_version = self._mesh._topology_version
+        self._mesh_topology_version = self._mesh._topology_version
+        r"""The topology version of the mesh on which this :class:`FunctionSpace` is defined."""
 
         self.value_size = self._ufl_function_space.value_size
         r"""The number of scalar components of this :class:`FunctionSpace`."""
@@ -602,7 +586,6 @@ class FunctionSpace:
         self.comm = mesh.comm
 
         self.set_shared_data()
-        r"""The topology version of the mesh on which the function space is defined."""
 
         self.dof_dset = self.make_dof_dset()
         r"""A :class:`pyop2.types.dataset.DataSet` representing the function space
@@ -613,25 +596,23 @@ class FunctionSpace:
 
     @property
     def _shared_data(self):
-        if hasattr(self, "_vom_topology_version") \
-            and self._vom_topology_version != self._mesh._topology_version:
-            self.refresh_shared_data()
-        return self.__shared_data
-
+        # I have deliberately NOT set @cached_property_until here, although the version check is the
+        # same pattern: on staleness this property must refresh the whole shared data object -- based on which
+        # several properties like which dof_dset, global_numbering etc. get re-assigned as a side effect --
+        # while the caching decorator can only memoise a single return value. 
+        if self._mesh_topology_version != self._mesh._topology_version:
+            self.refresh_shared_data() # owns the refresh
+        return self._shared_data_private
 
     def refresh_shared_data(self):
-        if getattr(self, "_vom_topology_version", None) == self._mesh._topology_version:
+        if self._mesh_topology_version == self._mesh._topology_version:
             return
         sdata = get_shared_data(self._mesh, self.ufl_element())
-        self.__shared_data = sdata
-        self._vom_topology_version = self._mesh._topology_version
+        self._shared_data_private = sdata
+        self._mesh_topology_version = self._mesh._topology_version
         self.global_numbering = sdata.global_numbering
         self.dof_dset = self.make_dof_dset()
         self.node_set = self.dof_dset.set
-        for name in ("_dm_cache", "_cell_node_list_cache", "_ises_cache"):
-            if name in self.__dict__:
-                del self.__dict__[name]
-
 
     def set_shared_data(self):
         element = self.ufl_element()
@@ -641,7 +622,7 @@ class FunctionSpace:
         self.finat_element = create_element(element)
         # Used for reconstruction of mixed/component spaces.
         # sdata carries real_tensorproduct.
-        self.__shared_data = sdata
+        self._shared_data_private = sdata
         self.real_tensorproduct = sdata.real_tensorproduct
         self.extruded = sdata.extruded
         self.offset = sdata.offset
@@ -649,6 +630,7 @@ class FunctionSpace:
         self.cell_boundary_masks = sdata.cell_boundary_masks
         self.interior_facet_boundary_masks = sdata.interior_facet_boundary_masks
         self.global_numbering = sdata.global_numbering
+
 
     def make_dof_dset(self):
         return op2.DataSet(self._shared_data.node_set, self.shape or 1,
@@ -686,29 +668,16 @@ class FunctionSpace:
     def _ad_parent_space(self):
         return self.parent
 
-    # @cached_property
-    @property
+    @cached_property_until(lambda self: self._mesh._topology_version)
     def dm(self):
         r"""A PETSc DM describing the data layout for this FunctionSpace."""
-        # dm = self._dm()
-        # dmhooks.set_function_space(dm, self)
-        # return dm
-
-        # Trigger version check every time this property is accessed which may delete 
-        # the cache and force a rebuild with updated shared data (provided one exists)
         try:
-            _ = self._shared_data
-        except AttributeError:
-            # Some FS such as RealFunctionSpace don't have shared data
-            pass
-        try:
-            return self._dm_cache
-        except AttributeError:
-            dm = self._dm()
-            dmhooks.set_function_space(dm, self)
-            self._dm_cache = dm
-            return self._dm_cache
-        
+            _ = self._shared_data # trigger refresh
+        except AttributeError: 
+            pass # RealFunctionSpace has no shared data
+        dm = self._dm()
+        dmhooks.set_function_space(dm, self)
+        return dm
 
     def _dm(self):
         from firedrake.mg.utils import get_level
@@ -721,28 +690,15 @@ class FunctionSpace:
         dmhooks.set_function_space(dm, self)
         return dm
 
-    # @cached_property
-    @property
+    @cached_property_until(lambda self: self._mesh._topology_version)
     def _ises(self):
-        # return self.dof_dset.field_ises
-        _ = self._shared_data # trigger version check which may delete the cache
-        try:
-            return self._ises_cache
-        except AttributeError:
-            self._ises_cache = self.dof_dset.field_ises
-            return self._ises_cache
+        _ = self._shared_data # trigger refresh
+        return self.dof_dset.field_ises
 
-    # @cached_property
-    @property
+    @cached_property_until(lambda self: self._mesh._topology_version)
     def cell_node_list(self):
         r"""A numpy array mapping mesh cells to function space nodes."""
-        # return self._shared_data.entity_node_lists[self.mesh().cell_set]
-        _ = self._shared_data # trigger version check which may delete the cache
-        try:
-            return self._cell_node_list_cache
-        except AttributeError:
-            self._cell_node_list_cache = self._shared_data.entity_node_lists[self.mesh().cell_set]
-            return self._cell_node_list_cache
+        self._shared_data.entity_node_lists[self.mesh().cell_set]
 
     @cached_property
     def topological(self):
@@ -805,23 +761,21 @@ class FunctionSpace:
         :class:`.FunctionSpace` and other"""
         from firedrake.functionspace import MixedFunctionSpace
         return MixedFunctionSpace((self, other))
+    
 
-    # @cached_property
-    # No gains from caching so recompute
-    @property
+    @cached_property_until(lambda self: self._mesh._topology_version)
     def node_count(self):
         r"""The number of nodes (includes halo nodes) of this function space on
         this process.  If the :class:`FunctionSpace` has :attr:`FunctionSpace.rank` 0, this
         is equal to the :attr:`FunctionSpace.dof_count`, otherwise the :attr:`FunctionSpace.dof_count` is
         :attr:`dim` times the :attr:`node_count`."""
-        _ = self._shared_data # trigger version check which may delete the cache
+        _ = self._shared_data
         constrained_node_set = set()
         for sub_domain in self.boundary_set:
             constrained_node_set.update(self._shared_data.boundary_nodes(self, sub_domain))
         return self.node_set.total_size - len(constrained_node_set)
 
-    # @cached_property
-    # No gains from caching so recompute
+
     @property
     def dof_count(self):
         r"""The number of degrees of freedom (includes halo dofs) of this

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -19,7 +19,7 @@ from pyop2 import op2
 from pyop2.utils import as_tuple
 
 from firedrake import dmhooks
-from firedrake.mesh import MeshGeometry, MeshSequenceTopology, MeshSequenceGeometry
+from firedrake.mesh import MeshGeometry, MeshSequenceTopology, MeshSequenceGeometry, VertexOnlyMeshTopology
 from firedrake.functionspacedata import get_shared_data, create_element
 from firedrake.petsc import PETSc
 from functools import cached_property
@@ -101,6 +101,7 @@ class WithGeometryBase:
                 raise TypeError(f"Can only use MixedFunctionSpace with MeshSequenceGeometry: got {type(mesh)}")
 
         function_space = function_space.topological
+
         assert mesh.topology == function_space.mesh()
         assert mesh.topology != mesh
 
@@ -185,11 +186,28 @@ class WithGeometryBase:
         data = self.subspaces if mixed else self._components
         return data[i]
 
-    @cached_property
+    # @cached_property
+    # def dm(self):
+    #     dm = self._dm()
+    #     dmhooks.set_function_space(dm, self)
+    #     return dm
+    
+    @property
     def dm(self):
-        dm = self._dm()
+        current_version = getattr(self.topological.mesh(), "_topology_version", None)
+        try:
+            if self._wg_dm_version == current_version:
+                # always returns for meshes that are not VOMs
+                return self._wg_dm_cache
+        except AttributeError:
+            pass
+        # For VOMs: trigger a rebuild when the versions don't match
+        dm = self.topological.dm
         dmhooks.set_function_space(dm, self)
+        self._wg_dm_version = current_version
+        self._wg_dm_cache = dm
         return dm
+
 
     @property
     def num_work_functions(self):
@@ -328,8 +346,11 @@ class WithGeometryBase:
         return MixedFunctionSpace((self, other))
 
     def __getattr__(self, name):
+        # Always fetch attributes from the topological FS
         val = getattr(self.topological, name)
-        setattr(self, name, val)
+        # Avoid caching if the topological FS is a VOM as we expect it to be changing
+        if not hasattr(self.topological, "_vom_topology_version"):
+            setattr(self, name, val)
         return val
 
     def __dir__(self):
@@ -559,6 +580,10 @@ class FunctionSpace:
         self._ufl_function_space = ufl.FunctionSpace(mesh.ufl_mesh(), element, label=self._label)
         self._mesh = mesh
 
+        if isinstance(self._mesh, VertexOnlyMeshTopology):
+            # Store the topology version of the VOM the FS was built against
+            self._vom_topology_version = self._mesh._topology_version
+
         self.value_size = self._ufl_function_space.value_size
         r"""The number of scalar components of this :class:`FunctionSpace`."""
 
@@ -577,11 +602,36 @@ class FunctionSpace:
         self.comm = mesh.comm
 
         self.set_shared_data()
+        r"""The topology version of the mesh on which the function space is defined."""
+
         self.dof_dset = self.make_dof_dset()
         r"""A :class:`pyop2.types.dataset.DataSet` representing the function space
         degrees of freedom."""
         self.node_set = self.dof_dset.set
         r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
+
+
+    @property
+    def _shared_data(self):
+        if hasattr(self, "_vom_topology_version") \
+            and self._vom_topology_version != self._mesh._topology_version:
+            self.refresh_shared_data()
+        return self.__shared_data
+
+
+    def refresh_shared_data(self):
+        if getattr(self, "_vom_topology_version", None) == self._mesh._topology_version:
+            return
+        sdata = get_shared_data(self._mesh, self.ufl_element())
+        self.__shared_data = sdata
+        self._vom_topology_version = self._mesh._topology_version
+        self.global_numbering = sdata.global_numbering
+        self.dof_dset = self.make_dof_dset()
+        self.node_set = self.dof_dset.set
+        for name in ("_dm_cache", "_cell_node_list_cache", "_ises_cache"):
+            if name in self.__dict__:
+                del self.__dict__[name]
+
 
     def set_shared_data(self):
         element = self.ufl_element()
@@ -591,7 +641,7 @@ class FunctionSpace:
         self.finat_element = create_element(element)
         # Used for reconstruction of mixed/component spaces.
         # sdata carries real_tensorproduct.
-        self._shared_data = sdata
+        self.__shared_data = sdata
         self.real_tensorproduct = sdata.real_tensorproduct
         self.extruded = sdata.extruded
         self.offset = sdata.offset
@@ -636,12 +686,29 @@ class FunctionSpace:
     def _ad_parent_space(self):
         return self.parent
 
-    @cached_property
+    # @cached_property
+    @property
     def dm(self):
         r"""A PETSc DM describing the data layout for this FunctionSpace."""
-        dm = self._dm()
-        dmhooks.set_function_space(dm, self)
-        return dm
+        # dm = self._dm()
+        # dmhooks.set_function_space(dm, self)
+        # return dm
+
+        # Trigger version check every time this property is accessed which may delete 
+        # the cache and force a rebuild with updated shared data (provided one exists)
+        try:
+            _ = self._shared_data
+        except AttributeError:
+            # Some FS such as RealFunctionSpace don't have shared data
+            pass
+        try:
+            return self._dm_cache
+        except AttributeError:
+            dm = self._dm()
+            dmhooks.set_function_space(dm, self)
+            self._dm_cache = dm
+            return self._dm_cache
+        
 
     def _dm(self):
         from firedrake.mg.utils import get_level
@@ -654,14 +721,28 @@ class FunctionSpace:
         dmhooks.set_function_space(dm, self)
         return dm
 
-    @cached_property
+    # @cached_property
+    @property
     def _ises(self):
-        return self.dof_dset.field_ises
+        # return self.dof_dset.field_ises
+        _ = self._shared_data # trigger version check which may delete the cache
+        try:
+            return self._ises_cache
+        except AttributeError:
+            self._ises_cache = self.dof_dset.field_ises
+            return self._ises_cache
 
-    @cached_property
+    # @cached_property
+    @property
     def cell_node_list(self):
         r"""A numpy array mapping mesh cells to function space nodes."""
-        return self._shared_data.entity_node_lists[self.mesh().cell_set]
+        # return self._shared_data.entity_node_lists[self.mesh().cell_set]
+        _ = self._shared_data # trigger version check which may delete the cache
+        try:
+            return self._cell_node_list_cache
+        except AttributeError:
+            self._cell_node_list_cache = self._shared_data.entity_node_lists[self.mesh().cell_set]
+            return self._cell_node_list_cache
 
     @cached_property
     def topological(self):
@@ -725,18 +806,23 @@ class FunctionSpace:
         from firedrake.functionspace import MixedFunctionSpace
         return MixedFunctionSpace((self, other))
 
-    @cached_property
+    # @cached_property
+    # No gains from caching so recompute
+    @property
     def node_count(self):
         r"""The number of nodes (includes halo nodes) of this function space on
         this process.  If the :class:`FunctionSpace` has :attr:`FunctionSpace.rank` 0, this
         is equal to the :attr:`FunctionSpace.dof_count`, otherwise the :attr:`FunctionSpace.dof_count` is
         :attr:`dim` times the :attr:`node_count`."""
+        _ = self._shared_data # trigger version check which may delete the cache
         constrained_node_set = set()
         for sub_domain in self.boundary_set:
             constrained_node_set.update(self._shared_data.boundary_nodes(self, sub_domain))
         return self.node_set.total_size - len(constrained_node_set)
 
-    @cached_property
+    # @cached_property
+    # No gains from caching so recompute
+    @property
     def dof_count(self):
         r"""The number of degrees of freedom (includes halo dofs) of this
         function space on this process. Cf. :attr:`FunctionSpace.node_count` ."""

--- a/firedrake/functionspaceimpl.py
+++ b/firedrake/functionspaceimpl.py
@@ -335,7 +335,7 @@ class WithGeometryBase:
         # Avoid caching on the WG FS if the topological FS is defined on a mutable mesh as we expect these FS to change
         # and want to be able to detect staleness in such cases
         if not getattr(self.topological.mesh(), "_topology_is_mutable", False):
-            setattr(self, name, val)            
+            setattr(self, name, val)
         return val
 
     def __dir__(self):
@@ -593,15 +593,14 @@ class FunctionSpace:
         self.node_set = self.dof_dset.set
         r"""A :class:`pyop2.types.set.Set` representing the function space nodes."""
 
-
     @property
     def _shared_data(self):
         # I have deliberately NOT set @cached_property_until here, although the version check is the
         # same pattern: on staleness this property must refresh the whole shared data object -- based on which
         # several properties like which dof_dset, global_numbering etc. get re-assigned as a side effect --
-        # while the caching decorator can only memoise a single return value. 
+        # while the caching decorator can only memoise a single return value.
         if self._mesh_topology_version != self._mesh._topology_version:
-            self.refresh_shared_data() # owns the refresh
+            self.refresh_shared_data()  # owns the refresh
         return self._shared_data_private
 
     def refresh_shared_data(self):
@@ -630,7 +629,6 @@ class FunctionSpace:
         self.cell_boundary_masks = sdata.cell_boundary_masks
         self.interior_facet_boundary_masks = sdata.interior_facet_boundary_masks
         self.global_numbering = sdata.global_numbering
-
 
     def make_dof_dset(self):
         return op2.DataSet(self._shared_data.node_set, self.shape or 1,
@@ -672,9 +670,9 @@ class FunctionSpace:
     def dm(self):
         r"""A PETSc DM describing the data layout for this FunctionSpace."""
         try:
-            _ = self._shared_data # trigger refresh
-        except AttributeError: 
-            pass # RealFunctionSpace has no shared data
+            _ = self._shared_data  # trigger refresh
+        except AttributeError:
+            pass  # RealFunctionSpace has no shared data
         dm = self._dm()
         dmhooks.set_function_space(dm, self)
         return dm
@@ -692,7 +690,7 @@ class FunctionSpace:
 
     @cached_property_until(lambda self: self._mesh._topology_version)
     def _ises(self):
-        _ = self._shared_data # trigger refresh
+        _ = self._shared_data  # trigger refresh
         return self.dof_dset.field_ises
 
     @cached_property_until(lambda self: self._mesh._topology_version)
@@ -761,7 +759,6 @@ class FunctionSpace:
         :class:`.FunctionSpace` and other"""
         from firedrake.functionspace import MixedFunctionSpace
         return MixedFunctionSpace((self, other))
-    
 
     @cached_property_until(lambda self: self._mesh._topology_version)
     def node_count(self):
@@ -774,7 +771,6 @@ class FunctionSpace:
         for sub_domain in self.boundary_set:
             constrained_node_set.update(self._shared_data.boundary_nodes(self, sub_domain))
         return self.node_set.total_size - len(constrained_node_set)
-
 
     @property
     def dof_count(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2053,7 +2053,15 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
                                          "overlap_type": (DistributedMeshOverlapType.NONE, 0)}
         self.input_ordering_swarm = input_ordering_swarm
         self._parent_mesh = parentmesh
+
+        self._topology_version = 0
+        self._topology_step_sfs = {}
+
         super().__init__(swarm, name, reorder, None, perm_is, distribution_name, permutation_name, parentmesh.comm)
+
+    # @property
+    # def topology_version(self):
+    #     return self._topology_version
 
     def _distribute(self):
         pass

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -501,6 +501,9 @@ def plex_from_cell_list(dim, cells, coords, comm, name=None):
 class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
+    
+    _topology_is_mutable = False
+    """Whether this topology may change in place after construction."""
 
     def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None):
         """Initialise a mesh topology.
@@ -604,6 +607,11 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         # To set, do e.g.
         # target_mesh._parallel_compatible = {weakref.ref(source_mesh)}
         self._parallel_compatible = None
+
+        self._topology_version = 0
+        if self._topology_is_mutable:
+            self._topology_step_sfs = {}
+
 
     layers = None
     """No layers on unstructured mesh"""
@@ -2017,6 +2025,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
     Representation of a vertex-only mesh topology immersed within
     another mesh.
     """
+    _topology_is_mutable = True
 
     @PETSc.Log.EventDecorator()
     def __init__(self, swarm, parentmesh, name, reorder, input_ordering_swarm=None, perm_is=None, distribution_name=None, permutation_name=None):
@@ -2054,14 +2063,7 @@ class VertexOnlyMeshTopology(AbstractMeshTopology):
         self.input_ordering_swarm = input_ordering_swarm
         self._parent_mesh = parentmesh
 
-        self._topology_version = 0
-        self._topology_step_sfs = {}
-
         super().__init__(swarm, name, reorder, None, perm_is, distribution_name, permutation_name, parentmesh.comm)
-
-    # @property
-    # def topology_version(self):
-    #     return self._topology_version
 
     def _distribute(self):
         pass

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1850,6 +1850,9 @@ class ExtrudedMeshTopology(MeshTopology):
         # submesh
         self.submesh_parent = None
 
+        # NOTE: Once super().__init__ is implemented, the following line can be removed
+        self._topology_version = 0
+
     @cached_property
     def _ufl_cell(self):
         return ufl.TensorProductCell(self._base_mesh.ufl_cell(), ufl.interval)

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -501,7 +501,7 @@ def plex_from_cell_list(dim, cells, coords, comm, name=None):
 class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
-    
+
     _topology_is_mutable = False
     """Whether this topology may change in place after construction."""
 
@@ -611,7 +611,6 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         self._topology_version = 0
         if self._topology_is_mutable:
             self._topology_step_sfs = {}
-
 
     layers = None
     """No layers on unstructured mesh"""

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -502,9 +502,6 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
 
-    _topology_is_mutable = False
-    """Whether this topology may change in place after construction."""
-
     def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None):
         """Initialise a mesh topology.
 
@@ -637,6 +634,11 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     def _renumber_entities(self, reorder):
         """Renumber entities."""
         pass
+
+    @property
+    @abc.abstractmethod
+    def _topology_is_mutable(self):
+        """Boolean flag indicating whether this mesh's topology may change after construction."""
 
     @property
     def comm(self):
@@ -1077,6 +1079,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
 
 class MeshTopology(AbstractMeshTopology):
     """A representation of mesh topology implemented on a PETSc DMPlex."""
+    _topology_is_mutable = False
 
     @PETSc.Log.EventDecorator("CreateMesh")
     def __init__(


### PR DESCRIPTION
This PR describes my first attempt at making `FunctionSpace`s mutable. Note: this currently only works for FS defined on VOMs (the generalisation to arbitrary meshes is TBD). 

The main idea is that FS need to detect somehow that the VOM, against which they were built, has changed (topologically). We want this is to be done lazily. This is because there are usually a large number of FS laying around and there is no straightforward way of keeping track through all of them: from the mesh's perspective, `FunctionSpace`s with the same element, DoF layout etc. share the same `_shared_data` object cached on the mesh - a`FunctionSpaceData` object carrying all topology-derived numerical data.

Using this cached attribute allows us to invalidate the FS at the mesh level. At the same time, we want each FS to detect this invalidation and to refresh itself upon on its own **first** use after the VOM has mutated. Mutating the VOM does the following:

1. invalidates all the topological properties relating to FS defined on it: `topology._shared_data.clear()`
2. bumps the version number stored on the mesh topology object: `topology._topology_version += 1`

The lazy FS rebuild is implemented here as follows:

1. first, stash the mesh topology version on the FS object
2. add a version check at the upstream source i.e., `_shared_data` which, upon detecting a topology version mismatch, causes all the attributes to be recomputed (`refresh_shared_data` calls `get_shared_data` which returns a new `FunctionSpaceData` object with the updated data)
3. re-set all the downstream topology-depend properties using the updated `_shared_data`
4. sets the FS topology version tracker to the current VOM topology version

To trigger the indirect rebuild, cached properties  such as `cell_node_list` (derived from `_shared_data`) were turned into version-gated properties (which execute steps 2-4 upon a version mismatch). This required changing these properties from being `@cached_property` to being plain `@property` with their own caching mechanism. All other, non-topology-related properties were kept as `@cached_property`. 

Final note: The version gating mechanism described above has only been implemented for `FunctionSpace` and has not been ported yet into `MixedFunctionSpace`.