### PR TITLE
single-cell periodic quad work

### DIFF
--- a/firedrake/cython/dmcommon.pyx
+++ b/firedrake/cython/dmcommon.pyx
@@ -845,9 +845,42 @@ def quadrilateral_closure_ordering(PETSc.DM plex,
         #
         # and only have 6 entries instead of 9. For the following to work we have
         # to blow this out to a 9 entry array including the repeats.
+        # A single-cell quad periodic in both directions has only four
+        # unique entities in its transitive closure:
+        #
+        #     3--1--3
+        #     |     |
+        #     2  0  2   (vertical and horizontal periodicity)
+        #     |     |
+        #     3--1--3
+        #
+        # Blow this out to the nine-entry quadrilateral closure by
+        # repeating the two edges and the single vertex.
+
+
         if nclosure == 4:
-            raise NotImplementedError("Single-cell periodic quad meshes are "
-                                      "not supported")
+            horiz_periodicity, vert_periodicity = _get_periodicity(plex)
+            (_, horiz_unit_periodic) = horiz_periodicity
+            (_, vert_unit_periodic) = vert_periodicity
+
+            assert horiz_unit_periodic
+            assert vert_unit_periodic
+
+            closure_tmp[2*0] = closure[2*0]
+
+            closure_tmp[2*1] = closure[2*1]
+            closure_tmp[2*2] = closure[2*2]
+            closure_tmp[2*3] = closure[2*1]
+            closure_tmp[2*4] = closure[2*2]
+
+            closure_tmp[2*5] = closure[2*3]
+            closure_tmp[2*6] = closure[2*3]
+            closure_tmp[2*7] = closure[2*3]
+            closure_tmp[2*8] = closure[2*3]
+
+            nclosure = 9
+            for i in range(9):
+                closure[2*i] = closure_tmp[2*i]
         elif nclosure == 6:
             horiz_periodicity, vert_periodicity = _get_periodicity(plex)
             (_, horiz_unit_periodic) = horiz_periodicity

--- a/tests/firedrake/regression/test_mesh_generation.py
+++ b/tests/firedrake/regression/test_mesh_generation.py
@@ -152,6 +152,12 @@ def test_one_element_mesh():
     err = assemble(inner(u-r, u-r)*dx)
     assert err > 1.0e-3
 
+def test_periodic_one_element_mesh():
+    Lx = 2*pi
+    Ly = 2*pi
+    mesh = PeriodicRectangleMesh(1, 1, Lx, Ly, direction="both", quadrilateral=True)
+    
+    assert abs(integrate_one(mesh) - Lx*Ly) < 1e-3
 
 @pytest.mark.parametrize("hexahedral", [False, True])
 def test_box(hexahedral):


### PR DESCRIPTION
Support single-cell doubly periodic quadrilateral closure

Handle the four-entity DMPlex closure that occurs for a single quadrilateral cell periodic in both directions.

DMPlex returns the unique cell, two edges, and one vertex. Expand these to the nine local entities expected by Firedrake by repeating each edge twice and the vertex four times, analogous to the existing nclosure == 6 handling.

# Description

This is a draft implementation adding closure ordering support for a single quadrilateral cell that is periodic in both directions.

DMPlexGetTransitiveClosure returns only the four unique entities in this case: one cell, two edges and one vertex. Firedrake's quadrilateral closure ordering expects the nine local entities of the reference quadrilateral.

This change handles the nclosure == 4 case analogously to the existing nclosure == 6 handling, repeating the two edges and single vertex to construct the expected nine-entry local closure.

With this change, PeriodicRectangleMesh(1, 1, ..., direction="both", quadrilateral=True) successfully constructs and produces the expected cell closure.

Still to do / discussion

The continuous coordinate field is degenerate for a one-cell periodic direction. I have verified locally that constructing DQ1 coordinates and passing them through _postprocess_periodic_mesh gives the correct localized geometry. My test problem is a 2π×2π one-cell torus on which I integrate 1 to get an area of 4π.
Without the DQ coordinate postprocessing, I think the 1 × 1 doubly-periodic PeriodicRectangleMesh has only a single coordinate value (0, 0), since all four corners are identified with the same topological vertex. This results in a geometrically collapsed cell (zero area). I think this also holds for the 1 x ny, and nx x 1 doubly periodic cases where ny, nx >1. 

I'm opening this as a draft while working out the preferred way to integrate the localized-coordinate handling into PeriodicRectangleMesh, and would welcome guidance on whether reusing _postprocess_periodic_mesh is the intended approach.

Equally I might be incorrect! 
