### PR TITLE
DEBUG: diagnose the stochastic appctx loss in test_baseform_coarsening

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -138,9 +138,10 @@ jobs:
           : # Use pytest-xdist here so we can have a single collated output (not possible
           : # for parallel tests)
           firedrake-run-split-tests 1 1 -n 8 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
-          firedrake-run-split-tests 2 4 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
-          firedrake-run-split-tests 3 2 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
-          firedrake-run-split-tests 4 2 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
+          : # DEBUG: parallel runs are off, this branch chases a serial-only flake
+          : # firedrake-run-split-tests 2 4 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
+          : # firedrake-run-split-tests 3 2 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
+          : # firedrake-run-split-tests 4 2 "$EXTRA_PYTEST_ARGS" --timeout 30 firedrake-repo/tests/pyop2
         timeout-minutes: 10
 
 
@@ -154,49 +155,49 @@ jobs:
         timeout-minutes: 90
 
       - name: Run tests (nprocs = 2)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 2 4 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 3)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 3 2 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 60
 
       - name: Run tests (nprocs = 4)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 4 2 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 5)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 5 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 6)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 6 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 7)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 7 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake
         timeout-minutes: 15
 
       - name: Run tests (nprocs = 8)
-        if: success() || steps.install.conclusion == 'success'
+        if: false  # DEBUG: parallel runs are off, this branch chases a serial-only flake
         run: |
           . venv/bin/activate
           firedrake-run-split-tests 8 1 "$EXTRA_PYTEST_ARGS" firedrake-repo/tests/firedrake

--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -37,6 +37,8 @@ fieldsplit preconditioning, without having to set everything up in
 advance.
 """
 
+import collections
+import warnings
 import weakref
 import numpy
 from functools import partial
@@ -103,6 +105,49 @@ def set_function_space(dm, V):
     dm.setAttr("__fs_info__", info)
 
 
+# Bounded record of every stack operation below, oldest first. A DM's stacks
+# are touched a handful of times per solve. Recording them costs nothing, and
+# lets a broken stack report how it got that way.
+_attr_trace = collections.deque(maxlen=512)
+
+
+def _record(event, attr, dm, obj):
+    """Note one operation on a DM attribute stack.
+
+    Parameters
+    ----------
+    event : str
+        What happened, either ``"push"`` or ``"pop"``.
+    attr : str
+        Name of the DM attribute holding the stack.
+    dm : PETSc.DM
+        The DM the stack lives on.
+    obj : object
+        The object pushed or popped.
+
+    Returns
+    -------
+    None
+    """
+    stack = dm.getAttr(attr)
+    _attr_trace.append((event, attr, dm.handle, type(obj).__name__, id(obj),
+                        len(stack) if stack else 0))
+
+
+def format_attr_trace():
+    """Format the recorded history of DM attribute stack operations.
+
+    Returns
+    -------
+    str
+        One line per recorded operation, oldest first.
+    """
+    return "\n".join(
+        f"  {event:4s} {attr:18s} dm={handle:#x} {name}(id={ident:#x}) -> depth {depth}"
+        for event, attr, handle, name, ident, depth in _attr_trace
+    )
+
+
 # Attribute management on DMs. Since they are reused in multiple
 # places, use a stack.
 def push_attr(attr, dm, obj):
@@ -111,17 +156,21 @@ def push_attr(attr, dm, obj):
         stack = []
         dm.setAttr(attr, stack)
     stack.append(obj)
+    _record("push", attr, dm, obj)
 
 
 def pop_attr(attr, dm, match=None):
     stack = dm.getAttr(attr)
     if not stack:
+        _record("pop", attr, dm, None)
         return None
     obj = stack.pop()
     if match is not None and obj != match:
         stack.append(obj)
+        _record("pop", attr, dm, None)
         return None
     else:
+        _record("pop", attr, dm, obj)
         return obj
 
 
@@ -247,9 +296,21 @@ class add_hooks(object):
     def __exit__(self, typ, value, traceback):
         hooks = pop_attr("__setup_hooks__", self.dm)
         if self.first_time:
-            assert hooks is not None
+            expected = "the hooks pushed on entry"
+            broken = hooks is None
         else:
-            assert hooks == self.obj.setup_hooks
+            expected = self.obj.setup_hooks
+            broken = hooks != expected
+        if broken:
+            message = (f"Setup hooks for {self.obj} are gone from DM "
+                       f"{self.dm.handle:#x}: expected {expected}, found {hooks}.\n"
+                       f"DM attribute stack history:\n{format_attr_trace()}")
+            if typ is None:
+                raise RuntimeError(message)
+            # An exception is already on its way out, and it is the one worth
+            # seeing, so report the broken stack without replacing it.
+            warnings.warn(message, RuntimeWarning)
+            return
         hooks.teardown()
 
 
@@ -271,7 +332,6 @@ def get_transfer_manager(dm):
     appctx = get_appctx(dm)
     if appctx is None:
         # We're not in a solve, so all we can do is make a new one (not cached)
-        import warnings
         warnings.warn("Creating new TransferManager to transfer data to coarse grids. "
                       "This might be slow (you probably want to save it on an appctx)", RuntimeWarning)
         transfer = firedrake.TransferManager()

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -135,6 +135,34 @@ Reason:
    %s""" % (snes.getIterationNumber(), msg))
 
 
+def _callback_appctx(solver):
+    """Return the application context PETSc should call back into.
+
+    Parameters
+    ----------
+    solver : PETSc.SNES or PETSc.KSP
+        The solver driving the callback.
+
+    Returns
+    -------
+    _SNESContext
+        The application context attached to the solver's DM.
+
+    Raises
+    ------
+    RuntimeError
+        If the solver's DM carries no application context.
+    """
+    dm = solver.getDM()
+    ctx = dmhooks.get_appctx(dm)
+    if ctx is None:
+        raise RuntimeError(
+            f"No application context on DM {dm.handle:#x} of "
+            f"{type(solver).__name__} '{solver.getOptionsPrefix()}'.\n"
+            f"DM attribute stack history:\n{dmhooks.format_attr_trace()}")
+    return ctx
+
+
 class _SNESContext(object):
     """Context holding information for SNES callbacks.
 
@@ -509,8 +537,7 @@ class _SNESContext(object):
         :arg snes: a PETSc SNES object
         :arg X: the current guess (a Vec)
         """
-        dm = snes.getDM()
-        ctx = dmhooks.get_appctx(dm)
+        ctx = _callback_appctx(snes)
         # X may not be the same vector as the vec behind self._x, so
         # copy guess in from X.
         with ctx._x.dat.vec_wo as v:
@@ -531,8 +558,7 @@ class _SNESContext(object):
         :arg X: the current guess (a Vec)
         :arg F: the residual at X (a Vec)
         """
-        dm = snes.getDM()
-        ctx = dmhooks.get_appctx(dm)
+        ctx = _callback_appctx(snes)
         # X may not be the same vector as the vec behind self._x, so
         # copy guess in from X.
         with ctx._x.dat.vec_wo as v:
@@ -566,8 +592,7 @@ class _SNESContext(object):
         :arg J: the Jacobian (a Mat)
         :arg P: the preconditioner matrix (a Mat)
         """
-        dm = snes.getDM()
-        ctx = dmhooks.get_appctx(dm)
+        ctx = _callback_appctx(snes)
         problem = ctx._problem
 
         assert J.handle == ctx._jac.petscmat.handle
@@ -600,8 +625,7 @@ class _SNESContext(object):
 
     @staticmethod
     def create_operators(ksp):
-        dm = ksp.getDM()
-        ctx = dmhooks.get_appctx(dm)
+        ctx = _callback_appctx(ksp)
         A = ctx._jac.petscmat
         if ctx.Jp is None:
             return A
@@ -617,8 +641,7 @@ class _SNESContext(object):
         :arg J: the Jacobian (a Mat)
         :arg P: the preconditioner matrix (a Mat)
         """
-        dm = ksp.getDM()
-        ctx = dmhooks.get_appctx(dm)
+        ctx = _callback_appctx(ksp)
         problem = ctx._problem
 
         if problem._constant_jacobian and ctx._jacobian_assembled:

--- a/tests/firedrake/regression/test_appctx_cleanup.py
+++ b/tests/firedrake/regression/test_appctx_cleanup.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 from firedrake import *
 
 
@@ -54,3 +55,32 @@ def test_appctx_cleanup():
         V = V._coarse
 
     assert numpy.allclose(uh.dat.data_ro, 1.0)
+
+
+class Solver(object):
+    """Stand-in for the solver object that :class:`~.add_hooks` saves hooks on."""
+
+
+def test_broken_hook_stack_does_not_mask_error():
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+    dm = V.dm
+
+    # An empty hook stack under a live context manager is what a solve looks
+    # like when the appctx goes missing. The error raised inside the block is
+    # the one worth reporting, not the state of the stack.
+    with pytest.warns(RuntimeWarning, match="Setup hooks"):
+        with pytest.raises(ZeroDivisionError):
+            with dmhooks.add_hooks(dm, Solver(), appctx=None):
+                dmhooks.pop_attr("__setup_hooks__", dm)
+                raise ZeroDivisionError
+
+
+def test_broken_hook_stack_is_reported():
+    mesh = UnitSquareMesh(1, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+    dm = V.dm
+
+    with pytest.raises(RuntimeError, match="Setup hooks"):
+        with dmhooks.add_hooks(dm, Solver(), appctx=None):
+            dmhooks.pop_attr("__setup_hooks__", dm)


### PR DESCRIPTION
# Description
AI-assisted (Claude Code)

**Draft, for debugging.** This branch exists to make one stochastic CI failure diagnosable. The
parallel test steps are switched off while it runs, so it must not be merged as it stands.

## The failure

`tests/firedrake/multigrid/test_poisson_gmg.py::test_baseform_coarsening[scalar-mg]` fails
occasionally at `nprocs = 1` ([one instance][run]). CI reports it as a bare `AssertionError` at
`dmhooks.py:250`, which is not where anything went wrong.

The real error is in `solving_utils.form_jacobian`:

```
    ctx = dmhooks.get_appctx(dm)
>   problem = ctx._problem
E   AttributeError: 'NoneType' object has no attribute '_problem'
```

`get_appctx(snes.getDM())` returned `None`, that surfaced as `PETSc.Error(101)` out of
`SNESSolve`, and while `ExitStack` unwound it, `add_hooks.__exit__` asserted on a hook stack that
was empty as well. The assertion is the failure pytest reports, and it discards the traceback of
the error that caused it.

The window is narrow. In `SNESSolve_KSPONLY`, `SNESComputeFunction` is line 27 and
`SNESComputeJacobian` is line 41; `form_function` performs the identical `get_appctx` lookup and
succeeded. Between the two, PETSc runs `SNESGetNormSchedule`, a monitor block that is skipped
(`snes->numbermonitors` is 0 here) and `PetscTryTypeMethod(snes, update)`, for which Firedrake
registers nothing. So the application context went missing from a live DM during
`ctx._assemble_residual`, and by unwind time the setup hooks had gone with it.

I could not reproduce this, in isolation or otherwise. Ruled out so far: petsc4py holds `setAttr`
data on the C object, where it survives collection, temporary-wrapper collection and reference
cycles routed through the shared dict; the DM cannot be silently rebuilt, since `DataSet.dm` is a
`cached_property` on an `ObjectCached` `DataSet` held in `mesh._shared_data_cache`, a plain
`defaultdict(dict)` with no eviction; and the push/pop of `__appctx__` balances exactly over all
four right-hand sides. The scalar-mg case survived 89 iterations of all eight parametrizations in
one process with `gc.set_threshold(1, 1, 1)` and a forced `gc.collect()` at the end of every
`form_function`. CI runs Python 3.14.4 against 3.12.13 locally, which is the obvious remaining
difference.

## What's in it

- **`dmhooks.add_hooks.__exit__` no longer masks an in-flight exception.** A broken hook stack now
  raises a `RuntimeError` naming the DM and the solver when nothing else is propagating, and warns
  instead of raising when something is, so the original error reaches the report intact. This is
  the change that makes the next occurrence readable.
- **`solving_utils._callback_appctx`** replaces the five open-coded `get_appctx` lookups in the
  PETSc callbacks. A missing context is now a `RuntimeError` naming the DM and the options prefix,
  rather than an `AttributeError` on `None` several lines later.
- **A bounded trace of DM attribute stack operations** in `dmhooks`, printed by both of the above.
  A DM's stacks are touched a handful of times per solve, so recording the last 512 pushes and
  pops costs nothing and shows which DM lost what, and when.
- **Parallel test steps disabled** in the Linux default job of `core.yml` (`nprocs` 2 to 8, and the
  parallel `tests/pyop2` runs). The failure is serial, so the parallel runs are pure cost while
  this branch is being re-run. The `linux_extra` jobs are untouched; they only run behind a label.

## What to do with it

Re-run the `nprocs = 1` step until it trips. The report should then carry the `RuntimeError` from
`_callback_appctx` together with the stack history, which says whether the appctx was popped, by
what, and off which DM.

## Notes for review

Two related weaknesses turned up while reading this code. Neither is addressed here, and neither
explains the failure, but both let a missing application context pass unnoticed:

- `mg/ufl_utils.py:447` pushes an appctx onto the coarse DM and registers the matching teardown
  only `if parentdm.getAttr("__setup_hooks__")`. When that is falsy the push leaks, and the
  `if get_appctx(newdm) is None` guard then makes later solves reuse a stale context.
- `dmhooks.get_transfer_manager` treats a missing appctx as "not in a solve" and builds a fresh
  `TransferManager`. `test_baseform_coarsening[mixed-*]` trips this today: `reconstruct_function`
  calls `get_transfer_manager(V.dm)` for an `IndexedProxyFunctionSpace` coming off a
  `DirichletBC`, and that sub-DM never receives an appctx. It warns and carries on; the same
  condition in `form_jacobian` is fatal.

[run]: https://github.com/firedrakeproject/firedrake/actions/runs/32771650773/job/97573124985?pr=5381#step:8:15615
