### PR TITLE
Contract quadrature reductions in loop nest order

### DIFF
--- a/tests/tsfc/test_sum_factorisation.py
+++ b/tests/tsfc/test_sum_factorisation.py
@@ -70,6 +70,29 @@ def count_flops(form):
     return flops
 
 
+def count_storage(form):
+    """Count the scalar entries a kernel writes to its temporaries.
+
+    Parameters
+    ----------
+    form
+        Form to compile in spectral mode.
+
+    Returns
+    -------
+    int
+        Entries of every temporary the kernel writes.  Read-only tables
+        carry their own initializer and cost tabulation, not contraction
+        storage, so they are excluded.
+    """
+    kernel, = compile_form(form, parameters=dict(mode='spectral'))
+    temporaries = kernel.ast.default_entrypoint.temporary_variables
+    return sum(numpy.prod(temporary.shape, dtype=int)
+               for temporary in temporaries.values()
+               if temporary.shape and not (temporary.read_only
+                                           and temporary.initializer is not None))
+
+
 @pytest.mark.parametrize(('cell', 'order'),
                          [(quadrilateral, 5),
                           (TensorProductCell(interval, interval), 5),
@@ -82,6 +105,19 @@ def test_lhs(cell, order):
     flops = [count_flops(helmholtz(cell, degree))
              for degree in degrees]
     rates = numpy.diff(numpy.log(flops)) / numpy.diff(numpy.log(degrees))
+    assert (rates < order).all()
+
+
+@pytest.mark.parametrize(('cell', 'order'),
+                         [(quadrilateral, 1),
+                          (TensorProductCell(interval, interval), 1),
+                          (TensorProductCell(triangle, interval), 1),
+                          (TensorProductCell(quadrilateral, interval), 2)])
+def test_contraction_storage_rate(cell, order):
+    degrees = list(range(3, 8))
+    storage = [count_storage(action(helmholtz(cell, degree)))
+               for degree in degrees]
+    rates = numpy.diff(numpy.log(storage)) / numpy.diff(numpy.log(degrees))
     assert (rates < order).all()
 
 

--- a/tests/tsfc/test_sum_factorisation.py
+++ b/tests/tsfc/test_sum_factorisation.py
@@ -71,20 +71,6 @@ def count_flops(form):
 
 
 def count_storage(form):
-    """Count the scalar entries a kernel writes to its temporaries.
-
-    Parameters
-    ----------
-    form
-        Form to compile in spectral mode.
-
-    Returns
-    -------
-    int
-        Entries of every temporary the kernel writes.  Read-only tables
-        carry their own initializer and cost tabulation, not contraction
-        storage, so they are excluded.
-    """
     kernel, = compile_form(form, parameters=dict(mode='spectral'))
     temporaries = kernel.ast.default_entrypoint.temporary_variables
     return sum(numpy.prod(temporary.shape, dtype=int)

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -109,12 +109,6 @@ def flatten(var_reps, index_cache):
         sum_indices = set(chain.from_iterable(m.sum_indices for m in monomial_sum))
         # Put them in a deterministic order
         sum_indices = [i for i in quadrature_indices if i in sum_indices]
-        # Sort for increasing index extent, this obtains the good
-        # factorisation for triangle x interval cells.  Python sort is
-        # stable, so in the common case when index extents are equal,
-        # the previous deterministic ordering applies which is good
-        # for getting smaller temporaries.
-        sum_indices = sorted(sum_indices, key=lambda index: index.extent)
         # Apply sum factorisation combined with COFFEE technology
         expression = sum_factorise(variable, sum_indices, monomial_sum)
         yield (variable, expression)


### PR DESCRIPTION
## Description

`tsfc.spectral.flatten` chooses the order in which quadrature reductions are
placed, and hands it to `sum_factorise` as the tail ordering. The loop nest is
built separately, by `get_index_ordering`, from the quadrature indices in
**source order**.

On `main` the reduction order is sorted by index extent, so on any cell whose
quadrature axes have different extents the two disagree. Every partial
contraction then outlives the loop that produced it and is declared as an array
instead of staying a scalar. This PR drops the sort, so reductions are placed in
the order the nest visits them.

Where all quadrature extents are equal the sort was already the identity —
Python's sort is stable — so quadrilaterals, hexahedra and all hexahedral
H(curl)/H(div) elements are unaffected. The change only reaches anisotropic
cells, in practice `triangle x interval`.

## Benchmark

Helmholtz action, `(inner(u, v) + inner(grad(u), grad(v)))*dx`, spectral mode.
Storage counts the scalar entries of every loopy temporary the kernel writes,
excluding read-only tables that carry their own initializer.

### Hexahedron (`quadrilateral x interval`) — unchanged

| degree | flops (main) | flops (branch) | storage (main) | storage (branch) |
|---|---|---|---|---|
| Q3 | 92,884 | 92,884 | 312 | 312 |
| Q4 | 204,376 | 204,376 | 470 | 470 |
| Q5 | 393,516 | 393,516 | 660 | 660 |
| Q6 | 689,536 | 689,536 | 882 | 882 |
| Q7 | 1,126,276 | 1,126,276 | 1,136 | 1,136 |

Native hexahedra are identical too (Q3 26,491/183 through Q7 254,223/583 on both
sides), as are `NCE2`/`NCE3`/`NCE4` curl-curl.

### Prism (`triangle x interval`)

| degree | flops (main) | flops (branch) | flops | storage (main) | storage (branch) | storage |
|---|---|---|---|---|---|---|
| P3 | 86,140 | 77,804 | −9.7% | 252 | 104 | 2.4x less |
| P4 | 206,596 | 178,046 | −13.8% | 415 | 130 | 3.2x less |
| P5 | 441,774 | 365,274 | −17.3% | 642 | 156 | 4.1x less |
| P6 | 874,154 | 697,362 | −20.2% | 945 | 182 | 5.2x less |
| P7 | 1,562,272 | 1,207,904 | −22.7% | 1,336 | 208 | 6.4x less |
| P3 vector | 226,684 | 201,676 | −11.0% | 596 | 152 | 3.9x less |
| P4 vector | 561,536 | 475,886 | −15.3% | 1,045 | 190 | 5.5x less |

Both metrics improve together; there is no trade. On this branch prism storage
runs 104, 130, 156, 182, 208 — linear in degree — where on `main` it runs 252,
415, 642, 945, 1,336, which is quadratic. The flop gap widens with degree for
the same reason.

## Testing

`test_lhs` and `test_rhs` bound only the *growth rate* of the flop count, so
neither this change nor an equal-sized regression moves them. The new
`test_contraction_storage_rate` bounds the growth rate of the declared
temporary storage instead. It passes here and fails on `main` for the prism,
with rates `[1.73, 1.96, 2.12, 2.25]` against a bound of 1; the other three
cells are unaffected in both directions.

Reordering a contraction reassociates a sum, so the result may move by rounding
and no more. A degree-5 prism residual assembled under all six reduction
orderings — one process each, with its own kernel cache so the comparison is
not vacuous — agrees to `4.09e-16`.

The full `tests/tsfc` suite passes (363 tests) and `make srclint` is clean.

## Notes for the reviewer

The sort arrived in 14970cff (Aug 2017) to fix a prism test that was failing at
the time, and the codegen it was compensating for has since changed. Those prism
tests only exercise degrees 3–5, which is the range where the difference between
the two orderings is smallest.

---

AI was used in preparing this change (Claude Code). The benchmark above was run
locally against FIAT `main`; it needs nothing from FIAT and is deliberately not
added to the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
