### PR TITLE
cache `sniff_compiler`

### DIFF
--- a/pyop3/compile.py
+++ b/pyop3/compile.py
@@ -149,6 +149,7 @@ def sniff_compiler_version(compiler, cpp=False):
     return version
 
 
+@parallel_cache()
 def sniff_compiler(exe, comm=mpi.COMM_WORLD):
     """Obtain the correct compiler class by calling the compiler executable.
 


### PR DESCRIPTION
Cache `sniff_compiler` using `parallel_cache`

Using `serial_cache` gave the error:

```
  File "/Users/lac224/Coding/work/firedrake-pyop3/venv-firedrake/lib/python3.14/site-packages/cachetools/_cached.py", line 207, in wrapper
    return cache[k]
           ~~~~~^^^
TypeError: cannot use 'cachetools.keys._HashedTuple' as a dict key (unhashable type: 'mpi4py.MPI.Intracomm')
```