### PR TITLE
zero initial guess for Riesz Map solve

### DIFF
--- a/firedrake/cofunction.py
+++ b/firedrake/cofunction.py
@@ -519,6 +519,7 @@ class RieszMap:
             else:
                 solve, rhs, soln = self._solver
                 rhs.assign(value)
+                soln.zero()
                 solve()
                 output = Function(self._function_space)
                 output.assign(soln)


### PR DESCRIPTION
The Riesz representation calculation should be completely independent of previous calculations. Zero-ing the initial guess enforces this.

Not zeroing the initial guess can cause finite-precision problems if consecutive solves have vastly different scales for the rhs.