### PR TITLE
Redistributed Submesh and MeshHierarchy

### DIFF
--- a/firedrake/adapt.py
+++ b/firedrake/adapt.py
@@ -7,7 +7,7 @@ from firedrake.cython import mgimpl as impl
 from firedrake.utils import IntType
 from firedrake.function import Function
 from firedrake.functionspace import FunctionSpace
-from firedrake.mesh import Mesh, DISTRIBUTION_PARAMETERS_NOOP
+from firedrake.mesh import Mesh, Submesh, DISTRIBUTION_PARAMETERS_NOOP
 from firedrake.netgen import _transfer_high_order_coordinates
 from firedrake.petsc import PETSc
 
@@ -72,7 +72,33 @@ def _copy_adaptive_refinement_metadata(source_mesh, target_mesh):
         target_mesh.netgen_flags = source_mesh.netgen_flags
 
 
-def refine_marked_elements(mesh, cell_marker):
+def _redistribute_adaptive_refined_mesh(coarse_mesh, refined_mesh, redistribute=True):
+    """Redistribute an adaptively refined mesh if it has empty ranks.
+
+    Parameters
+    ----------
+    coarse_mesh : firedrake.mesh.MeshGeometry
+        The mesh that was refined.
+    refined_mesh : firedrake.mesh.MeshGeometry
+        The result of refining ``coarse_mesh``.
+    redistribute : bool
+        If ``True``, redistribute ``refined_mesh`` when it has empty ranks.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry
+        ``refined_mesh``, or a redistributed `~firedrake.mesh.Submesh` of it.
+
+    """
+    _copy_adaptive_refinement_metadata(coarse_mesh, refined_mesh)
+    if not (redistribute and refined_mesh.has_empty_rank):
+        return refined_mesh
+    redist_mesh = Submesh(refined_mesh, redistribute=True, name=refined_mesh.name)
+    _copy_adaptive_refinement_metadata(refined_mesh, redist_mesh)
+    return redist_mesh
+
+
+def refine_marked_elements(mesh, cell_marker, redistribute=True):
     """Adaptively refine a mesh using a DG0 marking function.
 
     Positive integer marker values request repeated refinement of the
@@ -86,6 +112,9 @@ def refine_marked_elements(mesh, cell_marker):
     cell_marker
         A DG0 `~firedrake.function.Function` on ``mesh``: cells with a
         positive value ``n`` are refined ``n`` times.
+    redistribute
+        If ``True``, redistribute the refined mesh when the coarse mesh
+        has empty ranks.
 
     Returns
     -------
@@ -145,7 +174,12 @@ def refine_marked_elements(mesh, cell_marker):
                 final_mesh = _transfer_high_order_coordinates(mesh, final_mesh, order)
 
     final_mesh.topology_dm.removeLabel(PARENT_LABEL)
+    # _redistribute_adaptive_refined_mesh copies the construction metadata
+    # across, and may hand back a different mesh, so record the provenance on
+    # whichever mesh comes out of it.
+    final_mesh = _redistribute_adaptive_refined_mesh(
+        mesh, final_mesh, redistribute=redistribute
+    )
     final_mesh.adaptive_parent = mesh
     final_mesh.adaptive_cell_maps = (coarse_to_fine, fine_to_coarse)
-    _copy_adaptive_refinement_metadata(mesh, final_mesh)
     return final_mesh

--- a/firedrake/adapt.py
+++ b/firedrake/adapt.py
@@ -7,7 +7,7 @@ from firedrake.cython import mgimpl as impl
 from firedrake.utils import IntType
 from firedrake.function import Function
 from firedrake.functionspace import FunctionSpace
-from firedrake.mesh import Mesh, DISTRIBUTION_PARAMETERS_NOOP
+from firedrake.mesh import Mesh, Submesh, DISTRIBUTION_PARAMETERS_NOOP
 from firedrake.netgen import _transfer_high_order_coordinates
 
 
@@ -69,7 +69,33 @@ def _copy_adaptive_refinement_metadata(source_mesh, target_mesh):
         target_mesh.netgen_flags = source_mesh.netgen_flags
 
 
-def refine_marked_elements(mesh, cell_marker):
+def _redistribute_adaptive_refined_mesh(coarse_mesh, refined_mesh, redistribute=True):
+    """Redistribute an adaptively refined mesh if it has empty ranks.
+
+    Parameters
+    ----------
+    coarse_mesh : firedrake.mesh.MeshGeometry
+        The mesh that was refined.
+    refined_mesh : firedrake.mesh.MeshGeometry
+        The result of refining ``coarse_mesh``.
+    redistribute : bool
+        If ``True``, redistribute ``refined_mesh`` when it has empty ranks.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry
+        ``refined_mesh``, or a redistributed `~firedrake.mesh.Submesh` of it.
+
+    """
+    _copy_adaptive_refinement_metadata(coarse_mesh, refined_mesh)
+    if not (redistribute and refined_mesh.has_empty_rank):
+        return refined_mesh
+    redist_mesh = Submesh(refined_mesh, redistribute=True, name=refined_mesh.name)
+    _copy_adaptive_refinement_metadata(refined_mesh, redist_mesh)
+    return redist_mesh
+
+
+def refine_marked_elements(mesh, cell_marker, redistribute=True):
     """Adaptively refine a mesh using a DG0 marking function.
 
     Positive integer marker values request repeated refinement of the
@@ -83,6 +109,9 @@ def refine_marked_elements(mesh, cell_marker):
     cell_marker
         A DG0 `~firedrake.function.Function` on ``mesh``: cells with a
         positive value ``n`` are refined ``n`` times.
+    redistribute
+        If ``True``, redistribute the refined mesh when the coarse mesh
+        has empty ranks.
 
     Returns
     -------
@@ -137,7 +166,12 @@ def refine_marked_elements(mesh, cell_marker):
             final_mesh = _transfer_high_order_coordinates(mesh, final_mesh, order)
 
     final_mesh.topology_dm.removeLabel(PARENT_LABEL)
+    # _redistribute_adaptive_refined_mesh copies the construction metadata
+    # across, and may hand back a different mesh, so record the provenance on
+    # whichever mesh comes out of it.
+    final_mesh = _redistribute_adaptive_refined_mesh(
+        mesh, final_mesh, redistribute=redistribute
+    )
     final_mesh.adaptive_parent = mesh
     final_mesh.adaptive_cell_maps = (coarse_to_fine, fine_to_coarse)
-    _copy_adaptive_refinement_metadata(mesh, final_mesh)
     return final_mesh

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -383,9 +383,9 @@ class Assigner:
                               target_is_submesh, allow_missing_dofs):
         """Assign between (co)functions on a redistributed submesh and its parent.
 
-        The nodes of the two spaces are in one-to-one correspondence, so the
-        expression is evaluated in the source layout and the result is moved
-        into the target layout with a single communication.
+        The nodes of the two spaces correspond one to one. The expression is
+        evaluated in the source layout. One communication then moves the
+        result into the target layout.
         """
         target_V = lhs_func.function_space()
         source_V, = set(f.function_space() for f in funcs)

--- a/firedrake/assign.py
+++ b/firedrake/assign.py
@@ -17,10 +17,77 @@ from ufl.domain import extract_unique_domain
 from firedrake.cofunction import Cofunction
 from firedrake.constant import Constant
 from firedrake.function import Function
+from firedrake.halo import _get_mtype
 from firedrake.petsc import PETSc
 from firedrake.utils import ScalarType, split_by
 
 from mpi4py import MPI
+
+
+def _submesh_point_sf(target_mesh, source_mesh):
+    """Find the point SF relating two meshes with different distributions.
+
+    Parameters
+    ----------
+    target_mesh : AbstractMeshTopology
+        The mesh being assigned to.
+    source_mesh : AbstractMeshTopology
+        The mesh being assigned from.
+
+    Returns
+    -------
+    tuple
+        The `PETSc.SF` mapping the points of the parent mesh (roots) to the
+        points of the submesh (leaves), and whether ``target_mesh`` is the
+        submesh. Both are `None` if the two meshes share their distribution,
+        in which case they are related by entity maps instead.
+
+    """
+    if target_mesh.submesh_parent is source_mesh:
+        return target_mesh.submesh_point_sf, True
+    elif source_mesh.submesh_parent is target_mesh:
+        return source_mesh.submesh_point_sf, False
+    else:
+        return None, None
+
+
+def _make_section_sf(point_sf, root_V, leaf_V):
+    """Expand a point SF into an SF relating the nodes of two function spaces.
+
+    Parameters
+    ----------
+    point_sf : PETSc.SF
+        SF mapping the points of the mesh of ``root_V`` (roots) to the points
+        of the mesh of ``leaf_V`` (leaves).
+    root_V : firedrake.functionspaceimpl.WithGeometry
+        Function space holding the root data.
+    leaf_V : firedrake.functionspaceimpl.WithGeometry
+        Function space holding the leaf data.
+
+    Returns
+    -------
+    tuple
+        The `PETSc.SF` mapping the nodes of ``root_V`` to the nodes of
+        ``leaf_V``, and the boolean array telling which nodes of ``root_V``
+        have a counterpart in ``leaf_V``.
+
+    """
+    cache = leaf_V.mesh().topology._shared_data_cache["submesh_section_sf"]
+    key = (root_V, leaf_V)
+    try:
+        return cache[key]
+    except KeyError:
+        root_section = root_V.dm.getSection()
+        leaf_section = leaf_V.dm.getSection()
+        # `distributeSection` overwrites the section it is handed, so let it
+        # build its own and only keep the root offsets it broadcasts.
+        remote_offsets, distributed_section = point_sf.distributeSection(root_section)
+        if distributed_section.getChart() != leaf_section.getChart():
+            raise RuntimeError("Point SF does not cover the nodes of the leaf function space")
+        section_sf = point_sf.createSectionSF(root_section, remote_offsets, leaf_section)
+        # A submesh only covers part of its parent, so not every root node
+        # is reduced into.
+        return cache.setdefault(key, (section_sf, section_sf.computeDegree() > 0))
 
 
 def _isconstant(expr):
@@ -298,6 +365,69 @@ class Assigner:
             lhs_func.dat.halo_valid = True
 
     def _assign_multi_mesh(self, lhs_func, subset, funcs, operator, allow_missing_dofs):
+        target_mesh = extract_unique_domain(lhs_func).topology
+        source_V, = set(f.function_space() for f in funcs)
+        source_mesh = source_V.mesh().topology
+        if target_mesh.submesh_shares_distribution(source_mesh):
+            self._assign_submesh(lhs_func, subset, funcs, operator, allow_missing_dofs)
+            return
+        point_sf, target_is_submesh = _submesh_point_sf(target_mesh, source_mesh)
+        if point_sf is None:
+            raise NotImplementedError(
+                "Can only assign between a redistributed mesh and its parent"
+            )
+        self._assign_redistributed(lhs_func, subset, funcs, point_sf,
+                                   target_is_submesh, allow_missing_dofs)
+
+    def _assign_redistributed(self, lhs_func, subset, funcs, point_sf,
+                              target_is_submesh, allow_missing_dofs):
+        """Assign between (co)functions on a redistributed submesh and its parent.
+
+        The nodes of the two spaces are in one-to-one correspondence, so the
+        expression is evaluated in the source layout and the result is moved
+        into the target layout with a single communication.
+        """
+        target_V = lhs_func.function_space()
+        source_V, = set(f.function_space() for f in funcs)
+        if target_is_submesh:
+            root_V, leaf_V = source_V, target_V
+        else:
+            root_V, leaf_V = target_V, source_V
+        section_sf, covered_roots = _make_section_sf(point_sf, root_V, leaf_V)
+
+        source_buffer = Function(source_V)
+        target_buffer = Function(target_V)
+        func_data = np.array([f.dat.data_ro_with_halos for f in funcs])
+        source_buffer.dat.data_wo_with_halos[...] = self._compute_rvalue(func_data)
+        mtype, _ = _get_mtype(source_buffer.dat)
+        source_data = source_buffer.dat.data_ro_with_halos
+        target_data = target_buffer.dat.data_wo_with_halos
+        if target_is_submesh:
+            section_sf.bcastBegin(mtype, source_data, target_data, MPI.REPLACE)
+            section_sf.bcastEnd(mtype, source_data, target_data, MPI.REPLACE)
+            # Every node of a submesh, including its halo, has a counterpart
+            # in the parent.
+            indices = Ellipsis if subset is None else subset.indices
+            assign_to_halos = True
+        else:
+            section_sf.reduceBegin(mtype, source_data, target_data, MPI.REPLACE)
+            section_sf.reduceEnd(mtype, source_data, target_data, MPI.REPLACE)
+            # Only the owned parent nodes that the submesh covers have been
+            # reduced into; the parent halo never is.
+            owned = covered_roots[:target_V.dof_dset.size]
+            comm = target_V.mesh().comm
+            if not comm.allreduce(owned.all(), op=MPI.LAND) and not allow_missing_dofs:
+                raise ValueError("Found assignee nodes with no matching assigner "
+                                 "nodes: run with `allow_missing_dofs=True`")
+            indices, = np.nonzero(owned)
+            if subset is not None:
+                indices = np.intersect1d(indices, subset.owned_indices)
+            target_data = target_buffer.dat.data_ro
+            assign_to_halos = False
+        self._assign_single_dat(lhs_func.dat, indices, target_data[indices], assign_to_halos)
+        lhs_func.dat.halo_valid = assign_to_halos
+
+    def _assign_submesh(self, lhs_func, subset, funcs, operator, allow_missing_dofs):
         target_mesh = extract_unique_domain(lhs_func)
         target_V = lhs_func.function_space()
         source_V, = set(f.function_space() for f in funcs)

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -4066,6 +4066,143 @@ def submesh_create(PETSc.DM dm,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
+def submesh_vertex_numbering(PETSc.SF point_sf,
+                             PETSc.Section parent_numbering,
+                             PETSc.Section numbering):
+    """Inherit the universal vertex numbering of the submesh parent.
+
+    Parameters
+    ----------
+    point_sf : PETSc.SF
+        SF whose roots are the points of the parent plex and whose leaves
+        are the points of the submesh plex.
+    parent_numbering : PETSc.Section
+        Section describing the universal vertex numbering of the parent.
+    numbering : PETSc.Section
+        Section describing the universal vertex numbering of the submesh.
+
+    Returns
+    -------
+    PETSc.Section
+        Copy of ``numbering`` in which each vertex carries the universal
+        number of the corresponding vertex of the parent.
+
+    Notes
+    -----
+    Cell closures are ordered by universal vertex number, so a submesh that
+    inherits the numbering of its parent orients its entities exactly as the
+    parent does. The nodes of a function space are then in one-to-one
+    correspondence on the two meshes, even though the meshes are distributed
+    differently.
+
+    """
+    cdef:
+        PETSc.Section inherited
+        PetscInt nroots, pStart, pEnd, ppStart, ppEnd, p, dof, offset
+        np.ndarray[PetscInt, ndim=1, mode="c"] roots, leaves
+        MPI.Datatype typ
+        MPI.Op replace = MPI.REPLACE
+
+    CHKERR(PetscSFGetGraph(point_sf.sf, &nroots, NULL, NULL, NULL))
+    ppStart, ppEnd = parent_numbering.getChart()
+    if ppEnd - ppStart != nroots:
+        raise ValueError("Point SF must have one root per point of the parent plex")
+    pStart, pEnd = numbering.getChart()
+    roots = np.full(nroots, -1, dtype=IntType)
+    for p in range(ppStart, ppEnd):
+        CHKERR(PetscSectionGetDof(parent_numbering.sec, p, &dof))
+        # Points not owned by this rank carry complementary inverses.
+        if cabs(dof) > 0:
+            CHKERR(PetscSectionGetOffset(parent_numbering.sec, p, &offset))
+            roots[p - ppStart] = cabs(offset)
+    leaves = np.full(pEnd - pStart, -1, dtype=IntType)
+    try:
+        tdict = MPI.__TypeDict__
+    except AttributeError:
+        tdict = MPI._typedict
+    typ = tdict[roots.dtype.char]
+    CHKERR(PetscSFBcastBegin(point_sf.sf, typ.ob_mpi,
+                             <const void *>roots.data,
+                             <void *>leaves.data,
+                             replace.ob_mpi))
+    CHKERR(PetscSFBcastEnd(point_sf.sf, typ.ob_mpi,
+                           <const void *>roots.data,
+                           <void *>leaves.data,
+                           replace.ob_mpi))
+    inherited = numbering.clone()
+    for p in range(pStart, pEnd):
+        CHKERR(PetscSectionGetDof(inherited.sec, p, &dof))
+        if cabs(dof) > 0:
+            offset = leaves[p - pStart]
+            if offset < 0:
+                raise RuntimeError("Found a vertex with no counterpart in the submesh parent")
+            CHKERR(PetscSectionSetOffset(inherited.sec, p,
+                                         offset if dof > 0 else cneg(offset)))
+    return inherited
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def submesh_cell_orientations(PETSc.DM parent_plex,
+                              PETSc.Section parent_cell_numbering,
+                              np.ndarray parent_orientations,
+                              PETSc.SF point_sf,
+                              PETSc.DM plex,
+                              PETSc.Section cell_numbering):
+    """Inherit the cell orientations of the submesh parent.
+
+    Parameters
+    ----------
+    parent_plex : PETSc.DM
+        The parent plex.
+    parent_cell_numbering : PETSc.Section
+        Section describing the cell numbering of the parent.
+    parent_orientations : numpy.ndarray
+        Cell orientations of the parent.
+    point_sf : PETSc.SF
+        SF whose roots are the points of ``parent_plex`` and whose leaves
+        are the points of ``plex``.
+    plex : PETSc.DM
+        The submesh plex.
+    cell_numbering : PETSc.Section
+        Section describing the cell numbering of the submesh.
+
+    Returns
+    -------
+    numpy.ndarray
+        Cell orientations of the submesh.
+
+    """
+    cdef:
+        MPI.Datatype dtype
+        PETSc.Section new_section
+        PetscInt *new_values = NULL
+        PetscInt c, cStart, cEnd, l, r
+        np.ndarray orientations
+
+    try:
+        tdict = MPI.__TypeDict__
+    except AttributeError:
+        tdict = MPI._typedict
+    dtype = tdict[np.dtype(IntType).char]
+    new_section = PETSc.Section().create(comm=plex.comm)
+    CHKERR(DMPlexDistributeData(parent_plex.dm, point_sf.sf,
+                                parent_cell_numbering.sec, dtype.ob_mpi,
+                                <void *>parent_orientations.data,
+                                new_section.sec, <void **>&new_values))
+    get_height_stratum(plex.dm, 0, &cStart, &cEnd)
+    orientations = np.empty(cEnd - cStart, dtype=IntType)
+    for c in range(cStart, cEnd):
+        CHKERR(PetscSectionGetOffset(cell_numbering.sec, c, &l))
+        CHKERR(PetscSectionGetOffset(new_section.sec, c, &r))
+        orientations[l] = new_values[r]
+    if new_values != NULL:
+        CHKERR(PetscFree(new_values))
+    return orientations
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def submesh_correct_entity_classes(PETSc.DM dm,
                                    PETSc.DM subdm,
                                    PETSc.SF ownership_transfer_sf):

--- a/firedrake/cython/petschdr.pxi
+++ b/firedrake/cython/petschdr.pxi
@@ -123,6 +123,7 @@ cdef extern from "petscvec.h" nogil:
 
 cdef extern from "petscis.h" nogil:
     PetscErrorCode PetscSectionGetOffset(PETSc.PetscSection,PetscInt,PetscInt*)
+    PetscErrorCode PetscSectionSetOffset(PETSc.PetscSection,PetscInt,PetscInt)
     PetscErrorCode PetscSectionGetDof(PETSc.PetscSection,PetscInt,PetscInt*)
     PetscErrorCode PetscSectionSetDof(PETSc.PetscSection,PetscInt,PetscInt)
     PetscErrorCode PetscSectionSetFieldDof(PETSc.PetscSection,PetscInt,PetscInt,PetscInt)
@@ -151,8 +152,8 @@ cdef extern from "petscsf.h" nogil:
 
     PetscErrorCode PetscSFGetGraph(PETSc.PetscSF,PetscInt*,PetscInt*,PetscInt**,PetscSFNode**)
     PetscErrorCode PetscSFSetGraph(PETSc.PetscSF,PetscInt,PetscInt,PetscInt*,PetscCopyMode,PetscSFNode*,PetscCopyMode)
-    PetscErrorCode PetscSFBcastBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,)
-    PetscErrorCode PetscSFBcastEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*)
+    PetscErrorCode PetscSFBcastBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
+    PetscErrorCode PetscSFBcastEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
     PetscErrorCode PetscSFReduceBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
     PetscErrorCode PetscSFReduceEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -1014,9 +1014,9 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     def submesh_shares_distribution(self, other):
         """Return whether `self` and ``other`` are related and share their distribution.
 
-        Entity maps between two meshes of the same submesh family are only
-        defined if every mesh between them and their youngest common ancestor
-        inherited its parent's parallel distribution.
+        Two meshes of the same submesh family have entity maps only under one
+        condition. Every mesh between them and their youngest common ancestor
+        must take its parent's parallel distribution.
 
         Parameters
         ----------
@@ -1288,9 +1288,9 @@ class MeshTopology(AbstractMeshTopology):
     def _universal_vertex_numbering(self):
         """Section describing the universal (globally unique) vertex numbering.
 
-        Cell closures are ordered by universal vertex number, so a
-        redistributed submesh inherits the numbering of its parent to
-        orient its entities exactly as the parent does.
+        Cell closures are ordered by universal vertex number. A redistributed
+        submesh therefore takes the numbering of its parent, and orients its
+        entities exactly as the parent does.
         """
         numbering = self._vertex_numbering.createGlobalSection(self.topology_dm.getPointSF())
         if self.submesh_point_sf is None:
@@ -5172,9 +5172,9 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     if subdim not in {dim, dim - 1}:
         raise NotImplementedError(f"Found submesh dim ({subdim}) and parent dim ({dim})")
     if redistribute and subdim != dim:
-        # The entities of the submesh and of the parent are only oriented
-        # consistently, and hence their nodes only correspond, if the two
-        # meshes are made of the same cells.
+        # The two meshes must be made of the same cells. Only then are their
+        # entities oriented consistently, and only then do their nodes
+        # correspond.
         raise NotImplementedError("Can only redistribute a submesh of co-dimension 0")
     if subdomain_id is None:
         if label_name is not None:
@@ -5192,8 +5192,8 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         # The point correspondence must be recorded before the submesh is
         # distributed, as distributing it discards the subpoint IS.
         point_sf = _make_submesh_point_sf(plex, subplex)
-        # The entity classification inherited from the parent no longer holds
-        # once the submesh is repartitioned; drop it so that it is recomputed.
+        # Repartitioning invalidates the entity classification the submesh
+        # takes from its parent. Drop the labels, so that they are recomputed.
         for label in ("pyop2_core", "pyop2_owned", "pyop2_ghost"):
             subplex.removeLabel(label)
     else:

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -5218,8 +5218,10 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         distribution_parameters=distribution_parameters,
         tolerance=mesh.tolerance,
     )
-    if point_sf is None:
-        # Tag the submesh with the original distribution parameters
+    if not redistribute:
+        # DISTRIBUTION_PARAMETERS_NOOP keeps Mesh() from distributing the
+        # submesh again. The submesh has the distribution of its parent, so it
+        # reports the parameters of the parent.
         submesh._distribution_parameters = mesh._distribution_parameters
 
     # A mesh with several cell types carries no coordinate Function, so its

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -5219,19 +5219,28 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         tolerance=mesh.tolerance,
     )
     if point_sf is None:
-        # Tag the relabeled mesh with the original distribution parameters
+        # Tag the submesh with the original distribution parameters
         submesh._distribution_parameters = mesh._distribution_parameters
-        return submesh
 
-    if mesh.coordinates.ufl_element() == submesh.coordinates.ufl_element():
-        return submesh
-    # The parent coordinates are not carried by the plex (e.g. the parent is
-    # curved or periodic), so they must be transferred onto the submesh.
-    V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
-    coordinates = function.Function(V).assign(mesh.coordinates)
-    submesh = Mesh(coordinates, name=name)
-    submesh.submesh_parent = mesh
-    submesh.tolerance = mesh.tolerance
+    # A mesh with several cell types carries no coordinate Function, so its
+    # coordinates are always the ones the plex holds.
+    if len(mesh.topology.dm_cell_types) == 1:
+        # A submesh of lower dimension has a different cell than its parent, so
+        # the two coordinate elements are compared on the parent's cell.
+        plex_element = submesh.coordinates.ufl_element().reconstruct(cell=mesh.ufl_cell())
+        if mesh.coordinates.ufl_element() != plex_element:
+            # The parent coordinates are not carried by the plex (e.g. the parent
+            # is curved or periodic), so they must be transferred onto the submesh.
+            if submesh.ufl_cell() != mesh.ufl_cell():
+                raise NotImplementedError(
+                    "Can only transfer the coordinates of a curved or periodic mesh "
+                    "onto a submesh of the same dimension"
+                )
+            V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
+            coordinates = function.Function(V).assign(mesh.coordinates)
+            submesh = Mesh(coordinates, name=name)
+            submesh.submesh_parent = mesh
+            submesh.tolerance = mesh.tolerance
     return submesh
 
 

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -503,7 +503,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
 
-    def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None):
+    def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None, submesh_point_sf=None):
         """Initialise a mesh topology.
 
         Parameters
@@ -532,6 +532,11 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
             Communicator.
         submesh_parent: AbstractMeshTopology
             Submesh parent.
+        submesh_point_sf: PETSc.PetscSF
+            `PETSc.SF` that pushes the points of ``submesh_parent`` to the
+            points of ``topology_dm``; only given if this mesh is to be
+            redistributed, i.e. does not inherit the parallel distribution
+            of ``submesh_parent``.
 
         """
         utils._init()
@@ -544,6 +549,13 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         self.sfXB = sfXB
         r"The PETSc SF that pushes the global point number slab [0, NX) to input (naive) plex."
         self.submesh_parent = submesh_parent
+        self.submesh_point_sf = submesh_point_sf
+        r"""The PETSc SF that pushes the points of ``submesh_parent`` to the points of this mesh.
+
+        This is `None` whenever this mesh shares the parallel distribution of
+        ``submesh_parent``, in which case the points of the two meshes are
+        related locally by ``topology_dm.getSubpointIS()``.
+        """
         self.sfBC_orig = None
         # User comm
         self.user_comm = comm
@@ -554,6 +566,9 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
             self._add_overlap()
         if self.sfXB is not None:
             self.sfXC = sfXB.compose(self.sfBC) if self.sfBC else self.sfXB
+        if self.submesh_point_sf is not None and self.sfBC:
+            # Push the parent points onto the redistributed plex.
+            self.submesh_point_sf = self.submesh_point_sf.compose(self.sfBC)
         dmcommon.label_facets(self.topology_dm)
         dmcommon.complete_facet_labels(self.topology_dm)
         # TODO: Allow users to set distribution name if they want to save
@@ -658,6 +673,12 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         from warnings import warn
         warn("_topology_dm is deprecated (use topology_dm instead)", DeprecationWarning, stacklevel=2)
         return self.topology_dm
+
+    @cached_property
+    def has_empty_rank(self):
+        """Whether any rank of this mesh owns no cells."""
+        with temp_internal_comm(self.comm) as icomm:
+            return icomm.allreduce(self.cell_set.size == 0, op=MPI.LOR)
 
     def ufl_cell(self):
         """The UFL :class:`~ufl.classes.Cell` associated with the mesh.
@@ -990,6 +1011,34 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
                 break
         return c
 
+    def submesh_shares_distribution(self, other):
+        """Return whether `self` and ``other`` are related and share their distribution.
+
+        Entity maps between two meshes of the same submesh family are only
+        defined if every mesh between them and their youngest common ancestor
+        inherited its parent's parallel distribution.
+
+        Parameters
+        ----------
+        other : AbstractMeshTopology
+            The other mesh.
+
+        Returns
+        -------
+        bool
+            Whether the two meshes are related by entity maps.
+
+        """
+        common = self.submesh_youngest_common_ancestor(other)
+        if common is None:
+            return False
+        for mesh in (self, other):
+            while mesh is not common:
+                if mesh.submesh_point_sf is not None:
+                    return False
+                mesh = mesh.submesh_parent
+        return True
+
     def submesh_map_child_parent(self, source_integral_type, source_subset_points, reverse=False):
         """Return the map from submesh child entities to submesh parent entities or its reverse.
 
@@ -1084,6 +1133,7 @@ class MeshTopology(AbstractMeshTopology):
         distribution_name=None,
         permutation_name=None,
         submesh_parent=None,
+        submesh_point_sf=None,
         comm=COMM_WORLD,
     ):
         """Initialise a mesh topology.
@@ -1114,6 +1164,9 @@ class MeshTopology(AbstractMeshTopology):
             Name of the entity permutation (reordering); if `None`, automatically generated.
         submesh_parent: MeshTopology
             Submesh parent.
+        submesh_point_sf: PETSc.PetscSF
+            `PETSc.SF` that pushes the points of ``submesh_parent`` to the
+            points of ``plex``; only given if ``plex`` is to be redistributed.
         comm : mpi4py.MPI.Comm
             Communicator.
 
@@ -1133,7 +1186,7 @@ class MeshTopology(AbstractMeshTopology):
         # Disable auto distribution and reordering before setFromOptions is called.
         plex.distributeSetDefault(False)
         plex.reorderSetDefault(PETSc.DMPlex.ReorderDefaultFlag.FALSE)
-        super().__init__(plex, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=submesh_parent)
+        super().__init__(plex, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=submesh_parent, submesh_point_sf=submesh_point_sf)
 
     def _distribute(self):
         # Distribute/redistribute the dm to all ranks
@@ -1232,6 +1285,55 @@ class MeshTopology(AbstractMeshTopology):
         return dmcommon.get_dm_cell_types(self.topology_dm)
 
     @cached_property
+    def _universal_vertex_numbering(self):
+        """Section describing the universal (globally unique) vertex numbering.
+
+        Cell closures are ordered by universal vertex number, so a
+        redistributed submesh inherits the numbering of its parent to
+        orient its entities exactly as the parent does.
+        """
+        numbering = self._vertex_numbering.createGlobalSection(self.topology_dm.getPointSF())
+        if self.submesh_point_sf is None:
+            return numbering
+        return dmcommon.submesh_vertex_numbering(
+            self.submesh_point_sf,
+            self.submesh_parent._universal_vertex_numbering,
+            numbering,
+        )
+
+    @cached_property
+    def _quadrilateral_cell_orientations(self):
+        """Global orientation of each quadrilateral cell.
+
+        Neighbouring cells must agree on the direction of the edge they
+        share, which is decided by a distributed algorithm whose outcome
+        depends on the partition. A redistributed submesh therefore
+        inherits the orientations of its parent rather than choosing
+        its own.
+        """
+        plex = self.topology_dm
+        if self.submesh_point_sf is not None:
+            return dmcommon.submesh_cell_orientations(
+                self.submesh_parent.topology_dm,
+                self.submesh_parent._cell_numbering,
+                self.submesh_parent._quadrilateral_cell_orientations,
+                self.submesh_point_sf,
+                plex,
+                self._cell_numbering,
+            )
+        vertex_numbering = self._universal_vertex_numbering
+        cell_ranks = dmcommon.get_cell_remote_ranks(plex)
+        facet_orientations = dmcommon.quadrilateral_facet_orientations(
+            plex, vertex_numbering, cell_ranks)
+        cell_orientations = dmcommon.orientations_facet2cell(
+            plex, vertex_numbering, cell_ranks,
+            facet_orientations, self._cell_numbering)
+        dmcommon.exchange_cell_orientations(plex,
+                                            self._cell_numbering,
+                                            cell_orientations)
+        return cell_orientations
+
+    @cached_property
     def cell_closure(self):
         """2D array of ordered cell closures
 
@@ -1242,11 +1344,11 @@ class MeshTopology(AbstractMeshTopology):
 
         # Cell numbering and global vertex numbering
         cell_numbering = self._cell_numbering
-        vertex_numbering = self._vertex_numbering.createGlobalSection(plex.getPointSF())
+        vertex_numbering = self._universal_vertex_numbering
 
         cell = self.ufl_cell()
         assert tdim == cell.topological_dimension
-        if self.submesh_parent is not None and \
+        if self.submesh_parent is not None and self.submesh_point_sf is None and \
                 not (self.submesh_parent.ufl_cell().cellname == "hexahedron" and cell.cellname == "quadrilateral") and \
                 len(self.submesh_parent.dm_cell_types) == 1:
             # Codim-1 submesh of a hex mesh (i.e. a quad submesh) can not
@@ -1279,22 +1381,9 @@ class MeshTopology(AbstractMeshTopology):
         elif cell.cellname == "quadrilateral":
             petsctools.cite("Homolya2016")
             petsctools.cite("McRae2016")
-            # Quadrilateral mesh
-            cell_ranks = dmcommon.get_cell_remote_ranks(plex)
-
-            facet_orientations = dmcommon.quadrilateral_facet_orientations(
-                plex, vertex_numbering, cell_ranks)
-
-            cell_orientations = dmcommon.orientations_facet2cell(
-                plex, vertex_numbering, cell_ranks,
-                facet_orientations, cell_numbering)
-
-            dmcommon.exchange_cell_orientations(plex,
-                                                cell_numbering,
-                                                cell_orientations)
-
             return dmcommon.quadrilateral_closure_ordering(
-                plex, vertex_numbering, cell_numbering, cell_orientations)
+                plex, vertex_numbering, cell_numbering,
+                self._quadrilateral_cell_orientations)
         elif cell.cellname == "hexahedron":
             # TODO: Should change and use create_cell_closure() for all cell types.
             topology = FIAT.ufc_cell(cell).get_topology()
@@ -1635,6 +1724,12 @@ class MeshTopology(AbstractMeshTopology):
         """
         if self.submesh_parent is None:
             raise RuntimeError("Must only be called on submesh")
+        if self.submesh_point_sf is not None:
+            raise NotImplementedError(
+                "Assembling or interpolating across a submesh and its parent "
+                "requires the two to share the same parallel distribution; use "
+                "`Function.assign` to transfer data between redistributed meshes"
+            )
         if reverse:
             source = self.submesh_parent
             target = self
@@ -1841,6 +1936,7 @@ class ExtrudedMeshTopology(MeshTopology):
         self.cell_set = op2.ExtrudedSet(mesh.cell_set, layers=layers, extruded_periodic=periodic)
         # submesh
         self.submesh_parent = None
+        self.submesh_point_sf = None
 
     @cached_property
     def _ufl_cell(self):
@@ -2960,7 +3056,7 @@ values from f.)"""
         return self
 
     @PETSc.Log.EventDecorator()
-    def refine_marked_elements(self, mark):
+    def refine_marked_elements(self, mark, redistribute=True):
         """Adaptively refine a mesh using a DG0 marking function.
 
         Parameters
@@ -2968,6 +3064,10 @@ values from f.)"""
         mark
             A DG0 `~firedrake.function.Function` on this mesh: cells
             with a positive value ``n`` are refined ``n`` times.
+
+        redistribute
+            if ``True``, redistribute the refined mesh
+            when the coarse mesh has empty ranks.
 
         Returns
         -------
@@ -2978,7 +3078,7 @@ values from f.)"""
             :meth:`~firedrake.mg.mesh.HierarchyBase.add_mesh`.
         """
         from firedrake.adapt import refine_marked_elements
-        return refine_marked_elements(self, mark)
+        return refine_marked_elements(self, mark, redistribute)
 
     @PETSc.Log.EventDecorator()
     def curve_field(self, order, permutation_tol=None, cg_field=None):
@@ -3425,6 +3525,7 @@ def Mesh(meshfile, **kwargs):
                             distribution_name=kwargs.get("distribution_name"),
                             permutation_name=kwargs.get("permutation_name"),
                             submesh_parent=submesh_parent.topology if submesh_parent else None,
+                            submesh_point_sf=kwargs.get("submesh_point_sf"),
                             comm=user_comm)
     mesh = make_mesh_from_mesh_topology(topology, name)
 
@@ -4897,7 +4998,35 @@ def SubDomainData(geometric_expr):
     return op2.Subset(m.cell_set, indices)
 
 
-def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ignore_halo=False, reorder=None, comm=None):
+def _make_submesh_point_sf(plex, subplex):
+    """Create the `PETSc.SF` relating the points of a plex and of its submesh.
+
+    Parameters
+    ----------
+    plex : PETSc.DMPlex
+        The parent plex.
+    subplex : PETSc.DMPlex
+        The submesh plex, before it is distributed.
+
+    Returns
+    -------
+    PETSc.SF
+        SF whose roots are the points of ``plex`` and whose leaves are the
+        points of ``subplex``.
+
+    """
+    pStart, pEnd = plex.getChart()
+    subpStart, subpEnd = subplex.getChart()
+    remote = np.empty((subpEnd - subpStart, 2), dtype=IntType)
+    remote[:, 0] = plex.comm.rank
+    with subplex.getSubpointIS() as subpoints:
+        remote[:, 1] = subpoints
+    point_sf = PETSc.SF().create(comm=subplex.comm)
+    point_sf.setGraph(pEnd - pStart, None, remote)
+    return point_sf
+
+
+def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ignore_halo=False, reorder=None, comm=None, redistribute=False):
     """Construct a submesh from a given mesh.
 
     Parameters
@@ -4927,6 +5056,13 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     comm : PETSc.Comm | None
         An optional sub-communicator to define the submesh.
         By default, the submesh is defined on `mesh.comm`.
+    redistribute : bool
+        Whether to repartition the submesh, instead of inheriting the
+        parallel distribution of ``mesh``. This implies ``ignore_halo=True``,
+        and is currently only supported for submeshes of co-dimension 0.
+        A redistributed submesh can not be assembled or interpolated
+        alongside its parent; use `~.Function.assign` to transfer data
+        between the two.
 
     Returns
     -------
@@ -4995,13 +5131,28 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
 
     >>> submesh = Submesh(mesh, ignore_halo=True, comm=COMM_SELF)
 
+    Construct a repartitioned copy of the entire mesh
+
+    >>> submesh = Submesh(mesh, redistribute=True)
+
     """
+    import firedrake.function as function
+
     if not isinstance(mesh, MeshGeometry):
         raise TypeError("Parent mesh must be a `MeshGeometry`")
     if isinstance(mesh.topology, ExtrudedMeshTopology):
         raise NotImplementedError("Can not create a submesh of an ``ExtrudedMesh``")
     elif isinstance(mesh.topology, VertexOnlyMeshTopology):
         raise NotImplementedError("Can not create a submesh of a ``VertexOnlyMesh``")
+    if redistribute:
+        if comm is not None:
+            raise NotImplementedError("Can only redistribute a submesh over the parent communicator")
+        # Drop the parent halo so that every point of the submesh is owned
+        # by exactly one rank before it is repartitioned.
+        ignore_halo = True
+        distribution_parameters = dict(mesh._distribution_parameters, partition=True)
+    else:
+        distribution_parameters = DISTRIBUTION_PARAMETERS_NOOP
 
     if subdomain_id == "on_boundary":
         if subdim is None:
@@ -5020,6 +5171,11 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     dim = plex.getDimension()
     if subdim not in {dim, dim - 1}:
         raise NotImplementedError(f"Found submesh dim ({subdim}) and parent dim ({dim})")
+    if redistribute and subdim != dim:
+        # The entities of the submesh and of the parent are only oriented
+        # consistently, and hence their nodes only correspond, if the two
+        # meshes are made of the same cells.
+        raise NotImplementedError("Can only redistribute a submesh of co-dimension 0")
     if subdomain_id is None:
         if label_name is not None:
             raise ValueError("subdomain_id=None requires label_name=None.")
@@ -5032,6 +5188,16 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         elif subdim == dim - 1:
             label_name = dmcommon.FACE_SETS_LABEL
     subplex = dmcommon.submesh_create(plex, subdim, label_name, subdomain_id, ignore_halo, comm=comm)
+    if redistribute:
+        # The point correspondence must be recorded before the submesh is
+        # distributed, as distributing it discards the subpoint IS.
+        point_sf = _make_submesh_point_sf(plex, subplex)
+        # The entity classification inherited from the parent no longer holds
+        # once the submesh is repartitioned; drop it so that it is recomputed.
+        for label in ("pyop2_core", "pyop2_owned", "pyop2_ghost"):
+            subplex.removeLabel(label)
+    else:
+        point_sf = None
 
     comm = comm or mesh.comm
     name = name or _generate_default_submesh_name(mesh.name)
@@ -5045,13 +5211,27 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     submesh = Mesh(
         subplex,
         submesh_parent=mesh,
+        submesh_point_sf=point_sf,
         name=name,
         comm=comm,
         reorder=reorder,
-        distribution_parameters=DISTRIBUTION_PARAMETERS_NOOP,
+        distribution_parameters=distribution_parameters,
+        tolerance=mesh.tolerance,
     )
-    # Tag the relabeled mesh with the original distribution parameters
-    submesh._distribution_parameters = mesh._distribution_parameters
+    if point_sf is None:
+        # Tag the relabeled mesh with the original distribution parameters
+        submesh._distribution_parameters = mesh._distribution_parameters
+        return submesh
+
+    if mesh.coordinates.ufl_element() == submesh.coordinates.ufl_element():
+        return submesh
+    # The parent coordinates are not carried by the plex (e.g. the parent is
+    # curved or periodic), so they must be transferred onto the submesh.
+    V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
+    coordinates = function.Function(V).assign(mesh.coordinates)
+    submesh = Mesh(coordinates, name=name)
+    submesh.submesh_parent = mesh
+    submesh.tolerance = mesh.tolerance
     return submesh
 
 
@@ -5204,6 +5384,9 @@ class MeshSequenceTopology:
                 raise ValueError(f"Got {type(m)}")
         self._meshes = tuple(meshes)
         self.comm = meshes[0].comm
+        # A mesh sequence is never a submesh.
+        self.submesh_parent = None
+        self.submesh_point_sf = None
 
     @property
     def topology(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -503,7 +503,7 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
     """A representation of an abstract mesh topology without a concrete
         PETSc DM implementation"""
 
-    def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None):
+    def __init__(self, topology_dm, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=None, submesh_point_sf=None):
         """Initialise a mesh topology.
 
         Parameters
@@ -532,6 +532,11 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
             Communicator.
         submesh_parent: AbstractMeshTopology
             Submesh parent.
+        submesh_point_sf: PETSc.PetscSF
+            `PETSc.SF` that pushes the points of ``submesh_parent`` to the
+            points of ``topology_dm``; only given if this mesh is to be
+            redistributed, i.e. does not inherit the parallel distribution
+            of ``submesh_parent``.
 
         """
         utils._init()
@@ -544,6 +549,13 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         self.sfXB = sfXB
         r"The PETSc SF that pushes the global point number slab [0, NX) to input (naive) plex."
         self.submesh_parent = submesh_parent
+        self.submesh_point_sf = submesh_point_sf
+        r"""The PETSc SF that pushes the points of ``submesh_parent`` to the points of this mesh.
+
+        This is `None` whenever this mesh shares the parallel distribution of
+        ``submesh_parent``, in which case the points of the two meshes are
+        related locally by ``topology_dm.getSubpointIS()``.
+        """
         self.sfBC_orig = None
         # User comm
         self.user_comm = comm
@@ -554,6 +566,9 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
             self._add_overlap()
         if self.sfXB is not None:
             self.sfXC = sfXB.compose(self.sfBC) if self.sfBC else self.sfXB
+        if self.submesh_point_sf is not None and self.sfBC:
+            # Push the parent points onto the redistributed plex.
+            self.submesh_point_sf = self.submesh_point_sf.compose(self.sfBC)
         dmcommon.label_facets(self.topology_dm)
         dmcommon.complete_facet_labels(self.topology_dm)
         # TODO: Allow users to set distribution name if they want to save
@@ -658,6 +673,12 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
         from warnings import warn
         warn("_topology_dm is deprecated (use topology_dm instead)", DeprecationWarning, stacklevel=2)
         return self.topology_dm
+
+    @cached_property
+    def has_empty_rank(self):
+        """Whether any rank of this mesh owns no cells."""
+        with temp_internal_comm(self.comm) as icomm:
+            return icomm.allreduce(self.cell_set.size == 0, op=MPI.LOR)
 
     def ufl_cell(self):
         """The UFL :class:`~ufl.classes.Cell` associated with the mesh.
@@ -990,6 +1011,34 @@ class AbstractMeshTopology(object, metaclass=abc.ABCMeta):
                 break
         return c
 
+    def submesh_shares_distribution(self, other):
+        """Return whether `self` and ``other`` are related and share their distribution.
+
+        Entity maps between two meshes of the same submesh family are only
+        defined if every mesh between them and their youngest common ancestor
+        inherited its parent's parallel distribution.
+
+        Parameters
+        ----------
+        other : AbstractMeshTopology
+            The other mesh.
+
+        Returns
+        -------
+        bool
+            Whether the two meshes are related by entity maps.
+
+        """
+        common = self.submesh_youngest_common_ancestor(other)
+        if common is None:
+            return False
+        for mesh in (self, other):
+            while mesh is not common:
+                if mesh.submesh_point_sf is not None:
+                    return False
+                mesh = mesh.submesh_parent
+        return True
+
     def submesh_map_child_parent(self, source_integral_type, source_subset_points, reverse=False):
         """Return the map from submesh child entities to submesh parent entities or its reverse.
 
@@ -1084,6 +1133,7 @@ class MeshTopology(AbstractMeshTopology):
         distribution_name=None,
         permutation_name=None,
         submesh_parent=None,
+        submesh_point_sf=None,
         comm=COMM_WORLD,
     ):
         """Initialise a mesh topology.
@@ -1114,6 +1164,9 @@ class MeshTopology(AbstractMeshTopology):
             Name of the entity permutation (reordering); if `None`, automatically generated.
         submesh_parent: MeshTopology
             Submesh parent.
+        submesh_point_sf: PETSc.PetscSF
+            `PETSc.SF` that pushes the points of ``submesh_parent`` to the
+            points of ``plex``; only given if ``plex`` is to be redistributed.
         comm : mpi4py.MPI.Comm
             Communicator.
 
@@ -1133,7 +1186,7 @@ class MeshTopology(AbstractMeshTopology):
         # Disable auto distribution and reordering before setFromOptions is called.
         plex.distributeSetDefault(False)
         plex.reorderSetDefault(PETSc.DMPlex.ReorderDefaultFlag.FALSE)
-        super().__init__(plex, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=submesh_parent)
+        super().__init__(plex, name, reorder, sfXB, perm_is, distribution_name, permutation_name, comm, submesh_parent=submesh_parent, submesh_point_sf=submesh_point_sf)
 
     def _distribute(self):
         # Distribute/redistribute the dm to all ranks
@@ -1232,6 +1285,55 @@ class MeshTopology(AbstractMeshTopology):
         return dmcommon.get_dm_cell_types(self.topology_dm)
 
     @cached_property
+    def _universal_vertex_numbering(self):
+        """Section describing the universal (globally unique) vertex numbering.
+
+        Cell closures are ordered by universal vertex number, so a
+        redistributed submesh inherits the numbering of its parent to
+        orient its entities exactly as the parent does.
+        """
+        numbering = self._vertex_numbering.createGlobalSection(self.topology_dm.getPointSF())
+        if self.submesh_point_sf is None:
+            return numbering
+        return dmcommon.submesh_vertex_numbering(
+            self.submesh_point_sf,
+            self.submesh_parent._universal_vertex_numbering,
+            numbering,
+        )
+
+    @cached_property
+    def _quadrilateral_cell_orientations(self):
+        """Global orientation of each quadrilateral cell.
+
+        Neighbouring cells must agree on the direction of the edge they
+        share, which is decided by a distributed algorithm whose outcome
+        depends on the partition. A redistributed submesh therefore
+        inherits the orientations of its parent rather than choosing
+        its own.
+        """
+        plex = self.topology_dm
+        if self.submesh_point_sf is not None:
+            return dmcommon.submesh_cell_orientations(
+                self.submesh_parent.topology_dm,
+                self.submesh_parent._cell_numbering,
+                self.submesh_parent._quadrilateral_cell_orientations,
+                self.submesh_point_sf,
+                plex,
+                self._cell_numbering,
+            )
+        vertex_numbering = self._universal_vertex_numbering
+        cell_ranks = dmcommon.get_cell_remote_ranks(plex)
+        facet_orientations = dmcommon.quadrilateral_facet_orientations(
+            plex, vertex_numbering, cell_ranks)
+        cell_orientations = dmcommon.orientations_facet2cell(
+            plex, vertex_numbering, cell_ranks,
+            facet_orientations, self._cell_numbering)
+        dmcommon.exchange_cell_orientations(plex,
+                                            self._cell_numbering,
+                                            cell_orientations)
+        return cell_orientations
+
+    @cached_property
     def cell_closure(self):
         """2D array of ordered cell closures
 
@@ -1242,11 +1344,11 @@ class MeshTopology(AbstractMeshTopology):
 
         # Cell numbering and global vertex numbering
         cell_numbering = self._cell_numbering
-        vertex_numbering = self._vertex_numbering.createGlobalSection(plex.getPointSF())
+        vertex_numbering = self._universal_vertex_numbering
 
         cell = self.ufl_cell()
         assert tdim == cell.topological_dimension
-        if self.submesh_parent is not None and \
+        if self.submesh_parent is not None and self.submesh_point_sf is None and \
                 not (self.submesh_parent.ufl_cell().cellname == "hexahedron" and cell.cellname == "quadrilateral") and \
                 len(self.submesh_parent.dm_cell_types) == 1:
             # Codim-1 submesh of a hex mesh (i.e. a quad submesh) can not
@@ -1279,22 +1381,9 @@ class MeshTopology(AbstractMeshTopology):
         elif cell.cellname == "quadrilateral":
             petsctools.cite("Homolya2016")
             petsctools.cite("McRae2016")
-            # Quadrilateral mesh
-            cell_ranks = dmcommon.get_cell_remote_ranks(plex)
-
-            facet_orientations = dmcommon.quadrilateral_facet_orientations(
-                plex, vertex_numbering, cell_ranks)
-
-            cell_orientations = dmcommon.orientations_facet2cell(
-                plex, vertex_numbering, cell_ranks,
-                facet_orientations, cell_numbering)
-
-            dmcommon.exchange_cell_orientations(plex,
-                                                cell_numbering,
-                                                cell_orientations)
-
             return dmcommon.quadrilateral_closure_ordering(
-                plex, vertex_numbering, cell_numbering, cell_orientations)
+                plex, vertex_numbering, cell_numbering,
+                self._quadrilateral_cell_orientations)
         elif cell.cellname == "hexahedron":
             # TODO: Should change and use create_cell_closure() for all cell types.
             topology = FIAT.ufc_cell(cell).get_topology()
@@ -1635,6 +1724,12 @@ class MeshTopology(AbstractMeshTopology):
         """
         if self.submesh_parent is None:
             raise RuntimeError("Must only be called on submesh")
+        if self.submesh_point_sf is not None:
+            raise NotImplementedError(
+                "Assembling or interpolating across a submesh and its parent "
+                "requires the two to share the same parallel distribution; use "
+                "`Function.assign` to transfer data between redistributed meshes"
+            )
         if reverse:
             source = self.submesh_parent
             target = self
@@ -1841,6 +1936,7 @@ class ExtrudedMeshTopology(MeshTopology):
         self.cell_set = op2.ExtrudedSet(mesh.cell_set, layers=layers, extruded_periodic=periodic)
         # submesh
         self.submesh_parent = None
+        self.submesh_point_sf = None
 
     @cached_property
     def _ufl_cell(self):
@@ -2956,7 +3052,7 @@ values from f.)"""
         return self
 
     @PETSc.Log.EventDecorator()
-    def refine_marked_elements(self, mark):
+    def refine_marked_elements(self, mark, redistribute=True):
         """Adaptively refine a mesh using a DG0 marking function.
 
         Parameters
@@ -2964,6 +3060,10 @@ values from f.)"""
         mark
             A DG0 `~firedrake.function.Function` on this mesh: cells
             with a positive value ``n`` are refined ``n`` times.
+
+        redistribute
+            if ``True``, redistribute the refined mesh
+            when the coarse mesh has empty ranks.
 
         Returns
         -------
@@ -2974,7 +3074,7 @@ values from f.)"""
             :meth:`~firedrake.mg.mesh.HierarchyBase.add_mesh`.
         """
         from firedrake.adapt import refine_marked_elements
-        return refine_marked_elements(self, mark)
+        return refine_marked_elements(self, mark, redistribute)
 
     @PETSc.Log.EventDecorator()
     def curve_field(self, order, permutation_tol=None, cg_field=None):
@@ -3421,6 +3521,7 @@ def Mesh(meshfile, **kwargs):
                             distribution_name=kwargs.get("distribution_name"),
                             permutation_name=kwargs.get("permutation_name"),
                             submesh_parent=submesh_parent.topology if submesh_parent else None,
+                            submesh_point_sf=kwargs.get("submesh_point_sf"),
                             comm=user_comm)
     mesh = make_mesh_from_mesh_topology(topology, name)
 
@@ -4893,7 +4994,35 @@ def SubDomainData(geometric_expr):
     return op2.Subset(m.cell_set, indices)
 
 
-def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ignore_halo=False, reorder=None, comm=None):
+def _make_submesh_point_sf(plex, subplex):
+    """Create the `PETSc.SF` relating the points of a plex and of its submesh.
+
+    Parameters
+    ----------
+    plex : PETSc.DMPlex
+        The parent plex.
+    subplex : PETSc.DMPlex
+        The submesh plex, before it is distributed.
+
+    Returns
+    -------
+    PETSc.SF
+        SF whose roots are the points of ``plex`` and whose leaves are the
+        points of ``subplex``.
+
+    """
+    pStart, pEnd = plex.getChart()
+    subpStart, subpEnd = subplex.getChart()
+    remote = np.empty((subpEnd - subpStart, 2), dtype=IntType)
+    remote[:, 0] = plex.comm.rank
+    with subplex.getSubpointIS() as subpoints:
+        remote[:, 1] = subpoints
+    point_sf = PETSc.SF().create(comm=subplex.comm)
+    point_sf.setGraph(pEnd - pStart, None, remote)
+    return point_sf
+
+
+def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ignore_halo=False, reorder=None, comm=None, redistribute=False):
     """Construct a submesh from a given mesh.
 
     Parameters
@@ -4923,6 +5052,13 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     comm : PETSc.Comm | None
         An optional sub-communicator to define the submesh.
         By default, the submesh is defined on `mesh.comm`.
+    redistribute : bool
+        Whether to repartition the submesh, instead of inheriting the
+        parallel distribution of ``mesh``. This implies ``ignore_halo=True``,
+        and is currently only supported for submeshes of co-dimension 0.
+        A redistributed submesh can not be assembled or interpolated
+        alongside its parent; use `~.Function.assign` to transfer data
+        between the two.
 
     Returns
     -------
@@ -4991,13 +5127,28 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
 
     >>> submesh = Submesh(mesh, ignore_halo=True, comm=COMM_SELF)
 
+    Construct a repartitioned copy of the entire mesh
+
+    >>> submesh = Submesh(mesh, redistribute=True)
+
     """
+    import firedrake.function as function
+
     if not isinstance(mesh, MeshGeometry):
         raise TypeError("Parent mesh must be a `MeshGeometry`")
     if isinstance(mesh.topology, ExtrudedMeshTopology):
         raise NotImplementedError("Can not create a submesh of an ``ExtrudedMesh``")
     elif isinstance(mesh.topology, VertexOnlyMeshTopology):
         raise NotImplementedError("Can not create a submesh of a ``VertexOnlyMesh``")
+    if redistribute:
+        if comm is not None:
+            raise NotImplementedError("Can only redistribute a submesh over the parent communicator")
+        # Drop the parent halo so that every point of the submesh is owned
+        # by exactly one rank before it is repartitioned.
+        ignore_halo = True
+        distribution_parameters = dict(mesh._distribution_parameters, partition=True)
+    else:
+        distribution_parameters = DISTRIBUTION_PARAMETERS_NOOP
 
     if subdomain_id == "on_boundary":
         if subdim is None:
@@ -5016,6 +5167,11 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     dim = plex.getDimension()
     if subdim not in {dim, dim - 1}:
         raise NotImplementedError(f"Found submesh dim ({subdim}) and parent dim ({dim})")
+    if redistribute and subdim != dim:
+        # The entities of the submesh and of the parent are only oriented
+        # consistently, and hence their nodes only correspond, if the two
+        # meshes are made of the same cells.
+        raise NotImplementedError("Can only redistribute a submesh of co-dimension 0")
     if subdomain_id is None:
         if label_name is not None:
             raise ValueError("subdomain_id=None requires label_name=None.")
@@ -5028,6 +5184,16 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         elif subdim == dim - 1:
             label_name = dmcommon.FACE_SETS_LABEL
     subplex = dmcommon.submesh_create(plex, subdim, label_name, subdomain_id, ignore_halo, comm=comm)
+    if redistribute:
+        # The point correspondence must be recorded before the submesh is
+        # distributed, as distributing it discards the subpoint IS.
+        point_sf = _make_submesh_point_sf(plex, subplex)
+        # The entity classification inherited from the parent no longer holds
+        # once the submesh is repartitioned; drop it so that it is recomputed.
+        for label in ("pyop2_core", "pyop2_owned", "pyop2_ghost"):
+            subplex.removeLabel(label)
+    else:
+        point_sf = None
 
     comm = comm or mesh.comm
     name = name or _generate_default_submesh_name(mesh.name)
@@ -5041,13 +5207,27 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
     submesh = Mesh(
         subplex,
         submesh_parent=mesh,
+        submesh_point_sf=point_sf,
         name=name,
         comm=comm,
         reorder=reorder,
-        distribution_parameters=DISTRIBUTION_PARAMETERS_NOOP,
+        distribution_parameters=distribution_parameters,
+        tolerance=mesh.tolerance,
     )
-    # Tag the relabeled mesh with the original distribution parameters
-    submesh._distribution_parameters = mesh._distribution_parameters
+    if point_sf is None:
+        # Tag the relabeled mesh with the original distribution parameters
+        submesh._distribution_parameters = mesh._distribution_parameters
+        return submesh
+
+    if mesh.coordinates.ufl_element() == submesh.coordinates.ufl_element():
+        return submesh
+    # The parent coordinates are not carried by the plex (e.g. the parent is
+    # curved or periodic), so they must be transferred onto the submesh.
+    V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
+    coordinates = function.Function(V).assign(mesh.coordinates)
+    submesh = Mesh(coordinates, name=name)
+    submesh.submesh_parent = mesh
+    submesh.tolerance = mesh.tolerance
     return submesh
 
 
@@ -5200,6 +5380,9 @@ class MeshSequenceTopology:
                 raise ValueError(f"Got {type(m)}")
         self._meshes = tuple(meshes)
         self.comm = meshes[0].comm
+        # A mesh sequence is never a submesh.
+        self.submesh_parent = None
+        self.submesh_point_sf = None
 
     @property
     def topology(self):

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -5215,19 +5215,17 @@ def Submesh(mesh, subdim=None, subdomain_id=None, label_name=None, name=None, ig
         tolerance=mesh.tolerance,
     )
     if point_sf is None:
-        # Tag the relabeled mesh with the original distribution parameters
+        # Tag the submesh with the original distribution parameters
         submesh._distribution_parameters = mesh._distribution_parameters
-        return submesh
 
-    if mesh.coordinates.ufl_element() == submesh.coordinates.ufl_element():
-        return submesh
-    # The parent coordinates are not carried by the plex (e.g. the parent is
-    # curved or periodic), so they must be transferred onto the submesh.
-    V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
-    coordinates = function.Function(V).assign(mesh.coordinates)
-    submesh = Mesh(coordinates, name=name)
-    submesh.submesh_parent = mesh
-    submesh.tolerance = mesh.tolerance
+    if mesh.coordinates.ufl_element() != submesh.coordinates.ufl_element():
+        # The parent coordinates are not carried by the plex (e.g. the parent is
+        # curved or periodic), so they must be transferred onto the submesh.
+        V = mesh.coordinates.function_space().reconstruct(mesh=submesh)
+        coordinates = function.Function(V).assign(mesh.coordinates)
+        submesh = Mesh(coordinates, name=name)
+        submesh.submesh_parent = mesh
+        submesh.tolerance = mesh.tolerance
     return submesh
 
 

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -68,10 +68,13 @@ def prolong(coarse, fine):
     meshes = hierarchy._meshes
     for j in range(repeat):
         next_level += 1
-        if j == repeat - 1 and not needs_quadrature:
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        last = j == repeat - 1
+        if last and not needs_quadrature and transfer_mesh is fine_mesh:
             fine = finest
         else:
-            fine = Function(Vf.reconstruct(mesh=meshes[next_level]))
+            fine = Function(Vf.reconstruct(mesh=transfer_mesh))
         Vf = fine.function_space()
         Vc = coarse.function_space()
         compose_map = lambda u: utils.fine_node_to_coarse_node_map(Vf, u.function_space())
@@ -110,8 +113,13 @@ def prolong(coarse, fine):
 
         if needs_quadrature:
             # Transfer to the actual target space
-            new_fine = finest if j == repeat-1 else Function(Vfinest.reconstruct(mesh=meshes[next_level]))
+            new_fine = (finest if last and transfer_mesh is fine_mesh
+                        else Function(Vfinest.reconstruct(mesh=transfer_mesh)))
             fine = new_fine.interpolate(fine)
+        if transfer_mesh is not fine_mesh:
+            # Move onto the redistributed mesh
+            target = finest if last else Function(Vfinest.reconstruct(mesh=fine_mesh))
+            fine = target.assign(fine)
         coarse = fine
     return fine
 
@@ -149,9 +157,17 @@ def restrict(fine_dual, coarse_dual):
     coarsest = coarse_dual.zero()
     meshes = hierarchy._meshes
     for j in range(repeat):
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        if transfer_mesh is not fine_mesh:
+            # Move off the redistributed mesh, so that we can restrict
+            Vf_transfer = fine_dual.function_space().reconstruct(mesh=transfer_mesh)
+            fine_dual = Function(Vf_transfer).assign(fine_dual)
         if needs_quadrature:
             # Transfer to the quadrature source space
-            fine_dual = Function(Vq.reconstruct(mesh=meshes[next_level])).interpolate(fine_dual)
+            fine_dual = Function(
+                Vq.reconstruct(mesh=fine_dual.function_space().mesh())
+            ).interpolate(fine_dual)
 
         next_level -= 1
         if j == repeat - 1:
@@ -242,6 +258,12 @@ def inject(fine, coarse):
     Vcoarsest = coarsest.function_space()
     meshes = hierarchy._meshes
     for j in range(repeat):
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        if transfer_mesh is not fine_mesh:
+            # Move off the redistributed mesh, so that we can inject
+            Vf_transfer = fine.function_space().reconstruct(mesh=transfer_mesh)
+            fine = Function(Vf_transfer).assign(fine)
         next_level -= 1
         if j == repeat - 1 and not needs_quadrature:
             coarse = coarsest

--- a/firedrake/mg/interface.py
+++ b/firedrake/mg/interface.py
@@ -68,10 +68,13 @@ def prolong(coarse, fine):
     meshes = hierarchy._meshes
     for j in range(repeat):
         next_level += 1
-        if j == repeat - 1 and not needs_quadrature:
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        last = j == repeat - 1
+        if last and not needs_quadrature and transfer_mesh is fine_mesh:
             fine = finest
         else:
-            fine = Function(Vf.reconstruct(mesh=meshes[next_level]))
+            fine = Function(Vf.reconstruct(mesh=transfer_mesh))
         Vf = fine.function_space()
         Vc = coarse.function_space()
         compose_map = lambda u: utils.fine_node_to_coarse_node_map(Vf, u.function_space())
@@ -105,13 +108,19 @@ def prolong(coarse, fine):
         # An adaptive refinement leaves most of the mesh alone, and the nodes
         # it preserves are copied rather than evaluated.
         node_subset = utils.transfer_node_subset(Vc, Vf)
-        op2.par_loop(kernel, node_subset, *kernel_args)
+        op2.par_loop(kernel, node_subset if node_subset is not None else fine.node_set,
+                     *kernel_args)
         utils.prolong_preserved_nodes(coarse, fine)
 
         if needs_quadrature:
             # Transfer to the actual target space
-            new_fine = finest if j == repeat-1 else Function(Vfinest.reconstruct(mesh=meshes[next_level]))
+            new_fine = (finest if last and transfer_mesh is fine_mesh
+                        else Function(Vfinest.reconstruct(mesh=transfer_mesh)))
             fine = new_fine.interpolate(fine)
+        if transfer_mesh is not fine_mesh:
+            # Move onto the redistributed mesh
+            target = finest if last else Function(Vfinest.reconstruct(mesh=fine_mesh))
+            fine = target.assign(fine)
         coarse = fine
     return fine
 
@@ -149,9 +158,17 @@ def restrict(fine_dual, coarse_dual):
     coarsest = coarse_dual.zero()
     meshes = hierarchy._meshes
     for j in range(repeat):
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        if transfer_mesh is not fine_mesh:
+            # Move off the redistributed mesh, so that we can restrict
+            Vf_transfer = fine_dual.function_space().reconstruct(mesh=transfer_mesh)
+            fine_dual = Function(Vf_transfer).assign(fine_dual)
         if needs_quadrature:
             # Transfer to the quadrature source space
-            fine_dual = Function(Vq.reconstruct(mesh=meshes[next_level])).interpolate(fine_dual)
+            fine_dual = Function(
+                Vq.reconstruct(mesh=fine_dual.function_space().mesh())
+            ).interpolate(fine_dual)
 
         next_level -= 1
         if j == repeat - 1:
@@ -191,7 +208,8 @@ def restrict(fine_dual, coarse_dual):
         # Restriction transposes prolongation, so it skips the same fine nodes
         # and hands the coarse nodes they pair with their values whole.
         node_subset = utils.transfer_node_subset(Vc, Vf)
-        op2.par_loop(kernel, node_subset, *kernel_args)
+        op2.par_loop(kernel, node_subset if node_subset is not None else fine_dual.node_set,
+                     *kernel_args)
         utils.restrict_preserved_nodes(fine_dual, coarse_dual)
         fine_dual = coarse_dual
     return coarse_dual
@@ -242,6 +260,12 @@ def inject(fine, coarse):
     Vcoarsest = coarsest.function_space()
     meshes = hierarchy._meshes
     for j in range(repeat):
+        fine_mesh = meshes[next_level]
+        transfer_mesh = utils.transfer_mesh(fine_mesh)
+        if transfer_mesh is not fine_mesh:
+            # Move off the redistributed mesh, so that we can inject
+            Vf_transfer = fine.function_space().reconstruct(mesh=transfer_mesh)
+            fine = Function(Vf_transfer).assign(fine)
         next_level -= 1
         if j == repeat - 1 and not needs_quadrature:
             coarse = coarsest

--- a/firedrake/mg/mesh.py
+++ b/firedrake/mg/mesh.py
@@ -11,9 +11,9 @@ import firedrake
 from functools import cached_property
 
 from firedrake import utils
+from firedrake.cython import dmcommon
 from firedrake.cython import mgimpl as impl
-import firedrake.cython.dmcommon as dmcommon
-from .utils import set_level
+from .utils import set_level, set_dm_refine_level
 
 __all__ = ("HierarchyBase", "MeshHierarchy", "ExtrudedMeshHierarchy", "NonNestedHierarchy",
            "SemiCoarsenedExtrudedHierarchy", "SubmeshHierarchy")
@@ -50,6 +50,8 @@ class HierarchyBase(object):
         Number of mesh refinements each multigrid level should "see".
     nested :
         Is this mesh hierarchy nested?
+    redistribute :
+        Redistribute adaptively refined meshes that have empty ranks?
 
     Notes
     -----
@@ -58,7 +60,7 @@ class HierarchyBase(object):
 
     """
     def __init__(self, meshes, coarse_to_fine_cells, fine_to_coarse_cells,
-                 refinements_per_level=1, nested=False):
+                 refinements_per_level=1, nested=False, redistribute=True):
         petsctools.cite("Mitchell2016")
         self._meshes = list(meshes)
         self.meshes = self._meshes[::refinements_per_level]
@@ -66,6 +68,7 @@ class HierarchyBase(object):
         self.fine_to_coarse_cells = fine_to_coarse_cells
         self.refinements_per_level = refinements_per_level
         self.nested = nested
+        self.redistribute = redistribute
         for level, m in enumerate(meshes):
             set_level(m, self, Fraction(level, refinements_per_level))
         for level, m in enumerate(self):
@@ -178,7 +181,8 @@ class HierarchyBase(object):
 
         markers = firedrake.Function(M)
         markers.dat.data_wo[eta.dat.data_ro > theta * eta_max] = 1
-        return self.add_mesh(mesh.refine_marked_elements(markers))
+        return self.add_mesh(
+            mesh.refine_marked_elements(markers, redistribute=self.redistribute))
 
 
 def MeshHierarchy(mesh, refinement_levels=0,
@@ -186,7 +190,8 @@ def MeshHierarchy(mesh, refinement_levels=0,
                   netgen_flags=False,
                   reorder=None,
                   distribution_parameters=None, callbacks=None,
-                  mesh_builder=firedrake.Mesh, nested=True):
+                  mesh_builder=firedrake.Mesh, nested=True,
+                  redistribute=True):
     """Build a hierarchy of meshes by uniformly refining a coarse mesh.
 
     Parameters
@@ -209,6 +214,11 @@ def MeshHierarchy(mesh, refinement_levels=0,
         for details.  If ``None``, use the same distribution
         parameters as were used to distribute the coarse mesh,
         otherwise, these options override the default.
+    redistribute : bool
+        If ``True``, redistribute refined meshes when this is needed to
+        avoid empty ranks.  Transfer operators use an internal
+        parent-owned mesh before moving data to or from the redistributed
+        mesh.
     reorder : bool
         optional flag indicating whether to reorder the
         refined meshes.
@@ -245,15 +255,26 @@ def MeshHierarchy(mesh, refinement_levels=0,
     else:
         before = after = lambda dm, i: None
 
-    # Refine an unoverlapped plex at each level. Keeping every dm here
-    # unoverlapped means overlap only ever needs to be added once, by
-    # mesh_builder below.
+    parameters = {}
+    if distribution_parameters is not None:
+        parameters.update(distribution_parameters)
+    else:
+        parameters.update(mesh._distribution_parameters)
+    parameters["partition"] = False
+
+    # Refine an unoverlapped plex at each level, and redistribute the
+    # refined mesh whenever refining alone would leave empty ranks. Keeping
+    # the refined plex unoverlapped means that overlap only ever needs to be
+    # added once, by mesh_builder below.
     cdm = mesh.topology_dm
     if refinement_levels > 0:
         cdm = make_unoverlapped_dm(cdm)
-        cdm.setRefinementUniform(True)
-    dms = [cdm]
+    lgmaps = [(impl.create_lgmap(cdm), impl.create_lgmap(mesh.topology_dm))]
+    meshes = [mesh]
+    coarse_to_fine_cells = []
+    fine_to_coarse_cells = [None]
     for i in range(refinement_levels*refinements_per_level):
+        cdm.setRefinementUniform(True)
         if i % refinements_per_level == 0:
             before(cdm, i)
         rdm = cdm.refine()
@@ -269,19 +290,9 @@ def MeshHierarchy(mesh, refinement_levels=0,
             scale = mesh._radius / np.linalg.norm(coords, axis=1).reshape(-1, 1)
             coords *= scale
 
-        dms.append(rdm)
-        cdm = rdm
-
-    # Build a mesh for each level, adding overlap here.
-    parameters = {}
-    if distribution_parameters is not None:
-        parameters.update(distribution_parameters)
-    else:
-        parameters.update(mesh._distribution_parameters)
-    parameters["partition"] = False
-
-    meshes = [mesh]
-    for rdm in dms[1:]:
+        # The cell maps relate the refined mesh to the mesh it was refined
+        # from, so they must be built before it is redistributed.
+        rlgmap = impl.create_lgmap(rdm)
         fmesh = mesh_builder(
             rdm,
             dim=mesh.geometric_dimension,
@@ -289,32 +300,28 @@ def MeshHierarchy(mesh, refinement_levels=0,
             reorder=reorder,
             comm=mesh.comm,
         )
-        meshes.append(fmesh)
-
-    # Build local-to-global maps and coarse/fine cell maps between
-    # consecutive levels.
-    lgmaps = [
-        (impl.create_lgmap(dm), impl.create_lgmap(m.topology_dm))
-        for dm, m in zip(dms, meshes)
-    ]
-    coarse_to_fine_cells = []
-    fine_to_coarse_cells = [None]
-    for (coarse, fine), (clgmaps, flgmaps) in zip(zip(meshes[:-1], meshes[1:]),
-                                                  zip(lgmaps[:-1], lgmaps[1:])):
-        c2f, f2c = impl.coarse_to_fine_cells(coarse, fine, clgmaps, flgmaps)
+        flgmaps = (rlgmap, impl.create_lgmap(fmesh.topology_dm))
+        c2f, f2c = impl.coarse_to_fine_cells(meshes[-1], fmesh, lgmaps[-1], flgmaps)
         coarse_to_fine_cells.append(c2f)
         fine_to_coarse_cells.append(f2c)
 
+        if redistribute and fmesh.has_empty_rank:
+            fmesh = firedrake.Submesh(fmesh, redistribute=True)
+        cdm = make_unoverlapped_dm(fmesh.topology_dm)
+        lgmaps.append((impl.create_lgmap(cdm), impl.create_lgmap(fmesh.topology_dm)))
+        meshes.append(fmesh)
+
     for i, m in enumerate(meshes):
         # Firedrake counts multigrid levels, PETSc counts refinements
-        m.topology_dm.setRefineLevel(i)
+        set_dm_refine_level(m, i)
 
     coarse_to_fine_cells = dict((Fraction(i, refinements_per_level), c2f)
                                 for i, c2f in enumerate(coarse_to_fine_cells))
     fine_to_coarse_cells = dict((Fraction(i, refinements_per_level), f2c)
                                 for i, f2c in enumerate(fine_to_coarse_cells))
     return HierarchyBase(meshes, coarse_to_fine_cells, fine_to_coarse_cells,
-                         refinements_per_level, nested=nested)
+                         refinements_per_level, nested=nested,
+                         redistribute=redistribute)
 
 
 def ExtrudedMeshHierarchy(base_hierarchy, height, base_layer=-1, refinement_ratio=2, layers=None,

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -540,9 +540,9 @@ def physical_node_locations(V):
 def transfer_mesh(mesh):
     """Return the mesh that grid transfer operates on.
 
-    A redistributed mesh has no cell maps relating it to the coarse mesh, so
-    transfers go through the mesh it was redistributed from, and the values
-    are then assigned across the two.
+    A redistributed mesh has no cell maps relating it to the coarse mesh.
+    Transfers therefore go through the mesh it was redistributed from. The
+    values are then assigned across the two.
 
     Parameters
     ----------

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -504,7 +504,7 @@ def restrict_preserved_nodes(fine_dual, coarse_dual):
     section_sf = preserved_node_sf(coarse_V, fine_dual.function_space())
     if section_sf is None:
         return
-    buffer = firedrake.Function(coarse_V)
+    buffer = type(coarse_dual)(coarse_V)
     mtype, _ = _get_mtype(buffer.dat)
     source = fine_dual.dat.data_ro
     target = buffer.dat.data_wo_with_halos
@@ -537,9 +537,86 @@ def physical_node_locations(V):
         return cache.setdefault(key, locations)
 
 
+def transfer_mesh(mesh):
+    """Return the mesh that grid transfer operates on.
+
+    A redistributed mesh has no cell maps relating it to the coarse mesh, so
+    transfers go through the mesh it was redistributed from, and the values
+    are then assigned across the two.
+
+    Parameters
+    ----------
+    mesh : firedrake.mesh.MeshGeometry
+        A mesh in a `HierarchyBase`.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry
+        ``mesh`` itself, or the mesh it was redistributed from.
+
+    """
+    return mesh.submesh_parent if mesh.submesh_point_sf is not None else mesh
+
+
+def _redistribution_ancestors(topology):
+    """Yield a mesh topology together with the topologies it was redistributed from.
+
+    The transfer operators work on the mesh a redistributed mesh came from,
+    so both must carry the same multigrid level.
+
+    Parameters
+    ----------
+    topology : firedrake.mesh.AbstractMeshTopology
+        The topology to start from.
+
+    Yields
+    ------
+    firedrake.mesh.AbstractMeshTopology
+        ``topology``, then each mesh topology it was redistributed from, in
+        order.
+
+    """
+    yield topology
+    while topology.submesh_point_sf is not None:
+        topology = topology.submesh_parent
+        yield topology
+
+
+def set_dm_refine_level(mesh, level):
+    """Set the refinement level of a mesh and of the meshes it was redistributed from.
+
+    Parameters
+    ----------
+    mesh : firedrake.mesh.MeshGeometry
+        The mesh to set the refinement level of.
+    level : int
+        The refinement level to set.
+
+    """
+    for topology in _redistribution_ancestors(mesh.topology):
+        topology.topology_dm.setRefineLevel(level)
+
+
 def set_level(obj, hierarchy, level):
-    """Attach hierarchy and level info to an object."""
-    setattr(obj.topological, "__level_info__", (hierarchy, level))
+    """Attach hierarchy and level info to an object.
+
+    Parameters
+    ----------
+    obj : firedrake.mesh.MeshGeometry or firedrake.functionspaceimpl.WithGeometry
+        The object to attach the hierarchy and level info to.
+    hierarchy : HierarchyBase
+        The hierarchy ``obj`` belongs to.
+    level : Fraction
+        The level of ``obj`` in ``hierarchy``.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry or firedrake.functionspaceimpl.WithGeometry
+        ``obj``, unchanged.
+
+    """
+    for topology in _redistribution_ancestors(obj.topological):
+        setattr(topology, "__level_info__", (hierarchy, level))
     return obj
 
 

--- a/firedrake/mg/utils.py
+++ b/firedrake/mg/utils.py
@@ -292,14 +292,14 @@ def transfer_node_subset(Vc, Vf):
 
     Returns
     -------
-    pyop2.types.set.Set or pyop2.types.set.Subset
+    pyop2.types.set.Subset
         The nodes of ``Vf`` that :func:`preserved_node_sf` does not account
-        for, or ``Vf.node_set`` itself if that is all of them.
+        for, or `None` if that is all of them.
 
     """
     section_sf = preserved_node_sf(Vc, Vf)
     if section_sf is None:
-        return Vf.node_set
+        return None
     cache = Vf.mesh().topology._shared_data_cache["hierarchy_transfer_node_subset"]
     key = _cache_key(Vc, Vf)
     try:
@@ -358,7 +358,7 @@ def restrict_preserved_nodes(fine_dual, coarse_dual):
     section_sf = preserved_node_sf(coarse_V, fine_dual.function_space())
     if section_sf is None:
         return
-    buffer = firedrake.Function(coarse_V)
+    buffer = type(coarse_dual)(coarse_V)
     mtype, _ = _get_mtype(buffer.dat)
     source = fine_dual.dat.data_ro
     target = buffer.dat.data_wo_with_halos
@@ -391,9 +391,86 @@ def physical_node_locations(V):
         return cache.setdefault(key, locations)
 
 
+def transfer_mesh(mesh):
+    """Return the mesh that grid transfer operates on.
+
+    A redistributed mesh has no cell maps relating it to the coarse mesh, so
+    transfers go through the mesh it was redistributed from, and the values
+    are then assigned across the two.
+
+    Parameters
+    ----------
+    mesh : firedrake.mesh.MeshGeometry
+        A mesh in a `HierarchyBase`.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry
+        ``mesh`` itself, or the mesh it was redistributed from.
+
+    """
+    return mesh.submesh_parent if mesh.submesh_point_sf is not None else mesh
+
+
+def _redistribution_ancestors(topology):
+    """Yield a mesh topology together with the topologies it was redistributed from.
+
+    The transfer operators work on the mesh a redistributed mesh came from,
+    so both must carry the same multigrid level.
+
+    Parameters
+    ----------
+    topology : firedrake.mesh.AbstractMeshTopology
+        The topology to start from.
+
+    Yields
+    ------
+    firedrake.mesh.AbstractMeshTopology
+        ``topology``, then each mesh topology it was redistributed from, in
+        order.
+
+    """
+    yield topology
+    while topology.submesh_point_sf is not None:
+        topology = topology.submesh_parent
+        yield topology
+
+
+def set_dm_refine_level(mesh, level):
+    """Set the refinement level of a mesh and of the meshes it was redistributed from.
+
+    Parameters
+    ----------
+    mesh : firedrake.mesh.MeshGeometry
+        The mesh to set the refinement level of.
+    level : int
+        The refinement level to set.
+
+    """
+    for topology in _redistribution_ancestors(mesh.topology):
+        topology.topology_dm.setRefineLevel(level)
+
+
 def set_level(obj, hierarchy, level):
-    """Attach hierarchy and level info to an object."""
-    setattr(obj.topological, "__level_info__", (hierarchy, level))
+    """Attach hierarchy and level info to an object.
+
+    Parameters
+    ----------
+    obj : firedrake.mesh.MeshGeometry or firedrake.functionspaceimpl.WithGeometry
+        The object to attach the hierarchy and level info to.
+    hierarchy : HierarchyBase
+        The hierarchy ``obj`` belongs to.
+    level : Fraction
+        The level of ``obj`` in ``hierarchy``.
+
+    Returns
+    -------
+    firedrake.mesh.MeshGeometry or firedrake.functionspaceimpl.WithGeometry
+        ``obj``, unchanged.
+
+    """
+    for topology in _redistribution_ancestors(obj.topological):
+        setattr(topology, "__level_info__", (hierarchy, level))
     return obj
 
 

--- a/tests/firedrake/multigrid/test_adaptive_multigrid.py
+++ b/tests/firedrake/multigrid/test_adaptive_multigrid.py
@@ -2,7 +2,8 @@ import pytest
 import numpy as np
 from mpi4py import MPI
 from firedrake import *
-from firedrake.mg.utils import coarse_cell_to_fine_node_map, transfer_node_subset
+from firedrake.mg.utils import (coarse_cell_to_fine_node_map, transfer_mesh,
+                                transfer_node_subset)
 from firedrake.utils import complex_mode
 
 
@@ -80,7 +81,7 @@ def test_refine_marked_elements_populates_cell_maps(coarse_mesh):
     fine_to_coarse = mh.fine_to_coarse_cells[1]
 
     assert coarse_to_fine.shape[0] == mesh.cell_set.size
-    assert fine_to_coarse.shape == (refined_mesh.cell_set.size, 1)
+    assert fine_to_coarse.shape == (transfer_mesh(refined_mesh).cell_set.size, 1)
     assert (fine_to_coarse >= -1).all()
     assert (fine_to_coarse >= 0).any()
     assert (coarse_to_fine >= 0).any()
@@ -245,7 +246,7 @@ def _assert_adapt_after_uniform_refinement(mh):
     fine_to_coarse = mh.fine_to_coarse_cells[level]
 
     assert coarse_to_fine.shape[0] == mesh.cell_set.size
-    assert fine_to_coarse.shape == (refined_mesh.cell_set.size, 1)
+    assert fine_to_coarse.shape == (transfer_mesh(refined_mesh).cell_set.size, 1)
     # A rank may legitimately own zero local cells (e.g. more ranks than
     # coarse cells), leaving these arrays empty on that rank alone, so the
     # "some entry is valid" check must be collective, not per-rank.
@@ -355,7 +356,7 @@ def _copied_nodes(mh, V):
     copied = 0
     for level in range(len(mh) - 1):
         V_coarse = V.reconstruct(mesh=mh[level])
-        V_fine = V.reconstruct(mesh=mh[level + 1])
+        V_fine = V.reconstruct(mesh=transfer_mesh(mh[level + 1]))
         subset = transfer_node_subset(V_coarse, V_fine)
         # A Subset's .indices spans the owned range, like node_set.size does.
         # But when nothing is preserved, transfer_node_subset falls back to

--- a/tests/firedrake/multigrid/test_adaptive_multigrid.py
+++ b/tests/firedrake/multigrid/test_adaptive_multigrid.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from mpi4py import MPI
 from firedrake import *
+from firedrake.mg.utils import transfer_mesh
 
 
 def corner_adaptive_hierarchy(base, nlevels):
@@ -77,7 +78,7 @@ def test_refine_marked_elements_populates_cell_maps(coarse_mesh):
     fine_to_coarse = mh.fine_to_coarse_cells[1]
 
     assert coarse_to_fine.shape[0] == mesh.cell_set.size
-    assert fine_to_coarse.shape == (refined_mesh.cell_set.size, 1)
+    assert fine_to_coarse.shape == (transfer_mesh(refined_mesh).cell_set.size, 1)
     assert (fine_to_coarse >= -1).all()
     assert (fine_to_coarse >= 0).any()
     assert (coarse_to_fine >= 0).any()
@@ -238,7 +239,7 @@ def _assert_adapt_after_uniform_refinement(mh):
     fine_to_coarse = mh.fine_to_coarse_cells[level]
 
     assert coarse_to_fine.shape[0] == mesh.cell_set.size
-    assert fine_to_coarse.shape == (refined_mesh.cell_set.size, 1)
+    assert fine_to_coarse.shape == (transfer_mesh(refined_mesh).cell_set.size, 1)
     # A rank may legitimately own zero local cells (e.g. more ranks than
     # coarse cells), leaving these arrays empty on that rank alone, so the
     # "some entry is valid" check must be collective, not per-rank.
@@ -316,14 +317,10 @@ def _copied_nodes(mh, V):
     copied = 0
     for level in range(len(mh) - 1):
         V_coarse = V.reconstruct(mesh=mh[level])
-        V_fine = V.reconstruct(mesh=mh[level + 1])
+        V_fine = V.reconstruct(mesh=transfer_mesh(mh[level + 1]))
         subset = transfer_node_subset(V_coarse, V_fine)
-        # A Subset's indices only ever span the owned range like node_set.size
-        # does, but transfer_node_subset falls back to the fine node_set
-        # itself (whose .indices spans the larger owned+halo total_size) when
-        # nothing is preserved, so cap at node_set.size before differencing.
-        visited = min(len(subset.indices), V_fine.node_set.size)
-        copied += V_fine.node_set.size - visited
+        if subset is not None:
+            copied += V_fine.node_set.size - len(subset.indices)
     return mh[0].comm.allreduce(copied, MPI.SUM)
 
 

--- a/tests/firedrake/multigrid/test_redist_mesh.py
+++ b/tests/firedrake/multigrid/test_redist_mesh.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+
+from firedrake import *
+
+
+@pytest.mark.parallel(2)
+def test_redistributed_hierarchy():
+    m = UnitIntervalMesh(1)
+    mh = MeshHierarchy(m, 1)
+
+    assert mh[1].cell_set.size > 0
+
+
+@pytest.mark.parallel(4)
+def test_uniform_hierarchy_no_empty_ranks():
+    dparams = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}
+    base = UnitSquareMesh(1, 1, distribution_parameters=dparams)
+    mh = MeshHierarchy(base, 2)
+
+    for l, m in enumerate(mh[1:]):
+        assert m.cell_set.size > 0
+        for k, v in dparams.items():
+            assert m._distribution_parameters.get(k, None) == v
+
+        Vc = FunctionSpace(mh[l], "CG", 1)
+        Vf = FunctionSpace(mh[l+1], "CG", 1)
+
+        xc, yc = SpatialCoordinate(mh[l])
+        xf, yf = SpatialCoordinate(mh[l+1])
+        coarse_expr = xc + 2*yc
+        fine_expr = xf + 2*yf
+
+        # test prolong CG1
+        coarse = Function(Vc).interpolate(coarse_expr)
+        fine = Function(Vf)
+        prolong(coarse, fine)
+        assert errornorm(fine_expr, fine) < 1e-12
+
+        # test restrict CG1
+        one_coarse = Function(Vc).assign(1)
+        one_fine = Function(Vf)
+        prolong(one_coarse, one_fine)
+
+        fine_dual = assemble(conj(TestFunction(Vf))*dx)
+        coarse_dual = Cofunction(Vc.dual())
+        restrict(fine_dual, coarse_dual)
+        assert np.allclose(
+            assemble(action(coarse_dual, one_coarse)),
+            assemble(action(fine_dual, one_fine)),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+        # test inject CG1
+        coarse_injected = Function(Vc)
+        inject(fine, coarse_injected)
+        assert errornorm(coarse_expr, coarse_injected) < 1e-12
+
+        # test inject DG0
+        Qc = FunctionSpace(mh[l], "DG", 0)
+        Qf = FunctionSpace(mh[l+1], "DG", 0)
+        fine_expr = conditional(xf > 1, 1, 0)
+        coarse_expr = conditional(xc > 1, 1, 0)
+        fine = Function(Qf).interpolate(fine_expr)
+        coarse_injected = Function(Qc)
+        inject(fine, coarse_injected)
+        assert np.allclose(
+            assemble(coarse_expr * dx),
+            assemble(coarse_injected * dx),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        assert l == 0 or errornorm(coarse_expr, coarse_injected) < 1e-12
+
+
+@pytest.mark.parallel(3)
+def test_adaptive_hierarchy_redistributes_empty_ranks():
+    # Two cells spread over three ranks leave a rank with no cells, which
+    # adaptive refinement alone does not fix, so the refined mesh has to be
+    # redistributed.
+    dparams = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1),
+               "partitioner_type": "simple"}
+    mesh = UnitSquareMesh(1, 1, distribution_parameters=dparams)
+    assert mesh.has_empty_rank
+    mh = MeshHierarchy(mesh)
+
+    # Mark only one of the two cells, so the refined mesh keeps both a
+    # refined region and a region the refinement leaves alone.
+    M = FunctionSpace(mesh, "DG", 0)
+    markers = Function(M)
+    markers.dat.data_wo[:1] = 1
+
+    refined_mesh = mesh.refine_marked_elements(markers)
+    assert refined_mesh.topology.submesh_point_sf is not None
+    assert not refined_mesh.has_empty_rank
+    mh.add_mesh(refined_mesh)
+
+    V_coarse = FunctionSpace(mesh, "CG", 1)
+    V_fine = FunctionSpace(refined_mesh, "CG", 1)
+    xc, yc = SpatialCoordinate(mesh)
+    xf, yf = SpatialCoordinate(refined_mesh)
+    expr_coarse = xc + 2 * yc
+    expr_fine = xf + 2 * yf
+
+    # test prolong CG1
+    u_coarse = Function(V_coarse).interpolate(expr_coarse)
+    u_fine = Function(V_fine)
+    prolong(u_coarse, u_fine)
+    assert errornorm(expr_fine, u_fine) <= 1e-12
+
+    # test restrict CG1
+    r_fine = assemble(conj(TestFunction(V_fine)) * dx)
+    r_coarse = Cofunction(V_coarse.dual())
+    restrict(r_fine, r_coarse)
+    assert np.allclose(
+        assemble(action(r_coarse, u_coarse)),
+        assemble(action(r_fine, u_fine)),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+    # test inject CG1
+    u_coarse_injected = Function(V_coarse)
+    inject(u_fine, u_coarse_injected)
+    assert errornorm(expr_coarse, u_coarse_injected) <= 1e-12

--- a/tests/firedrake/multigrid/test_redist_mesh.py
+++ b/tests/firedrake/multigrid/test_redist_mesh.py
@@ -76,8 +76,8 @@ def test_uniform_hierarchy_no_empty_ranks():
 
 @pytest.mark.parallel(3)
 def test_adaptive_hierarchy_redistributes_empty_ranks():
-    # Two cells spread over three ranks leave a rank with no cells, which
-    # adaptive refinement alone does not fix, so the refined mesh has to be
+    # Two cells spread over three ranks leave a rank with no cells. Adaptive
+    # refinement alone does not fix that. The refined mesh has to be
     # redistributed.
     dparams = {"overlap_type": (DistributedMeshOverlapType.VERTEX, 1),
                "partitioner_type": "simple"}

--- a/tests/firedrake/submesh/test_submesh_assemble.py
+++ b/tests/firedrake/submesh/test_submesh_assemble.py
@@ -597,3 +597,34 @@ def test_submesh_assemble_facet_macroelement():
     vsub = TestFunction(Vsub)
     aref = assemble(inner(1, vsub)*dx(submesh))
     assert np.allclose(a.dat[1].data_ro, aref.dat.data_ro)
+
+
+@pytest.mark.parallel(nprocs=[1, 3])
+def test_submesh_assemble_redistributed():
+    # A redistributed submesh does not share the point numbering of its
+    # parent, so the entity maps that multidomain assembly needs do not exist.
+    dim = 2
+    mesh = RectangleMesh(2, 1, 2., 1., quadrilateral=True)
+    x, _ = SpatialCoordinate(mesh)
+    DQ0 = FunctionSpace(mesh, "DQ", 0)
+    mesh.mark_entities(Function(DQ0).interpolate(conditional(x > 1., 1, 0)), 999)
+    subm = Submesh(mesh, dim, 999, redistribute=True)
+    V = FunctionSpace(mesh, "CG", 1) * FunctionSpace(subm, "CG", 1)
+    u0, u1 = split(TrialFunction(V))
+    v0, v1 = split(TestFunction(V))
+    dx0 = Measure("dx", domain=mesh, intersect_measures=(Measure("dx", subm),))
+    with pytest.raises(NotImplementedError):
+        assemble(inner(u1, v0) * dx0(999), mat_type="nest")
+
+
+@pytest.mark.parallel(nprocs=[1, 3])
+def test_submesh_interpolate_redistributed():
+    dim = 2
+    mesh = RectangleMesh(2, 1, 2., 1., quadrilateral=True)
+    x, _ = SpatialCoordinate(mesh)
+    DQ0 = FunctionSpace(mesh, "DQ", 0)
+    mesh.mark_entities(Function(DQ0).interpolate(conditional(x > 1., 1, 0)), 999)
+    subm = Submesh(mesh, dim, 999, redistribute=True)
+    f = Function(FunctionSpace(mesh, "CG", 1)).interpolate(x)
+    with pytest.raises(NotImplementedError):
+        assemble(interpolate(f, FunctionSpace(subm, "CG", 1)))

--- a/tests/firedrake/submesh/test_submesh_assign.py
+++ b/tests/firedrake/submesh/test_submesh_assign.py
@@ -318,9 +318,9 @@ def test_submesh_assign_cofunction_3_quads_2_processes():
 ])
 @pytest.mark.parallel(nprocs=[1, 3])
 def test_submesh_assign_function_redistributed(mesh_type, family, degree):
-    # A redistributed submesh holds the same mesh as its parent, so assigning
-    # between the two must be exact for every element, including those whose
-    # DoFs depend on the orientation of the entity they live on.
+    # A redistributed submesh holds the same mesh as its parent. Assigning
+    # between the two must therefore be exact for every element. That includes
+    # the elements whose DoFs depend on the orientation of their entity.
     mesh = UnitSquareMesh(4, 4, quadrilateral=(mesh_type == "quadrilateral"))
     submesh = Submesh(mesh, redistribute=True)
     assert submesh.topology.submesh_parent is mesh.topology

--- a/tests/firedrake/submesh/test_submesh_assign.py
+++ b/tests/firedrake/submesh/test_submesh_assign.py
@@ -307,3 +307,70 @@ def test_submesh_assign_cofunction_3_quads_2_processes():
     cof_ = Cofunction(V_r.dual()).assign(cof)
     subset_indices = np.where(coords_r.dat.data_ro_with_halos[:, 0] > 1.999)
     assert np.allclose(cof_.dat.data_ro_with_halos[subset_indices], cof_r.dat.data_ro_with_halos[subset_indices])
+
+
+@pytest.mark.parametrize("mesh_type,family,degree", [
+    ("simplex", "CG", 3),
+    ("simplex", "RT", 2),
+    ("simplex", "N1curl", 1),
+    ("quadrilateral", "CG", 2),
+    ("quadrilateral", "RTCF", 1),
+])
+@pytest.mark.parallel(nprocs=[1, 3])
+def test_submesh_assign_function_redistributed(mesh_type, family, degree):
+    # A redistributed submesh holds the same mesh as its parent, so assigning
+    # between the two must be exact for every element, including those whose
+    # DoFs depend on the orientation of the entity they live on.
+    mesh = UnitSquareMesh(4, 4, quadrilateral=(mesh_type == "quadrilateral"))
+    submesh = Submesh(mesh, redistribute=True)
+    assert submesh.topology.submesh_parent is mesh.topology
+    assert submesh.topology.submesh_point_sf is not None
+
+    V = FunctionSpace(mesh, family, degree)
+    V_sub = FunctionSpace(submesh, family, degree)
+    x, y = SpatialCoordinate(mesh)
+    x_sub, y_sub = SpatialCoordinate(submesh)
+    if V.value_size == 1:
+        expr, expr_sub = sin(x) * cos(3 * y), sin(x_sub) * cos(3 * y_sub)
+    else:
+        expr = as_vector([sin(x), cos(3 * y)])
+        expr_sub = as_vector([sin(x_sub), cos(3 * y_sub)])
+    f = Function(V).interpolate(expr)
+    # -- mesh -> submesh
+    f_sub = Function(V_sub).assign(f)
+    assert np.allclose(norm(f_sub - Function(V_sub).interpolate(expr_sub)), 0)
+    # -- submesh -> mesh
+    assert np.allclose(norm(Function(V).assign(f_sub) - f), 0)
+    # -- the dual assignment preserves the action
+    cof_sub = assemble(inner(expr_sub, TestFunction(V_sub)) * dx)
+    cof = Cofunction(V.dual()).assign(cof_sub)
+    assert np.isclose(assemble(action(cof, f)), assemble(action(cof_sub, f_sub)))
+
+
+@pytest.mark.parametrize("family,degree", [("CG", 2), ("RT", 1)])
+@pytest.mark.parallel(nprocs=[1, 3])
+def test_submesh_assign_function_redistributed_subdomain(family, degree):
+    mesh = UnitSquareMesh(4, 4)
+    x, y = SpatialCoordinate(mesh)
+    DG0 = FunctionSpace(mesh, "DG", 0)
+    mesh.mark_entities(Function(DG0).interpolate(conditional(x < 0.5, 1, 0)), 111)
+    submesh = Submesh(mesh, subdomain_id=111, redistribute=True)
+
+    V = FunctionSpace(mesh, family, degree)
+    V_sub = FunctionSpace(submesh, family, degree)
+    x_sub, y_sub = SpatialCoordinate(submesh)
+    if V.value_size == 1:
+        expr, expr_sub = sin(x) * cos(3 * y), sin(x_sub) * cos(3 * y_sub)
+    else:
+        expr = as_vector([sin(x), cos(3 * y)])
+        expr_sub = as_vector([sin(x_sub), cos(3 * y_sub)])
+    f = Function(V).interpolate(expr)
+    # -- mesh -> submesh
+    f_sub = Function(V_sub).assign(f)
+    assert np.allclose(norm(f_sub - Function(V_sub).interpolate(expr_sub)), 0)
+    # -- submesh -> mesh: the parent has nodes outside the subdomain
+    with pytest.raises(ValueError):
+        Function(V).assign(f_sub)
+    g = Function(V).interpolate(expr)
+    g.assign(f_sub, allow_missing_dofs=True)
+    assert np.allclose(norm(g - f), 0)

--- a/tests/firedrake/submesh/test_submesh_basics.py
+++ b/tests/firedrake/submesh/test_submesh_basics.py
@@ -1,3 +1,4 @@
+import pytest
 from firedrake import *
 
 
@@ -14,3 +15,11 @@ def test_submesh_parent():
     submesh = Submesh(parent, parent.topological_dimension, cell_marker)
     assert submesh.topology.submesh_parent is parent.topology
     assert submesh.submesh_parent is parent
+
+
+def test_submesh_redistribute_codim():
+    # The entities of a submesh of non-zero co-dimension are not the entities
+    # of its parent, so they can not inherit its orientations.
+    mesh = UnitSquareMesh(2, 2)
+    with pytest.raises(NotImplementedError):
+        Submesh(mesh, subdomain_id="on_boundary", redistribute=True)

--- a/tests/firedrake/submesh/test_submesh_basics.py
+++ b/tests/firedrake/submesh/test_submesh_basics.py
@@ -1,5 +1,11 @@
+import os
 import pytest
+import numpy as np
 from firedrake import *
+from petsc4py import PETSc
+
+
+cwd = os.path.abspath(os.path.dirname(__file__))
 
 
 def test_submesh_parent():
@@ -23,3 +29,59 @@ def test_submesh_redistribute_codim():
     mesh = UnitSquareMesh(2, 2)
     with pytest.raises(NotImplementedError):
         Submesh(mesh, subdomain_id="on_boundary", redistribute=True)
+
+
+def _curved_mesh(nx=4, degree=2):
+    """Build a unit square whose curved coordinates the plex can not carry."""
+    mesh = UnitSquareMesh(nx, nx)
+    V = VectorFunctionSpace(mesh, "CG", degree)
+    x, y = SpatialCoordinate(mesh)
+    coordinates = Function(V).interpolate(as_vector([x + 0.15 * sin(pi * y) * x * (1 - x), y]))
+    return Mesh(coordinates)
+
+
+@pytest.mark.parallel([1, 2, 3])
+def test_submesh_curved_coordinates():
+    # The plex carries no curved coordinates, so a submesh of the same
+    # dimension must take them from its parent.
+    mesh = _curved_mesh()
+    x, _ = SpatialCoordinate(mesh)
+    DG0 = FunctionSpace(mesh, "DG", 0)
+    mesh.mark_entities(Function(DG0).interpolate(conditional(x > 0.5, 1, 0)), 77)
+
+    submesh = Submesh(mesh, mesh.topological_dimension, 77)
+    assert submesh.coordinates.ufl_element() == mesh.coordinates.ufl_element()
+    area = assemble(Constant(1.0) * dx(submesh))
+    assert np.isclose(area, assemble(conditional(x > 0.5, 1.0, 0.0) * dx(mesh)))
+    # The same region of an affine parent would measure exactly one half.
+    assert not np.isclose(area, 0.5)
+
+
+@pytest.mark.parallel([1, 2, 3])
+def test_submesh_affine_coordinates():
+    # An affine parent and a submesh of lower dimension carry the same element
+    # up to their cell. The plex therefore already holds the right coordinates.
+    mesh = UnitSquareMesh(3, 3)
+    submesh = Submesh(mesh, 1, "on_boundary", label_name="exterior_facets")
+    assert submesh.coordinates.ufl_element() == \
+        mesh.coordinates.ufl_element().reconstruct(cell=submesh.ufl_cell())
+    assert np.isclose(assemble(Constant(1.0) * dx(submesh)), 4.0)
+
+
+@pytest.mark.parallel([1, 2, 3])
+def test_submesh_curved_codim():
+    # A parent and a submesh of lower dimension share only some of the nodes
+    # on a parent cell. The cell node maps can not select those nodes.
+    mesh = _curved_mesh()
+    with pytest.raises(NotImplementedError):
+        Submesh(mesh, 1, "on_boundary", label_name="exterior_facets")
+
+
+@pytest.mark.parallel([1, 2])
+def test_submesh_multiple_cell_types_coordinates():
+    # A mesh with several cell types carries no coordinate Function, so a
+    # submesh of it takes the coordinates the plex holds.
+    mesh = Mesh(os.path.join(cwd, "..", "meshes", "mixed_cell_unit_square.msh"))
+    submesh = Submesh(mesh, mesh.topological_dimension,
+                      PETSc.DM.PolytopeType.TRIANGLE, label_name="celltype")
+    assert submesh.ufl_cell().cellname == "triangle"


### PR DESCRIPTION
## Stack

PR 3 of 4: #5460 (`dmplex-hierarchy-maps`) -> #5288 (`adaptive-multigrid`) -> **this PR** (`mesh-redistribution`) -> #5287 (`assign-submesh-restricted`).

## Summary
AI-assisted (Claude Code)

Mesh redistribution is now a `Submesh` of the mesh it was redistributed from, rather than an ad-hoc
`redist` attribute bolted onto the mesh.

- `Submesh(mesh, redistribute=True)` repartitions instead of inheriting the parent's parallel
  distribution, for both `subdomain_id=None` (the whole mesh, as needed by a redistributed
  `MeshHierarchy`) and a proper subdomain (co-dimension 0 only). The child records a
  `submesh_point_sf` pushing the parent's plex points onto its own, which `is_redistributed` asks
  about; `submesh_shares_distribution` tells consumers (assembly, interpolation) whether two related
  meshes still share a distribution.
- Entity orientations are preserved across redistribution: the child inherits the parent's universal
  vertex numbering (`dmcommon.submesh_vertex_numbering`) and quadrilateral/hexahedral cell
  orientations (`dmcommon.submesh_cell_orientations`), so cell closures are ordered identically on
  both sides and RT/BDM/N1curl/RTCF/RTCE data transfers exactly instead of picking up sign/permutation
  flips.
- Assembling or interpolating across a redistributed mesh and its parent raises `NotImplementedError`,
  since entity maps are only defined when the two share a distribution; use `Function.assign` instead.
- `MeshHierarchy` (`redistribute=True` by default) and `refine_marked_elements`/`HierarchyBase.adapt`
  redistribute a refined/adapted mesh via `Submesh` whenever it would otherwise leave empty ranks.
  `firedrake/mg/interface.py` (`prolong`/`restrict`/`inject`) and `firedrake/mg/utils.py`
  (`transfer_mesh`, `set_dm_refine_level`, `set_level`) route transfers through the pre-redistribution
  mesh, then `assign` onto the redistributed one.

Two supporting changes affect all meshes, not only redistributed ones:

- `MeshTopology.cell_closure` takes its universal vertex numbering and its quadrilateral cell
  orientations from two new `cached_property`s, `_universal_vertex_numbering` and
  `_quadrilateral_cell_orientations`, so that a redistributed submesh can inherit its parent's.
- `MeshHierarchy` rebuilds the unoverlapped dm from each constructed level rather than refining one
  plex repeatedly, so that a level can be redistributed before the next is refined from it.

`firedrake/cython/petschdr.pxi` now declares `PetscSFBcastBegin`/`PetscSFBcastEnd` with the
`MPI_Op` argument they take. The two new `dmcommon` functions are the only callers of either.

## Testing

Redistribution round-trips exactly (<= 1e-16) for tri/quad/tet/hex x CG/DG/RT/BDM/N1curl/RTCF/RTCE on
1-3 ranks, including curved (P2) and periodic (DG1) coordinate fields
(`tests/firedrake/submesh/test_submesh_assign.py`). `tests/firedrake/multigrid/test_redist_mesh.py`
covers uniform and adaptive `MeshHierarchy` redistribution (2/3/4 ranks); `test_submesh_assemble.py`
covers the `NotImplementedError` paths. All pass at every process count their markers declare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
