### PR TITLE
Fix flaky int64 test

### DIFF
--- a/tests/firedrake/regression/test_projection_zany.py
+++ b/tests/firedrake/regression/test_projection_zany.py
@@ -80,7 +80,7 @@ def run_convergence_test(mh, el, degree, convrate):
                           ('Hermite', 3, 3.8),
                           ('Bell', 5, 4.7),
                           ('Argyris', 5, 5.8),
-                          ('Argyris', 6, 6.7),
+                          ('Argyris', 6, 6.6),
                           ('Nonconforming Robust Wu-Xu', 7, 3.8)])
 def test_projection_zany_convergence_2d(hierarchy_2d, el, deg, convrate):
     run_convergence_test(hierarchy_2d[2:], el, deg, convrate)


### PR DESCRIPTION
This test was often returning a convergence rate of 6.695 and consequently failing on int64 builds