### PR TITLE
Don't pass restricted BCs into assemble

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -5,6 +5,7 @@ import ufl
 
 from pyop2 import op2
 from firedrake import dmhooks
+from firedrake.bcs import DirichletBC
 from firedrake.function import Function
 from firedrake.cofunction import Cofunction
 from firedrake.matrix import MatrixBase
@@ -254,9 +255,12 @@ class _SNESContext(object):
             # pmat_type == mat_type and Jp_eq_J
             self.Jp = None
 
-        self.bcs_F = tuple(bc.extract_form('F') for bc in problem.bcs)
-        self.bcs_J = tuple(bc.extract_form('J') for bc in problem.bcs)
-        self.bcs_Jp = tuple(bc.extract_form('Jp') for bc in problem.bcs)
+        # Exclude DirichletBCs with nonempty boundary sets
+        assembly_bcs = tuple(bc for bc in problem.bcs if
+                             not (isinstance(bc, DirichletBC) and bc.function_space().boundary_set))
+        self.bcs_F = tuple(bc.extract_form('F') for bc in assembly_bcs)
+        self.bcs_J = tuple(bc.extract_form('J') for bc in assembly_bcs)
+        self.bcs_Jp = tuple(bc.extract_form('Jp') for bc in assembly_bcs)
 
         self._bc_residual = None
         if not pre_apply_bcs and next(problem.dirichlet_bcs(), None) is not None:


### PR DESCRIPTION
Don't pass the restricted BCs in to assembly. When `restrict=True`, the boundary DoFs are removed in the restricted function space so passing in these BCs does nothing. This lets us use `restrict=True` for residuals containing things we cannot apply BCs to (e.g. cross-mesh interpolation currently) in the traditional way. 