### PR TITLE
Use CachedSolverBlock for project (-> #4638)

### DIFF
--- a/firedrake/adjoint_utils/__init__.py
+++ b/firedrake/adjoint_utils/__init__.py
@@ -9,7 +9,7 @@ from firedrake.adjoint_utils.function import (  # noqa F401
     FunctionMixin, CofunctionMixin
 )
 from firedrake.adjoint_utils.assembly import annotate_assemble  # noqa F401
-from firedrake.adjoint_utils.projection import annotate_project  # noqa F401
+from firedrake.adjoint_utils.projection import annotate_super_project  # noqa F401
 from firedrake.adjoint_utils.variational_solver import (  # noqa F401
     NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin
 )

--- a/firedrake/adjoint_utils/__init__.py
+++ b/firedrake/adjoint_utils/__init__.py
@@ -9,6 +9,7 @@ from firedrake.adjoint_utils.function import (  # noqa F401
     FunctionMixin, CofunctionMixin
 )
 from firedrake.adjoint_utils.assembly import annotate_assemble  # noqa F401
+from firedrake.adjoint_utils.projection import annotate_project  # noqa F401
 from firedrake.adjoint_utils.projection import annotate_super_project  # noqa F401
 from firedrake.adjoint_utils.variational_solver import (  # noqa F401
     NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin

--- a/firedrake/adjoint_utils/function.py
+++ b/firedrake/adjoint_utils/function.py
@@ -1,10 +1,9 @@
 from functools import wraps
 from pyop2.mpi import temp_internal_comm
 import ufl
-from ufl.domain import extract_unique_domain
 from pyadjoint.overloaded_type import create_overloaded_object, FloatingType
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
-from firedrake.adjoint_utils.blocks import FunctionAssignBlock, ProjectBlock, SubfunctionBlock, FunctionMergeBlock, SupermeshProjectBlock
+from firedrake.adjoint_utils.blocks import FunctionAssignBlock, SubfunctionBlock, FunctionMergeBlock
 import firedrake
 from .checkpointing import disk_checkpointing, CheckpointFunction, \
     CheckpointBase, checkpoint_init_data, DelegatedFunctionCheckpoint
@@ -25,32 +24,6 @@ class FunctionMixin(FloatingType):
                                   _ad_outputs=kwargs.pop("_ad_outputs", None),
                                   ad_block_tag=kwargs.pop("ad_block_tag", None), **kwargs)
             init(self, *args, **kwargs)
-        return wrapper
-
-    @staticmethod
-    def _ad_annotate_project(project):
-        @wraps(project)
-        def wrapper(self, b, *args, **kwargs):
-            ad_block_tag = kwargs.pop("ad_block_tag", None)
-            annotate = annotate_tape(kwargs)
-
-            if annotate:
-                bcs = kwargs.get("bcs", [])
-                if isinstance(b, firedrake.Function) and extract_unique_domain(b) != self.function_space().mesh():
-                    block = SupermeshProjectBlock(b, self.function_space(), self, bcs, ad_block_tag=ad_block_tag)
-                else:
-                    block = ProjectBlock(b, self.function_space(), self, bcs, ad_block_tag=ad_block_tag)
-
-                tape = get_working_tape()
-                tape.add_block(block)
-
-            with stop_annotating():
-                output = project(self, b, *args, **kwargs)
-
-            if annotate:
-                block.add_output(output.create_block_variable())
-
-            return output
         return wrapper
 
     @staticmethod

--- a/firedrake/adjoint_utils/projection.py
+++ b/firedrake/adjoint_utils/projection.py
@@ -12,7 +12,6 @@ def annotate_super_project(project):
 
     @wraps(project)
     def wrapper(self, **kwargs):
-        ad_block_tag = kwargs.pop("ad_block_tag", None)
         annotate = annotate_tape(kwargs)
         V = self.target.function_space()
         if annotate:
@@ -20,7 +19,7 @@ def annotate_super_project(project):
             sb_kwargs = ProjectBlock.pop_kwargs(kwargs)
             if self._target_is_function:
                 # block should be created before project because output might also be an input that needs checkpointing
-                block = SupermeshProjectBlock(self.source, V, self.target, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
+                block = SupermeshProjectBlock(self.source, V, self.target, bcs, ad_block_tag=self.ad_block_tag, **sb_kwargs)
 
         with stop_annotating():
             output = project(self, **kwargs)
@@ -28,7 +27,7 @@ def annotate_super_project(project):
         if annotate:
             tape = get_working_tape()
             if not self._target_is_function:
-                block = SupermeshProjectBlock(self.source, V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
+                block = SupermeshProjectBlock(self.source, V, output, bcs, ad_block_tag=self.ad_block_tag, **sb_kwargs)
             tape.add_block(block)
             block.add_output(output.create_block_variable())
 

--- a/firedrake/adjoint_utils/projection.py
+++ b/firedrake/adjoint_utils/projection.py
@@ -1,45 +1,34 @@
 from functools import wraps
 from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from firedrake.adjoint_utils.blocks import ProjectBlock, SupermeshProjectBlock
-from firedrake import function
-from ufl.domain import extract_unique_domain
 
 
-def annotate_project(project):
+def annotate_super_project(project):
+    """
+    A wrapper for SupermeshProjector.project(), only handles
+    the code path that leads to the creation of a
+    SupermeshProjectBlock.
+    """
+
     @wraps(project)
-    def wrapper(*args, **kwargs):
-        """The project call performs an equation solve, and so it too must be annotated so that the
-        adjoint and tangent linear models may be constructed automatically by pyadjoint.
-
-        To disable the annotation of this function, just pass :py:data:`annotate=False`. This is useful in
-        cases where the solve is known to be irrelevant or diagnostic for the purposes of the adjoint
-        computation (such as projecting fields to other function spaces for the purposes of
-        visualisation)."""
-
+    def wrapper(self, **kwargs):
         ad_block_tag = kwargs.pop("ad_block_tag", None)
         annotate = annotate_tape(kwargs)
+        V = self.target.function_space()
         if annotate:
             bcs = kwargs.get("bcs", [])
             sb_kwargs = ProjectBlock.pop_kwargs(kwargs)
-            if isinstance(args[1], function.Function):
+            if self._target_is_function:
                 # block should be created before project because output might also be an input that needs checkpointing
-                output = args[1]
-                V = output.function_space()
-                if isinstance(args[0], function.Function) and extract_unique_domain(args[0]) != V.mesh():
-                    block = SupermeshProjectBlock(args[0], V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
-                else:
-                    block = ProjectBlock(args[0], V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
+                block = SupermeshProjectBlock(self.source, V, self.target, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
 
         with stop_annotating():
-            output = project(*args, **kwargs)
+            output = project(self, **kwargs)
 
         if annotate:
             tape = get_working_tape()
-            if not isinstance(args[1], function.Function):
-                if isinstance(args[0], function.Function) and extract_unique_domain(args[0]) != args[1].mesh():
-                    block = SupermeshProjectBlock(args[0], args[1], output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
-                else:
-                    block = ProjectBlock(args[0], args[1], output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
+            if not self._target_is_function:
+                block = SupermeshProjectBlock(self.source, V, output, bcs, ad_block_tag=ad_block_tag, **sb_kwargs)
             tape.add_block(block)
             block.add_output(output.create_block_variable())
 

--- a/firedrake/adjoint_utils/projection.py
+++ b/firedrake/adjoint_utils/projection.py
@@ -3,6 +3,25 @@ from pyadjoint.tape import annotate_tape, stop_annotating, get_working_tape
 from firedrake.adjoint_utils.blocks import ProjectBlock, SupermeshProjectBlock
 
 
+def annotate_project(project):
+    """
+    A wrapper for the bare project() call to handle
+    switching annotation on/off without dispatching
+    into all the types of projectors.
+    """
+
+    @wraps(project)
+    def wrapper(*args, **kwargs):
+        annotate = annotate_tape(kwargs)
+        if annotate:
+            return project(*args, **kwargs)
+
+        with stop_annotating():
+            return project(*args, **kwargs)
+
+    return wrapper
+
+
 def annotate_super_project(project):
     """
     A wrapper for SupermeshProjector.project(), only handles

--- a/firedrake/function.py
+++ b/firedrake/function.py
@@ -339,7 +339,6 @@ class Function(ufl.Coefficient, FunctionMixin):
         return data[i]
 
     @PETSc.Log.EventDecorator()
-    @FunctionMixin._ad_annotate_project
     def project(self, b, *args, **kwargs):
         r"""Project ``b`` onto ``self``. ``b`` must be a :class:`Function` or a
         UFL expression.

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -83,8 +83,6 @@ def project(
         Quadrature degree to use when approximating integrands.
     name
         The name of the resulting :class:`.Function`.
-    ad_block_tag
-        String for tagging the resulting block on the Pyadjoint tape.
 
     Returns
     -------
@@ -110,19 +108,22 @@ def project(
         solver_parameters=solver_parameters,
         form_compiler_parameters=form_compiler_parameters,
         use_slate_for_inverse=use_slate_for_inverse,
-        quadrature_degree=quadrature_degree
+        quadrature_degree=quadrature_degree,
+        ad_block_tag=ad_block_tag,
     ).project()
     val.rename(name)
     return val
 
 
 class Assigner(object):
-    def __init__(self, source, target):
+    def __init__(self, source, target, **kwargs):
         self.source = source
         self.target = target
 
+        self._kwargs = kwargs
+
     def project(self):
-        self.target.assign(self.source)
+        self.target.assign(self.source, **self._kwargs)
         return self.target
 
 
@@ -245,6 +246,7 @@ class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
     """
 
     def __init__(self, *args, **kwargs):
+        ad_block_tag = kwargs.pop("ad_block_tag", None)
         super().__init__(*args, **kwargs)
 
         V = self.target.function_space()
@@ -257,7 +259,7 @@ class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
         L = firedrake.inner(self.source, w) * dx
         p = firedrake.LinearVariationalProblem(a, L, self.target)
 
-        self._init_as_solver(p)
+        self._init_as_solver(p, ad_block_tag=ad_block_tag)
 
     @NonlinearVariationalSolverMixin._ad_annotate_init
     def _init_as_solver(self, problem):
@@ -309,6 +311,8 @@ class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
 class SupermeshProjector(ProjectorBase):
     def __init__(self, *args, **kwargs):
         self._target_is_function = kwargs.pop("target_is_function", True)
+        self.ad_block_tag = kwargs.pop("ad_block_tag", None)
+
         super().__init__(*args, **kwargs)
 
     @cached_property
@@ -337,7 +341,8 @@ def Projector(
     form_compiler_parameters: Optional[dict] = None,
     constant_jacobian: Optional[bool] = True,
     use_slate_for_inverse: Optional[bool] = False,
-    quadrature_degree: Optional[Union[int, tuple[int]]] = None
+    quadrature_degree: Optional[Union[int, tuple[int]]] = None,
+    ad_block_tag: Optional[str] = None,
 ):
     """ Projection class.
 
@@ -369,6 +374,8 @@ def Projector(
         function spaces)(only valid for DG function spaces).
     quadrature_degree
         Quadrature degree to use when approximating integrands.
+    ad_block_tag
+        String for tagging the resulting block on the Pyadjoint tape.
     """
     target = create_output(v_out)
     source = sanitise_input(v, target.function_space())
@@ -377,14 +384,15 @@ def Projector(
         raise ValueError("Shape mismatch between source %s and target %s in project" %
                          (source.ufl_shape, target.ufl_shape))
     if isinstance(v, function.Function) and not bcs and v.function_space() == target.function_space():
-        return Assigner(source, target)
+        return Assigner(source, target, ad_block_tag=ad_block_tag)
     elif source_mesh == target_mesh:
         return BasicProjector(
             source, target, bcs=bcs, solver_parameters=solver_parameters,
             form_compiler_parameters=form_compiler_parameters,
             constant_jacobian=constant_jacobian,
             use_slate_for_inverse=use_slate_for_inverse,
-            quadrature_degree=quadrature_degree
+            quadrature_degree=quadrature_degree,
+            ad_block_tag=ad_block_tag,
         )
     else:
         if bcs is not None:
@@ -398,4 +406,5 @@ def Projector(
             use_slate_for_inverse=use_slate_for_inverse,
             quadrature_degree=quadrature_degree,
             target_is_function=isinstance(v_out, firedrake.Function),
+            ad_block_tag=ad_block_tag,
         )

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -6,6 +6,7 @@ from ufl.domain import extract_unique_domain
 from typing import Optional, Union
 
 import firedrake
+from firedrake.adjoint_utils import NonlinearVariationalSolverMixin, annotate_super_project
 from firedrake.bcs import BCBase
 from firedrake.petsc import PETSc
 from functools import cached_property
@@ -13,7 +14,6 @@ from functools import cached_property
 from firedrake.utils import complex_mode, SLATE_SUPPORTS_COMPLEX
 from firedrake import functionspaceimpl
 from firedrake import function
-from firedrake.adjoint_utils import annotate_project
 
 
 __all__ = ['project', 'Projector']
@@ -51,7 +51,6 @@ def check_meshes(source, target):
 
 
 @PETSc.Log.EventDecorator()
-@annotate_project
 def project(
     v: ufl.core.expr.Expr,
     V: Union[firedrake.functionspaceimpl.WithGeometry, firedrake.Function],
@@ -236,7 +235,7 @@ class ProjectorBase(object, metaclass=abc.ABCMeta):
         return self.target
 
 
-class BasicProjector(ProjectorBase):
+class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
     """
     A basic projector projects a UFL expression into a function space
     and places the result in a function from that function space,
@@ -244,6 +243,29 @@ class BasicProjector(ProjectorBase):
     :class:`.SupermeshProjector` is that both function spaces are
     defined on the same mesh.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        V = self.target.function_space()
+        mesh = V.mesh()
+
+        dx = firedrake.dx(mesh)
+        w = firedrake.TestFunction(V)
+        Pv = firedrake.TrialFunction(V)
+        a = firedrake.inner(Pv, w) * dx
+        L = firedrake.inner(self.source, w) * dx
+        p = firedrake.LinearVariationalProblem(a, L, self.target)
+
+        self._init_as_solver(p)
+
+    @NonlinearVariationalSolverMixin._ad_annotate_init
+    def _init_as_solver(self, problem):
+        return
+
+    @NonlinearVariationalSolverMixin._ad_annotate_solve
+    def project(self):
+        return super().project()
 
     @cached_property
     def rhs_form(self):
@@ -285,6 +307,10 @@ class BasicProjector(ProjectorBase):
 
 
 class SupermeshProjector(ProjectorBase):
+    def __init__(self, *args, **kwargs):
+        self._target_is_function = kwargs.pop("target_is_function", True)
+        super().__init__(*args, **kwargs)
+
     @cached_property
     def mixed_mass(self):
         from firedrake.supermeshing import assemble_mixed_mass_matrix
@@ -296,6 +322,10 @@ class SupermeshProjector(ProjectorBase):
         with self.source.dat.vec_ro as u, self.residual.dat.vec_wo as v:
             self.mixed_mass.mult(u, v)
         return self.residual
+
+    @annotate_super_project
+    def project(self):
+        return super().project()
 
 
 @PETSc.Log.EventDecorator()
@@ -366,5 +396,6 @@ def Projector(
             form_compiler_parameters=form_compiler_parameters,
             constant_jacobian=constant_jacobian,
             use_slate_for_inverse=use_slate_for_inverse,
-            quadrature_degree=quadrature_degree
+            quadrature_degree=quadrature_degree,
+            target_is_function=isinstance(v_out, firedrake.Function),
         )

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -261,10 +261,12 @@ class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
         L = firedrake.inner(self.source, w) * dx
         p = firedrake.LinearVariationalProblem(a, L, self.target)
 
-        self._init_as_solver(p, ad_block_tag=ad_block_tag)
+        solver_params = firedrake.LinearVariationalSolver.DEFAULT_SNES_PARAMETERS | self.solver_parameters
+
+        self._init_as_solver(p, forward_kwargs={"solver_parameters": solver_params}, ad_block_tag=ad_block_tag)
 
     @NonlinearVariationalSolverMixin._ad_annotate_init
-    def _init_as_solver(self, problem):
+    def _init_as_solver(self, problem, **kwargs):
         return
 
     @NonlinearVariationalSolverMixin._ad_annotate_solve

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -253,13 +253,24 @@ class BasicProjector(ProjectorBase, NonlinearVariationalSolverMixin):
 
         V = self.target.function_space()
         mesh = V.mesh()
+        ad_target = firedrake.Function(V)
 
         dx = firedrake.dx(mesh)
         w = firedrake.TestFunction(V)
         Pv = firedrake.TrialFunction(V)
         a = firedrake.inner(Pv, w) * dx
         L = firedrake.inner(self.source, w) * dx
-        p = firedrake.LinearVariationalProblem(a, L, self.target)
+        p = firedrake.LinearVariationalProblem(a, L, ad_target)
+
+        # If we project from an expression containing u (e.g. u + c) onto u, the
+        # resulting form looks nonlinear. However, the projection is in effect a
+        # solve onto a temporary function (here ad_target), followed by an implicit
+        # assignment. Instead of representing this as an explicit solve and assign
+        # block, we solve for a temporary function and modify _ad_u on the problem.
+        # This is used for creating the output variable (and thus the dependency
+        # resolution), in effect merging the implicit assignment into the block
+        # output phase.
+        p._ad_u = self.target
 
         solver_params = firedrake.LinearVariationalSolver.DEFAULT_SNES_PARAMETERS | self.solver_parameters
 

--- a/firedrake/projection.py
+++ b/firedrake/projection.py
@@ -6,7 +6,8 @@ from ufl.domain import extract_unique_domain
 from typing import Optional, Union
 
 import firedrake
-from firedrake.adjoint_utils import NonlinearVariationalSolverMixin, annotate_super_project
+from firedrake.adjoint_utils import NonlinearVariationalSolverMixin
+from firedrake.adjoint_utils import annotate_project, annotate_super_project
 from firedrake.bcs import BCBase
 from firedrake.petsc import PETSc
 from functools import cached_property
@@ -51,6 +52,7 @@ def check_meshes(source, target):
 
 
 @PETSc.Log.EventDecorator()
+@annotate_project
 def project(
     v: ufl.core.expr.Expr,
     V: Union[firedrake.functionspaceimpl.WithGeometry, firedrake.Function],


### PR DESCRIPTION
# Description

The `ProjectBlock` was essentially an extension of `SolveVarFormBlock` that sets up the mass matrix system for the adjoint machinery. For the original (forward) `project()` call, the optimised solver-free path is used. However, any of the adjoint operations including a forward recomputation would solve the system.

The approach here replicates that behaviour, but it's routed through the new `CachedSolverBlock`. As a consequence however, we have annotation on the `Projector` factory, which means that adjoint-friendly projection can occur through either the bare `project()` call, or by creating a `Projector` object.

The implementation is a bit ugly: because a lot of the caching machinery belongs to the `NonlinearVariationalSolverMixin`, we essentially dispatch to a dummy initialiser when creating a `BasicProjector` to ensure the solver caches are created correctly. A call to `project() `annotates as though a solve occurred, but uses the underlying projection implementation.

The `SupermeshSolveBlock` is actually a standalone object, so we just create that when `SupermeshProjector.project()` is called. Again, this allows for both bare and object-based projection to be taped.

The final case is the "null" project from one function to another on the same space. This creates an `Assigner`, and I assume it will "just work" through the annotation on `assign()`.

## Questions
- Does this break the API (also the `solve()` change) by removing the `annotate` kwarg? Now we have to wrap things in `with stop_annotating()` or similar
- There's probably a better way to manage `ad_block_tag`
- There's probably a better way to manage the solver parameters (indeed, if you just solve `inner(u,w)*dx == inner(u+c,w)*dx` for a Real c and try to evaluate the tape, there's a divergence... guess there aren't any adjoint tests for dead simple solves)