### PR TITLE
Leo/deprecate clear rtree

### DIFF
--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2506,7 +2506,8 @@ values from f.)"""
         the coordinate field)."""
         warnings.warn(
             "The ``clear_rtree`` method is deprecated and will be removed in a future release. "
-            "There is no need to manually clear the rtree.", FutureWarning
+            "There is no need to manually clear the rtree after changing the mesh coordinates;"
+            "the rtree will be automatically rebuilt.", FutureWarning
         )
         # `cached_property_until` stores the cached rtree in self._rtree_cache
         # setting it to None will force the rtree to be rebuilt on next access.

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2497,7 +2497,6 @@ values from f.)"""
         if not isinstance(value, numbers.Number):
             raise TypeError("tolerance must be a number")
         if value != self._tolerance:
-            self.clear_rtree()
             self._tolerance = value
 
     def clear_rtree(self):
@@ -2506,8 +2505,8 @@ values from f.)"""
         Use this if you move the mesh (for example by reassigning to
         the coordinate field)."""
         warnings.warn(
-            "The ``Function.at`` method is deprecated and will be removed in a future release. "
-            "Please use the ``PointEvaluator`` class instead.", FutureWarning
+            "The ``clear_rtree`` method is deprecated and will be removed in a future release. "
+            "There is no need to manually clear the rtree.", FutureWarning
         )
         # `cached_property_until` stores the cached rtree in self._rtree_cache
         # setting it to None will force the rtree to be rebuilt on next access.

--- a/firedrake/mesh.py
+++ b/firedrake/mesh.py
@@ -2505,6 +2505,10 @@ values from f.)"""
 
         Use this if you move the mesh (for example by reassigning to
         the coordinate field)."""
+        warnings.warn(
+            "The ``Function.at`` method is deprecated and will be removed in a future release. "
+            "Please use the ``PointEvaluator`` class instead.", FutureWarning
+        )
         # `cached_property_until` stores the cached rtree in self._rtree_cache
         # setting it to None will force the rtree to be rebuilt on next access.
         self._rtree_cache = None


### PR DESCRIPTION
Deprecate the `clear_rtree` method. The rtree is automatically cleared and rebuilt via the `cached_property_until` decorator when either the mesh coordinates or the tolerance changes.