### PR TITLE
Fix DG injection for symmetric tensors

### DIFF
--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -1,5 +1,6 @@
 import numpy
 import string
+from collections import defaultdict
 from pyop2 import op2
 from pyop2.utils import as_tuple
 from firedrake.utils import IntType, as_cstr, complex_mode, ScalarType
@@ -8,6 +9,7 @@ from firedrake.functionspaceimpl import FiredrakeDualSpace
 from firedrake.mg import utils
 
 from ufl.algorithms import estimate_total_polynomial_degree
+from ufl.classes import ReferenceValue
 from ufl.domain import extract_unique_domain
 
 import loopy as lp
@@ -444,7 +446,7 @@ def dg_injection_kernel(Vf, Vc, ncell):
                      scalar_type=parameters["scalar_type"])
 
     macro_context = fem.PointSetContext(**macro_cfg)
-    fexpr, = fem.compile_ufl(f, macro_context)
+    fexpr, = fem.compile_ufl(ReferenceValue(f), macro_context)
     X = ufl.SpatialCoordinate(Vf.mesh())
     C_a, = fem.compile_ufl(X, macro_context)
     detJ = ufl_utils.preprocess_expression(abs(ufl.JacobianDeterminant(extract_unique_domain(f))),
@@ -513,8 +515,20 @@ def dg_injection_kernel(Vf, Vc, ncell):
 
     phi_c = gem.Indexed(phi_c, argument_multiindex + tensor_indices)
     fexpr = gem.Indexed(fexpr, tensor_indices)
+    inner_prod = gem.Product(phi_c, fexpr)
+
+    if Vf.ufl_element().mapping() == "symmetries":
+        symmetry = Vf.ufl_element().symmetry()
+        multiplicity = defaultdict(int)
+        for idx in numpy.ndindex(Vf.value_shape):
+            idx = symmetry.get(idx, idx)
+            multiplicity[idx] += 1
+        block_scale = numpy.array([scale for idx, scale in multiplicity.items()])
+        scale = gem.Indexed(gem.Literal(block_scale), tensor_indices)
+        inner_prod = gem.Product(scale, inner_prod)
+
     quadrature_weight = macro_quadrature_rule.weight_expression
-    expr = gem.Product(gem.IndexSum(gem.Product(phi_c, fexpr), tensor_indices),
+    expr = gem.Product(gem.IndexSum(inner_prod, tensor_indices),
                        gem.Product(macro_detJ, quadrature_weight))
 
     quadrature_indices = macro_builder.indices + macro_quadrature_rule.point_set.indices

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -518,6 +518,9 @@ def dg_injection_kernel(Vf, Vc, ncell):
     inner_prod = gem.Product(phi_c, fexpr)
 
     if Vf.ufl_element().mapping() == "symmetries":
+        # Symmetric elements only store independent components.
+        # The L2 inner product adds entrywise products of every component of the full tensor.
+        # We work with the reference components so we need to scale by their multiplicities.
         symmetry = Vf.ufl_element().symmetry()
         multiplicity = defaultdict(int)
         for idx in numpy.ndindex(Vf.value_shape):

--- a/firedrake/mg/kernels.py
+++ b/firedrake/mg/kernels.py
@@ -446,7 +446,6 @@ def dg_injection_kernel(Vf, Vc, ncell):
                      scalar_type=parameters["scalar_type"])
 
     macro_context = fem.PointSetContext(**macro_cfg)
-    fexpr, = fem.compile_ufl(ReferenceValue(f), macro_context)
     X = ufl.SpatialCoordinate(Vf.mesh())
     C_a, = fem.compile_ufl(X, macro_context)
     detJ = ufl_utils.preprocess_expression(abs(ufl.JacobianDeterminant(extract_unique_domain(f))),
@@ -514,6 +513,7 @@ def dg_injection_kernel(Vf, Vc, ncell):
     tensor_indices = tuple(gem.Index(extent=d) for d in index_shape)
 
     phi_c = gem.Indexed(phi_c, argument_multiindex + tensor_indices)
+    fexpr, = fem.compile_ufl(ReferenceValue(f), macro_context)
     fexpr = gem.Indexed(fexpr, tensor_indices)
     inner_prod = gem.Product(phi_c, fexpr)
 

--- a/tests/firedrake/multigrid/test_grid_transfer.py
+++ b/tests/firedrake/multigrid/test_grid_transfer.py
@@ -197,11 +197,11 @@ def test_grid_transfer_parallel(hierarchy, transfer_type):
 
 @pytest.mark.parallel([1, 2])
 @pytest.mark.parametrize("transfer_type", ["prolongation", "restriction", "injection"])
-def test_grid_transfer_symmetric(transfer_type):
+@pytest.mark.parametrize("space", ("CG", "DG"))
+def test_grid_transfer_symmetric(transfer_type, space):
     base = UnitSquareMesh(3, 3)
     hierarchy = MeshHierarchy(base, 1)
 
-    space = "Lagrange"
     degrees = (1,)
     shape = "symmetric-tensor"
     run_transfer(hierarchy, shape, space, degrees, transfer_type)


### PR DESCRIPTION
# Description
Bugfix, therefore targetting release

Fixes https://github.com/firedrakeproject/firedrake/issues/5218 Multigrid DG injection finds a mismatch between reference values and physical values (symmetry only stores the independent components as the reference values) 

Follows https://github.com/firedrakeproject/firedrake/pull/4764 which applied a similar fix: work on the reference values, and take into account their multiplicity when taking the inner product for the L2 projection.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
