### PR TITLE
Compile interpolation through the GEM optimisation pipeline

### DIFF
--- a/tsfc/driver.py
+++ b/tsfc/driver.py
@@ -14,7 +14,6 @@ from ufl.domain import extract_unique_domain, extract_domains
 
 import gem
 import gem.impero_utils as impero_utils
-from gem.unconcatenate import unconcatenate
 
 import finat
 from finat.element_factory import as_fiat_cell
@@ -25,6 +24,7 @@ from tsfc.modified_terminals import analyse_modified_terminal
 from tsfc.parameters import default_parameters, is_complex
 from tsfc.ufl_utils import apply_mapping, extract_firedrake_constants, simplify_abs
 import tsfc.kernel_interface.firedrake_loopy as firedrake_interface_loopy
+from tsfc.kernel_interface.common import get_index_ordering, pick_mode
 from tsfc.exceptions import MismatchingDomainError
 
 
@@ -345,26 +345,23 @@ def compile_expression_dual_evaluation(expression, ufl_element, *,
         coordinate_mapping = fem.CoordinateMapping(mt, ctx)
     else:
         coordinate_mapping = None
-    evaluation, basis_indices = to_element.dual_evaluation(fn, coordinate_mapping)
+    evaluation, point_indices, basis_indices = to_element.dual_evaluation(fn, coordinate_mapping)
+    quadrature_multiindex = tuple(point_indices)
 
     # Compute the action against the dual argument
     if isinstance(dual_arg, ufl.Cofunction):
         gem_dual = builder.coefficient_map[dual_arg]
         if complex_mode:
             evaluation = gem.MathFunction('conj', evaluation)
-        evaluation = gem.IndexSum(evaluation * gem_dual[basis_indices], basis_indices)
+        # The dual argument contracts over the nodes, so the basis indices are
+        # reduction indices like the points, not indices of the return value.
+        evaluation = evaluation * gem_dual[basis_indices]
+        quadrature_multiindex += tuple(basis_indices)
         basis_indices = ()
     else:
         argument_multiindices[dual_arg.number()] = basis_indices
 
     argument_multiindices = dict(sorted(argument_multiindices.items()))
-
-    # Unroll
-    max_extent = parameters["unroll_indexsum"]
-    if max_extent:
-        def predicate(index):
-            return index.extent <= max_extent
-        evaluation, = gem.optimise.unroll_indexsum([evaluation], predicate=predicate)
 
     # Build kernel body
     return_indices = tuple(chain.from_iterable(argument_multiindices.values()))
@@ -373,14 +370,20 @@ def compile_expression_dual_evaluation(expression, ufl_element, *,
     return_expr = gem.Indexed(gem.reshape(return_var, return_shape), return_indices)
     return_expr, = gem.optimise.remove_componenttensors([return_expr])
 
-    # TODO: one should apply some GEM optimisations as in assembly,
-    # but we don't for now.
-    evaluation, = impero_utils.preprocess_gem([evaluation])
-    pairs = unconcatenate([(return_expr, evaluation)])
-    impero_c = impero_utils.compile_gem(pairs, return_indices)
+    # Contract over the points with the same GEM optimisations as in assembly.
+    mode = pick_mode(parameters["mode"])
+    reps = mode.Integrals([evaluation], quadrature_multiindex,
+                          tuple(argument_multiindices.values()), parameters)
+    assignments = list(mode.flatten([(return_expr, reps)], kernel_cfg["index_cache"]))
+    return_variables, expressions = zip(*assignments)
+    # Argument factorisation does not cancel every Delta here, so lower them.
+    finalise_options = dict(mode.finalise_options, replace_delta=True)
+    expressions = impero_utils.preprocess_gem(expressions, **finalise_options)
+    index_ordering = get_index_ordering(quadrature_multiindex, return_variables)
+    impero_c = impero_utils.compile_gem(list(zip(return_variables, expressions)), index_ordering)
     index_names = {idx: f"p{i}" for (i, idx) in enumerate(basis_indices)}
     # Handle kernel interface requirements
-    builder.register_requirements([evaluation])
+    builder.register_requirements(expressions)
     builder.set_output(return_var)
     # Build kernel tuple
     return builder.construct_kernel(impero_c, index_names, needs_external_coords, parameters["add_petsc_events"], name=name)


### PR DESCRIPTION
# Description

`assemble(interpolate)` now contracts over the points with the same GEM optimisations as in `assemble(Form)`.

Depends on https://github.com/firedrakeproject/fiat/pull/288

## Benchmark

Interpolation into CG on a 16x16x16 extruded hex mesh, minimum of 15 timed
batches. `f` scalar, `u` vector, `A` tensor, all CG of the given degree.

| case | flops main | flops PR | ratio | time main | time PR | ratio |
|---|--:|--:|--:|--:|--:|--:|
| `f*f*f -> S` (CG1) | 96 | 96 | 1.00x | 0.85 ms | 0.85 ms | 1.00x |
| `dot(u,u)*u -> V` (CG1) | 520 | 304 | 1.71x | 1.49 ms | 1.43 ms | 1.04x |
| `inner(A,A) -> S` (CG1) | 792 | 792 | 1.00x | 1.48 ms | 1.52 ms | 0.97x |
| `dot(A,A) -> T` (CG1) | 1728 | 1080 | 1.60x | 2.18 ms | 2.04 ms | 1.07x |
| `dot(A,dot(A,u)) -> V` (CG1) | 1776 | 1128 | 1.57x | 2.15 ms | 2.08 ms | 1.03x |
| `dot(A,dot(A,A)) -> T` (CG1) | 2736 | 1440 | 1.90x | 2.72 ms | 2.47 ms | 1.10x |
| `f*f*f -> S` (CG2) | 486 | 486 | 1.00x | 1.13 ms | 1.16 ms | 0.97x |
| `dot(u,u)*u -> V` (CG2) | 2727 | 1512 | 1.80x | 2.76 ms | 2.43 ms | 1.14x |
| `inner(A,A) -> S` (CG2) | 4131 | 4131 | 1.00x | 2.94 ms | 2.93 ms | 1.01x |
| `dot(A,A) -> T` (CG2) | 8748 | 5103 | 1.71x | 6.83 ms | 6.63 ms | 1.03x |
| `dot(A,dot(A,u)) -> V` (CG2) | 9396 | 5751 | 1.63x | 6.35 ms | 5.61 ms | 1.13x |
| `dot(A,dot(A,A)) -> T` (CG2) | 13608 | 6318 | 2.15x | 9.42 ms | 7.29 ms | 1.29x |
| `f*f*f -> S` (CG3) | 1728 | 1728 | 1.00x | 2.65 ms | 2.80 ms | 0.95x |
| `dot(u,u)*u -> V` (CG3) | 9920 | 5312 | 1.87x | 11.25 ms | 7.55 ms | 1.49x |
| `inner(A,A) -> S` (CG3) | 14976 | 14976 | 1.00x | 6.45 ms | 6.51 ms | 0.99x |
| `dot(A,A) -> T` (CG3) | 31104 | 17280 | 1.80x | 27.49 ms | 15.93 ms | 1.73x |
| `dot(A,dot(A,u)) -> V` (CG3) | 34368 | 20544 | 1.67x | 23.89 ms | 14.43 ms | 1.66x |
| `dot(A,dot(A,A)) -> T` (CG3) | 47808 | 20160 | 2.37x | 33.72 ms | 16.91 ms | 1.99x |

Speed up comes from Delta cancellation that was missing for tensor-valued expressions.

`f*f*f` and `inner(A,A)` have an empty value shape, so this change cannot
affect them: they are the control, and come out at 1.00x flops and
0.95-1.01x time. Every case with a value shape improves.

Temporaries rise in two cases (81 to 120 at CG2 `dot(A,A)`, 44 to 65 at CG1
`dot(A,A)`), and both are still faster, so the extra register pressure does
not cost anything measurable.

Generated with Claude Code

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->

