### PR TITLE
Constrain Cython to <3.3.0 due to petsc4py build error

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -135,6 +135,10 @@ runs:
         : # Empty the pip cache to ensure that everything is compiled from scratch
         pip cache purge
 
+        # Fix for petsc4py build to be removed after #5372 is resolved.
+        echo 'Cython<3.3.0' > constraints.txt
+        export PIP_CONSTRAINT=constraints.txt
+
         if [ ${{ inputs.base_ref }} = 'main' ]; then
           : # Install build dependencies
           pip install "$PETSC_DIR"/src/binding/petsc4py

--- a/docker/Dockerfile.vanilla
+++ b/docker/Dockerfile.vanilla
@@ -143,6 +143,10 @@ ENV CFLAGS="-O3 -mtune=generic" CPPFLAGS="-O3 -mtune=generic"
 #     The order these are installed is important, e.g. FIAT must be installed
 #     before UFL otherwise `pip install fiat` will reinstall pypi ufl.
 
+# Fix for petsc4py build to be removed after #5372 is resolved.
+RUN echo 'Cython<3.3.0' > /opt/constraints.txt
+ENV PIP_CONSTRAINT=/opt/constraints.txt
+
 RUN git clone --branch ${BRANCH} \
       https://github.com/firedrakeproject/firedrake.git /opt/firedrake \
     && pip cache purge || exit; \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -239,6 +239,12 @@ install Firedrake. To do this perform the following steps:
       so that it can be detected by mpi4py. See `here <https://mpi4py.readthedocs.io/en/stable/install.html#linux>`__
       for more information.
 
+#. Set ``PIP_CONSTRAINT`` to work around
+   `an issue with Cython <https://gitlab.com/petsc/petsc/-/work_items/1929>`__::
+
+      $ echo 'Cython<3.3.0' > constraints.txt
+      $ export PIP_CONSTRAINT=$PWD/constraints.txt
+
 #. Install Firedrake::
 
       $ pip install --no-binary h5py 'firedrake[check]'


### PR DESCRIPTION
See https://gitlab.com/petsc/petsc/-/work_items/1929 and https://gitlab.com/petsc/petsc/-/work_items/1929

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
