### PR TITLE
Increase default timeout for firedrake-run-split-tests to 1 hour

### DIFF
--- a/scripts/firedrake-run-split-tests
+++ b/scripts/firedrake-run-split-tests
@@ -18,7 +18,7 @@ Usage:
   outer process-tree timeout for each split job:
 
     * FIREDRAKE_RUN_SPLIT_TESTS_TIMEOUT: maximum wall time for each job
-      (default: 1800s)
+      (default: 3600s)
     * FIREDRAKE_RUN_SPLIT_TESTS_KILL_AFTER: grace period before forcibly
       killing a timed-out job (default: 60s)
 
@@ -51,7 +51,7 @@ fi
 num_procs=$1
 num_jobs=$2
 extra_args=${@:3}
-job_timeout=${FIREDRAKE_RUN_SPLIT_TESTS_TIMEOUT:-1800s}
+job_timeout=${FIREDRAKE_RUN_SPLIT_TESTS_TIMEOUT:-3600s}
 kill_after=${FIREDRAKE_RUN_SPLIT_TESTS_KILL_AFTER:-60s}
 
 # Callback to kill child processes if Ctrl-C hit


### PR DESCRIPTION
30 minutes was cutting it too fine for some steps in our CI run and the job was terminating with no clear idea why.

# Description


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
