### PR TITLE
Cost and fuse preserved pullbacks, and cancel indirect Deltas

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -165,6 +165,13 @@ runs:
           --extra-index-url https://download.pytorch.org/whl/cpu \
           "./firedrake-repo[${{ inputs.deps }}]"
 
+        : # DROP BEFORE MERGE: the TSFC changes here need the GEM changes in the
+        : # FIAT stack firedrakeproject/fiat#282 -> #284 -> #281, whose head
+        : # carries all three.  This has to land before anything imports
+        : # Firedrake, firedrake-clean below included.
+        pip install --no-deps --force-reinstall --ignore-installed \
+          git+https://github.com/firedrakeproject/fiat.git@pbrubeck/zany-matvec
+
         firedrake-clean
         pip list
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -567,6 +567,14 @@ jobs:
           pip install --verbose -r ./firedrake-repo/requirements-build.txt
           CC=mpicc CXX=mpicxx \
             pip install --verbose --no-build-isolation './firedrake-repo[docs]'
+
+          : # DROP BEFORE MERGE: this job installs Firedrake itself rather than
+          : # going through .github/actions/install, so it needs its own copy of
+          : # the FIAT stack, and for the same reason: firedrake-clean below
+          : # imports Firedrake, and so the tsfc that needs those GEM changes.
+          pip install --no-deps --force-reinstall --ignore-installed \
+            git+https://github.com/firedrakeproject/fiat.git@pbrubeck/zany-matvec
+
           firedrake-clean
           pip list
 

--- a/tests/tsfc/test_delta_elimination.py
+++ b/tests/tsfc/test_delta_elimination.py
@@ -1,6 +1,8 @@
+import numpy
 import pytest
 
-from gem.gem import Delta, Identity, Index, Indexed, one
+from gem.gem import (Delta, Identity, Index, Indexed, Literal, Variable,
+                     VariableIndex, one, uint_type)
 from gem.optimise import delta_elimination, remove_componenttensors
 
 
@@ -18,6 +20,28 @@ def test_delta_elimination():
 
     assert sum_indices == []
     assert factors == [one, one, Indexed(I, (k, k))]
+
+
+def test_delta_elimination_indirect_only():
+    i = Index()
+    k = Index()
+    A = Variable("A", (3,))
+    columns = Literal(numpy.array([2, 0, 1]), dtype=uint_type)
+    indirect = VariableIndex(Indexed(columns, (k,)))
+
+    # An indirect Delta cancels either way round: no later pass can lower one.
+    factors = [Delta(indirect, i), Indexed(A, (i,))]
+    cancelled, gathered = delta_elimination((i,), factors, indirect_only=True)
+    assert cancelled == []
+    assert remove_componenttensors(gathered) == [one, Indexed(A, (indirect,))]
+
+    # A Delta between two plain indices is left to monomial collection.
+    factors = [Delta(i, k), Indexed(A, (i,))]
+    cancelled, kept = delta_elimination((i,), factors, indirect_only=True)
+    assert cancelled == [i]
+    assert kept == factors
+
+    assert delta_elimination((i,), factors)[0] == []
 
 
 if __name__ == "__main__":

--- a/tests/tsfc/test_impero_loopy_flop_counts.py
+++ b/tests/tsfc/test_impero_loopy_flop_counts.py
@@ -6,9 +6,9 @@ import numpy
 import loopy
 from tsfc import compile_form
 from ufl import (FunctionSpace, Mesh, TestFunction,
-                 TrialFunction, dx, grad, inner,
+                 TrialFunction, div, dx, grad, inner,
                  interval, triangle, quadrilateral,
-                 TensorProductCell)
+                 tetrahedron, TensorProductCell)
 from finat.ufl import FiniteElement, VectorElement
 from tsfc.parameters import target
 
@@ -64,3 +64,20 @@ def test_flop_count(cell, parameters):
     loopy_flops = numpy.asarray(loopy_flops)
 
     assert all(new_flops == loopy_flops)
+
+
+@pytest.mark.parametrize("cell", [triangle, tetrahedron],
+                         ids=lambda cell: cell.cellname)
+def test_flop_count_mapped_tabulation(cell):
+    # Preserving a Piola map materialises it as a ComponentTensor.
+    # Scheduling emits that as an assignment, not a loop nest, so counting
+    # it needs its own extents.
+    mesh = Mesh(VectorElement("P", cell, 1))
+    for k in range(1, 4):
+        V = FunctionSpace(mesh, FiniteElement("RT", cell, k))
+        u = TrialFunction(V)
+        v = TestFunction(V)
+        a = inner(u, v)*dx + inner(div(u), div(v))*dx
+        kernel, = compile_form(a, prefix="form",
+                               parameters={"mode": "spectral"})
+        assert kernel.flop_count == count_loopy_flops(kernel)

--- a/tests/tsfc/test_sum_factorisation.py
+++ b/tests/tsfc/test_sum_factorisation.py
@@ -81,6 +81,11 @@ def count_storage(form):
                                            and temporary.initializer is not None))
 
 
+def count_loops(form):
+    kernel, = compile_form(form, parameters=dict(mode='spectral'))
+    return len(kernel.ast.default_entrypoint.all_inames())
+
+
 @pytest.mark.parametrize(('cell', 'order'),
                          [(quadrilateral, 5),
                           (TensorProductCell(interval, interval), 5),
@@ -249,6 +254,20 @@ def test_preserving_a_map_is_never_worse(cell, degree, expanded):
     selected = count_flops(form)
     expanded()
     assert selected <= count_flops(form)
+
+
+@pytest.mark.parametrize('cell', [triangle, tetrahedron],
+                         ids=lambda cell: cell.cellname)
+@pytest.mark.parametrize('degree', [1, 3])
+def test_shared_map_is_tabulated_in_one_loop(cell, degree, expanded):
+    # A map that both argument axes share is tabulated once, so it must be
+    # tabulated in one loop.  An index per axis fissions the loop nest that
+    # the expanded representation keeps whole, which costs more than the
+    # flops it saves.
+    form = piola_helmholtz(cell, degree)
+    selected = count_loops(form)
+    expanded()
+    assert selected <= count_loops(form)
 
 
 if __name__ == "__main__":

--- a/tests/tsfc/test_sum_factorisation.py
+++ b/tests/tsfc/test_sum_factorisation.py
@@ -3,10 +3,12 @@ import pytest
 
 from ufl import (Mesh, FunctionSpace, TestFunction, TrialFunction,
                  TensorProductCell, dx, action, interval, triangle,
-                 quadrilateral, hexahedron, curl, dot, div, grad)
+                 quadrilateral, hexahedron, tetrahedron, curl, dot, div,
+                 grad, inner)
 from finat.ufl import (FiniteElement, VectorElement, EnrichedElement,
                        TensorProductElement, HCurlElement, HDivElement)
 
+import tsfc.spectral
 from tsfc import compile_form
 
 
@@ -201,6 +203,52 @@ def test_equivalent_cells(cell, equivalent_cell, degree):
     b = helmholtz(equivalent_cell, degree)
     assert count_flops(a) == count_flops(b)
     assert count_flops(action(a)) == count_flops(action(b))
+
+
+@pytest.fixture
+def expanded(monkeypatch):
+    """Force the expanded representation, for comparison."""
+    def force(monkeypatch=monkeypatch):
+        collect_monomials = tsfc.spectral.collect_monomials
+        monkeypatch.setattr(
+            tsfc.spectral, "collect_monomials",
+            lambda expressions, classifier, _: collect_monomials(
+                expressions, classifier))
+    return force
+
+
+def piola_helmholtz(cell, degree):
+    m = Mesh(VectorElement('CG', cell, 1))
+    V = FunctionSpace(m, FiniteElement('RT', cell, degree))
+    u = TrialFunction(V)
+    v = TestFunction(V)
+    return (inner(u, v) + inner(div(u), div(v)))*dx
+
+
+@pytest.mark.parametrize('cell', [triangle, tetrahedron],
+                         ids=lambda cell: cell.cellname)
+@pytest.mark.parametrize('degree', [1, 2, 3])
+def test_piola_map_is_preserved(cell, degree, expanded):
+    # Test and trial apply the same Piola map, so preserving it evaluates
+    # the physical basis once instead of pushing the geometry through both
+    # argument axes.
+    form = piola_helmholtz(cell, degree)
+    selected = count_flops(form)
+    expanded()
+    assert selected < count_flops(form)
+
+
+@pytest.mark.parametrize('cell', [triangle, tetrahedron],
+                         ids=lambda cell: cell.cellname)
+@pytest.mark.parametrize('degree', [1, 3])
+def test_preserving_a_map_is_never_worse(cell, degree, expanded):
+    # Expanding a map exposes scalar factorisation of its entries, which at
+    # some degrees beats sharing it.  Selection costs both, so neither
+    # representation may regress the other.
+    form = helmholtz(cell, degree)
+    selected = count_flops(form)
+    expanded()
+    assert selected <= count_flops(form)
 
 
 if __name__ == "__main__":

--- a/tsfc/loopy.py
+++ b/tsfc/loopy.py
@@ -123,6 +123,7 @@ class LoopyContext(object):
         self.indices = {}  # indices for declarations and referencing values, from ImperoC
         self.active_indices = {}  # gem index -> pymbolic variable
         self.index_extent = OrderedDict()  # pymbolic variable for indices -> extent
+        self.tabulated = (None, ())  # axes and inames of the preceding tabulation
         self.gem_to_pymbolic = {}  # gem node -> pymbolic variable
         self.name_gen = UniqueNameGenerator()
         self.target = target
@@ -304,10 +305,27 @@ def statement(tree, ctx):
     raise AssertionError("cannot generate loopy from %s" % type(tree))
 
 
+def tabulated_axes(tree):
+    """The axes a statement binds, if it tabulates a tensor over its own."""
+    if isinstance(tree, imp.Evaluate) \
+            and isinstance(tree.expression, gem.ComponentTensor):
+        return tree.expression.multiindex
+    return None
+
+
 @statement.register(imp.Block)
 def statement_block(tree, ctx):
-    from itertools import chain
-    return list(chain(*(statement(child, ctx) for child in tree.children)))
+    # Tabulations of the same axes share a loop while they stay adjacent.
+    # Anything between them is a statement the schedule placed outside that
+    # loop, so the loop has to close before it and reopen after.
+    instructions = []
+    ctx.tabulated = (None, ())
+    for child in tree.children:
+        instructions.extend(statement(child, ctx))
+        if tabulated_axes(child) is None:
+            ctx.tabulated = (None, ())
+    ctx.tabulated = (None, ())
+    return instructions
 
 
 @statement.register(imp.For)
@@ -360,7 +378,10 @@ def statement_evaluate(leaf, ctx):
     elif isinstance(expr, gem.Constant):
         return []
     elif isinstance(expr, gem.ComponentTensor):
-        idx = ctx.gem_to_pym_multiindex(expr.multiindex)
+        axes, idx = ctx.tabulated
+        if axes != expr.multiindex:
+            idx = ctx.gem_to_pym_multiindex(expr.multiindex)
+            ctx.tabulated = (expr.multiindex, idx)
         var, sub_idx = ctx.pymbolic_variable_and_destruct(expr)
         lhs = p.Subscript(var, sub_idx + idx)
         with active_indices(dict(zip(expr.multiindex, idx)), ctx) as ctx_active:

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -4,7 +4,8 @@ from itertools import chain, zip_longest
 
 from gem.gem import Delta, Indexed, Sum, index_sum, one
 from gem.node import Memoizer, MemoizerArg
-from gem.optimise import filtered_replace_indices
+from gem.cost import estimate_cost
+from gem.optimise import filtered_replace_indices, has_linear_maps
 from gem.optimise import delta_elimination as _delta_elimination
 from gem.optimise import replace_division, unroll_indexsum
 from gem.refactorise import ATOMIC, COMPOUND, OTHER, MonomialSum, collect_monomials
@@ -52,6 +53,89 @@ def _delta_inside(node, self):
                for child in node.children)
 
 
+def _group_key(pair):
+    variable, expression = pair
+    return frozenset(variable.free_indices)
+
+
+def _preservable(pairs):
+    """Is there a linear map whose preservation could change a plan?
+
+    Parameters
+    ----------
+    pairs : tuple of tuple
+        Output variables and the integrands assigned to them.
+
+    Returns
+    -------
+    bool
+        Whether any assignment contains a sum over one argument axis.
+
+    """
+    return any(
+        has_linear_maps([expression], set(free_indices))
+        for free_indices, pair_group in groupby(pairs, _group_key)
+        for _, expression in pair_group)
+
+
+def _factorise(pairs, quadrature_indices, preserve_maps):
+    """Factorise the arguments of each assignment.
+
+    Parameters
+    ----------
+    pairs : tuple of tuple
+        Output variables and the integrands assigned to them.
+    quadrature_indices : tuple of Index
+        Every quadrature index of the integral, in source order.
+    preserve_maps : bool
+        Keep a sum over one argument axis whole, as a finite element linear
+        map, rather than distributing it into scalar monomials.
+
+    Returns
+    -------
+    tuple of tuple
+        Output variables and their factorised GEM expressions.
+
+    """
+    # Common memoizer to remove ComponentTensors
+    index_replacer = MemoizerArg(filtered_replace_indices)
+    # Common memoizer to test for Deltas inside expressions
+    delta_inside = Memoizer(_delta_inside)
+    # Variable ordering after delta cancellation
+    narrow_variables = OrderedDict()
+    # Assignments are variable -> MonomialSum map
+    delta_simplified = defaultdict(MonomialSum)
+    # Group assignment pairs by argument indices
+    for free_indices, pair_group in groupby(pairs, _group_key):
+        variables, expressions = zip(*pair_group)
+        argument_indices = set(free_indices)
+        classifier = partial(classify, argument_indices, delta_inside=delta_inside)
+        # Argument factorise expressions
+        monomial_sums = collect_monomials(
+            expressions, classifier,
+            argument_indices if preserve_maps else ())
+        # For each monomial, apply delta cancellation and insert
+        # result into delta_simplified.
+        for variable, monomial_sum in zip(variables, monomial_sums):
+            for monomial in monomial_sum:
+                var, s, a, r = delta_elimination(variable, *monomial, index_replacer)
+                narrow_variables.setdefault(var)
+                delta_simplified[var].add(s, a, r)
+
+    # Final factorisation
+    plan = []
+    for variable in narrow_variables:
+        monomial_sum = delta_simplified[variable]
+        # Collect sum indices applicable to the current MonomialSum
+        sum_indices = set(chain.from_iterable(m.sum_indices for m in monomial_sum))
+        # Put them in a deterministic order
+        sum_indices = [i for i in quadrature_indices if i in sum_indices]
+        # Apply sum factorisation combined with COFFEE technology
+        expression = sum_factorise(variable, sum_indices, monomial_sum)
+        plan.append((variable, expression))
+    return tuple(plan)
+
+
 def flatten(var_reps, index_cache):
     quadrature_indices = OrderedDict()
 
@@ -76,45 +160,18 @@ def flatten(var_reps, index_cache):
     # Split Concatenate nodes
     pairs = unconcatenate(pairs, cache=index_cache)
 
-    def group_key(pair):
-        variable, expression = pair
-        return frozenset(variable.free_indices)
-
-    # Common memoizer to remove ComponentTensors
-    index_replacer = MemoizerArg(filtered_replace_indices)
-    # Common memoizer to test for Deltas inside expressions
-    delta_inside = Memoizer(_delta_inside)
-    # Variable ordering after delta cancellation
-    narrow_variables = OrderedDict()
-    # Assignments are variable -> MonomialSum map
-    delta_simplified = defaultdict(MonomialSum)
-    # Group assignment pairs by argument indices
-    for free_indices, pair_group in groupby(pairs, group_key):
-        variables, expressions = zip(*pair_group)
-        # Argument factorise expressions
-        classifier = partial(classify, set(free_indices), delta_inside=delta_inside)
-        monomial_sums = collect_monomials(expressions, classifier)
-        # For each monomial, apply delta cancellation and insert
-        # result into delta_simplified.
-        for variable, monomial_sum in zip(variables, monomial_sums):
-            for monomial in monomial_sum:
-                var, s, a, r = delta_elimination(variable, *monomial, index_replacer)
-                narrow_variables.setdefault(var)
-                delta_simplified[var].add(s, a, r)
-
-    # Final factorisation
-    for variable in narrow_variables:
-        monomial_sum = delta_simplified[variable]
-        # Collect sum indices applicable to the current MonomialSum
-        sum_indices = set(chain.from_iterable(m.sum_indices for m in monomial_sum))
-        # Put them in a deterministic order
-        sum_indices = [i for i in quadrature_indices if i in sum_indices]
-        # Apply sum factorisation combined with COFFEE technology
-        expression = sum_factorise(variable, sum_indices, monomial_sum)
-        yield (variable, expression)
+    # Expanding a linear map exposes scalar factorisation across its
+    # entries, preserving one exposes a tabulation that several argument
+    # axes share, and neither dominates.  Cost both and keep the cheaper,
+    # skipping the second factorisation when there is no map to preserve.
+    plans = [_factorise(pairs, quadrature_indices, False)]
+    if _preservable(pairs):
+        plans.append(_factorise(pairs, quadrature_indices, True))
+    return min(plans, key=lambda plan: estimate_cost(
+        expression for _, expression in plan))
 
 
-finalise_options = dict(replace_delta=False)
+finalise_options = dict(replace_delta=False, remove_componenttensors=False)
 
 
 def classify(argument_indices, expression, delta_inside):

--- a/tsfc/spectral.py
+++ b/tsfc/spectral.py
@@ -5,7 +5,8 @@ from itertools import chain, zip_longest
 from gem.gem import Delta, Indexed, Sum, index_sum, one
 from gem.node import Memoizer, MemoizerArg
 from gem.cost import estimate_cost
-from gem.optimise import filtered_replace_indices, has_linear_maps
+from gem.optimise import (cancel_nested_deltas, filtered_replace_indices,
+                          has_linear_maps)
 from gem.optimise import delta_elimination as _delta_elimination
 from gem.optimise import replace_division, unroll_indexsum
 from gem.refactorise import ATOMIC, COMPOUND, OTHER, MonomialSum, collect_monomials
@@ -34,6 +35,12 @@ def Integrals(expressions, quadrature_multiindex, argument_multiindices, paramet
     """
     # Rewrite: a / b => a * (1 / b)
     expressions = replace_division(expressions)
+
+    # Cancel the indirect Deltas that select a basis transformation's columns.
+    # No later pass can: monomial collection only cancels Deltas that surface
+    # as factors of a monomial, and one buried in a preserved linear map never
+    # does, so it would reach code generation.
+    expressions = [cancel_nested_deltas(e) for e in expressions]
 
     # Unroll
     max_extent = parameters["unroll_indexsum"]


### PR DESCRIPTION
## TLDR

This is the TSFC half of firedrakeproject/fiat#284 and firedrakeproject/fiat#281.

It does three things. TSFC **costs two factorisation plans and keeps the cheaper
one**, instead of choosing by a rule. Loopy **puts adjacent shared tabulations in
one loop**, instead of one loop each. And TSFC **cancels the indirect Deltas that
select a padded basis transformation's columns**, which is what makes fiat#281's
transformation viable at all.

Raviart--Thomas in 3D loses a third of its operations. Q and NCE do not change.

Base: `main`. Needs firedrakeproject/fiat#281. The TSFC half of
firedrakeproject/fiat#286 is stacked on this branch in #5438.

## What this does

**Cost the two plans** (`tsfc/spectral.py`).

A pullback reaches TSFC as a sum over one argument axis. There are two ways to
handle it.

- Expand it. This exposes scalar factorisation across its entries.
- Keep it. This exposes one tabulation that several argument axes can share.

Neither wins everywhere. So `flatten` builds both plans and keeps the cheaper
one by `estimate_cost`. It skips the second plan when `has_linear_maps` says
there is no map to keep, so the extra work is only paid where it can help.

On a CG degree 3 Laplacian in 2D, keeping the map costs 8,305 operations against
8,125 for expanding it. Only a cost model rejects it there.

**Fuse adjacent tabulations** (`tsfc/loopy.py`).

One kept map per `ComponentTensor` gave one loop each, so a single fused nest
became three loops over the same extent. TSFC now reuses one iname per bound
index and fuses them back.

The iname is reused only between **adjacent** tabulations. Impero can place
other statements between two tabulations that depend on each other, and one
iname cannot be both inside and outside such a statement. `statement_block`
therefore resets the memo on any statement that is not a `ComponentTensor`
`Evaluate`.

**Cancel the indirect Deltas** (`tsfc/spectral.py`).

fiat#281 selects a padded transformation's columns with a Delta over a variable
index. Monomial collection only cancels a Delta that surfaces as a factor of a
monomial, and one buried in a kept linear map never does, so it would reach code
generation as a full-width contraction against an identity. `Integrals` cancels
the indirect Deltas up front and leaves the plain-index ones to monomial
collection.

This is not an optimisation, it is what makes the padded transformation usable.
Paired with fiat#281 and without it, the Johnson--Mercier action in 3D costs
319,963 operations against 44,248 on `main`.

## Effect

Raviart--Thomas is where keeping the pullback pays. On
`inner(u, v)*dx + inner(div(u), div(v))*dx`, `main` against this PR:

| family | dim | degree | flops main | flops PR | AST lines main | AST lines PR |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RT | 2 | 3 | 23,318 | **18,038** | 90 | 81 |
| RT | 2 | 5 | 253,051 | **192,564** | 90 | 81 |
| RT | 3 | 3 | 374,589 | **255,933** | 136 | 109 |
| RT | 3 | 5 | 12,965,694 | **8,711,463** | 136 | 109 |

Arithmetic falls 32% at degree 3 and 33% at degree 5 in 3D. There are 31% fewer
scalar temporaries and 20% fewer lines of C.

Q and NCE do not change. On a tensor-product cell no sum depends on exactly one
argument index, so the second plan is never built.

## The zany elements need the whole stack

This PR paired with fiat#281 regresses the Johnson--Mercier and Argyris actions,
because a padded transformation reads its reference tabulation once per padded
column. fiat#286 and #5438 are what tabulate that contraction one time. Numbers
are in #5438; do not merge this pair on its own.

## Validation

`tests/tsfc` paired with fiat#281: 386 passed. That pairing did not build
before this split, because the branch also carried fiat#286's call site.

## AI assistance

Claude Code was used for the split, the benchmarking and this description. The
human contributor remains responsible for understanding, validating and
maintaining the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1NNAv95LANgpBX61ozPE2

