### PR TITLE
check periodicity from unique mesh in ASMExtrudedStarPC

### DIFF
--- a/firedrake/preconditioners/asm.py
+++ b/firedrake/preconditioners/asm.py
@@ -440,7 +440,7 @@ class ASMExtrudedStarPC(ASMStarPC):
         nlayers = mesh_unique.layers
         if not mesh_unique.cell_set._extruded:
             return super(ASMExtrudedStarPC, self).get_patches(V)
-        periodic = mesh.extruded_periodic
+        periodic = mesh_unique.extruded_periodic
 
         # Obtain the topological entities to use to construct the stars
         opts = PETSc.Options(self.prefix)


### PR DESCRIPTION
For `MixedFunctionSpace` the `mesh` is a `MeshSequenceGeometry`, but this doesn't have the `extruded_periodic` attribute.
This attribute is held on `mesh.unique()` instead.