### PR TITLE
Allow firedrake-configure --show-env on unsupported OS

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -74,8 +74,7 @@ def main():
     gpu_arch = GPUPlatform(args.gpu_arch)
     os_ = OS(args.os) if args.os else detect_os(show_error=not args.show_env)
 
-    if os_ is None:
-        assert args.show_env
+    if os_ is None and args.show_env:
         Arch(name=petsc_arch_name(scalar_type, gpu_arch)).show_env()
 
     arch_key = (os_, scalar_type, gpu_arch)

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -70,9 +70,13 @@ def main():
         )
         args.os = "unknown"
 
-    os_ = OS(args.os) if args.os else detect_os()
     scalar_type = ScalarType(args.scalar_type)
     gpu_arch = GPUPlatform(args.gpu_arch)
+    os_ = OS(args.os) if args.os else detect_os(show_error=not args.show_env)
+
+    if os_ is None:
+        assert args.show_env
+        Arch(name=petsc_arch_name(scalar_type, gpu_arch)).show_env()
 
     arch_key = (os_, scalar_type, gpu_arch)
     arch_key_str = f"{{{', '.join(f'{k.__class__.__name__}: {k.value}' for k in arch_key)}}}"
@@ -207,7 +211,7 @@ Please see https://firedrakeproject.org/install for more information."""
     return parser
 
 
-def detect_os() -> "OS":
+def detect_os(*, show_error: bool = True) -> "OS | None":
     if platform.system() == "Linux":
         try:
             os_info = platform.freedesktop_os_release()
@@ -230,10 +234,13 @@ def detect_os() -> "OS":
         if platform.machine() == "arm64":
             return OS.MACOS_ARM64
 
-    error("""\
+    if show_error:
+        error("""\
 Cannot identify operating system, to configure Firedrake please specify the
 operating system manually. Run 'python3 firedrake-configure --help' to see
 the available options.""")
+
+    return None
 
 
 class OS(enum.Enum):
@@ -253,6 +260,13 @@ class ScalarType(enum.Enum):
 class GPUPlatform(enum.Enum):
     NO_GPU = "none"
     CUDA = "cuda"
+
+
+def petsc_arch_name(scalar_type: ScalarType, gpu_arch: GPUPlatform) -> str:
+    name = scalar_type.value
+    if gpu_arch is not GPUPlatform.NO_GPU:
+        name = f"{name}-{gpu_arch.value}"
+    return name
 
 
 class InvalidConfigurationError(Exception):


### PR DESCRIPTION
# Description
We should not be throwing a hard error for `firedrake-configure --show-env`

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
