### PR TITLE
Cap islpy below 2026.2 on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dependencies = [
   "requests",
   "scipy",
   "sympy",
+  # TODO RELEASE
+  # islpy 2026.2 stops converting a BasicSet to a Set implicitly, which loopy
+  # 2025.2 relies on. Lift once loopy releases the fix.
+  "islpy<2026.2",
   "islpy>=2025.1.5; sys_platform == 'darwin'",
 ]
 classifiers = [


### PR DESCRIPTION
`islpy` 2026.2 removed the implicit conversion of a `BasicSet` to a `Set`. `loopy` 2025.2 — the newest release, and what `loopy>2024.1` resolves to — calls `BasicSet.make_disjoint()` in `count_insn_runs`, so every flop count in the test suite fails:

```
AttributeError: 'islpy._isl.BasicSet' object has no attribute 'make_disjoint'
```

loopy converts explicitly on main, but taking loopy from git is not an option yet: its `_AccessCheckMapper.map_subscript` asks for the dependencies of every shape axis without guarding `None`, and PyOP2 builds args with an unknown leading axis (`dat0` has `shape=(None, 2)` in `wrap_to_reference_coords`), so `firedrake-check` dies with `DependencyMapperWithReductionInames encountered invalid foreign object: None`.

So cap islpy at the last version that still converts. With islpy 2026.1 and loopy 2025.2, `tests/tsfc` and `tests/firedrake/regression/test_locate_cell.py` are green locally.

Lift the cap once loopy makes a release containing the explicit `to_set()`. #5378 does the same for `release`.

---
AI was used in preparing this contribution (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)