### PR TITLE
Fix broken test with exact comparisons

### DIFF
--- a/tests/firedrake/regression/test_matrix_free.py
+++ b/tests/firedrake/regression/test_matrix_free.py
@@ -59,23 +59,24 @@ def bcs(problem, V):
                                      "ilu",
                                      "lu"))
 @pytest.mark.parametrize("pmat_type", ("matfree", "aij"))
-def test_assembled_pc_equivalence(V, a, L, bcs, tmpdir, pc_type, pmat_type):
+def test_assembled_pc_equivalence(V, a, L, bcs, pc_type, pmat_type):
 
     u = Function(V)
 
-    assembled = str(tmpdir.join("assembled"))
-    matrixfree = str(tmpdir.join("matrixfree"))
+    def residuals(parameters):
+        u.assign(0)
+        problem = LinearVariationalProblem(a, L, u, bcs=bcs)
+        solver = LinearVariationalSolver(problem, solver_parameters=parameters)
+        solver.snes.ksp.setConvergenceHistory()
+        solver.solve()
+        return solver.snes.ksp.getConvergenceHistory()
 
     assembled_parameters = {"ksp_type": "cg",
-                            "pc_type": pc_type,
-                            "ksp_monitor_short": "ascii:%s:" % assembled}
-    u.assign(0)
-    solve(a == L, u, bcs=bcs, solver_parameters=assembled_parameters)
+                            "pc_type": pc_type}
 
     matrixfree_parameters = {"mat_type": "matfree",
                              "pmat_type": pmat_type,
-                             "ksp_type": "cg",
-                             "ksp_monitor_short": "ascii:%s:" % matrixfree}
+                             "ksp_type": "cg"}
 
     if pmat_type == "aij":
         matrixfree_parameters["pc_type"] = pc_type
@@ -84,18 +85,13 @@ def test_assembled_pc_equivalence(V, a, L, bcs, tmpdir, pc_type, pmat_type):
         matrixfree_parameters["pc_python_type"] = "firedrake.AssembledPC"
         matrixfree_parameters["assembled_pc_type"] = pc_type
 
-    u.assign(0)
-    solve(a == L, u, bcs=bcs, solver_parameters=matrixfree_parameters)
+    expect = residuals(assembled_parameters)
+    actual = residuals(matrixfree_parameters)
 
-    with open(assembled, "r") as f:
-        f.readline()            # Skip over header
-        expect = f.read()
-
-    with open(matrixfree, "r") as f:
-        f.readline()            # Skip over header
-        actual = f.read()
-
-    assert expect == actual
+    # The converged residual sits at the cancellation floor, so scale the
+    # tolerance by the initial residual rather than by each entry.
+    assert len(expect) == len(actual)
+    assert np.allclose(actual, expect, rtol=0, atol=1E-11*expect[0])
 
 
 @pytest.mark.parametrize("bcs", [False, True],

--- a/tests/firedrake/regression/test_nullspace.py
+++ b/tests/firedrake/regression/test_nullspace.py
@@ -53,7 +53,7 @@ def test_transpose_nullspace():
         a = inner(grad(u), grad(v))*dx
         L = conj(v)*dx
 
-        nullspace = VectorSpaceBasis(constant=True)
+        nullspace = VectorSpaceBasis(constant=True, comm=mesh.comm)
         u = Function(V)
         u.interpolate(SpatialCoordinate(mesh)[0])
         # Solver diverges with indefinite PC if we don't remove
@@ -179,7 +179,7 @@ def test_near_nullspace(tmpdir):
 
     w1 = Function(V)
     solve(lhs(F) == rhs(F), w1, bcs=bcs, solver_parameters={
-        'ksp_monitor_short': "ascii:%s:" % w_nns_log,
+        'ksp_monitor': "ascii:%s:" % w_nns_log,
         'ksp_rtol': 1e-8, 'ksp_atol': 1e-8, 'ksp_type': 'cg',
         'pc_type': 'gamg',
         'mg_levels_ksp_max_it': 3,
@@ -187,7 +187,7 @@ def test_near_nullspace(tmpdir):
 
     w2 = Function(V)
     solve(lhs(F) == rhs(F), w2, bcs=bcs, solver_parameters={
-        'ksp_monitor_short': "ascii:%s:" % wo_nns_log,
+        'ksp_monitor': "ascii:%s:" % wo_nns_log,
         'ksp_rtol': 1e-8, 'ksp_atol': 1e-8, 'ksp_type': 'cg',
         'pc_type': 'gamg',
         'mg_levels_ksp_max_it': 3,
@@ -270,7 +270,7 @@ def test_nullspace_mixed_multiple_components():
     uv_nullspace = VectorSpaceBasis([ux0, uy0])
     uv_nullspace.orthonormalize()
 
-    p_nullspace = VectorSpaceBasis(constant=True)
+    p_nullspace = VectorSpaceBasis(constant=True, comm=mesh.comm)
 
     mix_nullspace = MixedVectorSpaceBasis(Z, [uv_nullspace, p_nullspace])
 
@@ -342,7 +342,7 @@ def test_near_nullspace_mixed(aux_pc, rhs):
     near_nullmodes.orthonormalize()
     near_nullmodes_W = MixedVectorSpaceBasis(W, [near_nullmodes, W.sub(1)])
 
-    pressure_nullspace = MixedVectorSpaceBasis(W, [W.sub(0), VectorSpaceBasis(constant=True)])
+    pressure_nullspace = MixedVectorSpaceBasis(W, [W.sub(0), VectorSpaceBasis(constant=True, comm=mesh.comm)])
 
     w = Function(W)
     solver_parameters = {


### PR DESCRIPTION
# Description
Fix for a broken test comparing bit-identity of assembled vs matrix-free KSP.

The test originally compared two `ksp_monitor_short` files, and now that it has been deprecated it no longer prints the short residual. https://gitlab.com/petsc/petsc/-/merge_requests/9434

Due to floating-point errors, CG residual history differs at every iteration for the assembled matvec and the matrix-free action. We only notice it now due to the deprecation of `ksp_monitor_short`.

This test shold not continue relying on `ksp_monitor_short` or any monitor printed into a file. The residual history now comes numerically from the KSP rather than a monitor file.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
