### PR TITLE
pyop2: add a safe_math option to opt out of relaxed floating point

### DIFF
--- a/pyop2/compilation.py
+++ b/pyop2/compilation.py
@@ -228,6 +228,13 @@ class Compiler(ABC):
     _ldflags = ()
 
     _optflags = ()
+    _safe_optflags = ()
+    """Optimisation flags used when ``safe_math`` is set.
+
+    Should match ``_optflags`` with the relaxed floating point flags removed,
+    so that opting in to IEEE semantics does not silently also give up
+    unrelated optimisations.
+    """
     _debugflags = ()
 
     def __init__(self, extra_compiler_flags=(), extra_linker_flags=(), version=None, debug=False):
@@ -278,10 +285,25 @@ class Compiler(ABC):
         return self._ld
 
     @property
+    def optflags(self) -> tuple[str, ...]:
+        """Optimisation flags, honouring the ``safe_math`` configuration.
+
+        By default this includes ``-ffast-math`` or its equivalent, which
+        grants the compiler licence to reassociate floating point arithmetic
+        and to assume NaN and infinity do not occur. Kernels that are
+        sensitive to either need a way to decline; ``safe_math`` selects
+        ``_safe_optflags`` instead. Devito exposes the same switch under the
+        same name.
+        """
+        if configuration["safe_math"]:
+            return self._safe_optflags
+        return self._optflags
+
+    @property
     def cflags(self) -> tuple[str, ...]:
         return (
             *self._cflags,
-            *(self._debugflags if self._debug else self._optflags),
+            *(self._debugflags if self._debug else self.optflags),
             *self.bugfix_cflags,
             *self._extra_compiler_flags,
             *shlex.split(configuration["cflags"]),
@@ -291,7 +313,7 @@ class Compiler(ABC):
     def cxxflags(self) -> tuple[str, ...]:
         return (
             *self._cxxflags,
-            *(self._debugflags if self._debug else self._optflags),
+            *(self._debugflags if self._debug else self.optflags),
             *self.bugfix_cflags,
             *self._extra_compiler_flags,
             *shlex.split(configuration["cxxflags"]),
@@ -319,6 +341,7 @@ class MacClangCompiler(Compiler):
     _ldflags = ("-dynamiclib",)
 
     _optflags = ("-O3", "-ffast-math", "-march=native")
+    _safe_optflags = ("-O3", "-march=native")
     _debugflags = ("-O0", "-g")
 
 
@@ -326,6 +349,7 @@ class MacClangARMCompiler(MacClangCompiler):
     """A compiler for building a shared library on ARM based Mac systems."""
     # See https://stackoverflow.com/q/65966969
     _optflags = ("-O3", "-ffast-math", "-mcpu=apple-a14")
+    _safe_optflags = ("-O3", "-mcpu=apple-a14")
     # Need to pass -L/opt/homebrew/opt/gcc/lib/gcc/11 to prevent linker error:
     # ld: file not found: @rpath/libgcc_s.1.1.dylib for architecture arm64 This
     # seems to be a homebrew configuration issue somewhere. Hopefully this
@@ -347,6 +371,7 @@ class LinuxGnuCompiler(Compiler):
     _ldflags = ("-shared",)
 
     _optflags = ("-march=native", "-O3", "-ffast-math")
+    _safe_optflags = ("-march=native", "-O3")
     _debugflags = ("-O0", "-g")
 
     @property
@@ -374,6 +399,7 @@ class LinuxClangCompiler(Compiler):
     _ldflags = ("-shared", "-L/usr/lib")
 
     _optflags = ("-march=native", "-O3", "-ffast-math")
+    _safe_optflags = ("-march=native", "-O3")
     _debugflags = ("-O0", "-g")
 
 
@@ -385,7 +411,10 @@ class LinuxIntelCompiler(Compiler):
     _cxxflags = ("-fPIC", "-no-multibyte-chars")
     _ldflags = ("-shared",)
 
+    # -Ofast implies -fp-model=fast, so the safe variant drops to -O3 and asks
+    # for precise semantics explicitly rather than relying on the default.
     _optflags = ("-Ofast", "-xHost")
+    _safe_optflags = ("-O3", "-xHost", "-fp-model=precise")
     _debugflags = ("-O0", "-g")
 
 
@@ -398,6 +427,7 @@ class LinuxCrayCompiler(Compiler):
     _ldflags = ("-shared",)
 
     _optflags = ("-march=native", "-O3", "-ffast-math")
+    _safe_optflags = ("-march=native", "-O3")
     _debugflags = ("-O0", "-g")
 
     @property

--- a/pyop2/configuration.py
+++ b/pyop2/configuration.py
@@ -56,6 +56,10 @@ class Configuration(dict):
         (e.g. 4 for AVX2, 8 for AVX512).
     :param debug: Turn on debugging for generated code (turns off
         compiler optimisations).
+    :param safe_math: Compile generated code with IEEE-conforming floating
+        point semantics, dropping ``-ffast-math`` and equivalents.  Slower,
+        but required if a kernel is sensitive to reassociation or relies on
+        NaN or infinity behaviour.  (Default no)
     :param type_check: Should PyOP2 type-check API-calls?  (Default,
         yes)
     :param check_src_hashes: Should PyOP2 check that generated code is
@@ -91,6 +95,8 @@ class Configuration(dict):
             ("PYOP2_SIMD_WIDTH", int, 4),
         "debug":
             ("PYOP2_DEBUG", bool, False),
+        "safe_math":
+            ("PYOP2_SAFE_MATH", bool, False),
         "compute_kernel_flops":
             ("PYOP2_COMPUTE_KERNEL_FLOPS", bool, False),
         "type_check":

--- a/tests/pyop2/test_compilation.py
+++ b/tests/pyop2/test_compilation.py
@@ -1,0 +1,133 @@
+# This file is part of PyOP2
+#
+# PyOP2 is Copyright (c) 2012, Imperial College London and
+# others. Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Compilation flag unit tests."""
+
+import pytest
+from packaging.version import Version
+
+from pyop2.compilation import (
+    LinuxClangCompiler,
+    LinuxCrayCompiler,
+    LinuxGnuCompiler,
+    LinuxIntelCompiler,
+    MacClangARMCompiler,
+    MacClangCompiler,
+)
+from pyop2.configuration import configuration
+
+
+# Every compiler that enables relaxed floating point semantics by default, with
+# the flag it uses to do so.
+RELAXED_MATH_COMPILERS = [
+    (MacClangCompiler, "-ffast-math"),
+    (MacClangARMCompiler, "-ffast-math"),
+    (LinuxGnuCompiler, "-ffast-math"),
+    (LinuxClangCompiler, "-ffast-math"),
+    (LinuxCrayCompiler, "-ffast-math"),
+    # -Ofast implies -fp-model=fast on the Intel compilers.
+    (LinuxIntelCompiler, "-Ofast"),
+]
+
+
+@pytest.fixture
+def safe_math(request):
+    """Set ``safe_math`` for the duration of a test, then restore it."""
+    original = configuration["safe_math"]
+    configuration["safe_math"] = request.param
+    yield request.param
+    configuration["safe_math"] = original
+
+
+@pytest.mark.parametrize("compiler, relaxed_flag", RELAXED_MATH_COMPILERS)
+@pytest.mark.parametrize("safe_math", [False], indirect=True)
+def test_relaxed_math_is_the_default(compiler, relaxed_flag, safe_math):
+    """Without ``safe_math`` the relaxed floating point flag is passed.
+
+    This is the historical behaviour and the switch must not change it.
+    """
+    flags = compiler(version=Version("1.0")).cflags
+    assert relaxed_flag in flags
+
+
+@pytest.mark.parametrize("compiler, relaxed_flag", RELAXED_MATH_COMPILERS)
+@pytest.mark.parametrize("safe_math", [True], indirect=True)
+def test_safe_math_drops_the_relaxed_flag(compiler, relaxed_flag, safe_math):
+    """With ``safe_math`` set, no flag relaxing IEEE semantics is passed."""
+    flags = compiler(version=Version("1.0")).cflags
+    assert relaxed_flag not in flags
+    # Guard against a variant creeping in by another spelling.
+    for flag in flags:
+        assert "fast-math" not in flag
+        assert flag != "-Ofast"
+        assert flag != "-fp-model=fast"
+
+
+@pytest.mark.parametrize("compiler, relaxed_flag", RELAXED_MATH_COMPILERS)
+@pytest.mark.parametrize("safe_math", [True], indirect=True)
+def test_safe_math_keeps_optimising(compiler, relaxed_flag, safe_math):
+    """Opting in to IEEE semantics should not also give up optimisation.
+
+    Otherwise users face a false choice between correct arithmetic and
+    reasonable performance.
+    """
+    flags = compiler(version=Version("1.0")).cflags
+    assert any(flag in ("-O2", "-O3") for flag in flags)
+
+
+@pytest.mark.parametrize("safe_math", [True], indirect=True)
+def test_intel_asks_for_precise_semantics(safe_math):
+    """Intel needs the model stated explicitly, dropping -Ofast is not enough."""
+    flags = LinuxIntelCompiler(version=Version("1.0")).cflags
+    assert "-fp-model=precise" in flags
+
+
+@pytest.mark.parametrize("compiler, relaxed_flag", RELAXED_MATH_COMPILERS)
+def test_safe_optflags_differ_only_in_the_math_flag(compiler, relaxed_flag):
+    """``_safe_optflags`` should be ``_optflags`` minus the relaxed maths.
+
+    Kept as a static check on the class attributes so that a future edit to one
+    tuple and not the other is caught here rather than by a user wondering why
+    ``safe_math`` made their kernels slow.
+    """
+    dropped = set(compiler._optflags) - set(compiler._safe_optflags)
+    added = set(compiler._safe_optflags) - set(compiler._optflags)
+
+    assert relaxed_flag in dropped
+    # Intel swaps -Ofast for -O3 plus an explicit model, everything else only
+    # removes a flag.
+    if compiler is LinuxIntelCompiler:
+        assert added == {"-O3", "-fp-model=precise"}
+    else:
+        assert not added
+        assert dropped == {relaxed_flag}


### PR DESCRIPTION
# Description

PyOP2 compiles every generated kernel with relaxed floating point semantics, and there is no way to decline.

| compiler class | `_optflags` |
| --- | --- |
| `MacClangCompiler` | `-O3 -ffast-math -march=native` |
| `MacClangARMCompiler` | `-O3 -ffast-math -mcpu=apple-a14` |
| `LinuxGnuCompiler` | `-march=native -O3 -ffast-math` |
| `LinuxClangCompiler` | `-march=native -O3 -ffast-math` |
| `LinuxCrayCompiler` | `-march=native -O3 -ffast-math` |
| `LinuxIntelCompiler` | `-Ofast -xHost` |

`-ffast-math` implies `-fassociative-math`, `-ffinite-math-only`, `-funsafe-math-optimizations`, `-fno-signed-zeros` and `-fno-trapping-math`, and `-Ofast` implies `-fp-model=fast` on the Intel compilers. So a kernel that is sensitive to reassociation, or that relies on NaN or infinity propagating, has no recourse short of editing PyOP2.

### What this adds

`safe_math`, off by default, settable through `pyop2.configuration` or as `PYOP2_SAFE_MATH=1`. When it is set, `Compiler.optflags` returns `_safe_optflags` instead of `_optflags`.

The safe tuples are the existing ones with the relaxed maths removed and nothing else changed, so opting in to IEEE semantics does not silently also give up unrelated optimisations. `-O3` and `-march=native` stay. Intel is the exception worth calling out: dropping `-Ofast` on its own would still leave the default model in place, so the safe variant is `-O3 -xHost -fp-model=precise`.

`bugfix_cflags` is untouched. The GCC 15 `-O2` workaround still applies, independently, under either setting.

### Prior art

Devito exposes the same switch under the name `safe-math`, so the naming here is deliberately the same. FFCx passes no `-O` flags at all, so the question does not arise there.

### Relation to #5107

In #5107 I named `-ftree-loop-distribution` and `-fpredictive-commoning` as the likely culprits. That was wrong. Bisecting the thirteen flags `-O3` adds over `-O2`, on both gcc-13 and gcc-14, none of them change the result. `-fno-associative-math` does. And since PyOP2 appends the `-O2` workaround after `-O3`, the `-O2` wins but `-ffast-math` is still active, which would explain why that workaround does not always help.

I am not proposing `safe_math` as the fix for #5107 here. But if that reading holds it is the more targeted lever, and this is the prerequisite for reaching for it.

### Tests

`tests/pyop2/test_compilation.py`, parametrised over all six backends:

- the relaxed flag is still passed by default
- it is gone under `safe_math`, and no other spelling of it has crept in
- `-O2` or `-O3` survives, so the switch is not a choice between correct arithmetic and no optimisation
- Intel states `-fp-model=precise`
- `_safe_optflags` differs from `_optflags` only by the maths, checked statically so that a future edit to one tuple and not the other fails here rather than surprising a user
