### PR TITLE
Fix docs makefile to automatically regenerate authors list

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -103,7 +103,7 @@ copy_notebooks:
 source/element_list.csv: source/element_list.py
 	cd source; python3 element_list.py
 
-source/team.rst: source/team2.py
+source/team.rst: source/team2.py source/team.ini
 	cd source; python3 team2.py; mv AUTHORS.rst ../..
 
 source/apt_deps.txt:


### PR DESCRIPTION
Currently, modifying `team.ini` then rebuilding the docs - by running `make html` in the docs directory locally - doesn't update the authors list `AUTHORS.rst` unless `team.rst` is missing or older than the `team2.py` script.

Fix: modify the makefile recipe so that any changes to `team.ini` are picked up by the rebuild.