### PR TITLE
Fix firedrake-configure for macOS netCDF build failure

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -869,7 +869,10 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
+        extra_env_vars={
+            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
+            "CC": "mpicc",
+        },
     ),
 
     (OS.MACOS_ARM64, ScalarType.COMPLEX, IntType.INT32, GPUPlatform.NO_GPU): Arch(
@@ -922,7 +925,10 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
+        extra_env_vars={
+            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
+            "CC": "mpicc",
+        },
     ),
 
     # Sane default configurations for unknown platforms

--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -837,7 +837,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "cmake",
             "fftw",
             "hwloc",
-            "hdf5-mpi",
             "metis",
             "openblas",
             "openmpi",
@@ -849,7 +848,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         extra_petsc_configure_options=[
             # External packages
             "--with-fftw-dir=/opt/homebrew",
-            "--with-hdf5-dir=/opt/homebrew",
             "--with-hwloc-dir=/opt/homebrew",
             "--with-metis-dir=/opt/homebrew",
             "--with-pnetcdf-dir=/opt/homebrew",
@@ -857,6 +855,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "--with-suitesparse-dir=/opt/homebrew",
             "--with-zlib-dir=/opt/homebrew",
             "--download-bison",
+            "--download-hdf5",
             "--download-hypre",
             "--download-mumps",
             "--download-netcdf",
@@ -870,7 +869,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={"HDF5_DIR": "/opt/homebrew"},
+        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
     ),
 
     (OS.MACOS_ARM64, ScalarType.COMPLEX, IntType.INT32, GPUPlatform.NO_GPU): Arch(
@@ -890,7 +889,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "cmake",
             "fftw",
             "hwloc",
-            "hdf5-mpi",
             "metis",
             "openblas",
             "openmpi",
@@ -904,7 +902,6 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
 
             # External packages
             "--with-fftw-dir=/opt/homebrew",
-            "--with-hdf5-dir=/opt/homebrew",
             "--with-hwloc-dir=/opt/homebrew",
             "--with-metis-dir=/opt/homebrew",
             "--with-pnetcdf-dir=/opt/homebrew",
@@ -912,6 +909,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "--with-suitesparse-dir=/opt/homebrew",
             "--with-zlib-dir=/opt/homebrew",
             "--download-bison",
+            "--download-hdf5",
             "--download-mumps",
             "--download-netcdf",
             "--download-ptscotch",
@@ -924,7 +922,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={"HDF5_DIR": "/opt/homebrew"},
+        extra_env_vars={"HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH"},
     ),
 
     # Sane default configurations for unknown platforms


### PR DESCRIPTION
We have to switch to `--download-hdf5` on macOS because netCDF isn't building with HDF5 2.2.0.

PETSc issue: https://gitlab.com/petsc/petsc/-/work_items/1918


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
