### PR TITLE
Cap islpy below 2026.2 on release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ dependencies = [
   "rtree>=1.2",
   "scipy",
   "sympy",
-  # TODO RELEASE
-  # islpy 2026.2 stops converting a BasicSet to a Set implicitly, which loopy
-  # 2025.2 relies on. Lift once loopy releases the fix.
   "islpy<2026.2",
   "islpy>=2025.1.5; sys_platform == 'darwin'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ dependencies = [
   "rtree>=1.2",
   "scipy",
   "sympy",
+  # TODO RELEASE
+  # islpy 2026.2 stops converting a BasicSet to a Set implicitly, which loopy
+  # 2025.2 relies on. Lift once loopy releases the fix.
+  "islpy<2026.2",
   "islpy>=2025.1.5; sys_platform == 'darwin'",
 ]
 classifiers = [


### PR DESCRIPTION
`islpy` 2026.2 removed the implicit conversion of a `BasicSet` to a `Set`. `loopy` 2025.2 — the newest release, and what `loopy>2024.1` resolves to — calls `BasicSet.make_disjoint()` in `count_insn_runs`, so every flop count in the test suite fails:

```
AttributeError: 'islpy._isl.BasicSet' object has no attribute 'make_disjoint'
```

islpy 2026.2.1 was published on 2026-08-22, after the last CI run on this branch, so `release` has not hit this yet — but the next run will, and so will anyone installing a released Firedrake today.

`main` takes loopy from git instead (#5377). That is not appropriate here, where every dependency is a released version, so cap islpy at the last one that still converts. With islpy 2026.1 and loopy 2025.2, `tests/tsfc` is 369 passed locally (run against `main`'s copy of those tests, which is the same loopy/islpy interaction).

Lift the cap once loopy makes a release containing the explicit `to_set()`.

---
AI was used in preparing this contribution (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)