### PR TITLE
tsfc: contract each block after unconcatenating

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -390,6 +390,12 @@ def compile_expression_dual_evaluation(expression, ufl_element, *,
     # but we don't for now.
     evaluation, = impero_utils.preprocess_gem([evaluation])
     pairs = unconcatenate([(return_expr, evaluation)], cache=concatenate_cache)
+    # Contract each block once the Concatenate nodes are gone.  An H(div) or
+    # H(curl) element selects the component each block maps to with a Delta,
+    # and only here, with the blocks separated, do those Deltas meet pairwise
+    # and cancel the pairs that map to different components.
+    pairs = [(variable, gem.optimise.contraction(expression))
+             for variable, expression in pairs]
     impero_c = impero_utils.compile_gem(pairs, return_indices)
     index_names = {idx: f"p{i}" for (i, idx) in enumerate(basis_indices)}
     # Handle kernel interface requirements

--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -383,6 +383,8 @@ def compile_expression_dual_evaluation(expression, ufl_element, *,
     # but we don't for now.
     evaluation, = impero_utils.preprocess_gem([evaluation])
     pairs = unconcatenate([(return_expr, evaluation)], cache=unconcatenate_cache)
+    pairs = [(variable, gem.optimise.contraction(expression))
+             for variable, expression in pairs]
     impero_c = impero_utils.compile_gem(pairs, return_indices)
     index_names = {idx: f"p{i}" for (i, idx) in enumerate(basis_indices)}
     # Handle kernel interface requirements


### PR DESCRIPTION
> ### Stack
>
> Merge in this order, each PR retargets to `main` once the one above it lands:
>
> | # | PR | what |
> |---|----|------|
> | 1 | firedrakeproject/fiat#269 | gem: sum factorise independent contractions |
> | 2 | firedrakeproject/fiat#271 | FInAT: select H(div)/H(curl) components with a `Delta` |
> | 3 | firedrakeproject/fiat#268 | FInAT: dual evaluate on each sub-element's own points |
> | 4 | firedrakeproject/firedrake#5295 | tsfc: dual evaluation against a `Cofunction` |
> | 5 | firedrakeproject/firedrake#5289 | p-multigrid: remove custom interpolation |
> | 6 | firedrakeproject/firedrake#5297 | tsfc: contract each block after unconcatenating |
>
> 2 and 6 are a pair: neither is worth anything alone, though 2 is harmless on its
> own — it changes how a component is selected, not what is selected.
> 5 and 6 are siblings on 4, in either order.
>
> Only 4 carries a `DROP BEFORE MERGE` commit, pinning FIAT to
> `pbrubeck/fix/dual-enriched`, which is now the top of the FIAT stack; 5 and 6
> inherit it. Drop it once the FIAT side has landed.

`compile_expression_dual_evaluation` had a standing TODO:

```python
# TODO: one should apply some GEM optimisations as in assembly,
# but we don't for now.
```

Apply one of them: contract each assignment once `unconcatenate` has split the
`Concatenate` nodes.

This matters for H(div) and H(curl). Those elements are a sum of blocks, each
mapping into one vector component, and with firedrakeproject/fiat#271 each
block selects its component with a `Delta`. Before unconcatenation the blocks are
branches of a `Concatenate`, so the Deltas never meet; afterwards each pair of
blocks is its own assignment, the Deltas multiply, and delta elimination cancels
every pair that maps to different components.

Paired with firedrakeproject/fiat#271. **Neither PR does anything on its own** —
without the Deltas there is nothing for the contraction to cancel, and without the
contraction the Deltas never meet.

### Effect

Coarse to fine interpolation, as p-multigrid prolongation. Kernel stack
temporaries and wall clock:

| | temporaries | time |
|---|---|---|
| NCF 1→4 | 832K → **68K** | **3.07×** |
| NCE 1→4 | 307K → **110K** | **2.23×** |
| NCE 1→3 | 131K → **61K** | **2.23×** |
| NCF 1→3 | 223K → **38K** | **1.86×** |

Form assembly is unchanged; it does not go through this function.

### Testing

Matrix-free `mult`/`multTranspose` against the assembled matrix, and an
interpolate/restrict round trip, for NCF/NCE on hexahedra and RTCF/RTCE on
quadrilaterals, spectral and fdm variants. Full FIAT suite on the paired branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


