### PR TITLE
TSFC: cache the kernel by the repo state, not just the form signature

### DIFF
--- a/firedrake/configuration.py
+++ b/firedrake/configuration.py
@@ -1,11 +1,12 @@
 """Replaces functionality from the removed `firedrake_configuration` module."""
 
 import os
+import sys
 from pathlib import Path
 
 
 def setup_cache_dirs():
-    root = Path(os.environ.get("VIRTUAL_ENV", Path.home())).joinpath(".cache")
+    root = Path(sys.prefix).joinpath(".cache")
     if "PYOP2_CACHE_DIR" not in os.environ:
         os.environ["PYOP2_CACHE_DIR"] = str(root.joinpath("pyop2"))
     if 'FIREDRAKE_TSFC_KERNEL_CACHE_DIR' not in os.environ:

--- a/firedrake/interpolation.py
+++ b/firedrake/interpolation.py
@@ -22,6 +22,7 @@ from pyop2.caching import memory_and_disk_cache
 from finat.ufl import TensorElement, VectorElement, MixedElement, FiniteElementBase
 from finat.element_factory import create_element
 
+from tsfc.caching import codegen_key
 from tsfc.driver import compile_expression_dual_evaluation
 from tsfc.ufl_utils import extract_firedrake_constants, hash_expr
 
@@ -1216,7 +1217,7 @@ except KeyError:
 def _compile_expression_key(comm, expr, ufl_element, domain, parameters) -> tuple[Hashable, ...]:
     """Generate a cache key suitable for :func:`tsfc.compile_expression_dual_evaluation`."""
     dual_arg, operand = expr.argument_slots()
-    return (hash_expr(operand), type(dual_arg), hash(ufl_element), tuplify(parameters))
+    return (hash_expr(operand), type(dual_arg), hash(ufl_element), tuplify(parameters), codegen_key())
 
 
 @memory_and_disk_cache(

--- a/firedrake/slate/slac/compiler.py
+++ b/firedrake/slate/slac/compiler.py
@@ -8,7 +8,10 @@ compiler with appropriate kernel functions (in C) for evaluating integral
 expressions (finite element variational forms written in UFL).
 """
 import time
+from pathlib import Path
 from typing import Hashable
+
+from tsfc.caching import codegen_key, stamp_source_tree
 
 from firedrake.tsfc_interface import SplitKernel, KernelInfo, TSFCKernel
 
@@ -64,6 +67,12 @@ class SlateKernel(TSFCKernel):
         self.split_kernel = generate_loopy_kernel(expr, compiler_parameters)
 
 
+#: Fingerprint of Slate's own code generator, in `firedrake/slate/slac/`. TSFC's
+#: `codegen_key` does not cover this: Slate lowers its own expressions to loopy
+#: directly, without going through TSFC. Fixed once, at import, to match `codegen_key`.
+_SLAC_CODEGEN_KEY: Hashable = stamp_source_tree(Path(__file__).resolve().parent)
+
+
 def _compile_expression_hashkey(slate_expr, compiler_parameters=None) -> tuple[Hashable, ...]:
     params = copy.deepcopy(parameters)
     if compiler_parameters and "slate_compiler" in compiler_parameters.keys():
@@ -72,7 +81,8 @@ def _compile_expression_hashkey(slate_expr, compiler_parameters=None) -> tuple[H
         params["form_compiler"].update(compiler_parameters)
     # The getattr here is to defer validation to the `compile_expression` call
     # as the test suite checks the correct exceptions are raised on invalid input.
-    return (getattr(slate_expr, "expression_hash", "ERROR") + str(sorted(params.items())))
+    return (getattr(slate_expr, "expression_hash", "ERROR") + str(sorted(params.items()))
+            + str(codegen_key()) + str(_SLAC_CODEGEN_KEY))
 
 
 def _compile_expression_comm(*args, **kwargs):

--- a/firedrake/tsfc_interface.py
+++ b/firedrake/tsfc_interface.py
@@ -14,6 +14,7 @@ from ufl import conj, Form, ZeroBaseForm
 from .ufl_expr import TestFunction, extract_domains
 
 from tsfc import compile_form as original_tsfc_compile_form
+from tsfc.caching import codegen_key
 from tsfc.parameters import PARAMETERS as tsfc_default_parameters
 from tsfc.ufl_utils import extract_firedrake_constants
 from tsfc.kernel_interface.firedrake_loopy import ActiveDomainNumbers
@@ -59,6 +60,7 @@ def tsfc_compile_form_hashkey(form, prefix, parameters, dont_split_numbers, diag
         utils.tuplify(parameters),
         dont_split_numbers,
         diagonal,
+        codegen_key(),
     )
 
 
@@ -158,6 +160,7 @@ def _compile_form_hashkey(form, name, parameters=None, split=True, dont_split=()
         split,
         _make_dont_split_numbers(dont_split, form),
         diagonal,
+        codegen_key(),
     )
 
 

--- a/tests/firedrake/regression/test_interpolate.py
+++ b/tests/firedrake/regression/test_interpolate.py
@@ -785,3 +785,23 @@ def test_interpolate_indexed():
     I1 = assemble(interpolate(u2, U), mat_type="nest")
     I1_block = assemble(interpolate(TrialFunction(U), U))
     assert np.allclose(I1.petscmat.getNestSubMatrix(0, 1)[:, :], I1_block.petscmat[:, :])
+
+
+def test_compile_expression_key_includes_codegen_key(monkeypatch):
+    """A changed toolchain fingerprint must produce a different expression-kernel
+    cache key, or a kernel compiled before the change will be served after it."""
+    import firedrake.interpolation as interpolation
+
+    mesh = UnitTriangleMesh()
+    V = FunctionSpace(mesh, "CG", 1)
+    expr = Interpolate(TestFunction(V), V)
+
+    monkeypatch.setattr(interpolation, "codegen_key", lambda: "before")
+    key1 = interpolation._compile_expression_key(
+        mesh.comm, expr, V.ufl_element(), mesh, {})
+
+    monkeypatch.setattr(interpolation, "codegen_key", lambda: "after")
+    key2 = interpolation._compile_expression_key(
+        mesh.comm, expr, V.ufl_element(), mesh, {})
+
+    assert key1 != key2

--- a/tests/firedrake/test_tsfc_interface.py
+++ b/tests/firedrake/test_tsfc_interface.py
@@ -79,6 +79,17 @@ def test_tsfc_different_names(mass):
     assert k1[-1] is not k2[-1]
 
 
+def test_tsfc_recompiles_when_codegen_key_changes(mass, monkeypatch):
+    """A changed toolchain fingerprint must not reuse a kernel compiled under the old one."""
+    monkeypatch.setattr(tsfc_interface, "codegen_key", lambda: "before")
+    k1, = tsfc_interface.compile_form(mass, 'mass_codegen_key')
+
+    monkeypatch.setattr(tsfc_interface, "codegen_key", lambda: "after")
+    k2, = tsfc_interface.compile_form(mass, 'mass_codegen_key')
+
+    assert k1[-1] is not k2[-1]
+
+
 def test_tsfc_cell_kernel(mass):
     k = tsfc_interface.compile_form(mass, 'mass')
     assert len(k) == 1 and 'cell_integral' in loopy.generate_code_v2(k[0][1][0].code).device_code()

--- a/tests/tsfc/test_caching.py
+++ b/tests/tsfc/test_caching.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import time
+
+import tsfc
+import tsfc.caching
+from tsfc.caching import codegen_key, stamp_source_tree
+
+
+def test_stamp_source_tree_moves_when_a_file_moves(tmp_path):
+    (tmp_path / "a.py").write_text("x = 1\n")
+    stamp1 = stamp_source_tree(tmp_path)
+
+    # A file system timestamp can be coarser than a single Python statement, so
+    # force the mtime forward instead of relying on wall-clock time to pass.
+    a = tmp_path / "a.py"
+    os.utime(a, (a.stat().st_atime, a.stat().st_mtime + 1))
+    stamp2 = stamp_source_tree(tmp_path)
+
+    assert stamp1 != stamp2
+
+
+def test_stamp_source_tree_is_stable(tmp_path):
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "b.py").write_text("y = 2\n")
+
+    assert stamp_source_tree(tmp_path) == stamp_source_tree(tmp_path)
+
+
+def test_codegen_key_is_stable_between_calls():
+    assert codegen_key() == codegen_key()
+
+
+def test_codegen_key_reflects_toolchain_source_at_import_time():
+    """This is the end-to-end property that the fix exists for.
+
+    A process that imports `tsfc.caching` after a file under `tsfc/` is edited
+    must get a different `codegen_key()`. A process that imported it before the
+    edit must not. `codegen_key()` is fixed at import time. It does not recompute
+    per compile. So this test simulates a fresh process with a reload, rather
+    than calling `codegen_key()` again in place.
+    """
+    edited = tsfc.__file__
+    original_mtime = os.stat(edited).st_mtime
+
+    key_before = codegen_key()
+    try:
+        os.utime(edited, (os.stat(edited).st_atime, original_mtime + 1))
+        importlib.reload(tsfc.caching)
+        key_after = codegen_key()
+        assert key_before != key_after
+    finally:
+        os.utime(edited, (os.stat(edited).st_atime, original_mtime))
+        importlib.reload(tsfc.caching)
+
+
+def test_importing_tsfc_caching_is_cheap():
+    """Guards against the mtime/size approach regressing to a content hash: the
+    one-time cost, paid when this module is imported, must stay small."""
+    t0 = time.perf_counter()
+    importlib.reload(tsfc.caching)
+    elapsed = time.perf_counter() - t0
+
+    assert elapsed < 1.0

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,6 +1,6 @@
 """A fingerprint of the toolchain that generates code, for callers that cache on a form.
 
-Firedrake keys its kernel caches by the form that it compiles, not by the compiler
+Firedrake keys its kernel caches on the form that it compiles, not on the compiler
 that lowered the form. An edit to this toolchain then leaves a stale kernel in place.
 :func:`codegen_key` closes that gap. A caller folds it into its own cache key. An
 edit to the toolchain then changes the key for every kernel that it could have

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,6 +1,6 @@
 """A fingerprint of the toolchain that generates code, for callers that cache on a form.
 
-Firedrake indexes its kernel caches by the form that it compiles, not by the compiler
+Firedrake keys its kernel caches by the form that it compiles, not by the compiler
 that lowered the form. An edit to this toolchain then leaves a stale kernel in place.
 :func:`codegen_key` closes that gap. A caller folds it into its own cache key. An
 edit to the toolchain then changes the key for every kernel that it could have

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,10 +1,10 @@
 """This module fingerprints the toolchain that generates code.
 
-A kernel cache that folds this in stays correct after an edit to the toolchain that
-produced it. It does not stay keyed only on the form.
+A kernel cache that adds this to its own key stays correct after an edit to the
+toolchain that produced it. It does not stay keyed only on the form.
 
-Firedrake's kernel caches fold :func:`codegen_key` into their own key, alongside the
-form that they key on. An edit to the toolchain then changes the key for every kernel
+Firedrake's kernel caches add :func:`codegen_key` to their own key, alongside the form
+that they key on. An edit to the toolchain then changes the key for every kernel
 that it could have changed.
 
 Every process computes this key once, at import, not on every compile. Two processes
@@ -83,6 +83,6 @@ def codegen_key() -> Hashable:
     Returns
     -------
     Hashable
-        A value suitable for folding into a `cachetools` hash key.
+        A value suitable for adding to a `cachetools` hash key.
     """
     return _CODEGEN_KEY

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,10 +1,7 @@
 """A fingerprint of the toolchain that generates code, for callers that cache on a form.
 
-Firedrake keys its kernel caches on the form that it compiles, not on the compiler
-that lowered the form. An edit to this toolchain then leaves a stale kernel in place.
-:func:`codegen_key` closes that gap. A caller folds it into its own cache key. An
-edit to the toolchain then changes the key for every kernel that it could have
-changed.
+A caller folds :func:`codegen_key` into its own cache key, alongside the form. An edit
+to the toolchain then changes the key for every kernel that it could have changed.
 
 Every process computes this key once, at import, not on every compile. Two processes
 that see the same toolchain files compute the same key. A later process then reuses

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,14 +1,19 @@
 """A fingerprint of the toolchain that generates code, for callers that cache on a form.
 
-Firedrake indexes its kernel caches by the form being compiled. It does not index
-them by the compiler that lowered the form. An edit to this toolchain leaves every
-kernel already on disk in place. :func:`codegen_key` closes that gap. A caller folds
-it into its own cache key. An edit anywhere in the toolchain then changes the key
-for every kernel that it could have changed.
+Firedrake indexes its kernel caches by the form that it compiles, not by the compiler
+that lowered the form. An edit to this toolchain then leaves a stale kernel in place.
+:func:`codegen_key` closes that gap. A caller folds it into its own cache key. An
+edit to the toolchain then changes the key for every kernel that it could have
+changed.
 
-The key is fixed once, when this module is imported. A process does not recompute it
-per compile. Import is the moment a process starts running a particular toolchain, so
-fixing the key there keeps the cost off the compile path entirely.
+Every process computes this key once, at import, not on every compile. Two processes
+that see the same toolchain files compute the same key. A later process then reuses
+a kernel that an earlier process cached on disk.
+
+:func:`stamp_source_tree` stats a file rather than reading it. It sees a file's path,
+size, and the time that the file was last written, not the file's content. Reading
+every file's content would catch more edits, but at a cost that this module cannot
+pay on every import.
 """
 from __future__ import annotations
 

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,0 +1,82 @@
+"""A fingerprint of the toolchain that generates code, for callers that cache on a form.
+
+Firedrake indexes its kernel caches by the form being compiled. It does not index
+them by the compiler that lowered the form. An edit to this toolchain leaves every
+kernel already on disk in place. :func:`codegen_key` closes that gap. A caller folds
+it into its own cache key. An edit anywhere in the toolchain then changes the key
+for every kernel that it could have changed.
+
+The key is fixed once, when this module is imported. A process does not recompute it
+per compile. Import is the moment a process starts running a particular toolchain, so
+fixing the key there keeps the cost off the compile path entirely.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Hashable
+
+#: Import names of the packages that TSFC's output depends on.
+#: TSFC lowers through FInAT, FIAT and GEM, and generates code through UFL and loopy.
+_TOOLCHAIN = ("tsfc", "finat", "FIAT", "gem", "ufl", "loopy")
+
+
+def stamp_source_tree(root: os.PathLike) -> Hashable:
+    """Fingerprint every ``.py`` file under `root`.
+
+    Stats each file rather than reading it, so the cost is cheap enough to pay at
+    import time.
+
+    Parameters
+    ----------
+    root : os.PathLike
+        Directory to scan, recursively.
+
+    Returns
+    -------
+    Hashable
+        A digest that changes when a file under `root` is added, removed, or has its
+        size or modification time change.
+    """
+    root = Path(root)
+    entries = tuple(sorted(
+        (str(path.relative_to(root)), stat.st_size, stat.st_mtime_ns)
+        for path in root.rglob("*.py")
+        for stat in (path.stat(),)
+    ))
+    return hashlib.sha1(repr(entries).encode()).hexdigest()
+
+
+def _is_editable(dist_name: str) -> bool:
+    dir_info = getattr(metadata.distribution(dist_name).origin, "dir_info", None)
+    return bool(getattr(dir_info, "editable", False))
+
+
+def _package_stamp(name: str, distributions: dict[str, list[str]]) -> Hashable:
+    module = import_module(name)
+    dist_names = distributions.get(name)
+    if dist_names and not _is_editable(dist_names[0]):
+        return metadata.version(dist_names[0])
+    return stamp_source_tree(Path(module.__file__).resolve().parent)
+
+
+# `packages_distributions()` scans every installed distribution's metadata, so it is
+# called once here and shared, rather than once per package in `_TOOLCHAIN`.
+_DISTRIBUTIONS = metadata.packages_distributions()
+_CODEGEN_KEY: Hashable = tuple(_package_stamp(name, _DISTRIBUTIONS) for name in _TOOLCHAIN)
+
+
+def codegen_key() -> Hashable:
+    """Fingerprint the toolchain that TSFC compiles through.
+
+    Two calls compare equal exactly when TSFC, FInAT, FIAT, GEM, UFL and loopy were all
+    unchanged at the time this module was imported.
+
+    Returns
+    -------
+    Hashable
+        A value suitable for folding into a `cachetools` hash key.
+    """
+    return _CODEGEN_KEY

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,7 +1,8 @@
-"""A fingerprint of the toolchain that generates code, for callers that cache on a form.
+"""A fingerprint of the toolchain that generates code.
 
-A caller folds :func:`codegen_key` into its own cache key, alongside the form. An edit
-to the toolchain then changes the key for every kernel that it could have changed.
+Firedrake's kernel caches fold :func:`codegen_key` into their own key, alongside the
+form that they key on. An edit to the toolchain then changes the key for every kernel
+that it could have changed.
 
 Every process computes this key once, at import, not on every compile. Two processes
 that see the same toolchain files compute the same key. A later process then reuses

--- a/tsfc/caching.py
+++ b/tsfc/caching.py
@@ -1,4 +1,7 @@
-"""A fingerprint of the toolchain that generates code.
+"""This module fingerprints the toolchain that generates code.
+
+A kernel cache that folds this in stays correct after an edit to the toolchain that
+produced it. It does not stay keyed only on the form.
 
 Firedrake's kernel caches fold :func:`codegen_key` into their own key, alongside the
 form that they key on. An edit to the toolchain then changes the key for every kernel


### PR DESCRIPTION
TSFC originally indexed its kernel caches by the form being compiled, not by the compiler that lowered it, so an editable was retrieving a stale kernel after tsfc, finat/FIAT/gem, ufl or loopy changes -- silently, as a wrong answer rather than a cache miss.

Add `tsfc.caching.codegen_key()`, fixed at import, and fold it into the three cache keys that index a kernel by its form signature (tsfc_interface, interpolation) plus Slate's own (which also stamps firedrake/slate/slac/, the generator that it owns outside TSFC). Also point `setup_cache_dirs()` at `sys.prefix` instead of `$VIRTUAL_ENV`, so an activated shell and a bare `venv/bin/python` share one cache.

# Description


<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
