### PR TITLE
interpolator init cleanup

### DIFF
--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -172,6 +172,8 @@ class Interpolate(UFLInterpolate):
         try:
             source_mesh = extract_unique_domain(operand) or target_mesh
         except ValueError:
+            if has_mixed_arguments or len(self.target_space) > 1:
+                return MixedInterpolator(self)
             raise NotImplementedError(
                 "Interpolating an expression with no arguments defined on multiple meshes is not implemented yet."
             )

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -833,9 +833,7 @@ class SameMeshInterpolator(Interpolator):
 class VomOntoVomInterpolator(SameMeshInterpolator):
 
     def __init__(self, expr: Interpolate, source_mesh, target_mesh):
-        super().__init__(expr)
-        self.source_mesh = source_mesh
-        self.target_mesh = target_mesh
+        super().__init__(expr, source_mesh, target_mesh)
 
         if self.source_mesh.input_ordering is self.target_mesh:
             # The forward interpolation is a star forest reduction

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -188,19 +188,19 @@ class Interpolate(UFLInterpolate):
             and target_mesh.topological_dimension == source_mesh.topological_dimension
         )
         if target_mesh is source_mesh or submesh_interp_implemented:
-            return SameMeshInterpolator(self)
+            return SameMeshInterpolator(self, source_mesh, target_mesh)
 
         if isinstance(target_mesh.topology, VertexOnlyMeshTopology):
             if isinstance(source_mesh.topology, VertexOnlyMeshTopology):
-                return VomOntoVomInterpolator(self)
+                return VomOntoVomInterpolator(self, source_mesh, target_mesh)
             if target_mesh.geometric_dimension != source_mesh.geometric_dimension:
                 raise ValueError("Cannot interpolate onto a VertexOnlyMesh of a different geometric dimension.")
-            return SameMeshInterpolator(self)
+            return SameMeshInterpolator(self, source_mesh, target_mesh)
 
         if has_mixed_arguments or len(self.target_space) > 1:
             return MixedInterpolator(self)
 
-        return CrossMeshInterpolator(self)
+        return CrossMeshInterpolator(self, source_mesh, target_mesh)
 
 
 @PETSc.Log.EventDecorator()
@@ -250,16 +250,6 @@ class Interpolator(abc.ABC):
         """The dual argument slot of the Interpolate expression."""
         self.target_space = dual_arg.function_space().dual()
         """The primal space we are interpolating into."""
-        # Delay calling .unique() because MixedInterpolator is fine with MeshSequence
-        self.target_mesh = self.target_space.mesh()
-        """The domain we are interpolating into."""
-
-        try:
-            source_mesh = extract_unique_domain(operand)
-        except ValueError:
-            source_mesh = extract_unique_domain(operand, expand_mesh_sequence=False)
-        self.source_mesh = source_mesh or self.target_mesh
-        """The domain we are interpolating from."""
 
         # Interpolation options
         self.subset = expr.options.subset
@@ -423,8 +413,11 @@ class CrossMeshInterpolator(Interpolator):
     For arguments, see :class:`.Interpolator`.
     """
     @no_annotations
-    def __init__(self, expr: Interpolate):
+    def __init__(self, expr: Interpolate, source_mesh, target_mesh):
         super().__init__(expr)
+        self.source_mesh = source_mesh
+        self.target_mesh = target_mesh
+
         if self.access and self.access != op2.WRITE:
             raise NotImplementedError(
                 "Access other than op2.WRITE not implemented for cross-mesh interpolation."
@@ -678,8 +671,11 @@ class SameMeshInterpolator(Interpolator):
     """
 
     @no_annotations
-    def __init__(self, expr):
+    def __init__(self, expr, source_mesh, target_mesh):
         super().__init__(expr)
+        self.source_mesh = source_mesh
+        self.target_mesh = target_mesh
+
         subset = self.subset
         if subset is None:
             target = self.target_mesh.unique().topology
@@ -834,8 +830,11 @@ class SameMeshInterpolator(Interpolator):
 
 class VomOntoVomInterpolator(SameMeshInterpolator):
 
-    def __init__(self, expr: Interpolate):
+    def __init__(self, expr: Interpolate, source_mesh, target_mesh):
         super().__init__(expr)
+        self.source_mesh = source_mesh
+        self.target_mesh = target_mesh
+
         if self.source_mesh.input_ordering is self.target_mesh:
             # The forward interpolation is a star forest reduction
             self.forward_reduce = True
@@ -1624,15 +1623,6 @@ class VomOntoVomMatContext:
 
 class MixedInterpolator(Interpolator):
     """Interpolator between MixedFunctionSpaces."""
-    def __init__(self, expr: Interpolate):
-        """Initialise MixedInterpolator. Should not be called directly; use `get_interpolator`.
-
-        Parameters
-        ----------
-        expr : Interpolate
-            Symbolic Interpolate expression.
-        """
-        super().__init__(expr)
 
     def _get_sub_interpolators(
             self, bcs: Iterable[DirichletBC] | None = None

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -757,6 +757,7 @@ def test_mixed_interpolator_cross_mesh():
             res_block = assemble(interpolate(TrialFunction(W.sub(j)), U.sub(i), allow_missing_dofs=True))
             assert np.allclose(res.petscmat.getNestSubMatrix(i, j)[:, :], res_block.petscmat[:, :])
 
+
 @pytest.mark.parallel([1, 3])
 @pytest.mark.parametrize("rank", [0, 1])
 def test_interpolate_mixed_expr(rank):
@@ -771,7 +772,7 @@ def test_interpolate_mixed_expr(rank):
     V = FunctionSpace(mesh1, "CG", 1)
     U = FunctionSpace(mesh2, "CG", 2)
     W = V * U
-    
+
     if rank == 1:
         result = assemble(interpolate(expr, W))
         expected1 = assemble(interpolate(expr1, V))

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -756,3 +756,22 @@ def test_mixed_interpolator_cross_mesh():
             assert isinstance(interp_ij, Interpolate)
             res_block = assemble(interpolate(TrialFunction(W.sub(j)), U.sub(i), allow_missing_dofs=True))
             assert np.allclose(res.petscmat.getNestSubMatrix(i, j)[:, :], res_block.petscmat[:, :])
+
+def test_interpolate_mixed_expr():
+    mesh1 = UnitSquareMesh(2, 2)
+    mesh2 = UnitSquareMesh(3, 3)
+    x1, y1 = SpatialCoordinate(mesh1)
+    x2, y2 = SpatialCoordinate(mesh2)
+    expr1 = x1 + y1
+    expr2 = x2 - y2
+
+    V = FunctionSpace(mesh1, "CG", 1)
+    U = FunctionSpace(mesh2, "CG", 2)
+    W = V * U
+
+    f = Function(W).interpolate(as_vector([expr1, expr2]))
+    f1 = Function(V).interpolate(expr1)
+    f2 = Function(U).interpolate(expr2)
+
+    assert np.allclose(f.subfunctions[0].dat.data_ro, f1.dat.data_ro)
+    assert np.allclose(f.subfunctions[1].dat.data_ro, f2.dat.data_ro)

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -782,7 +782,7 @@ def test_interpolate_mixed_expr(rank):
         assert np.allclose(result.subfunctions[1].dat.data_ro, expected2.dat.data_ro)
     else:
         v1, v2 = TestFunctions(W)
-        form = v1 * dx(domain=mesh1) + v2 * dx(domain=mesh2)
+        form = conj(v1) * dx(domain=mesh1) + conj(v2) * dx(domain=mesh2)
         result1 = assemble(interpolate(expr, form))
         expected = assemble(expr1 * dx(domain=mesh1) + expr2 * dx(domain=mesh2))
         assert np.isclose(result1, expected)

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -757,21 +757,35 @@ def test_mixed_interpolator_cross_mesh():
             res_block = assemble(interpolate(TrialFunction(W.sub(j)), U.sub(i), allow_missing_dofs=True))
             assert np.allclose(res.petscmat.getNestSubMatrix(i, j)[:, :], res_block.petscmat[:, :])
 
-def test_interpolate_mixed_expr():
-    mesh1 = UnitSquareMesh(2, 2)
-    mesh2 = UnitSquareMesh(3, 3)
+@pytest.mark.parallel([1, 3])
+@pytest.mark.parametrize("rank", [0, 1])
+def test_interpolate_mixed_expr(rank):
+    mesh1 = UnitSquareMesh(3, 3)
+    mesh2 = UnitSquareMesh(4, 4)
     x1, y1 = SpatialCoordinate(mesh1)
     x2, y2 = SpatialCoordinate(mesh2)
     expr1 = x1 + y1
     expr2 = x2 - y2
+    expr = as_vector([expr1, expr2])
 
     V = FunctionSpace(mesh1, "CG", 1)
     U = FunctionSpace(mesh2, "CG", 2)
     W = V * U
+    
+    if rank == 1:
+        result = assemble(interpolate(expr, W))
+        expected1 = assemble(interpolate(expr1, V))
+        expected2 = assemble(interpolate(expr2, U))
 
-    f = Function(W).interpolate(as_vector([expr1, expr2]))
-    f1 = Function(V).interpolate(expr1)
-    f2 = Function(U).interpolate(expr2)
+        assert np.allclose(result.subfunctions[0].dat.data_ro, expected1.dat.data_ro)
+        assert np.allclose(result.subfunctions[1].dat.data_ro, expected2.dat.data_ro)
+    else:
+        v1, v2 = TestFunctions(W)
+        form = v1 * dx(domain=mesh1) + v2 * dx(domain=mesh2)
+        result1 = assemble(interpolate(expr, form))
+        expected = assemble(expr1 * dx(domain=mesh1) + expr2 * dx(domain=mesh2))
+        assert np.isclose(result1, expected)
 
-    assert np.allclose(f.subfunctions[0].dat.data_ro, f1.dat.data_ro)
-    assert np.allclose(f.subfunctions[1].dat.data_ro, f2.dat.data_ro)
+        cofunc = assemble(form)
+        result2 = assemble(interpolate(expr, cofunc))
+        assert np.isclose(result2, expected)

--- a/tests/firedrake/regression/test_interpolate_cross_mesh.py
+++ b/tests/firedrake/regression/test_interpolate_cross_mesh.py
@@ -767,7 +767,7 @@ def test_interpolate_mixed_expr(rank):
     x2, y2 = SpatialCoordinate(mesh2)
     expr1 = x1 + y1
     expr2 = x2 - y2
-    expr = as_vector([expr1, expr2])
+    expr = as_vector([expr2, expr1])
 
     V = FunctionSpace(mesh1, "CG", 1)
     U = FunctionSpace(mesh2, "CG", 2)
@@ -775,8 +775,8 @@ def test_interpolate_mixed_expr(rank):
 
     if rank == 1:
         result = assemble(interpolate(expr, W))
-        expected1 = assemble(interpolate(expr1, V))
-        expected2 = assemble(interpolate(expr2, U))
+        expected1 = assemble(interpolate(expr2, V))
+        expected2 = assemble(interpolate(expr1, U))
 
         assert np.allclose(result.subfunctions[0].dat.data_ro, expected1.dat.data_ro)
         assert np.allclose(result.subfunctions[1].dat.data_ro, expected2.dat.data_ro)


### PR DESCRIPTION
Tidy up the init methods for the interpolator classes. Before we were determining the source and target meshes both in the `__init__` of `Interpolator` and the `_interpolator` dispatcher. This sorts out the ugly `Delay calling .unique() because MixedInterpolator is fine with MeshSequence` inheritance we had before.

This also allows the nice `interpolate(mixed_expr, mixed_space)` in the case when `mixed_space` is defined over multiple domains.