### PR TITLE
Lint cython code

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -536,7 +536,7 @@ jobs:
       - name: Setup flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Install linting packages
-        run: pip install flake8 pylint
+        run: pip install flake8 pylint cython-lint
       - name: Lint codebase
         run: make lint GITHUB_ACTIONS_FORMATTING=1
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ srclint:
 	@python -m flake8 $(FLAKE8_FORMAT) pyop2/scripts --filename=*
 	@echo "    Linting TSFC"
 	@python -m flake8 $(FLAKE8_FORMAT) tsfc
+	@echo "    Linting Cython code"
+	@cython-lint firedrake/cython
 
 .PHONY: actionlint
 actionlint:

--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -2,8 +2,6 @@
 
 # Utility functions common to all DMs used in Firedrake
 import enum
-import functools
-import math
 import cython
 import numpy as np
 import firedrake
@@ -277,6 +275,7 @@ def count_labelled_points(PETSc.DM dm, name,
     CHKERR(DMLabelDestroyIndex(label))
     return n
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def facet_numbering(PETSc.DM plex, kind,
@@ -316,39 +315,39 @@ def facet_numbering(PETSc.DM plex, kind,
         CHKERR(DMPlexGetSupport(plex.dm, facets[f], &cells))
         CHKERR(DMPlexGetSupportSize(plex.dm, facets[f], &ncells))
         CHKERR(PetscSectionGetOffset(cell_numbering.sec, cells[0], &cell))
-        facet_cells[f,0] = cell
+        facet_cells[f, 0] = cell
         if cells_per_facet > 1:
             if ncells > 1:
                 CHKERR(PetscSectionGetOffset(cell_numbering.sec,
                                              cells[1], &cell))
-                facet_cells[f,1] = cell
+                facet_cells[f, 1] = cell
             else:
-                facet_cells[f,1] = -1
+                facet_cells[f, 1] = -1
 
     # Run through the sorted closure to get the
     # local facet number within each parent cell
     for f in range(nfacets):
         # First cell
-        cell = facet_cells[f,0]
+        cell = facet_cells[f, 0]
         fi = 0
         for c in range(nclosure):
             if cell_closures[cell, c] == facets[f]:
-                facet_local_num[f,0] = fi
+                facet_local_num[f, 0] = fi
             if fStart <= cell_closures[cell, c] < fEnd:
                 fi += 1
 
         # Second cell
         if facet_cells.shape[1] > 1:
-            cell = facet_cells[f,1]
+            cell = facet_cells[f, 1]
             if cell >= 0:
                 fi = 0
                 for c in range(nclosure):
                     if cell_closures[cell, c] == facets[f]:
-                        facet_local_num[f,1] = fi
+                        facet_local_num[f, 1] = fi
                     if fStart <= cell_closures[cell, c] < fEnd:
                         fi += 1
             else:
-                facet_local_num[f,1] = -1
+                facet_local_num[f, 1] = -1
     return np.asarray(facet_local_num), np.asarray(facet_cells)
 
 
@@ -369,7 +368,7 @@ cdef inline PetscInt _reorder_plex_cone(PETSc.DM dm,
     compute orientations.
     """
     if dm.getCellType(p) == PETSc.DM.PolytopeType.POINT:
-        raise RuntimeError(f"POINT has no cone")
+        raise RuntimeError("POINT has no cone")
     elif dm.getCellType(p) == PETSc.DM.PolytopeType.SEGMENT:
         raise NotImplementedError(f"Not implemented for {dm.getCellType(p)}")
     elif dm.getCellType(p) == PETSc.DM.PolytopeType.TRIANGLE:
@@ -438,7 +437,7 @@ cdef inline PetscInt _reorder_plex_closure(PETSc.DM dm,
     _reorder_plex_cone() and ensuring that the cell orientation is 0.
     """
     if dm.getCellType(p) == PETSc.DM.PolytopeType.POINT:
-        raise RuntimeError(f"POINT has no cone")
+        raise RuntimeError("POINT has no cone")
     elif dm.getCellType(p) == PETSc.DM.PolytopeType.SEGMENT:
         # UFCInterval:            0---2---1
         #
@@ -608,7 +607,7 @@ def closure_ordering(PETSc.DM dm,
     """
     cdef:
         PetscInt c, cStart, cEnd, v, vStart, vEnd
-        PetscInt f, fStart, fEnd, e, eStart, eEnd
+        PetscInt f, fStart, fEnd, eStart, eEnd
         PetscInt dim, vi, ci, fi, v_per_cell, f_per_cell, cell
         PetscInt offset, cell_offset, nfaces, nfacets
         PetscInt nclosure, nfacet_closure, nface_vertices
@@ -666,7 +665,7 @@ def closure_ordering(PETSc.DM dm,
                 vi += 1
 
         # Sort vertices by universal number
-        CHKERR(PetscSortIntWithArray(v_per_cell,v_global,vertices))
+        CHKERR(PetscSortIntWithArray(v_per_cell, v_global, vertices))
         for vi in range(v_per_cell):
             if dim == 1:
                 # Correct 1D edge numbering
@@ -698,7 +697,7 @@ def closure_ordering(PETSc.DM dm,
                     for v in range(v_per_cell):
                         incident = 0
                         for vi in range(nface_vertices):
-                            if cell_closure[cell,v] == face_vertices[vi]:
+                            if cell_closure[cell, v] == face_vertices[vi]:
                                 incident = 1
                                 break
                         if incident == 0:
@@ -745,13 +744,13 @@ def closure_ordering(PETSc.DM dm,
                 for v in range(v_per_cell):
                     incident = 0
                     for vi in range(v_per_cell-1):
-                        if cell_closure[cell,v] == facet_vertices[vi]:
+                        if cell_closure[cell, v] == facet_vertices[vi]:
                             incident = 1
                             break
                     # Only one non-incident vertex per facet, so
                     # local facet no. = non-incident vertex no.
                     if incident == 0:
-                        cell_closure[cell,offset+v] = facets[f]
+                        cell_closure[cell, offset+v] = facets[f]
                         break
 
             offset += nfacets
@@ -798,7 +797,6 @@ def quadrilateral_closure_ordering(PETSc.DM plex,
         PetscInt vertices[4]
         PetscInt facets[4]
         const PetscInt *cell_cone = NULL
-        int reverse
         np.ndarray cell_closure
 
     get_height_stratum(plex.dm, 0, &cStart, &cEnd)
@@ -1155,7 +1153,7 @@ cdef inline PetscInt _compute_orientation(PETSc.DM dm,
     Dispatches on PETSc.DM.PolytopeType.
     """
     cdef:
-        PetscInt p, coneSize, offset, i, dim, o
+        PetscInt p, coneSize, offset, i, dim
         const PetscInt *cone = NULL
         PetscDMPolytopeType ct
 
@@ -1247,7 +1245,6 @@ def entity_orientations(mesh,
         entity_cone_map_offset[i] = entity_cone_list_offset[i]
     #
     dm = mesh.topology_dm
-    dim = dm.getDimension()
     numCells = cell_closure.shape[0]
     numEntities = cell_closure.shape[1]
     entity_orientations = np.zeros_like(cell_closure)
@@ -1305,7 +1302,6 @@ def create_section(mesh, nodes_per_entity, on_base=False, block_size=1, boundary
         PetscInt i, p, layers, offset_top, pStart, pEnd, dof, j, k
         PetscInt dimension, ndof
         PetscInt *dof_array = NULL
-        const PetscInt *entity_point_map
         np.ndarray nodes
         np.ndarray layer_extents
         np.ndarray points
@@ -1348,7 +1344,7 @@ def create_section(mesh, nodes_per_entity, on_base=False, block_size=1, boundary
 
     CHKERR(PetscSectionSetPermutation(section.sec, renumbering.iset))
     for i in range(dimension + 1):
-        get_depth_stratum(dm.dm, i, &pStart, &pEnd) # gets all points at dim i
+        get_depth_stratum(dm.dm, i, &pStart, &pEnd)  # gets all points at dim i
         if not variable:
             ndof = nodes[i, 0]
         for p in range(pStart, pEnd):
@@ -1507,7 +1503,7 @@ def get_cell_nodes(mesh,
         PETSc.Section cell_numbering
         PetscInt nclosure, c, cStart, cEnd, cell, entity, i
         PetscInt dofs_per_cell, ndofs, off, j, k, orient
-        PetscInt entity_permutations_size, num_orientations_size, perm_offset
+        PetscInt perm_offset
         int *ceil_ndofs = NULL
         int *flat_index = NULL
         np.ndarray layer_extents
@@ -1533,9 +1529,7 @@ def get_cell_nodes(mesh,
         if offset is None:
             raise ValueError("Offset cannot be None with variable layer extents")
     # Special case: DoFs on the top layer are identified as those on the bottom layer.
-    extruded_periodic_1_layer = isinstance(mesh, firedrake.mesh.ExtrudedMeshTopology) and \
-                                mesh.extruded_periodic and \
-                                mesh.layers == 1 + 1
+    extruded_periodic_1_layer = isinstance(mesh, firedrake.mesh.ExtrudedMeshTopology) and mesh.extruded_periodic and mesh.layers == 1 + 1
     nclosure = cell_closures.shape[1]
     # Extract ordering from FInAT element entity DoFs
     ndofs_list = []
@@ -1620,12 +1614,12 @@ def get_facet_nodes(mesh, np.ndarray cell_nodes, label,
         DMLabel clabel = NULL
         np.ndarray facet_nodes
         np.ndarray layer_extents
-        PetscInt f, p, i, j, pStart, pEnd, fStart, fEnd, point
+        PetscInt p, i, j, pStart, pEnd, fStart, fEnd, point
         PetscInt supportSize, facet, cell, ndof, dof
         const PetscInt *renumbering
         const PetscInt *support
         PetscBool flg
-        bint variable, add_offset
+        bint variable
 
     if label not in {"interior_facets", "exterior_facets"}:
         raise ValueError("Unsupported facet label '%s'", label)
@@ -1811,7 +1805,7 @@ def complete_facet_labels(PETSc.DM dm):
     for name in [FACE_SETS_LABEL, "exterior_facets", "interior_facets"]:
         if dm.hasLabel(name):
             label = dm.getLabel(name)
-            CHKERR( DMPlexLabelComplete(dm.dm, label.dmlabel) )
+            CHKERR(DMPlexLabelComplete(dm.dm, label.dmlabel))
 
 
 @cython.boundscheck(False)
@@ -1836,9 +1830,8 @@ def cell_facet_labeling(PETSc.DM plex,
     """
     cdef:
         PetscInt c, cstart, cend, fi, cell, nfacet, p, nclosure
-        PetscInt f, fstart, fend, point, marker, pstart, pend
+        PetscInt fstart, fend, point, marker, pstart, pend
         PetscBool is_exterior
-        const PetscInt *facets
         DMLabel exterior = NULL, subdomain = NULL
         np.ndarray[np.int8_t, ndim=3, mode="c"] cell_facets
 
@@ -2010,9 +2003,7 @@ def _set_dg_coordinates(PETSc.DM dm,
         PETSc.DM coord_dm, dg_coord_dm
         PETSc.Section dg_coord_sec
         PETSc.Vec dg_coord_vec
-        PetscScalar *dg_coords
-        const PetscScalar *firedrake_dg_coords
-        PetscInt n, gdim, cStart, cEnd, c, offset, firedrake_offset, i, j, coord_size, ndof
+        PetscInt gdim, cStart, cEnd, c, coord_size, ndof
 
     gdim = firedrake_dg_coord_vec.getBlockSize()
     coord_dm = dm.getCoordinateDM()
@@ -2055,7 +2046,7 @@ def reordered_coords(PETSc.DM dm, PETSc.Section global_numbering, shape, referen
 
     Shape is a tuple of (mesh.num_vertices(), geometric_dim)."""
     cdef:
-        PETSc.Section dm_sec, coord_sec
+        PETSc.Section dm_sec
         PetscInt v, vStart, vEnd, offset, dm_offset, c, cStart, cEnd
         PetscInt i, j, dim = shape[1]
         np.ndarray dm_coords, coords
@@ -2229,7 +2220,8 @@ def _get_periodicity(dm: PETSc.DM) -> tuple[tuple[bool, bool], ...]:
 
     """
     cdef:
-        const PetscReal *maxCell, *L
+        const PetscReal *maxCell
+        const PetscReal *L
 
     dim = dm.getCoordinateDim()
     CHKERR(DMGetPeriodicity(dm.dm, &maxCell, NULL, &L))
@@ -2260,8 +2252,6 @@ def mark_entity_classes(PETSc.DM dm):
         PetscInt *closure = NULL
         PetscInt nclosure
         const PetscInt *ilocal = NULL
-        PetscBool non_exec
-        const PetscSFNode *iremote = NULL
         PETSc.SF point_sf = None
         PetscBool is_ghost, is_owned
         DMLabel lbl_core, lbl_owned, lbl_ghost
@@ -2342,9 +2332,10 @@ def mark_entity_classes_using_cell_dm(PETSc.DM swarm):
     """
     cdef:
         PETSc.DM plex
-        PetscInt cStart, cEnd, c
-        PetscInt *plex_cell_classes = NULL, plex_cell_class
-        DMLabel swarm_labels[3], plex_label
+        PetscInt cStart, cEnd, c, plex_cell_class
+        PetscInt *plex_cell_classes = NULL
+        DMLabel swarm_labels[3]
+        DMLabel plex_label
         PetscInt label_value = 1, op2class_size, i, ilabel
         PETSc.PetscIS op2class_is = NULL
         const PetscInt *class_indices = NULL
@@ -2529,15 +2520,12 @@ def get_facets_by_class(PETSc.DM plex, label,
     :arg label: Label string that marks the facets to order
     """
     cdef:
-        PetscInt dim, fi, ci, nfacets, nclass, lbl_val, o, f, fStart, fEnd
-        PetscInt pStart, pEnd, i, n
-        PetscInt *indices = NULL
-        PETSc.IS class_is = None
+        PetscInt fi, nfacets, nclass, o, f, fStart, fEnd
+        PetscInt pStart, pEnd, i
         PetscBool has_point, is_class
         DMLabel lbl_facets, lbl_class
         PetscInt[::1] facets
 
-    dim = get_topological_dimension(plex)
     get_height_stratum(plex.dm, 1, &fStart, &fEnd)
     get_chart(plex.dm, &pStart, &pEnd)
     nfacets = count_labelled_points(plex, label, fStart, fEnd)
@@ -2578,7 +2566,6 @@ def validate_mesh(PETSc.DM dm):
         PetscInt  nclosure, nseen
         PetscInt *closure = NULL
         PetscBT   seen = NULL
-        PetscBool flag
 
     from mpi4py import MPI
 
@@ -2637,13 +2624,11 @@ def plex_renumbering(PETSc.DM plex,
     the core/owned constrained block is returned, for use in create_section.
     """
     cdef:
-        PetscInt dim, cStart, cEnd, nfacets, nclosure, c, ci, l, p, f
+        PetscInt cStart, cEnd, nclosure, c, ci, p
         PetscInt pStart, pEnd, cell
-        np.ndarray lidx, ncells
-        PetscInt *facets = NULL
+        np.ndarray lidx
         PetscInt *closure = NULL
         PetscInt *perm = NULL
-        PETSc.IS facet_is = None
         PETSc.IS perm_is = None
         PetscBT seen = NULL
         PetscBT seen_boundary = NULL
@@ -2651,14 +2636,12 @@ def plex_renumbering(PETSc.DM plex,
         DMLabel labels[3]
         bint reorder = reordering is not None
 
-    dim = get_topological_dimension(plex)
     get_chart(plex.dm, &pStart, &pEnd)
     get_height_stratum(plex.dm, 0, &cStart, &cEnd)
     CHKERR(PetscMalloc1(pEnd - pStart, &perm))
     CHKERR(PetscBTCreate(pEnd - pStart, &seen))
     if boundary_set:
         CHKERR(PetscBTCreate(pEnd - pStart, &seen_boundary))
-    ncells = np.zeros(3, dtype=IntType)
 
     # Get label pointers and label-specific array indices
     CHKERR(DMGetLabel(plex.dm, b"pyop2_core", &labels[0]))
@@ -2697,7 +2680,7 @@ def plex_renumbering(PETSc.DM plex,
 
     # assign lists
     lidx = np.zeros(4, dtype=IntType)
-    lidx[1] = sum(entity_classes[:, 0]) -  constrained_core
+    lidx[1] = sum(entity_classes[:, 0]) - constrained_core
     lidx[2] = sum(entity_classes[:, 1])
     lidx[3] = lidx[2] - constrained_core - constrained_owned
 
@@ -2743,6 +2726,7 @@ def plex_renumbering(PETSc.DM plex,
                                perm, PETSC_OWN_POINTER))
     return perm_is
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def get_cell_remote_ranks(PETSc.DM plex):
@@ -2773,6 +2757,7 @@ def get_cell_remote_ranks(PETSc.DM plex):
                 result[p - cStart] = iremote[i].rank
 
     return result
+
 
 cdef inline PetscInt cneg(PetscInt i):
     """complementary inverse"""
@@ -2858,15 +2843,14 @@ cdef int CommFacet_cmp(const void *x_, const void *y_) noexcept nogil:
 
     return 0
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void get_communication_lists(
-    PETSc.DM plex, PETSc.Section vertex_numbering,
-    np.ndarray cell_ranks,
-    # Output parameters:
-    PetscInt *nranks, PetscInt **ranks, PetscInt **offsets,
-    PetscInt **facets, PetscInt **facet2index):
-
+cdef inline void get_communication_lists(PETSc.DM plex, PETSc.Section vertex_numbering,
+                                         np.ndarray cell_ranks,
+                                         # Output parameters:
+                                         PetscInt *nranks, PetscInt **ranks, PetscInt **offsets,
+                                         PetscInt **facets, PetscInt **facet2index):
     """Creates communication lists for shared facet information exchange.
 
     :arg plex: The DMPlex object encapsulating the mesh topology
@@ -3001,6 +2985,7 @@ cdef inline void get_communication_lists(
     #                                       facet2index[0][i],
     #                                       fStart + i)
 
+
 @cython.profile(False)
 cdef inline void plex_get_restricted_support(PETSc.DM plex,
                                              PetscInt *cell_ranks,
@@ -3018,7 +3003,7 @@ cdef inline void plex_get_restricted_support(PETSc.DM plex,
     :arg outbuf: Preallocated output buffer
     """
     cdef:
-        PetscInt cStart, cEnd, c
+        PetscInt cStart, cEnd
         PetscInt support_size
         const PetscInt *support = NULL
         PetscInt i, k
@@ -3034,6 +3019,7 @@ cdef inline void plex_get_restricted_support(PETSc.DM plex,
             outbuf[k] = support[i]
             k += 1
     size[0] = k
+
 
 @cython.cdivision(True)
 cdef inline PetscInt traverse_cell_string(PETSc.DM plex,
@@ -3133,6 +3119,7 @@ cdef inline PetscInt traverse_cell_string(PETSc.DM plex,
     # We must not reach this point here.
     raise RuntimeError("This should never happen!")
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef locally_orient_quadrilateral_plex(PETSc.DM plex,
@@ -3167,7 +3154,7 @@ cdef locally_orient_quadrilateral_plex(PETSc.DM plex,
                            which must have opposite global orientation.
     """
     cdef:
-        PetscInt nfacets, fStart, fEnd, f
+        PetscInt fStart, fEnd, f
         PetscInt size
         PetscInt support[2]
         PetscInt start_facet, end_facet
@@ -3176,7 +3163,6 @@ cdef locally_orient_quadrilateral_plex(PETSc.DM plex,
         np.ndarray result
 
     get_height_stratum(plex.dm, 1, &fStart, &fEnd)
-    nfacets = fEnd - fStart
 
     result = np.empty(nfacets_shared, dtype=IntType)
 
@@ -3250,14 +3236,13 @@ cdef locally_orient_quadrilateral_plex(PETSc.DM plex,
     # communications when we try and provide a globally consistent orientation.
     return result
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void exchange_edge_orientation_data(
-    PetscInt nranks, PetscInt *ranks, PetscInt *offsets,
-    np.ndarray ours,
-    np.ndarray theirs,
-    MPI.Comm comm):
-
+cdef inline void exchange_edge_orientation_data(PetscInt nranks, PetscInt *ranks, PetscInt *offsets,
+                                                np.ndarray ours,
+                                                np.ndarray theirs,
+                                                MPI.Comm comm):
     """Exchange edge orientation data between neighbouring MPI nodes.
 
     :arg nranks: Number of neighbouring MPI nodes
@@ -3285,12 +3270,11 @@ cdef inline void exchange_edge_orientation_data(
     for req in send_reqs:
         req.Wait()
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def quadrilateral_facet_orientations(
-    PETSc.DM plex, PETSc.Section vertex_numbering,
-    np.ndarray cell_ranks):
-
+def quadrilateral_facet_orientations(PETSc.DM plex, PETSc.Section vertex_numbering,
+                                     np.ndarray cell_ranks):
     """Returns globally synchronised facet orientations (edge directions)
     incident to locally owned quadrilateral cells.
 
@@ -3430,14 +3414,13 @@ def quadrilateral_facet_orientations(
     CHKERR(PetscFree(facets))
     return result
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def orientations_facet2cell(
-    PETSc.DM plex, PETSc.Section vertex_numbering,
-    np.ndarray cell_ranks,
-    np.ndarray[np.int8_t, ndim=1, mode="c"] facet_orientations,
-    PETSc.Section cell_numbering):
-
+def orientations_facet2cell(PETSc.DM plex, PETSc.Section vertex_numbering,
+                            np.ndarray cell_ranks,
+                            np.ndarray[np.int8_t, ndim=1, mode="c"] facet_orientations,
+                            PETSc.Section cell_numbering):
     """Converts local quadrilateral facet orientations into
     global quadrilateral cell orientations.
 
@@ -3530,10 +3513,8 @@ def orientations_facet2cell(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def exchange_cell_orientations(
-    PETSc.DM plex, PETSc.Section section,
-    np.ndarray orientations):
-
+def exchange_cell_orientations(PETSc.DM plex, PETSc.Section section,
+                               np.ndarray orientations):
     """Halo exchange of cell orientations.
 
     :arg plex: The DMPlex object encapsulating the mesh topology
@@ -3642,7 +3623,7 @@ cdef int DMPlexGetAdjacency_Facet_Support(PETSc.PetscDM dm,
     through right.
     """
     cdef:
-        const PetscInt *support = NULL;
+        const PetscInt *support = NULL
         PetscInt numAdj = 0
         PetscInt maxAdjSize = adjSize[0]
         PetscInt supportSize
@@ -3650,7 +3631,7 @@ cdef int DMPlexGetAdjacency_Facet_Support(PETSc.PetscDM dm,
         PetscInt fStart, fEnd
         PetscInt point, closureSize, ci, q
         PetscInt *closure = NULL
-        DMLabel label = <DMLabel>ctx;
+        DMLabel label = <DMLabel>ctx
         PetscBool flg = PETSC_TRUE
 
     CHKERR(DMPlexGetHeightStratum(dm, 1, &fStart, &fEnd))
@@ -3725,7 +3706,7 @@ cdef int DMPlexGetAdjacency_Closure_Star_Ridge(
 
     """
     cdef:
-        PetscInt *star = NULL;
+        PetscInt *star = NULL
         PetscInt numAdj = 0
         PetscInt maxAdjSize = adjSize[0]
         PetscInt starSize
@@ -3733,7 +3714,7 @@ cdef int DMPlexGetAdjacency_Closure_Star_Ridge(
         PetscInt pStart, pEnd
         PetscInt point, closureSize, ci, q
         PetscInt *closure = NULL
-        DMLabel label = <DMLabel>ctx;
+        DMLabel label = <DMLabel>ctx
         PetscBool flg = PETSC_TRUE
 
     # This function is general, and should also be able to replace
@@ -3855,7 +3836,6 @@ def compute_point_cone_global_sizes(PETSc.DM dm):
         PETSc.SF sf
         PetscInt nleaves
         const PetscInt *ilocal = NULL
-        const PetscSFNode *iremote = NULL
         PetscInt i, p, pStart, pEnd, coneSize
         np.ndarray arraySizes
         np.ndarray out
@@ -3870,10 +3850,10 @@ def compute_point_cone_global_sizes(PETSc.DM dm):
     arraySizes[0] = (pEnd - pStart) - nleaves
     for p in range(pStart, pEnd):
         CHKERR(DMPlexGetConeSize(dm.dm, p, &coneSize))
-        arraySizes[1] += coneSize;
+        arraySizes[1] += coneSize
     for i in range(nleaves):
         CHKERR(DMPlexGetConeSize(dm.dm, ilocal[i] if ilocal else i, &coneSize))
-        arraySizes[1] -= coneSize;
+        arraySizes[1] -= coneSize
     out = np.zeros((2, ), dtype=IntType)
     dm.comm.tompi4py().Allreduce(arraySizes, out, op=MPI.SUM)
     return out
@@ -3928,7 +3908,6 @@ def create_halo_exchange_sf(PETSc.DM dm):
     """
     cdef:
         PETSc.SF halo_exchange_sf
-        PetscInt dof_nroots, dof_nleaves
         PetscInt *dof_ilocal = NULL
         PetscSFNode *dof_iremote = NULL
         PETSc.SF point_sf
@@ -4187,7 +4166,7 @@ def submesh_update_facet_labels(PETSc.DM dm, PETSc.DM subdm):
         char *ext_facet_label_name = <char *>"exterior_facets"
         char *face_sets_label_name = <char *>"Face Sets"
         DMLabel ext_facet_label
-        PETSc.DMLabel sub_int_facet_label, sub_ext_facet_label
+        PETSc.DMLabel _sub_int_facet_label, _sub_ext_facet_label
         PetscBool has_point
 
     dim = dm.getDimension()
@@ -4198,8 +4177,8 @@ def submesh_update_facet_labels(PETSc.DM dm, PETSc.DM subdm):
         return
     # Mark interior and exterior facets
     label_facets(subdm)
-    sub_int_facet_label = subdm.getLabel("interior_facets")
-    sub_ext_facet_label = subdm.getLabel("exterior_facets")
+    _sub_int_facet_label = subdm.getLabel(int_facet_label_name)
+    _sub_ext_facet_label = subdm.getLabel(ext_facet_label_name)
     # Mark new exterior facets with current max label value + 1 in "Face Sets"
     subpoint_is = subdm.getSubpointIS()
     CHKERR(ISGetIndices(subpoint_is.iset, &subpoint_indices))
@@ -4208,8 +4187,8 @@ def submesh_update_facet_labels(PETSc.DM dm, PETSc.DM subdm):
             next_label_val = label_value_indices.max() + 1 if len(label_value_indices) > 0 else 0
         next_label_val = dm.comm.tompi4py().allreduce(next_label_val, op=MPI.MAX)
         subdm.createLabel(FACE_SETS_LABEL)
-        sub_ext_facet_size = subdm.getStratumSize("exterior_facets", 1)
-        sub_ext_facet_is = subdm.getStratumIS("exterior_facets", 1)
+        sub_ext_facet_size = subdm.getStratumSize(ext_facet_label_name, 1)
+        sub_ext_facet_is = subdm.getStratumIS(ext_facet_label_name, 1)
         if sub_ext_facet_is.iset:
             CHKERR(ISGetIndices(sub_ext_facet_is.iset, &sub_ext_facet_indices))
         CHKERR(DMGetLabel(dm.dm, ext_facet_label_name, &ext_facet_label))
@@ -4231,8 +4210,8 @@ def submesh_update_facet_labels(PETSc.DM dm, PETSc.DM subdm):
     else:
         raise NotImplementedError("Currently, only implemented for cell submesh")
     CHKERR(ISRestoreIndices(subpoint_is.iset, &subpoint_indices))
-    subdm.removeLabel("interior_facets")
-    subdm.removeLabel("exterior_facets")
+    subdm.removeLabel(int_facet_label_name)
+    subdm.removeLabel(ext_facet_label_name)
 
 
 @cython.boundscheck(False)
@@ -4277,7 +4256,7 @@ def submesh_create_cell_closure(
 
     dim = get_topological_dimension(dm)
     subdim = get_topological_dimension(subdm)
-    if subdim != dim and subdim !=  dim - 1:
+    if subdim != dim and subdim != dim - 1:
         raise NotImplementedError(f"subdim = {subdim} and dim = {dim}")
     get_chart(subdm.dm, &subpStart, &subpEnd)
     get_height_stratum(subdm.dm, 0, &subcStart, &subcEnd)

--- a/firedrake/cython/extrusion_numbering.pyx
+++ b/firedrake/cython/extrusion_numbering.pyx
@@ -184,7 +184,6 @@ This is guaranteed to pick up all the nodes in the closure of the
 facet column.
 """
 import cython
-import firedrake.extrusion_utils as eutils
 import numpy
 from firedrake.petsc import PETSc
 from firedrake.cython.dmcommon import count_labelled_points
@@ -193,7 +192,6 @@ from mpi4py.libmpi cimport (MPI_Op_create, MPI_OP_NULL, MPI_Op_free,
                             MPI_User_function)
 from pyop2 import op2
 from firedrake.utils import IntType
-from finat.element_factory import as_fiat_cell
 
 cimport numpy
 cimport mpi4py.MPI as MPI
@@ -203,7 +201,7 @@ numpy.import_array()
 
 include "petschdr.pxi"
 
-cdef inline void extents_reduce(void *in_, void *out, int *count, MPI.MPI_Datatype *datatype) nogil:
+cdef inline void extents_reduce(void *in_, void *out, int *count, MPI.MPI_Datatype *datatype) noexcept nogil:
     cdef:
         PetscInt *xin = <PetscInt *>in_
         PetscInt *xout = <PetscInt *>out
@@ -326,7 +324,6 @@ def node_classes(mesh, nodes_per_entity):
     """
     cdef:
         PETSc.DM dm
-        DMLabel label
         PetscInt p, point, layers, i, j, dimension
         numpy.ndarray[PetscInt, ndim=2, mode="c"] nodes
         numpy.ndarray[PetscInt, ndim=2, mode="c"] layer_extents = mesh.layer_extents
@@ -386,7 +383,6 @@ def facet_closure_nodes(V, sub_domain):
         int f, i, j, dof, facet, idx
         int nfacet, nlocal, layers
         PetscInt local_facet
-        PetscInt offset
 
     # We don't have to handle the "on_boundary" case, because the
     # caller handles it.
@@ -485,7 +481,7 @@ def entity_layers(mesh, height, label=None):
         DMLabel clabel = NULL
         numpy.ndarray[PetscInt, ndim=2, mode="c"] layer_extents
         numpy.ndarray[PetscInt, ndim=2, mode="c"] layers
-        PetscInt f, p, i, hStart, hEnd, pStart, pEnd
+        PetscInt p, hStart, hEnd, pStart, pEnd
         PetscInt point, offset
         const PetscInt *renumbering
         PetscBool flg

--- a/firedrake/cython/hdf5interface.pyx
+++ b/firedrake/cython/hdf5interface.pyx
@@ -8,7 +8,7 @@ cdef extern from "hdf5.h":
 
 
 cdef extern from "petscviewerhdf5.h":
-    int PetscViewerHDF5GetFileId(PETSc.PetscViewer,hid_t*)
+    int PetscViewerHDF5GetFileId(PETSc.PetscViewer, hid_t*)
 
 
 def get_h5py_file(PETSc.Viewer vwr not None):

--- a/firedrake/cython/mgimpl.pyx
+++ b/firedrake/cython/mgimpl.pyx
@@ -60,7 +60,7 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray coarse_to_fine_cells):
     cdef:
         np.ndarray fine_map, coarse_map, coarse_to_fine_map
         np.ndarray coarse_offset, fine_offset
-        PetscInt i, j, k, l, m, node, fine, layer
+        PetscInt i, j, k, ll, m, node, fine, layer
         PetscInt coarse_per_cell, fine_per_cell, fine_cell_per_coarse_cell, coarse_cells
         PetscInt fine_layer, fine_layers, coarse_layer, coarse_layers, ratio
         bint extruded
@@ -78,7 +78,7 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray coarse_to_fine_cells):
         fine_layers = Vf.mesh().layers - 1
 
         ratio = fine_layers // coarse_layers
-        assert ratio * coarse_layers == fine_layers # check ratio is an int
+        assert ratio * coarse_layers == fine_layers  # check ratio is an int
     coarse_cells = coarse_map.shape[0]
     coarse_per_cell = coarse_map.shape[1]
     fine_per_cell = fine_map.shape[1]
@@ -96,8 +96,8 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray coarse_to_fine_cells):
             if extruded:
                 for coarse_layer in range(coarse_layers):
                     k = 0
-                    for l in range(fine_cell_per_coarse_cell):
-                        fine = coarse_to_fine_cells[i, l]
+                    for ll in range(fine_cell_per_coarse_cell):
+                        fine = coarse_to_fine_cells[i, ll]
                         if fine < 0:
                             k += fine_per_cell * ratio
                             continue
@@ -109,8 +109,8 @@ def coarse_to_fine_nodes(Vc, Vf, np.ndarray coarse_to_fine_cells):
                                 k += 1
             else:
                 k = 0
-                for l in range(fine_cell_per_coarse_cell):
-                    fine = coarse_to_fine_cells[i, l]
+                for ll in range(fine_cell_per_coarse_cell):
+                    fine = coarse_to_fine_cells[i, ll]
                     if fine < 0:
                         k += fine_per_cell
                         continue
@@ -127,7 +127,7 @@ def fine_to_coarse_nodes(Vf, Vc, np.ndarray fine_to_coarse_cells):
     cdef:
         np.ndarray fine_map, coarse_map, fine_to_coarse_map
         np.ndarray coarse_offset, fine_offset
-        PetscInt i, j, k, node, fine_layer, fine_layers, coarse_layer, coarse_layers, ratio
+        PetscInt i, j, k, ll, node, fine_layer, fine_layers, coarse_layer, coarse_layers, ratio
         PetscInt coarse_per_cell, fine_per_cell, coarse_cell, fine_cells
         bint extruded
 
@@ -143,7 +143,7 @@ def fine_to_coarse_nodes(Vf, Vc, np.ndarray fine_to_coarse_cells):
         fine_layers = Vf.mesh().layers - 1
 
         ratio = fine_layers // coarse_layers
-        assert ratio * coarse_layers == fine_layers # check ratio is an int
+        assert ratio * coarse_layers == fine_layers  # check ratio is an int
 
     fine_cells = fine_to_coarse_cells.shape[0]
     coarse_per_fine = fine_to_coarse_cells.shape[1]
@@ -155,7 +155,7 @@ def fine_to_coarse_nodes(Vf, Vc, np.ndarray fine_to_coarse_cells):
                                  dtype=IntType)
 
     for i in range(fine_cells):
-        for l, coarse_cell in enumerate(fine_to_coarse_cells[i, :]):
+        for ll, coarse_cell in enumerate(fine_to_coarse_cells[i, :]):
             if coarse_cell < 0:
                 continue
             for j in range(fine_per_cell):
@@ -167,7 +167,7 @@ def fine_to_coarse_nodes(Vf, Vc, np.ndarray fine_to_coarse_cells):
                             fine_to_coarse_map[node + fine_offset[j]*fine_layer, k] = coarse_map[coarse_cell, k] + coarse_offset[k]*coarse_layer
                 else:
                     for k in range(coarse_per_cell):
-                        fine_to_coarse_map[node, coarse_per_cell*l + k] = coarse_map[coarse_cell, k]
+                        fine_to_coarse_map[node, coarse_per_cell*ll + k] = coarse_map[coarse_cell, k]
 
     return fine_to_coarse_map
 
@@ -183,7 +183,6 @@ def create_lgmap(PETSc.DM dm):
         PETSc.LGMap lgmap = PETSc.LGMap()
         PetscInt *indices
         PetscInt i, size
-        PetscInt start, end
 
     # Not necessary on one process
     if dm.comm.size == 1:
@@ -436,7 +435,7 @@ def coarse_to_fine_cells(mc, mf, clgmaps, flgmaps):
     """
     cdef:
         PETSc.DM cdm, fdm
-        PetscInt cStart, cEnd, c, val, dim, nref, ncoarse
+        PetscInt cStart, cEnd, c, dim, nref, ncoarse
         PetscInt i, ccell, fcell, nfine
         np.ndarray coarse_to_fine
         np.ndarray fine_to_coarse

--- a/firedrake/cython/patchimpl.pyx
+++ b/firedrake/cython/patchimpl.pyx
@@ -23,8 +23,8 @@ def pcpatch_set_compute_operator_exterior_facets(patch, function, ctx):
 
 def snespatch_set_compute_operator(patch, function, ctx):
     CHKERR(SNESPatchSetComputeOperator((<PETSc.SNES?>patch).snes,
-                                        <PetscPCPatchComputeOperator><uintptr_t>function,
-                                        <void *><uintptr_t>ctx))
+                                       <PetscPCPatchComputeOperator><uintptr_t>function,
+                                       <void *><uintptr_t>ctx))
 
 
 def snespatch_set_compute_function(patch, function, ctx):

--- a/firedrake/cython/petschdr.pxi
+++ b/firedrake/cython/petschdr.pxi
@@ -27,11 +27,11 @@ cdef extern from "petsc.h":
         PETSC_ERR_LIB
 
 cdef extern from "petscsys.h" nogil:
-    PetscErrorCode PetscMalloc1(PetscInt,void*)
-    PetscErrorCode PetscMalloc2(PetscInt,void*,PetscInt,void*)
+    PetscErrorCode PetscMalloc1(PetscInt, void*)
+    PetscErrorCode PetscMalloc2(PetscInt, void*, PetscInt, void*)
     PetscErrorCode PetscFree(void*)
-    PetscErrorCode PetscFree2(void*,void*)
-    PetscErrorCode PetscSortIntWithArray(PetscInt,PetscInt[],PetscInt[])
+    PetscErrorCode PetscFree2(void*, void*)
+    PetscErrorCode PetscSortIntWithArray(PetscInt, PetscInt[], PetscInt[])
 
 cdef extern from "petscdmtypes.h" nogil:
     ctypedef enum PetscDMPolytopeType "DMPolytopeType":
@@ -55,33 +55,33 @@ cdef extern from "petscdmtypes.h" nogil:
         DM_NUM_POLYTOPES
 
 cdef extern from "petscdmplex.h" nogil:
-    PetscErrorCode DMPlexGetHeightStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
-    PetscErrorCode DMPlexGetDepthStratum(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt*)
-    PetscErrorCode DMPlexGetPointHeight(PETSc.PetscDM,PetscInt,PetscInt*)
-    PetscErrorCode DMPlexGetPointDepth(PETSc.PetscDM,PetscInt,PetscInt*)
+    PetscErrorCode DMPlexGetHeightStratum(PETSc.PetscDM, PetscInt, PetscInt*, PetscInt*)
+    PetscErrorCode DMPlexGetDepthStratum(PETSc.PetscDM, PetscInt, PetscInt*, PetscInt*)
+    PetscErrorCode DMPlexGetPointHeight(PETSc.PetscDM, PetscInt, PetscInt*)
+    PetscErrorCode DMPlexGetPointDepth(PETSc.PetscDM, PetscInt, PetscInt*)
 
-    PetscErrorCode DMPlexGetChart(PETSc.PetscDM,PetscInt*,PetscInt*)
-    PetscErrorCode DMPlexGetConeSize(PETSc.PetscDM,PetscInt,PetscInt*)
-    PetscErrorCode DMPlexGetCone(PETSc.PetscDM,PetscInt,PetscInt*[])
-    PetscErrorCode DMPlexGetConeOrientation(PETSc.PetscDM,PetscInt,PetscInt*[])
-    PetscErrorCode DMPlexGetSupportSize(PETSc.PetscDM,PetscInt,PetscInt*)
-    PetscErrorCode DMPlexGetSupport(PETSc.PetscDM,PetscInt,PetscInt*[])
-    PetscErrorCode DMPlexGetMaxSizes(PETSc.PetscDM,PetscInt*,PetscInt*)
+    PetscErrorCode DMPlexGetChart(PETSc.PetscDM, PetscInt*, PetscInt*)
+    PetscErrorCode DMPlexGetConeSize(PETSc.PetscDM, PetscInt, PetscInt*)
+    PetscErrorCode DMPlexGetCone(PETSc.PetscDM, PetscInt, PetscInt*[])
+    PetscErrorCode DMPlexGetConeOrientation(PETSc.PetscDM, PetscInt, PetscInt*[])
+    PetscErrorCode DMPlexGetSupportSize(PETSc.PetscDM, PetscInt, PetscInt*)
+    PetscErrorCode DMPlexGetSupport(PETSc.PetscDM, PetscInt, PetscInt*[])
+    PetscErrorCode DMPlexGetMaxSizes(PETSc.PetscDM, PetscInt*, PetscInt*)
 
-    PetscErrorCode DMPlexGetTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
-    PetscErrorCode DMPlexRestoreTransitiveClosure(PETSc.PetscDM,PetscInt,PetscBool,PetscInt *,PetscInt *[])
-    PetscErrorCode DMPlexDistributeData(PETSc.PetscDM,PETSc.PetscSF,PETSc.PetscSection,MPI.MPI_Datatype,void*,PETSc.PetscSection,void**)
-    PetscErrorCode DMPlexSetAdjacencyUser(PETSc.PetscDM,int(*)(PETSc.PetscDM,PetscInt,PetscInt*,PetscInt[],void*),void*)
-    PetscErrorCode DMPlexCreatePointNumbering(PETSc.PetscDM,PETSc.PetscIS*)
+    PetscErrorCode DMPlexGetTransitiveClosure(PETSc.PetscDM, PetscInt, PetscBool, PetscInt*, PetscInt*[])
+    PetscErrorCode DMPlexRestoreTransitiveClosure(PETSc.PetscDM, PetscInt, PetscBool, PetscInt*, PetscInt*[])
+    PetscErrorCode DMPlexDistributeData(PETSc.PetscDM, PETSc.PetscSF, PETSc.PetscSection, MPI.MPI_Datatype, void*, PETSc.PetscSection, void**)
+    PetscErrorCode DMPlexSetAdjacencyUser(PETSc.PetscDM, int(*)(PETSc.PetscDM, PetscInt, PetscInt*, PetscInt[], void*), void*)
+    PetscErrorCode DMPlexCreatePointNumbering(PETSc.PetscDM, PETSc.PetscIS*)
     PetscErrorCode DMPlexLabelComplete(PETSc.PetscDM, PETSc.PetscDMLabel)
-    PetscErrorCode DMPlexDistributeOverlap(PETSc.PetscDM,PetscInt,PETSc.PetscSF*,PETSc.PetscDM*)
+    PetscErrorCode DMPlexDistributeOverlap(PETSc.PetscDM, PetscInt, PETSc.PetscSF*, PETSc.PetscDM*)
 
-    PetscErrorCode DMPlexGetSubpointIS(PETSc.PetscDM,PETSc.PetscIS*)
-    PetscErrorCode DMPlexGetSubpointMap(PETSc.PetscDM,PETSc.PetscDMLabel*)
-    PetscErrorCode DMPlexSetSubpointMap(PETSc.PetscDM,PETSc.PetscDMLabel)
+    PetscErrorCode DMPlexGetSubpointIS(PETSc.PetscDM, PETSc.PetscIS*)
+    PetscErrorCode DMPlexGetSubpointMap(PETSc.PetscDM, PETSc.PetscDMLabel*)
+    PetscErrorCode DMPlexSetSubpointMap(PETSc.PetscDM, PETSc.PetscDMLabel)
 
-    PetscErrorCode DMPlexSetCellType(PETSc.PetscDM,PetscInt,PetscDMPolytopeType)
-    PetscErrorCode DMPlexGetCellType(PETSc.PetscDM,PetscInt,PetscDMPolytopeType*)
+    PetscErrorCode DMPlexSetCellType(PETSc.PetscDM, PetscInt, PetscDMPolytopeType)
+    PetscErrorCode DMPlexGetCellType(PETSc.PetscDM, PetscInt, PetscDMPolytopeType*)
 
 cdef extern from "petscdmlabel.h" nogil:
     struct _n_DMLabel
@@ -97,48 +97,48 @@ cdef extern from "petscdmlabel.h" nogil:
     PetscErrorCode DMLabelGetStratumIS(DMLabel, PetscInt, PETSc.PetscIS*)
 
 cdef extern from "petscdm.h" nogil:
-    PetscErrorCode DMCreateLabel(PETSc.PetscDM,char[])
-    PetscErrorCode DMGetLabel(PETSc.PetscDM,char[],DMLabel*)
-    PetscErrorCode DMGetPointSF(PETSc.PetscDM,PETSc.PetscSF*)
-    PetscErrorCode DMSetLabelValue(PETSc.PetscDM,char[],PetscInt,PetscInt)
-    PetscErrorCode DMGetLabelValue(PETSc.PetscDM,char[],PetscInt,PetscInt*)
+    PetscErrorCode DMCreateLabel(PETSc.PetscDM, char[])
+    PetscErrorCode DMGetLabel(PETSc.PetscDM, char[], DMLabel*)
+    PetscErrorCode DMGetPointSF(PETSc.PetscDM, PETSc.PetscSF*)
+    PetscErrorCode DMSetLabelValue(PETSc.PetscDM, char[], PetscInt, PetscInt)
+    PetscErrorCode DMGetLabelValue(PETSc.PetscDM, char[], PetscInt, PetscInt*)
 
-    PetscErrorCode DMGetPeriodicity(PETSc.PetscDM,PetscReal *[], PetscReal *[], PetscReal *[])
-    PetscErrorCode DMGetSparseLocalize(PETSc.PetscDM,PetscBool *)
-    PetscErrorCode DMSetSparseLocalize(PETSc.PetscDM,PetscBool)
+    PetscErrorCode DMGetPeriodicity(PETSc.PetscDM, PetscReal*[], PetscReal*[], PetscReal*[])
+    PetscErrorCode DMGetSparseLocalize(PETSc.PetscDM, PetscBool*)
+    PetscErrorCode DMSetSparseLocalize(PETSc.PetscDM, PetscBool)
 
 cdef extern from "petscdmswarm.h" nogil:
-    PetscErrorCode DMSwarmGetLocalSize(PETSc.PetscDM,PetscInt*)
+    PetscErrorCode DMSwarmGetLocalSize(PETSc.PetscDM, PetscInt*)
     PetscErrorCode DMSwarmGetCellDM(PETSc.PetscDM, PETSc.PetscDM*)
     PetscErrorCode DMSwarmGetCellDMActive(PETSc.PetscDM, PETSc.PetscDMSwarmCellDM*)
-    PetscErrorCode DMSwarmCellDMGetCellID(PETSc.PetscDMSwarmCellDM, const char *[])
-    PetscErrorCode DMSwarmGetField(PETSc.PetscDM,const char[],PetscInt*,PetscDataType*,void**)
-    PetscErrorCode DMSwarmRestoreField(PETSc.PetscDM,const char[],PetscInt*,PetscDataType*,void**)
+    PetscErrorCode DMSwarmCellDMGetCellID(PETSc.PetscDMSwarmCellDM, const char*[])
+    PetscErrorCode DMSwarmGetField(PETSc.PetscDM, const char[], PetscInt*, PetscDataType*, void**)
+    PetscErrorCode DMSwarmRestoreField(PETSc.PetscDM, const char[], PetscInt*, PetscDataType*, void**)
 
 cdef extern from "petscvec.h" nogil:
-    PetscErrorCode VecGetArray(PETSc.PetscVec,PetscScalar**)
-    PetscErrorCode VecRestoreArray(PETSc.PetscVec,PetscScalar**)
-    PetscErrorCode VecGetArrayRead(PETSc.PetscVec,const PetscScalar**)
-    PetscErrorCode VecRestoreArrayRead(PETSc.PetscVec,const PetscScalar**)
+    PetscErrorCode VecGetArray(PETSc.PetscVec, PetscScalar**)
+    PetscErrorCode VecRestoreArray(PETSc.PetscVec, PetscScalar**)
+    PetscErrorCode VecGetArrayRead(PETSc.PetscVec, const PetscScalar**)
+    PetscErrorCode VecRestoreArrayRead(PETSc.PetscVec, const PetscScalar**)
 
 cdef extern from "petscis.h" nogil:
-    PetscErrorCode PetscSectionGetOffset(PETSc.PetscSection,PetscInt,PetscInt*)
-    PetscErrorCode PetscSectionGetDof(PETSc.PetscSection,PetscInt,PetscInt*)
-    PetscErrorCode PetscSectionSetDof(PETSc.PetscSection,PetscInt,PetscInt)
-    PetscErrorCode PetscSectionSetFieldDof(PETSc.PetscSection,PetscInt,PetscInt,PetscInt)
-    PetscErrorCode PetscSectionGetFieldDof(PETSc.PetscSection,PetscInt,PetscInt,PetscInt*)
-    PetscErrorCode PetscSectionGetConstraintDof(PETSc.PetscSection,PetscInt,PetscInt*)
-    PetscErrorCode PetscSectionSetConstraintDof(PETSc.PetscSection,PetscInt,PetscInt)
-    PetscErrorCode PetscSectionSetConstraintIndices(PETSc.PetscSection,PetscInt, PetscInt[])
-    PetscErrorCode PetscSectionGetConstraintIndices(PETSc.PetscSection,PetscInt, const PetscInt**)
-    PetscErrorCode PetscSectionGetMaxDof(PETSc.PetscSection,PetscInt*)
-    PetscErrorCode PetscSectionSetPermutation(PETSc.PetscSection,PETSc.PetscIS)
-    PetscErrorCode ISGetIndices(PETSc.PetscIS,PetscInt*[])
-    PetscErrorCode ISGetSize(PETSc.PetscIS,PetscInt*)
-    PetscErrorCode ISRestoreIndices(PETSc.PetscIS,PetscInt*[])
-    PetscErrorCode ISGeneralSetIndices(PETSc.PetscIS,PetscInt,PetscInt[],PetscCopyMode)
-    PetscErrorCode ISLocalToGlobalMappingCreateIS(PETSc.PetscIS,PETSc.PetscLGMap*)
-    PetscErrorCode ISLocalToGlobalMappingGetSize(PETSc.PetscLGMap,PetscInt*)
+    PetscErrorCode PetscSectionGetOffset(PETSc.PetscSection, PetscInt, PetscInt*)
+    PetscErrorCode PetscSectionGetDof(PETSc.PetscSection, PetscInt, PetscInt*)
+    PetscErrorCode PetscSectionSetDof(PETSc.PetscSection, PetscInt, PetscInt)
+    PetscErrorCode PetscSectionSetFieldDof(PETSc.PetscSection, PetscInt, PetscInt, PetscInt)
+    PetscErrorCode PetscSectionGetFieldDof(PETSc.PetscSection, PetscInt, PetscInt, PetscInt*)
+    PetscErrorCode PetscSectionGetConstraintDof(PETSc.PetscSection, PetscInt, PetscInt*)
+    PetscErrorCode PetscSectionSetConstraintDof(PETSc.PetscSection, PetscInt, PetscInt)
+    PetscErrorCode PetscSectionSetConstraintIndices(PETSc.PetscSection, PetscInt, PetscInt[])
+    PetscErrorCode PetscSectionGetConstraintIndices(PETSc.PetscSection, PetscInt, const PetscInt**)
+    PetscErrorCode PetscSectionGetMaxDof(PETSc.PetscSection, PetscInt*)
+    PetscErrorCode PetscSectionSetPermutation(PETSc.PetscSection, PETSc.PetscIS)
+    PetscErrorCode ISGetIndices(PETSc.PetscIS, PetscInt*[])
+    PetscErrorCode ISGetSize(PETSc.PetscIS, PetscInt*)
+    PetscErrorCode ISRestoreIndices(PETSc.PetscIS, PetscInt*[])
+    PetscErrorCode ISGeneralSetIndices(PETSc.PetscIS, PetscInt, PetscInt[], PetscCopyMode)
+    PetscErrorCode ISLocalToGlobalMappingCreateIS(PETSc.PetscIS, PETSc.PetscLGMap*)
+    PetscErrorCode ISLocalToGlobalMappingGetSize(PETSc.PetscLGMap, PetscInt*)
     PetscErrorCode ISLocalToGlobalMappingGetBlockIndices(PETSc.PetscLGMap, const PetscInt**)
     PetscErrorCode ISLocalToGlobalMappingRestoreBlockIndices(PETSc.PetscLGMap, const PetscInt**)
     PetscErrorCode ISDestroy(PETSc.PetscIS*)
@@ -149,53 +149,52 @@ cdef extern from "petscsf.h" nogil:
         PetscInt index
     ctypedef PetscSFNode_ PetscSFNode "PetscSFNode"
 
-    PetscErrorCode PetscSFGetGraph(PETSc.PetscSF,PetscInt*,PetscInt*,PetscInt**,PetscSFNode**)
-    PetscErrorCode PetscSFSetGraph(PETSc.PetscSF,PetscInt,PetscInt,PetscInt*,PetscCopyMode,PetscSFNode*,PetscCopyMode)
-    PetscErrorCode PetscSFBcastBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,)
-    PetscErrorCode PetscSFBcastEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*)
-    PetscErrorCode PetscSFReduceBegin(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
-    PetscErrorCode PetscSFReduceEnd(PETSc.PetscSF,MPI.MPI_Datatype,const void*, void*,MPI.MPI_Op)
+    PetscErrorCode PetscSFGetGraph(PETSc.PetscSF, PetscInt*, PetscInt*, PetscInt**, PetscSFNode**)
+    PetscErrorCode PetscSFSetGraph(PETSc.PetscSF, PetscInt, PetscInt, PetscInt*, PetscCopyMode, PetscSFNode*, PetscCopyMode)
+    PetscErrorCode PetscSFBcastBegin(PETSc.PetscSF, MPI.MPI_Datatype, const void*, void*,)
+    PetscErrorCode PetscSFBcastEnd(PETSc.PetscSF, MPI.MPI_Datatype, const void*, void*)
+    PetscErrorCode PetscSFReduceBegin(PETSc.PetscSF, MPI.MPI_Datatype, const void*, void*, MPI.MPI_Op)
+    PetscErrorCode PetscSFReduceEnd(PETSc.PetscSF, MPI.MPI_Datatype, const void*, void*, MPI.MPI_Op)
 
 ctypedef PetscErrorCode (*PetscPCPatchComputeFunction)(PETSc.PetscPC,
-                                            PetscInt,
-                                            PETSc.PetscVec,
-                                            PETSc.PetscVec,
-                                            PETSc.PetscIS,
-                                            PetscInt,
-                                            const PetscInt*,
-                                            const PetscInt*,
-                                            void*)
+                                                       PetscInt,
+                                                       PETSc.PetscVec,
+                                                       PETSc.PetscVec,
+                                                       PETSc.PetscIS,
+                                                       PetscInt,
+                                                       const PetscInt*,
+                                                       const PetscInt*,
+                                                       void*)
 ctypedef PetscErrorCode (*PetscPCPatchComputeOperator)(PETSc.PetscPC,
-                                            PetscInt,
-                                            PETSc.PetscVec,
-                                            PETSc.PetscMat,
-                                            PETSc.PetscIS,
-                                            PetscInt,
-                                            const PetscInt*,
-                                            const PetscInt*,
-                                            void*)
+                                                       PetscInt,
+                                                       PETSc.PetscVec,
+                                                       PETSc.PetscMat,
+                                                       PETSc.PetscIS,
+                                                       PetscInt,
+                                                       const PetscInt*,
+                                                       const PetscInt*,
+                                                       void*)
 cdef extern from "petscsnes.h" nogil:
-   PetscErrorCode SNESPatchSetComputeFunction(PETSc.PetscSNES, PetscPCPatchComputeFunction, void *)
-   PetscErrorCode SNESPatchSetComputeOperator(PETSc.PetscSNES, PetscPCPatchComputeOperator, void *)
+    PetscErrorCode SNESPatchSetComputeFunction(PETSc.PetscSNES, PetscPCPatchComputeFunction, void*)
+    PetscErrorCode SNESPatchSetComputeOperator(PETSc.PetscSNES, PetscPCPatchComputeOperator, void*)
 
 cdef extern from "petscpc.h" nogil:
-   PetscErrorCode PCPatchSetComputeFunction(PETSc.PetscPC, PetscPCPatchComputeFunction, void *)
-   PetscErrorCode PCPatchSetComputeFunctionInteriorFacets(PETSc.PetscPC, PetscPCPatchComputeFunction, void *)
-   PetscErrorCode PCPatchSetComputeOperator(PETSc.PetscPC, PetscPCPatchComputeOperator, void *)
-   PetscErrorCode PCPatchSetComputeOperatorInteriorFacets(PETSc.PetscPC, PetscPCPatchComputeOperator, void *)
-   PetscErrorCode PCPatchSetComputeOperatorExteriorFacets(PETSc.PetscPC, PetscPCPatchComputeOperator, void *)
-   PetscErrorCode PCPatchSetComputeFunctionExteriorFacets(PETSc.PetscPC, PetscPCPatchComputeFunction, void *)
+    PetscErrorCode PCPatchSetComputeFunction(PETSc.PetscPC, PetscPCPatchComputeFunction, void*)
+    PetscErrorCode PCPatchSetComputeFunctionInteriorFacets(PETSc.PetscPC, PetscPCPatchComputeFunction, void*)
+    PetscErrorCode PCPatchSetComputeOperator(PETSc.PetscPC, PetscPCPatchComputeOperator, void*)
+    PetscErrorCode PCPatchSetComputeOperatorInteriorFacets(PETSc.PetscPC, PetscPCPatchComputeOperator, void*)
+    PetscErrorCode PCPatchSetComputeOperatorExteriorFacets(PETSc.PetscPC, PetscPCPatchComputeOperator, void*)
+    PetscErrorCode PCPatchSetComputeFunctionExteriorFacets(PETSc.PetscPC, PetscPCPatchComputeFunction, void*)
 
 cdef extern from "petscbt.h" nogil:
-    ctypedef char * PetscBT
-    PetscErrorCode PetscBTCreate(PetscInt,PetscBT*)
+    ctypedef char* PetscBT
+    PetscErrorCode PetscBTCreate(PetscInt, PetscBT*)
     PetscErrorCode PetscBTDestroy(PetscBT*)
-    char PetscBTLookup(PetscBT,PetscInt)
-    PetscErrorCode PetscBTSet(PetscBT,PetscInt)
+    char PetscBTLookup(PetscBT, PetscInt)
+    PetscErrorCode PetscBTSet(PetscBT, PetscInt)
 
 cdef extern from "petscmat.h" nogil:
-    PetscErrorCode MatSetValuesLocal(PETSc.PetscMat, PetscInt, const PetscInt[], PetscInt, const PetscInt[],
-                          const PetscScalar[], PetscInt)
+    PetscErrorCode MatSetValuesLocal(PETSc.PetscMat, PetscInt, const PetscInt[], PetscInt, const PetscInt[], const PetscScalar[], PetscInt)
     PetscErrorCode MatAssemblyBegin(PETSc.PetscMat, PetscInt)
     PetscErrorCode MatAssemblyEnd(PETSc.PetscMat, PetscInt)
     PetscInt MAT_FINAL_ASSEMBLY = 0

--- a/firedrake/cython/rtree.pyx
+++ b/firedrake/cython/rtree.pyx
@@ -72,7 +72,7 @@ def build_from_aabb(np.ndarray[np.float64_t, ndim=2, mode="c"] coords_min,
     -------
     RTree
         An RTree object containing the Rtree.
-    """    
+    """
     cdef:
         RTreeH* rtree
         size_t n

--- a/firedrake/cython/supermeshimpl.pyx
+++ b/firedrake/cython/supermeshimpl.pyx
@@ -2,7 +2,7 @@
 
 import numpy
 from firedrake.petsc import PETSc
-from firedrake.utils import IntType, ScalarType, RealType
+from firedrake.utils import ScalarType, RealType
 
 cimport numpy
 cimport petsc4py.PETSc as PETSc
@@ -15,15 +15,15 @@ MAGIC = {2: (22, 3, 2),
          3: (81, 4, 3)}
 
 
-ctypedef int (*compiled_call)(PetscScalar *,PetscScalar *,PetscScalar *,
-                                PetscScalar *, PetscScalar *,
-                                PetscScalar *, PetscScalar *, int)
+ctypedef int (*compiled_call)(PetscScalar *, PetscScalar *, PetscScalar *,
+                              PetscScalar *, PetscScalar *,
+                              PetscScalar *, PetscScalar *, int)
 
 
 cdef extern from "libsupermesh-c.h" nogil:
-    void libsupermesh_tree_intersection_finder_set_input(long* nnodes_a, int* dim_a, long* nelements_a, int* loc_a, long* nnodes_b, int* dim_b, long* nelements_b, int* loc_b, double* positions_a, long* enlist_a, double* positions_b, long* enlist_b);
-    void libsupermesh_tree_intersection_finder_query_output(long* nindices);
-    void libsupermesh_tree_intersection_finder_get_output(long* nelements, long* nindices, long* indices, long* ind_ptr);
+    void libsupermesh_tree_intersection_finder_set_input(long* nnodes_a, int* dim_a, long* nelements_a, int* loc_a, long* nnodes_b, int* dim_b, long* nelements_b, int* loc_b, double* positions_a, long* enlist_a, double* positions_b, long* enlist_b)
+    void libsupermesh_tree_intersection_finder_query_output(long* nindices)
+    void libsupermesh_tree_intersection_finder_get_output(long* nelements, long* nindices, long* indices, long* ind_ptr)
 
 
 # Compute M_AB:
@@ -50,7 +50,7 @@ def assemble_mixed_mass_matrix(V_A, V_B, candidates,
         numpy.ndarray vertices_A, vertices_B
         numpy.ndarray outmat
         PetscInt cell_A, cell_B, i, gdim, num_dof_A, num_dof_B
-        PetscInt num_cell_B, num_cell_A, num_vertices
+        PetscInt num_cell_A, num_vertices
         PetscInt insert_mode = PETSc.InsertMode.ADD_VALUES
         const PetscInt *V_A_map
         const PetscInt *V_B_map
@@ -59,7 +59,6 @@ def assemble_mixed_mass_matrix(V_A, V_B, candidates,
         compiled_call library_call = (<compiled_call *><uintptr_t>lib)[0]
 
     num_cell_A = V_A.mesh().cell_set.size
-    num_cell_B = V_B.mesh().cell_set.size
 
     outmat = numpy.empty((V_B.cell_node_map().arity,
                           V_A.cell_node_map().arity), dtype=ScalarType)
@@ -161,7 +160,7 @@ def intersection_finder(mesh_A, mesh_B):
     libsupermesh_tree_intersection_finder_query_output(&nindices)
 
     indices = numpy.empty((nindices,), dtype=int)
-    indptr  = numpy.empty((mesh_A.num_cells() + 1,), dtype=int)
+    indptr = numpy.empty((mesh_A.num_cells() + 1,), dtype=int)
 
     libsupermesh_tree_intersection_finder_get_output(&ncells_A, &nindices, <long*>indices.data, <long*>indptr.data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,3 +197,9 @@ pyop2 = [
   "*.pyx",
   "codegen/c/*.c",
 ]
+
+[tool.cython-lint]
+max-line-length = 88 # default
+ignore = [
+  "E501", # line too long
+]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import numpy as np
 import pybind11
 import petsctools
 from Cython.Build import cythonize
+import Cython.Compiler.Options as cython_options
 from setuptools import setup, find_packages, Extension
 from setuptools.command.editable_wheel import editable_wheel as _editable_wheel
 from setuptools.command.sdist import sdist as _sdist
@@ -222,6 +223,8 @@ def extensions():
         sources=sorted(glob("tinyasm/*.cpp")),  # Sort source files for reproducibility
         **(mpi_ + petsc_ + pybind11_)
     ))
+    cython_options.extra_warnings = True
+    cython_options.warning_errors = True
     return cythonize(cython_list) + pybind11_list
 
 

--- a/tinyasm/tinyasm.cpp
+++ b/tinyasm/tinyasm.cpp
@@ -267,7 +267,7 @@ PetscErrorCode PCSetup_TinyASM(PC pc) {
     PetscCall(PetscLogEventBegin(PC_tinyasm_setup, pc, 0, 0, 0));
     auto P = pc -> pmat;
     auto blockjacobi = (BlockJacobi *)pc->data;
-    blockjacobi -> updateValuesPerBlock(P);
+    PetscCall(blockjacobi -> updateValuesPerBlock(P));
     PetscCall(PetscLogEventEnd(PC_tinyasm_setup, pc, 0, 0, 0));
     PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -293,7 +293,7 @@ PetscErrorCode PCApply_TinyASM(PC pc, Vec b, Vec x) {
 
     std::fill(blockjacobi->localx.begin(), blockjacobi->localx.end(), 0);
 
-    blockjacobi->solve(blockjacobi->localb.data(), blockjacobi->localx.data());
+    PetscCall(blockjacobi->solve(blockjacobi->localb.data(), blockjacobi->localx.data()));
     PetscCall(VecGetArray(x, &globalx));
     PetscCall(PetscSFReduceBegin(blockjacobi->sf, MPIU_SCALAR, &(blockjacobi->localx[0]), globalx, MPI_SUM));
     PetscCall(PetscSFReduceEnd(blockjacobi->sf, MPIU_SCALAR, &(blockjacobi->localx[0]), globalx, MPI_SUM));
@@ -368,7 +368,7 @@ PetscErrorCode PCCreate_TinyASM(PC pc) {
             VERIFY_PETSC4PY(PyPetsc##P4PYTYPE##_New);                                                                  \
             auto obj = PyPetsc##P4PYTYPE##_New(src);                                                                   \
             if (policy == pybind11::return_value_policy::take_ownership)                                               \
-                PetscObjectDereference((PetscObject)src);                                                              \
+                PETSC_UNUSED PetscErrorCode ierr = PetscObjectDereference((PetscObject)src);                           \
             return pybind11::handle(obj);                                                                              \
         }                                                                                                              \
                                                                                                                        \
@@ -387,10 +387,10 @@ namespace pybind11
 
 
 PYBIND11_MODULE(_tinyasm, m) {
-    PCRegister("tinyasm", PCCreate_TinyASM);
-    PetscLogEventRegister("PCTinyASMSetASMLocalSubdomains", PC_CLASSID, &PC_tinyasm_SetASMLocalSubdomains);
-    PetscLogEventRegister("PCTinyASMSetup", PC_CLASSID, &PC_tinyasm_setup);
-    PetscLogEventRegister("PCTinyASMApply", PC_CLASSID, &PC_tinyasm_apply);
+    PetscCallVoid(PCRegister("tinyasm", PCCreate_TinyASM));
+    PetscCallVoid(PetscLogEventRegister("PCTinyASMSetASMLocalSubdomains", PC_CLASSID, &PC_tinyasm_SetASMLocalSubdomains));
+    PetscCallVoid(PetscLogEventRegister("PCTinyASMSetup", PC_CLASSID, &PC_tinyasm_setup));
+    PetscCallVoid(PetscLogEventRegister("PCTinyASMApply", PC_CLASSID, &PC_tinyasm_apply));
     m.def("SetASMLocalSubdomains",
           [](PC pc, std::vector<IS> ises, std::vector<PetscSF> sfs, std::vector<PetscInt> blocksizes, int localsize) {
               PetscInt p, numDofs;


### PR DESCRIPTION
# Description

In `petsc4py`, we use `cython-lint` https://github.com/MarcoGorelli/cython-lint to lint the code and cythonize using `--warning-errors --warning-errors` as flags

I haven't activated the line-too-long error since there are many of them and I'm not sure you want to impose it