### PR TITLE
Use system HDF5 again for macOS

### DIFF
--- a/scripts/firedrake-configure
+++ b/scripts/firedrake-configure
@@ -845,6 +845,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "cmake",
             "fftw",
             "hwloc",
+            "hdf5-mpi",
             "metis",
             "openblas",
             "openmpi",
@@ -855,13 +856,13 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         extra_petsc_configure_options=[
             # External packages
             "--with-fftw-dir=/opt/homebrew",
+            "--with-hdf5-dir=/opt/homebrew",
             "--with-hwloc-dir=/opt/homebrew",
             "--with-metis-dir=/opt/homebrew",
             "--with-scalapack-dir=/opt/homebrew",
             "--with-suitesparse-dir=/opt/homebrew",
             "--with-zlib-dir=/opt/homebrew",
             "--download-bison",
-            "--download-hdf5",
             "--download-hypre",
             "--download-mumps",
             "--download-netcdf",
@@ -876,10 +877,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={
-            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
-            "CC": "mpicc",
-        },
+        extra_env_vars={"HDF5_DIR": "/opt/homebrew"},
     ),
 
     (OS.MACOS_ARM64, ScalarType.COMPLEX, IntType.INT32, GPUPlatform.NO_GPU): Arch(
@@ -899,6 +897,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
             "cmake",
             "fftw",
             "hwloc",
+            "hdf5-mpi",
             "metis",
             "openblas",
             "openmpi",
@@ -911,13 +910,13 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
 
             # External packages
             "--with-fftw-dir=/opt/homebrew",
+            "--with-hdf5-dir=/opt/homebrew",
             "--with-hwloc-dir=/opt/homebrew",
             "--with-metis-dir=/opt/homebrew",
             "--with-scalapack-dir=/opt/homebrew",
             "--with-suitesparse-dir=/opt/homebrew",
             "--with-zlib-dir=/opt/homebrew",
             "--download-bison",
-            "--download-hdf5",
             "--download-mumps",
             "--download-netcdf",
             "--download-pnetcdf",
@@ -931,10 +930,7 @@ OFFICIAL_ARCHS: Mapping[ArchKey, Arch] = {
         coptflags=["-O3", "-march=native", "-mtune=native"],
         cxxoptflags=["-O3", "-march=native", "-mtune=native"],
         foptflags=["-O3"],
-        extra_env_vars={
-            "HDF5_DIR": "$PETSC_DIR/$PETSC_ARCH",
-            "CC": "mpicc",
-        },
+        extra_env_vars={"HDF5_DIR": "/opt/homebrew"},
     ),
 
     # Sane default configurations for unknown platforms


### PR DESCRIPTION
This reverts commit a7c1e93705ad9e1e393982dd71c9c34ff7295143.

This is now possible due to upstream PETSc fixes (main only).




<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
