### PR TITLE
Skip adaptive BDDC elasticity test in complex mode; fix skipcomplex reason display

### DIFF
--- a/tests/firedrake/conftest.py
+++ b/tests/firedrake/conftest.py
@@ -177,8 +177,10 @@ def pytest_collection_modifyitems(session, config, items):
 
     for item in items:
         if complex_mode:
-            if item.get_closest_marker("skipcomplex") is not None:
-                item.add_marker(pytest.mark.skip(reason="Test makes no sense in complex mode"))
+            skipcomplex_marker = item.get_closest_marker("skipcomplex")
+            if skipcomplex_marker is not None:
+                reason = skipcomplex_marker.kwargs.get("reason", "Test makes no sense in complex mode")
+                item.add_marker(pytest.mark.skip(reason=reason))
             if item.get_closest_marker("skipcomplexnoslate") and not SLATE_SUPPORTS_COMPLEX:
                 item.add_marker(pytest.mark.skip(reason="Test skipped due to lack of Slate complex support"))
         else:

--- a/tests/firedrake/regression/test_bddc.py
+++ b/tests/firedrake/regression/test_bddc.py
@@ -292,6 +292,9 @@ def test_bddc_aij_simplex(rg, family, degree, cellwise):
     assert (np.diff(sqrt_kappa) <= 0.5).all(), str(sqrt_kappa)
 
 
+@pytest.mark.skipcomplex(
+    reason="Adaptive BDDC's sub-Schur factorization assumes SPD matrices, unsupported for complex Hermitian systems"
+)
 @pytest.mark.parallel(3)
 @pytest.mark.parametrize("family,degree,cellwise", [("CG", 2, False), ("GN", 1, False), ("MTW", 1, False)])
 def test_bddc_elasticity_aij_simplex(rg, family, degree, cellwise):


### PR DESCRIPTION
## Summary
- Marks `test_bddc_elasticity_aij_simplex` (`tests/firedrake/regression/test_bddc.py`) as `skipcomplex`. This test uses adaptive BDDC, and PETSc's adaptive sub-Schur factor-update path (`PCBDDCSubSchursSetUp`) assumes SPD local matrices. In complex mode the elasticity operator is Hermitian but not SPD, so depending on the element family the test either fails immediately with `"Factor update not yet implemented for non SPD matrices"` or hangs indefinitely until CI's timeout kills it (reproduced locally, see #5286).
- Fixes `pytest_collection_modifyitems` in `tests/firedrake/conftest.py`, which always displayed a hardcoded skip reason (`"Test makes no sense in complex mode"`) for the `skipcomplex` marker, silently discarding any `reason=` kwarg passed to it. That kwarg pattern is already used elsewhere (e.g. `test_l2pullbacks.py`) but was never actually read. Now the marker's `reason` is used when provided, falling back to the previous default otherwise.

## Test plan
- [x] Reproduced the underlying failure/hang locally against PETSc v3.25.0 in complex mode (3-process run): `CG-2-False` fails fast with the PCBDDC SPD error, `GN-1-False` hangs.
- [x] Confirmed all three parametrizations of `test_bddc_elasticity_aij_simplex` now report `SKIPPED` in complex mode, with the custom reason text now correctly displayed in `pytest -rs` output instead of the old hardcoded string.
- [ ] CI (complex-mode job requires the `ci:complex` label to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)