### PR TITLE
plotting extruded meshes

### DIFF
--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -84,16 +84,12 @@ def _get_collection_types(gdim, tdim):
 
 
 def _cycle(nodes):
-    r"""Order the vertices of an entity into a cycle around its perimeter
+    r"""Order the vertices of each entity into a cycle around its perimeter
 
-    FInAT numbers the vertices of a tensor product entity lexicographically, so
-    a quadrilateral comes out with vertices 1 and 2 diagonally opposite each
-    other; exchanging the last two vertices makes the polygon simple. Every
-    entity that this is applied to -- a cell of a 2D mesh, or a facet -- is a
-    simplex if it has any other number of vertices.
-
-    :arg nodes: array of node numbers, one entity per row
-    :return: array of the same shape with the vertices of each entity in order
+    FInAT numbers the vertices of a quadrilateral lexicographically, putting 1
+    and 2 diagonally opposite each other; exchanging the last two makes the
+    polygon simple. Entities with any other number of vertices are simplices,
+    which are already in order.
     """
     nodes = np.asarray(nodes)
     if nodes.shape[-1] == 4:
@@ -102,11 +98,8 @@ def _cycle(nodes):
 
 
 def _entity_node_list(cell, dimension):
-    r"""Local node numbers of each entity of a given dimension of a cell
+    r"""Local node numbers of each entity of the given dimension of a cell
 
-    :arg cell: the reference cell of the coordinate element
-    :arg dimension: dimension of the entities to return; a tuple of horizontal
-        and vertical dimensions if the cell is a tensor product
     :return: array of shape ``(num_entities, num_vertices_per_entity)``
     """
     entities = cell.get_topology()[dimension]
@@ -114,19 +107,27 @@ def _entity_node_list(cell, dimension):
 
 
 def _extrude(nodes, offset, num_layers):
-    r"""Replicate the nodes of the bottom layer of an extruded mesh up the columns
+    r"""Replicate the entities of the bottom layer up the columns of an extruded mesh
 
-    :arg nodes: array of node numbers of the entities in the bottom layer
-    :arg offset: increment of each node number between successive layers,
-        either one value per node or a full array of the same shape as ``nodes``
-    :arg num_layers: number of layers of cells in each column
-    :return: array of node numbers of the entities in every layer, with the
-        entities of each column contiguous
+    The ``offset`` between successive layers broadcasts against ``nodes``. The
+    entities of each column come out contiguous.
     """
     nodes = np.asarray(nodes)
     offset = np.broadcast_to(offset, nodes.shape)
     layers = np.arange(num_layers).reshape(1, -1, 1)
     return (nodes[:, None, :] + offset[:, None, :] * layers).reshape(-1, nodes.shape[-1])
+
+
+def _entity_dimensions(tdim, extruded):
+    r"""Dimensions of the cell, the vertical facets, and the horizontal facets
+
+    Tensor product cells index their entities by a pair of horizontal and
+    vertical dimensions. The horizontal facets bound the bottom and top of each
+    column of cells, so there are none unless the mesh is extruded.
+    """
+    if extruded:
+        return (tdim - 1, 1), (tdim - 2, 1), (tdim - 1, 0)
+    return tdim, tdim - 1, None
 
 
 @PETSc.Log.EventDecorator()
@@ -140,6 +141,12 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     :class:`LineCollection <matplotlib.collections.LineCollection>` and
     related types.
 
+    On an extruded mesh, the markers of the base mesh colour the vertical
+    facets, and the bottom and top of the columns of cells are coloured under
+    the markers ``"bottom"`` and ``"top"``, matching the subdomain ids of the
+    :data:`~.ds_b` and :data:`~.ds_t` measures. A periodic extrusion identifies
+    the bottom with the top, so neither is drawn.
+
     :arg mesh: mesh to be plotted
     :arg axes: matplotlib :class:`Axes <matplotlib.axes.Axes>` object on which to plot mesh
     :arg interior_kw: keyword arguments to apply when plotting the mesh interior
@@ -150,8 +157,9 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     tdim = mesh.topological_dimension
     BoundaryCollection, InteriorCollection = _get_collection_types(gdim, tdim)
 
-    if mesh.extruded:
-        raise NotImplementedError("Visualizing extruded meshes not implemented yet!")
+    if mesh.extruded and mesh.variable_layers:
+        raise NotImplementedError("Visualizing variable layer extruded meshes "
+                                  "not implemented yet!")
 
     if axes is None:
         figure = plt.figure()
@@ -162,22 +170,28 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
 
     coordinates = mesh.coordinates
     element = coordinates.function_space().ufl_element()
-    if element.degree() != 1:
+    if coordinates.function_space().finat_element.space_dimension() != mesh.ufl_cell().num_vertices:
         # Interpolate to piecewise linear.
         V = VectorFunctionSpace(mesh, element.family(), 1)
         coordinates = assemble(interpolate(coordinates, V))
 
     cell = coordinates.function_space().finat_element.cell
+    cell_dim, facet_dim, horiz_facet_dim = _entity_dimensions(tdim, mesh.extruded)
+    num_layers = mesh.layers - 1 if mesh.extruded else 1
 
     coords = toreal(coordinates.dat.data_ro_with_halos, "real")
+    cell_node_map = coordinates.cell_node_map()
+    cell_nodes = cell_node_map.values_with_halo
     result = []
     interior_kw = dict(interior_kw)
     # If the domain isn't a 3D volume, draw the interior.
     if tdim <= 2:
-        cell_node_map = coordinates.cell_node_map().values_with_halo
-        idx = _entity_node_list(cell, tdim)[0]
+        idx = _entity_node_list(cell, cell_dim)[0]
         idx = np.append(idx, idx[0])
-        vertices = coords[cell_node_map[:, idx]]
+        cells = cell_nodes[:, idx]
+        if mesh.extruded:
+            cells = _extrude(cells, cell_node_map.offset[idx], num_layers)
+        vertices = coords[cells]
 
         interior_kw["edgecolors"] = interior_kw.get("edgecolors", "k")
         interior_kw["linewidths"] = interior_kw.get("linewidths", 1.0)
@@ -190,7 +204,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
 
     # Add colored lines/polygons for the boundary facets. Each facet is drawn
     # from the nodes of the cell it belongs to that lie on it.
-    facet_node_list = _entity_node_list(cell, tdim - 1)
+    facet_node_list = _entity_node_list(cell, facet_dim)
 
     def facet_data(typ):
         if typ == "interior":
@@ -200,16 +214,43 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
             local_facet_ids = facets.local_facet_dat.data_ro_with_halos[:, 0]
         elif typ == "exterior":
             facets = mesh.exterior_facets
-            nodes = coordinates.exterior_facet_node_map().values_with_halo
+            node_map = coordinates.exterior_facet_node_map()
+            nodes = node_map.values_with_halo
             local_facet_ids = facets.local_facet_dat.data_ro_with_halos
         else:
             raise ValueError("Unhandled facet type")
-        faces = np.take_along_axis(nodes, facet_node_list[local_facet_ids], axis=1)
+        selection = facet_node_list[local_facet_ids]
+        faces = np.take_along_axis(nodes, selection, axis=1)
+        if mesh.extruded:
+            faces = _extrude(faces, node_map.offset[selection], num_layers)
         return facets, faces
 
     facet_data = {typ: facet_data(typ) for typ in ["interior", "exterior"]}
 
-    markers = mesh.exterior_facets.unique_markers
+    # The bottom and top of an extruded mesh are not facets of the base mesh,
+    # so they are drawn from the cells of the lowest and highest layer instead.
+    # A periodic extrusion identifies the two, leaving no boundary there.
+    horizontal_markers = ["bottom", "top"] if (mesh.extruded
+                                               and not mesh.extruded_periodic) else []
+
+    def marker_faces(marker):
+        if marker in horizontal_markers:
+            layer = 0 if marker == "bottom" else num_layers - 1
+            idx = _entity_node_list(cell, horiz_facet_dim)[horizontal_markers.index(marker)]
+            return cell_nodes[:, idx] + layer * cell_node_map.offset[idx]
+
+        faces = []
+        for facets, extruded_faces in facet_data.values():
+            indices = facets.subset(int(marker)).indices
+            if mesh.extruded:
+                # Every facet of the base mesh was extruded into `num_layers`
+                # facets lying consecutively in the array.
+                indices = (num_layers * indices[:, None]
+                           + np.arange(num_layers)).reshape(-1)
+            faces.append(extruded_faces[indices, :])
+        return np.concatenate(faces)
+
+    markers = list(mesh.exterior_facets.unique_markers) + horizontal_markers
     color_key = "colors" if tdim <= 2 else "facecolors"
     boundary_kw = dict(boundary_kw)
     boundary_colors = boundary_kw.pop(color_key, None)
@@ -229,12 +270,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
         boundary_kw["edgecolors"] = boundary_kw.get("edgecolors", "k")
         boundary_kw["linewidths"] = boundary_kw.get("linewidths", 1.0)
     for marker, color in zip(markers, colors):
-        vertices = []
-        for facets, faces in facet_data.values():
-            face_indices = facets.subset(int(marker)).indices
-            marker_faces = faces[face_indices, :]
-            vertices.append(coords[marker_faces])
-        vertices = np.concatenate(vertices)
+        vertices = coords[marker_faces(marker)]
         _boundary_kw = dict(**{color_key: color, "label": marker}, **boundary_kw)
         marker_collection = BoundaryCollection(vertices, **_boundary_kw)
         axes.add_collection(marker_collection)

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -255,12 +255,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     boundary_kw = dict(boundary_kw)
     boundary_colors = boundary_kw.pop(color_key, None)
     if boundary_colors is None:
-        # matplotlib.cm.get_cmap was deprecated in Matplotlib 3.9, see:
-        # https://matplotlib.org/3.9.0/api/prev_api_changes/api_changes_3.9.0.html#top-level-cmap-registration-and-access-functions-in-mpl-cm
-        try:
-            cmap = matplotlib.cm.get_cmap("Dark2")
-        except AttributeError:
-            cmap = matplotlib.colormaps["Dark2"]
+        cmap = matplotlib.colormaps["Dark2"]
         num_markers = len(markers)
         colors = cmap([k / num_markers for k in range(num_markers)])
     else:

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -179,10 +179,6 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     # If the domain isn't a 3D volume, draw the interior.
     if tdim <= 2:
         idx = _entity_node_list(cell, cell_dim)[0]
-        if tdim == 2:
-            # Close the polygon bounding the cell; the cells of a 1D mesh are
-            # already line segments.
-            idx = np.append(idx, idx[0])
         cells = cell_nodes[:, idx]
         if mesh.extruded:
             cells = _extrude(cells, cell_node_map.offset[idx], num_layers)

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -11,12 +11,14 @@ except ModuleNotFoundError as e:
     ) from e
 import matplotlib.colors
 import matplotlib.patches
+import matplotlib.transforms
 import matplotlib.tri
 from matplotlib.path import Path
 from matplotlib.lines import Line2D
 from matplotlib.collections import LineCollection, PathCollection, PolyCollection
 import mpl_toolkits.mplot3d
-from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
+from mpl_toolkits.mplot3d.art3d import (Line3DCollection, Poly3DCollection,
+                                        patch_collection_2d_to_3d)
 from math import factorial
 from firedrake import (interpolate, sqrt, inner, Function, SpatialCoordinate,
                        FunctionSpace, VectorFunctionSpace, PointNotInDomainError,
@@ -65,25 +67,54 @@ def _autoscale_view(axes, coords):
             setter(amin, amax)
 
 
-def _get_collection_types(gdim, tdim):
-    if gdim == 2:
-        if tdim == 1:
-            # The facets of a 1D mesh are points, so its boundary needs a
-            # collection of markers. Only a closed manifold works for now; the
-            # markers of an open one would have to take their offsets in data
-            # coordinates and their colours under `facecolors`.
-            return PathCollection, LineCollection
-        elif tdim == 2:
-            return LineCollection, PolyCollection
-    elif gdim == 3:
-        if tdim == 1:
-            raise NotImplementedError("Didn't get to this one yet...")
-        elif tdim == 2:
-            return Line3DCollection, Poly3DCollection
-        elif tdim == 3:
-            return Poly3DCollection, Poly3DCollection
+def _point_collection(axes, vertices, colors=None, **kwargs):
+    r"""Draw a collection of round markers at the given points
 
-    raise ValueError("Geometric dimension must be either 2 or 3!")
+    The markers are sized in points like those of a scatter plot, so their
+    paths live in display space and only their offsets are in data
+    coordinates. The colours arrive under the same keyword that the line
+    collections bounding a 2D mesh take them under.
+    """
+    kwargs.setdefault("sizes", [plt.rcParams["lines.markersize"] ** 2])
+    collection = PathCollection(
+        [Path.unit_circle()],
+        offsets=vertices[:, :2],
+        offset_transform=axes.transData,
+        transform=matplotlib.transforms.IdentityTransform(),
+        facecolors=colors,
+        **kwargs
+    )
+    if vertices.shape[1] == 3:
+        # Shading the markers by depth would take them off the colour that
+        # names them in the legend.
+        patch_collection_2d_to_3d(collection, zs=vertices[:, 2], depthshade=False)
+    return collection
+
+
+def _add_collection(axes, vertices, **kwargs):
+    r"""Draw the mesh entities whose vertices are given and add them to the axes
+
+    The shape of ``vertices`` decides how each entity is drawn: entities with a
+    single vertex become round markers, those with two vertices become line
+    segments, and those with more become polygons. The facets of a 1D mesh are
+    points and those of a 2D mesh are segments, so this covers every entity
+    that a mesh of any dimension is drawn from.
+
+    :arg vertices: array of shape ``(num_entities, num_vertices, gdim)``
+    :return: the matplotlib :class:`Collection <matplotlib.collections.Collection>`
+    """
+    num_vertices, gdim = vertices.shape[1:]
+    if num_vertices == 1:
+        collection = _point_collection(axes, vertices.reshape(-1, gdim), **kwargs)
+    elif num_vertices == 2:
+        segments = LineCollection if gdim == 2 else Line3DCollection
+        collection = segments(vertices, **kwargs)
+    else:
+        polygons = PolyCollection if gdim == 2 else Poly3DCollection
+        collection = polygons(vertices, **kwargs)
+
+    axes.add_collection(collection)
+    return collection
 
 
 def _entity_node_list(cell, dimension):
@@ -141,7 +172,8 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     """
     gdim = mesh.geometric_dimension
     tdim = mesh.topological_dimension
-    BoundaryCollection, InteriorCollection = _get_collection_types(gdim, tdim)
+    if gdim not in {2, 3}:
+        raise ValueError("Geometric dimension must be either 2 or 3!")
 
     if mesh.extruded and mesh.variable_layers:
         raise NotImplementedError("Visualizing variable layer extruded meshes "
@@ -189,9 +221,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
         if gdim == 2 and tdim == 2:
             interior_kw["facecolors"] = interior_kw.get("facecolors", "none")
 
-        interior_collection = InteriorCollection(vertices, **interior_kw)
-        axes.add_collection(interior_collection)
-        result.append(interior_collection)
+        result.append(_add_collection(axes, vertices, **interior_kw))
 
     # Add colored lines/polygons for the boundary facets. Each facet is drawn
     # from the nodes of the cell it belongs to that lie on it.
@@ -258,9 +288,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     for marker, color in zip(markers, colors):
         vertices = coords[marker_faces(marker)]
         _boundary_kw = dict(**{color_key: color, "label": marker}, **boundary_kw)
-        marker_collection = BoundaryCollection(vertices, **_boundary_kw)
-        axes.add_collection(marker_collection)
-        result.append(marker_collection)
+        result.append(_add_collection(axes, vertices, **_boundary_kw))
 
     # Dirty hack to enable legends for 3D volume plots. See the function
     # `Poly3DCollection.set_3d_properties`.

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -229,9 +229,6 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     if gdim not in {2, 3}:
         raise ValueError("Geometric dimension must be either 2 or 3!")
 
-    if mesh.extruded and mesh.variable_layers:
-        raise NotImplementedError("Visualizing variable layer extruded meshes "
-                                  "not implemented yet!")
 
     if axes is None:
         figure = plt.figure()

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -113,6 +113,22 @@ def _entity_node_list(cell, dimension):
     return _cycle([entities[key] for key in sorted(entities)])
 
 
+def _extrude(nodes, offset, num_layers):
+    r"""Replicate the nodes of the bottom layer of an extruded mesh up the columns
+
+    :arg nodes: array of node numbers of the entities in the bottom layer
+    :arg offset: increment of each node number between successive layers,
+        either one value per node or a full array of the same shape as ``nodes``
+    :arg num_layers: number of layers of cells in each column
+    :return: array of node numbers of the entities in every layer, with the
+        entities of each column contiguous
+    """
+    nodes = np.asarray(nodes)
+    offset = np.broadcast_to(offset, nodes.shape)
+    layers = np.arange(num_layers).reshape(1, -1, 1)
+    return (nodes[:, None, :] + offset[:, None, :] * layers).reshape(-1, nodes.shape[-1])
+
+
 @PETSc.Log.EventDecorator()
 def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     r"""Plot a mesh colouring marked facet segments
@@ -995,8 +1011,9 @@ class FunctionPlotter:
         fiat_element = Q.finat_element.fiat_equivalent
         elem = fiat_element.tabulate(0, self._reference_points)[keys[dimension]]
         cell_node_list = Q.cell_node_list
-        if mesh.layers:
-            cell_node_list = np.vstack([cell_node_list + k for k in range(mesh.layers - 1)])
+        if mesh.extruded:
+            cell_node_list = _extrude(cell_node_list, Q.cell_node_map().offset,
+                                      mesh.layers - 1)
         data = function.dat.data_ro_with_halos[cell_node_list]
         if function.ufl_shape == ():
             vec_length = 1

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -72,8 +72,26 @@ def _point_collection(axes, vertices, colors=None, **kwargs):
 
     The markers are sized in points like those of a scatter plot, so their
     paths live in display space and only their offsets are in data
-    coordinates. The colours arrive under the same keyword that the line
-    collections bounding a 2D mesh take them under.
+    coordinates.
+
+    Parameters
+    ----------
+    axes : matplotlib.axes.Axes
+        Axes whose data transform positions the markers.
+    vertices : numpy.ndarray
+        Array of shape ``(num_points, gdim)`` of point coordinates.
+    colors : optional
+        Colour or array of colours for the markers. The colours arrive under
+        the same keyword that the line collections bounding a 2D mesh take
+        them under.
+    **kwargs
+        Additional keyword arguments for
+        :class:`~matplotlib.collections.PathCollection`.
+
+    Returns
+    -------
+    matplotlib.collections.PathCollection
+        The marker collection, converted to 3D if ``gdim`` is 3.
     """
     kwargs.setdefault("sizes", [plt.rcParams["lines.markersize"] ** 2])
     collection = PathCollection(
@@ -100,8 +118,19 @@ def _add_collection(axes, vertices, **kwargs):
     points and those of a 2D mesh are segments, so this covers every entity
     that a mesh of any dimension is drawn from.
 
-    :arg vertices: array of shape ``(num_entities, num_vertices, gdim)``
-    :return: the matplotlib :class:`Collection <matplotlib.collections.Collection>`
+    Parameters
+    ----------
+    axes : matplotlib.axes.Axes
+        Axes to add the collection to.
+    vertices : numpy.ndarray
+        Array of shape ``(num_entities, num_vertices, gdim)``.
+    **kwargs
+        Additional keyword arguments for the collection type chosen.
+
+    Returns
+    -------
+    matplotlib.collections.Collection
+        The collection that was added to the axes.
     """
     num_vertices, gdim = vertices.shape[1:]
     if num_vertices == 1:
@@ -126,7 +155,18 @@ def _entity_node_list(cell, dimension):
     simple. Entities with any other number of vertices are simplices, which are
     already in order.
 
-    :return: array of shape ``(num_entities, num_vertices_per_entity)``
+    Parameters
+    ----------
+    cell : FIAT.reference_element.Cell
+        Reference cell whose topology is queried.
+    dimension : int or tuple of int
+        Dimension of the entities to look up. Tensor product cells index their
+        entities by a pair of horizontal and vertical dimensions.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(num_entities, num_vertices_per_entity)``.
     """
     entities = cell.get_topology()[dimension]
     nodes = np.array([entities[key] for key in sorted(entities)])
@@ -138,8 +178,22 @@ def _entity_node_list(cell, dimension):
 def _extrude(nodes, offset, num_layers):
     r"""Replicate the entities of the bottom layer up the columns of an extruded mesh
 
-    The ``offset`` between successive layers broadcasts against ``nodes``. The
-    entities of each column come out contiguous.
+    Parameters
+    ----------
+    nodes : numpy.ndarray
+        Array of shape ``(num_entities, num_nodes_per_entity)`` of node numbers
+        in the bottom layer.
+    offset : int or numpy.ndarray
+        Increment in node number between successive layers. This broadcasts
+        against ``nodes``.
+    num_layers : int
+        Number of layers of cells in the extruded mesh.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(num_entities * num_layers, num_nodes_per_entity)``.
+        The entities of each column come out contiguous.
     """
     nodes = np.asarray(nodes)
     offset = np.broadcast_to(offset, nodes.shape)

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -14,7 +14,7 @@ import matplotlib.patches
 import matplotlib.tri
 from matplotlib.path import Path
 from matplotlib.lines import Line2D
-from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.collections import LineCollection, PathCollection, PolyCollection
 import mpl_toolkits.mplot3d
 from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
 from math import factorial
@@ -68,8 +68,11 @@ def _autoscale_view(axes, coords):
 def _get_collection_types(gdim, tdim):
     if gdim == 2:
         if tdim == 1:
-            # Probably a CircleCollection?
-            raise NotImplementedError("Didn't get to this yet...")
+            # The facets of a 1D mesh are points, so its boundary needs a
+            # collection of markers. Only a closed manifold works for now; the
+            # markers of an open one would have to take their offsets in data
+            # coordinates and their colours under `facecolors`.
+            return PathCollection, LineCollection
         elif tdim == 2:
             return LineCollection, PolyCollection
     elif gdim == 3:
@@ -176,7 +179,10 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     # If the domain isn't a 3D volume, draw the interior.
     if tdim <= 2:
         idx = _entity_node_list(cell, cell_dim)[0]
-        idx = np.append(idx, idx[0])
+        if tdim == 2:
+            # Close the polygon bounding the cell; the cells of a 1D mesh are
+            # already line segments.
+            idx = np.append(idx, idx[0])
         cells = cell_nodes[:, idx]
         if mesh.extruded:
             cells = _extrude(cells, cell_node_map.offset[idx], num_layers)
@@ -184,7 +190,7 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
 
         interior_kw["edgecolors"] = interior_kw.get("edgecolors", "k")
         interior_kw["linewidths"] = interior_kw.get("linewidths", 1.0)
-        if gdim == 2:
+        if gdim == 2 and tdim == 2:
             interior_kw["facecolors"] = interior_kw.get("facecolors", "none")
 
         interior_collection = InteriorCollection(vertices, **interior_kw)

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -151,8 +151,8 @@ def _extrude(nodes, offset, num_layers):
 def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     r"""Plot a mesh colouring marked facet segments
 
-    Typically boundary segments will be marked and coloured, but
-    interior facets that are marked will also be coloured.
+    Only the exterior facets are coloured. Markers on interior facets are
+    ignored, so an internal boundary is drawn like the rest of the interior.
 
     The interior and boundary keyword arguments can be any keyword argument for
     :class:`LineCollection <matplotlib.collections.LineCollection>` and
@@ -227,26 +227,12 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     # from the nodes of the cell it belongs to that lie on it.
     facet_node_list = _entity_node_list(cell, facet_dim)
 
-    def facet_data(typ):
-        if typ == "interior":
-            facets = mesh.interior_facets
-            node_map = coordinates.interior_facet_node_map()
-            nodes = node_map.values_with_halo[:, :node_map.arity//2]
-            local_facet_ids = facets.local_facet_dat.data_ro_with_halos[:, 0]
-        elif typ == "exterior":
-            facets = mesh.exterior_facets
-            node_map = coordinates.exterior_facet_node_map()
-            nodes = node_map.values_with_halo
-            local_facet_ids = facets.local_facet_dat.data_ro_with_halos
-        else:
-            raise ValueError("Unhandled facet type")
-        selection = facet_node_list[local_facet_ids]
-        faces = np.take_along_axis(nodes, selection, axis=1)
-        if mesh.extruded:
-            faces = _extrude(faces, node_map.offset[selection], num_layers)
-        return facets, faces
-
-    facet_data = {typ: facet_data(typ) for typ in ["interior", "exterior"]}
+    exterior_facets = mesh.exterior_facets
+    node_map = coordinates.exterior_facet_node_map()
+    selection = facet_node_list[exterior_facets.local_facet_dat.data_ro_with_halos]
+    exterior_faces = np.take_along_axis(node_map.values_with_halo, selection, axis=1)
+    if mesh.extruded:
+        exterior_faces = _extrude(exterior_faces, node_map.offset[selection], num_layers)
 
     # The bottom and top of an extruded mesh are not facets of the base mesh,
     # so they are drawn from the cells of the lowest and highest layer instead.
@@ -260,18 +246,15 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
             idx = _entity_node_list(cell, horiz_facet_dim)[horizontal_markers.index(marker)]
             return cell_nodes[:, idx] + layer * cell_node_map.offset[idx]
 
-        faces = []
-        for facets, extruded_faces in facet_data.values():
-            indices = facets.subset(int(marker)).indices
-            if mesh.extruded:
-                # Every facet of the base mesh was extruded into `num_layers`
-                # facets lying consecutively in the array.
-                indices = (num_layers * indices[:, None]
-                           + np.arange(num_layers)).reshape(-1)
-            faces.append(extruded_faces[indices, :])
-        return np.concatenate(faces)
+        indices = exterior_facets.subset(int(marker)).indices
+        if mesh.extruded:
+            # Every facet of the base mesh was extruded into `num_layers`
+            # facets lying consecutively in the array.
+            indices = (num_layers * indices[:, None]
+                       + np.arange(num_layers)).reshape(-1)
+        return exterior_faces[indices, :]
 
-    markers = list(mesh.exterior_facets.unique_markers) + horizontal_markers
+    markers = list(exterior_facets.unique_markers) + horizontal_markers
     color_key = "colors" if tdim <= 2 else "facecolors"
     boundary_kw = dict(boundary_kw)
     boundary_colors = boundary_kw.pop(color_key, None)

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -83,27 +83,22 @@ def _get_collection_types(gdim, tdim):
     raise ValueError("Geometric dimension must be either 2 or 3!")
 
 
-def _cycle(nodes):
-    r"""Order the vertices of each entity into a cycle around its perimeter
-
-    FInAT numbers the vertices of a quadrilateral lexicographically, putting 1
-    and 2 diagonally opposite each other; exchanging the last two makes the
-    polygon simple. Entities with any other number of vertices are simplices,
-    which are already in order.
-    """
-    nodes = np.asarray(nodes)
-    if nodes.shape[-1] == 4:
-        return nodes[..., [0, 1, 3, 2]]
-    return nodes
-
-
 def _entity_node_list(cell, dimension):
     r"""Local node numbers of each entity of the given dimension of a cell
+
+    The vertices of each entity come out in a cycle around its perimeter. FInAT
+    numbers the vertices of a quadrilateral lexicographically, putting 1 and 2
+    diagonally opposite each other; exchanging the last two makes the polygon
+    simple. Entities with any other number of vertices are simplices, which are
+    already in order.
 
     :return: array of shape ``(num_entities, num_vertices_per_entity)``
     """
     entities = cell.get_topology()[dimension]
-    return _cycle([entities[key] for key in sorted(entities)])
+    nodes = np.array([entities[key] for key in sorted(entities)])
+    if nodes.shape[-1] == 4:
+        return nodes[:, [0, 1, 3, 2]]
+    return nodes
 
 
 def _extrude(nodes, offset, num_layers):
@@ -116,18 +111,6 @@ def _extrude(nodes, offset, num_layers):
     offset = np.broadcast_to(offset, nodes.shape)
     layers = np.arange(num_layers).reshape(1, -1, 1)
     return (nodes[:, None, :] + offset[:, None, :] * layers).reshape(-1, nodes.shape[-1])
-
-
-def _entity_dimensions(tdim, extruded):
-    r"""Dimensions of the cell, the vertical facets, and the horizontal facets
-
-    Tensor product cells index their entities by a pair of horizontal and
-    vertical dimensions. The horizontal facets bound the bottom and top of each
-    column of cells, so there are none unless the mesh is extruded.
-    """
-    if extruded:
-        return (tdim - 1, 1), (tdim - 2, 1), (tdim - 1, 0)
-    return tdim, tdim - 1, None
 
 
 @PETSc.Log.EventDecorator()
@@ -176,7 +159,13 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
         coordinates = assemble(interpolate(coordinates, V))
 
     cell = coordinates.function_space().finat_element.cell
-    cell_dim, facet_dim, horiz_facet_dim = _entity_dimensions(tdim, mesh.extruded)
+    # Tensor product cells index their entities by a pair of horizontal and
+    # vertical dimensions. The horizontal facets bound the bottom and top of
+    # each column of cells, so there are none unless the mesh is extruded.
+    if mesh.extruded:
+        cell_dim, facet_dim, horiz_facet_dim = (tdim - 1, 1), (tdim - 2, 1), (tdim - 1, 0)
+    else:
+        cell_dim, facet_dim, horiz_facet_dim = tdim, tdim - 1, None
     num_layers = mesh.layers - 1 if mesh.extruded else 1
 
     coords = toreal(coordinates.dat.data_ro_with_halos, "real")

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -83,6 +83,36 @@ def _get_collection_types(gdim, tdim):
     raise ValueError("Geometric dimension must be either 2 or 3!")
 
 
+def _cycle(nodes):
+    r"""Order the vertices of an entity into a cycle around its perimeter
+
+    FInAT numbers the vertices of a tensor product entity lexicographically, so
+    a quadrilateral comes out with vertices 1 and 2 diagonally opposite each
+    other; exchanging the last two vertices makes the polygon simple. Every
+    entity that this is applied to -- a cell of a 2D mesh, or a facet -- is a
+    simplex if it has any other number of vertices.
+
+    :arg nodes: array of node numbers, one entity per row
+    :return: array of the same shape with the vertices of each entity in order
+    """
+    nodes = np.asarray(nodes)
+    if nodes.shape[-1] == 4:
+        return nodes[..., [0, 1, 3, 2]]
+    return nodes
+
+
+def _entity_node_list(cell, dimension):
+    r"""Local node numbers of each entity of a given dimension of a cell
+
+    :arg cell: the reference cell of the coordinate element
+    :arg dimension: dimension of the entities to return; a tuple of horizontal
+        and vertical dimensions if the cell is a tensor product
+    :return: array of shape ``(num_entities, num_vertices_per_entity)``
+    """
+    entities = cell.get_topology()[dimension]
+    return _cycle([entities[key] for key in sorted(entities)])
+
+
 @PETSc.Log.EventDecorator()
 def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     r"""Plot a mesh colouring marked facet segments
@@ -103,7 +133,6 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     gdim = mesh.geometric_dimension
     tdim = mesh.topological_dimension
     BoundaryCollection, InteriorCollection = _get_collection_types(gdim, tdim)
-    quad = mesh.ufl_cell().cellname == "quadrilateral"
 
     if mesh.extruded:
         raise NotImplementedError("Visualizing extruded meshes not implemented yet!")
@@ -122,13 +151,16 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
         V = VectorFunctionSpace(mesh, element.family(), 1)
         coordinates = assemble(interpolate(coordinates, V))
 
+    cell = coordinates.function_space().finat_element.cell
+
     coords = toreal(coordinates.dat.data_ro_with_halos, "real")
     result = []
     interior_kw = dict(interior_kw)
     # If the domain isn't a 3D volume, draw the interior.
     if tdim <= 2:
         cell_node_map = coordinates.cell_node_map().values_with_halo
-        idx = (tuple(range(tdim + 1)) if not quad else (0, 1, 3, 2)) + (0,)
+        idx = _entity_node_list(cell, tdim)[0]
+        idx = np.append(idx, idx[0])
         vertices = coords[cell_node_map[:, idx]]
 
         interior_kw["edgecolors"] = interior_kw.get("edgecolors", "k")
@@ -140,29 +172,30 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
         axes.add_collection(interior_collection)
         result.append(interior_collection)
 
+    # Add colored lines/polygons for the boundary facets. Each facet is drawn
+    # from the nodes of the cell it belongs to that lie on it.
+    facet_node_list = _entity_node_list(cell, tdim - 1)
+
     def facet_data(typ):
         if typ == "interior":
             facets = mesh.interior_facets
             node_map = coordinates.interior_facet_node_map()
-            node_map = node_map.values_with_halo[:, :node_map.arity//2]
-            local_facet_ids = facets.local_facet_dat.data_ro_with_halos[:, :1].reshape(-1)
+            nodes = node_map.values_with_halo[:, :node_map.arity//2]
+            local_facet_ids = facets.local_facet_dat.data_ro_with_halos[:, 0]
         elif typ == "exterior":
             facets = mesh.exterior_facets
+            nodes = coordinates.exterior_facet_node_map().values_with_halo
             local_facet_ids = facets.local_facet_dat.data_ro_with_halos
-            node_map = coordinates.exterior_facet_node_map().values_with_halo
         else:
             raise ValueError("Unhandled facet type")
-        mask = np.zeros(node_map.shape, dtype=bool)
-        for facet_index, local_facet_index in enumerate(local_facet_ids):
-            mask[facet_index, topology[tdim - 1][local_facet_index]] = True
-        faces = node_map[mask].reshape(-1, tdim)
+        faces = np.take_along_axis(nodes, facet_node_list[local_facet_ids], axis=1)
         return facets, faces
 
-    # Add colored lines/polygons for the boundary facets
-    topology = coordinates.function_space().finat_element.cell.get_topology()
+    facet_data = {typ: facet_data(typ) for typ in ["interior", "exterior"]}
 
     markers = mesh.exterior_facets.unique_markers
     color_key = "colors" if tdim <= 2 else "facecolors"
+    boundary_kw = dict(boundary_kw)
     boundary_colors = boundary_kw.pop(color_key, None)
     if boundary_colors is None:
         # matplotlib.cm.get_cmap was deprecated in Matplotlib 3.9, see:
@@ -176,14 +209,12 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     else:
         colors = matplotlib.colors.to_rgba_array(boundary_colors)
 
-    boundary_kw = dict(boundary_kw)
     if tdim == 3:
         boundary_kw["edgecolors"] = boundary_kw.get("edgecolors", "k")
         boundary_kw["linewidths"] = boundary_kw.get("linewidths", 1.0)
     for marker, color in zip(markers, colors):
         vertices = []
-        for typ in ["interior", "exterior"]:
-            facets, faces = facet_data(typ)
+        for facets, faces in facet_data.values():
             face_indices = facets.subset(int(marker)).indices
             marker_faces = faces[face_indices, :]
             vertices.append(coords[marker_faces])

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -212,10 +212,8 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     :class:`LineCollection <matplotlib.collections.LineCollection>` and
     related types.
 
-    On an extruded mesh, the markers of the base mesh colour the vertical
-    facets, and the bottom and top of the columns of cells are coloured under
-    the markers ``"bottom"`` and ``"top"``, matching the subdomain ids of the
-    :data:`~.ds_b` and :data:`~.ds_t` measures. A periodic extrusion identifies
+    On an extruded mesh, the bottom and top of the mesh are coloured under
+    the markers ``"bottom"`` and ``"top"``. A periodic extrusion identifies
     the bottom with the top, so neither is drawn.
 
     :arg mesh: mesh to be plotted

--- a/firedrake/pyplot/mpl.py
+++ b/firedrake/pyplot/mpl.py
@@ -227,7 +227,6 @@ def triplot(mesh, axes=None, interior_kw={}, boundary_kw={}):
     if gdim not in {2, 3}:
         raise ValueError("Geometric dimension must be either 2 or 3!")
 
-
     if axes is None:
         figure = plt.figure()
         if gdim == 3:

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -182,6 +182,27 @@ def test_fn_plotter_extruded_mesh_multiple_layers():
 
 
 @pytest.mark.skipplot
+@pytest.mark.parametrize("family,degree", [("CG", 2), ("DG", 1)])
+@pytest.mark.xfail(reason="FunctionPlotter ignores the vertical node offset of "
+                          "the function space on extruded meshes")
+def test_fn_plotter_extruded_mesh_offsets(family, degree):
+    # Only spaces whose nodes are numbered consecutively up a column have a
+    # vertical offset of 1; CG2 has an offset of 2 and DQ1 an offset of 4.
+    mesh = ExtrudedMesh(UnitIntervalMesh(4), 3)
+    x, y = SpatialCoordinate(mesh)
+
+    fn_plotter = FunctionPlotter(mesh, num_sample_points=10)
+    coords = fn_plotter(mesh.coordinates).reshape(-1, 2)
+
+    V = FunctionSpace(mesh, family, degree)
+    u = assemble(interpolate(x + 2 * y, V))
+
+    # A linear function is in every one of these spaces, so sampling it must
+    # reproduce it exactly at the sample points.
+    assert np.allclose(fn_plotter(u), coords[:, 0] + 2 * coords[:, 1])
+
+
+@pytest.mark.skipplot
 def test_quiver_plot():
     mesh = UnitSquareMesh(10, 10)
     V = VectorFunctionSpace(mesh, "CG", 1)
@@ -371,3 +392,80 @@ def test_tripcolor_movie():
 
     # Use a method of the animation to prevent warning about it being unused
     movie.to_jshtml()
+
+
+@pytest.mark.skipplot
+@pytest.mark.xfail(reason="Plotting 1D manifolds embedded into 2D not implemented")
+def test_triplot_manifold_mesh():
+    mesh = CircleManifoldMesh(16)
+    fig, axes = plt.subplots()
+    collections = triplot(mesh, axes=axes)
+    assert collections
+
+
+@pytest.mark.skipplot
+@pytest.mark.xfail(reason="Extruded plotting not implemented")
+def test_triplot_extruded():
+    # The annulus is a periodic extrusion of an interval, so its inner and
+    # outer boundaries are the markers of the base mesh on vertical facets.
+    mesh = AnnulusMesh(2, 1, nr=4, nt=32)
+    fig, axes = plt.subplots()
+    collections = triplot(mesh, axes=axes)
+    assert collections
+    legend = axes.legend(loc='upper right')
+    assert len(legend.get_texts()) == 2
+
+
+@pytest.mark.skipplot
+@pytest.mark.xfail(reason="Extruded plotting not implemented")
+def test_triplot_extruded_horizontal_boundaries():
+    # Extruding a closed base mesh leaves the bottom and top of the columns as
+    # the only boundaries of the domain.
+    circle = CircleManifoldMesh(32, radius=1.0)
+    mesh = ExtrudedMesh(circle, layers=4, layer_height=0.15, extrusion_type="radial")
+
+    fig, axes = plt.subplots()
+    collections = triplot(mesh, axes=axes)
+    assert collections
+    legend = axes.legend(loc='upper right')
+    assert [text.get_text() for text in legend.get_texts()] == ["bottom", "top"]
+
+
+@pytest.mark.skipplot
+@pytest.mark.xfail(reason="triplot assumes that facets are simplices, so the "
+                          "quadrilateral facets of a hexahedron are mangled")
+def test_triplot_hex_mesh():
+    mesh = UnitCubeMesh(2, 2, 2, hexahedral=True)
+    fig = plt.figure()
+    axes = fig.add_subplot(111, projection='3d')
+    collections = triplot(mesh, axes=axes)
+    assert collections
+    legend = axes.legend(loc='upper right')
+    assert len(legend.get_texts()) == 6
+
+    # The paths of a Poly3DCollection are only populated once the polygons have
+    # been projected onto the viewing plane.
+    fig.canvas.draw()
+
+    # Every facet of a hexahedron is a quadrilateral, so each of the 6 * 2 * 2
+    # boundary facets must be drawn as a polygon with four distinct vertices.
+    paths = [path for collection in collections for path in collection.get_paths()]
+    assert len(paths) == 24
+    for path in paths:
+        assert len(np.unique(path.vertices, axis=0)) == 4
+
+
+@pytest.mark.skipplot
+@pytest.mark.xfail(reason="triplot pops the colours out of the caller's boundary_kw")
+def test_triplot_kwargs_not_mutated():
+    mesh = UnitSquareMesh(4, 4)
+    interior_kw = {'linewidths': 0.5}
+    boundary_kw = {'linewidths': 2.0, 'colors': ['tab:blue', 'tab:orange',
+                                                 'tab:green', 'tab:red']}
+
+    fig, axes = plt.subplots()
+    triplot(mesh, axes=axes, interior_kw=interior_kw, boundary_kw=boundary_kw)
+
+    assert interior_kw == {'linewidths': 0.5}
+    assert boundary_kw == {'linewidths': 2.0, 'colors': ['tab:blue', 'tab:orange',
+                                                         'tab:green', 'tab:red']}

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -400,6 +400,52 @@ def test_triplot_manifold_mesh():
     assert collections
 
 
+def _embedded_interval_mesh(expr, dim):
+    interval = UnitIntervalMesh(6)
+    V = VectorFunctionSpace(interval, "CG", 1, dim=dim)
+    x, = SpatialCoordinate(interval)
+    return Mesh(assemble(interpolate(expr(x), V)))
+
+
+@pytest.mark.skipplot
+def test_triplot_manifold_mesh_with_boundary():
+    # The facets of a 1D mesh are points, so the two ends of an interval
+    # embedded into the plane are drawn as markers rather than as segments.
+    mesh = _embedded_interval_mesh(lambda x: as_vector([x, x**2]), 2)
+
+    fig, axes = plt.subplots()
+    collections = triplot(mesh, axes=axes)
+    legend = axes.legend()
+    assert [text.get_text() for text in legend.get_texts()] == ["1", "2"]
+
+    offsets = np.concatenate([c.get_offsets() for c in collections[1:]])
+    assert np.allclose(np.sort(offsets, axis=0), [[0.0, 0.0], [1.0, 1.0]])
+    fig.canvas.draw()
+
+
+@pytest.mark.skipplot
+def test_triplot_manifold_mesh_3d():
+    # A curve in space is drawn like one in the plane, but its markers have to
+    # be promoted to 3D so that they are sorted by depth along with everything
+    # else in the axes.
+    mesh = _embedded_interval_mesh(
+        lambda x: as_vector([cos(6 * x), sin(6 * x), x]), 3
+    )
+
+    fig = plt.figure()
+    axes = fig.add_subplot(111, projection='3d')
+    collections = triplot(mesh, axes=axes)
+    legend = axes.legend()
+    assert [text.get_text() for text in legend.get_texts()] == ["1", "2"]
+
+    # The offsets of the markers are projected onto the viewing plane once the
+    # axes have been drawn, so read them beforehand.
+    offsets = np.concatenate([c.get_offsets() for c in collections[1:]])
+    endpoints = [[np.cos(6.0), np.sin(6.0)], [1.0, 0.0]]
+    assert np.allclose(np.sort(offsets, axis=0), np.sort(endpoints, axis=0))
+    fig.canvas.draw()
+
+
 @pytest.mark.skipplot
 def test_triplot_extruded():
     # The annulus is a periodic extrusion of an interval, so its inner and

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -183,8 +183,6 @@ def test_fn_plotter_extruded_mesh_multiple_layers():
 
 @pytest.mark.skipplot
 @pytest.mark.parametrize("family,degree", [("CG", 2), ("DG", 1)])
-@pytest.mark.xfail(reason="FunctionPlotter ignores the vertical node offset of "
-                          "the function space on extruded meshes")
 def test_fn_plotter_extruded_mesh_offsets(family, degree):
     # Only spaces whose nodes are numbered consecutively up a column have a
     # vertical offset of 1; CG2 has an offset of 2 and DQ1 an offset of 4.

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -432,8 +432,6 @@ def test_triplot_extruded_horizontal_boundaries():
 
 
 @pytest.mark.skipplot
-@pytest.mark.xfail(reason="triplot assumes that facets are simplices, so the "
-                          "quadrilateral facets of a hexahedron are mangled")
 def test_triplot_hex_mesh():
     mesh = UnitCubeMesh(2, 2, 2, hexahedral=True)
     fig = plt.figure()
@@ -456,7 +454,6 @@ def test_triplot_hex_mesh():
 
 
 @pytest.mark.skipplot
-@pytest.mark.xfail(reason="triplot pops the colours out of the caller's boundary_kw")
 def test_triplot_kwargs_not_mutated():
     mesh = UnitSquareMesh(4, 4)
     interior_kw = {'linewidths': 0.5}

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -393,7 +393,6 @@ def test_tripcolor_movie():
 
 
 @pytest.mark.skipplot
-@pytest.mark.xfail(reason="Plotting 1D manifolds embedded into 2D not implemented")
 def test_triplot_manifold_mesh():
     mesh = CircleManifoldMesh(16)
     fig, axes = plt.subplots()

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -402,7 +402,6 @@ def test_triplot_manifold_mesh():
 
 
 @pytest.mark.skipplot
-@pytest.mark.xfail(reason="Extruded plotting not implemented")
 def test_triplot_extruded():
     # The annulus is a periodic extrusion of an interval, so its inner and
     # outer boundaries are the markers of the base mesh on vertical facets.
@@ -415,7 +414,6 @@ def test_triplot_extruded():
 
 
 @pytest.mark.skipplot
-@pytest.mark.xfail(reason="Extruded plotting not implemented")
 def test_triplot_extruded_horizontal_boundaries():
     # Extruding a closed base mesh leaves the bottom and top of the columns as
     # the only boundaries of the domain.

--- a/tests/firedrake/output/test_plotting.py
+++ b/tests/firedrake/output/test_plotting.py
@@ -492,18 +492,3 @@ def test_triplot_hex_mesh():
     assert len(paths) == 24
     for path in paths:
         assert len(np.unique(path.vertices, axis=0)) == 4
-
-
-@pytest.mark.skipplot
-def test_triplot_kwargs_not_mutated():
-    mesh = UnitSquareMesh(4, 4)
-    interior_kw = {'linewidths': 0.5}
-    boundary_kw = {'linewidths': 2.0, 'colors': ['tab:blue', 'tab:orange',
-                                                 'tab:green', 'tab:red']}
-
-    fig, axes = plt.subplots()
-    triplot(mesh, axes=axes, interior_kw=interior_kw, boundary_kw=boundary_kw)
-
-    assert interior_kw == {'linewidths': 0.5}
-    assert boundary_kw == {'linewidths': 2.0, 'colors': ['tab:blue', 'tab:orange',
-                                                         'tab:green', 'tab:red']}


### PR DESCRIPTION
Fixes several plotting issues.

* We can plot extruded meshes.
* We can plot CircleManifoldMesh or an interval mesh lifted into 2D or 3D.
* Remove some warnings related to missing subdomains.
* Remove call to a deprecated matplotlib API for looking up color maps.
* General cleanup of dead code.

I think all of this is straightforward except for how to remove the warnings related to missing subdomains is in the last commit. Before, we were getting all unique markers found throughout the whole mesh and querying which markers were present in either the interior or exterior facets. This was there in order to draw the boundary facets with colors. But if you ask "give me all the interior facets have marker X" when there are no interior facets that have marker X, or any marker at all, you get this warning about an empty subdomain. The most common use case is that there are no marked interior facets at all, so I opted to silence the warning in that case. Fixing this in general is going to require some changes in mesh.py which should go in a separate PR.

The code is all vibed but I checked the outputs myself.