### PR TITLE
Adding dtype to pyop3.expr.Expression

### DIFF
--- a/pyop3/expr/base.py
+++ b/pyop3/expr/base.py
@@ -789,6 +789,10 @@ def _(expr):
 def _get_dtype(expr: Any) -> np.dtype:
     return None
 
+@_get_dtypes.register(np.number)
+def _(expr) -> np.dtype: 
+    raise NotImplementedError(f"Not implemented dtype for: {type(expr)}")
+
 @_get_dtype.register(Expression)
 def _(expr: Expression) -> np.dtype:
     return expr.dtype 

--- a/pyop3/expr/base.py
+++ b/pyop3/expr/base.py
@@ -789,7 +789,7 @@ def _(expr):
 def _get_dtype(expr: Any) -> np.dtype:
     return None
 
-@_get_dtypes.register(np.number)
+@_get_dtype.register(np.number)
 def _(expr) -> np.dtype: 
     raise NotImplementedError(f"Not implemented dtype for: {type(expr)}")
 

--- a/pyop3/expr/base.py
+++ b/pyop3/expr/base.py
@@ -29,6 +29,11 @@ class Expression(Node, abc.ABC):
 
     @property
     @abc.abstractmethod
+    def dtype(self) -> np.dtype:
+        pass
+
+    @property
+    @abc.abstractmethod
     def _full_str(self) -> str:
         pass
 
@@ -218,6 +223,11 @@ class UnaryOperator(Operator, metaclass=abc.ABCMeta):
     child_attrs = ("a",)
 
     @property
+    def dtype(self) -> str:
+        a_dtype = _get_dtype(self.a)
+        return a_dtype
+
+    @property
     def _full_str(self) -> str:
         return f"{self.symbol}{as_str(self.a)}"
 
@@ -295,6 +305,13 @@ class BinaryOperator(Operator, metaclass=abc.ABCMeta):
         a, b = operands
         return self.record_new(a=a, b=b)
 
+    @property
+    def dtype(self) -> np.dtype:
+        a_dtype = _get_dtype(self.a)
+        b_dtype = _get_dtype(self.b)
+        
+        return np.result_type(a_dtype, b_dtype)
+    
     # }}}
 
     # {{{ abstract methods
@@ -504,6 +521,14 @@ class TernaryOperator(Operator, metaclass=abc.ABCMeta):
         a, b, c = operands
         return self.record_new(a=a, b=b, c=c)
 
+    @property
+    def dtype(self) -> np.dtype:
+        a_dtype = _get_dtype(self.a)
+        b_dtype = _get_dtype(self.b)
+        c_dtype = _get_dtype(self.c)
+        
+        return np.result_type(a_dtype, b_dtype, c_dtype)
+
     # }}}
 
 
@@ -575,6 +600,9 @@ class NameVar(TerminalExpression):
 
     name: Hashable
 
+    def dtype(self) -> np.dtype:
+        return TypeError
+
     def _full_str(self) -> str:
         return f"{utils.pretty_type(self)}('{self.name}')"
 
@@ -631,6 +659,10 @@ class AxisVar(TerminalExpression):
         raise TypeError("not sure that this makes sense")
 
     @property
+    def dtype(self) -> np.dtype:
+        raise TypeError("not sure that this makes sense")
+
+    @property
     def _full_str(self) -> str:
         return f"i_{{{self.axis.label}}}"
 
@@ -662,6 +694,10 @@ class NaN(TerminalExpression):
 
     @property
     def local_min(self) -> NoReturn:
+        raise TypeError
+
+    @property
+    def dtype(self) -> NoReturn:
         raise TypeError
 
     _full_str = "NaN"
@@ -717,6 +753,11 @@ class LoopIndexVar(TerminalExpression):
         raise TypeError("not sure that this makes sense")
 
     @property
+    def dtype(self) -> np.dtype:
+        """ Returns int32 for indexing variable """
+        return np.dtype(np.int32)
+
+    @property
     def _full_str(self) -> str:
         return f"L_{{{self.loop_index.id}, {self.axis.label}}}"
 
@@ -745,6 +786,21 @@ def _(expr):
 def _(expr):
     return str(expr)
 
+@functools.singledispatch
+def _get_dtype(expr: Any) -> np.dtype:
+    return None
+
+@_get_dtype.register(Expression)
+def _(expr: Expression) -> np.dtype:
+    return expr.dtype 
+
+@_get_dtype.register(numbers.Number)
+def _(expr: numbers.Number) -> np.dtype:
+    # NOTE: Assumptions made about numerals here, i.e. float == float64, int == int32 
+    # However, type promotion/resolution happens on higher-level .dtype property. 
+    is_float = isinstance(expr, float) 
+    dtype = "float64" if is_float else "int32"
+    return np.dtype(dtype)
 
 def get_loop_tree(expr) -> tuple[AxisTree, Mapping[LoopIndexVar, AxisVar]]:
     from pyop3.expr.visitors import collect_loop_index_vars

--- a/pyop3/expr/base.py
+++ b/pyop3/expr/base.py
@@ -14,6 +14,7 @@ import pyop3.record
 from pyop3 import utils
 from pyop3.axis_tree import UNIT_AXIS_TREE, AxisTree
 from pyop3.node import Node, Terminal
+from pyop3.dtypes import RealType, IntType
 
 class Expression(Node, abc.ABC):
 
@@ -28,9 +29,8 @@ class Expression(Node, abc.ABC):
         raise NotImplementedError
 
     @property
-    @abc.abstractmethod
-    def dtype(self) -> np.dtype:
-        pass
+    def dtype(self):
+        raise NotImplementedError(f"dtype not implemented for {utils.pretty_type(self)}")
 
     @property
     @abc.abstractmethod
@@ -601,7 +601,7 @@ class NameVar(TerminalExpression):
     name: Hashable
 
     def dtype(self) -> np.dtype:
-        return TypeError
+        raise TypeError("dtype of NameVars cannot be determined") 
 
     def _full_str(self) -> str:
         return f"{utils.pretty_type(self)}('{self.name}')"
@@ -660,7 +660,7 @@ class AxisVar(TerminalExpression):
 
     @property
     def dtype(self) -> np.dtype:
-        raise TypeError("not sure that this makes sense")
+        return IntType
 
     @property
     def _full_str(self) -> str:
@@ -754,8 +754,7 @@ class LoopIndexVar(TerminalExpression):
 
     @property
     def dtype(self) -> np.dtype:
-        """ Returns int32 for indexing variable """
-        return np.dtype(np.int32)
+        return IntType
 
     @property
     def _full_str(self) -> str:
@@ -794,13 +793,15 @@ def _get_dtype(expr: Any) -> np.dtype:
 def _(expr: Expression) -> np.dtype:
     return expr.dtype 
 
-@_get_dtype.register(numbers.Number)
-def _(expr: numbers.Number) -> np.dtype:
-    # NOTE: Assumptions made about numerals here, i.e. float == float64, int == int32 
-    # However, type promotion/resolution happens on higher-level .dtype property. 
-    is_float = isinstance(expr, float) 
-    dtype = "float64" if is_float else "int32"
-    return np.dtype(dtype)
+@_get_dtype.register(numbers.Real)
+@_get_dtype.register(np.floating)
+def _(expr) -> np.dtype:
+    return RealType
+
+@_get_dtype.register(numbers.Integral)
+@_get_dtype.register(np.integer)
+def _(expr) -> np.dtype:
+    return IntType
 
 def get_loop_tree(expr) -> tuple[AxisTree, Mapping[LoopIndexVar, AxisVar]]:
     from pyop3.expr.visitors import collect_loop_index_vars

--- a/pyop3/expr/opaque.py
+++ b/pyop3/expr/opaque.py
@@ -56,11 +56,6 @@ class OpaqueTerminal(NamedTerminalExpression):
     # {{{ interface impls
 
     @property
-    def dtype(self) -> np.dtype:
-        # NOTE: Seems anti-pattern to provide dtype for object that we know nothing about 
-        raise TypeError("No dtype information for opaque object")
-
-    @property
     def _full_str(self) -> str:
         return str(self)
 

--- a/pyop3/expr/opaque.py
+++ b/pyop3/expr/opaque.py
@@ -56,6 +56,11 @@ class OpaqueTerminal(NamedTerminalExpression):
     # {{{ interface impls
 
     @property
+    def dtype(self) -> np.dtype:
+        # NOTE: Seems anti-pattern to provide dtype for object that we know nothing about 
+        raise TypeError("No dtype information for opaque object")
+
+    @property
     def _full_str(self) -> str:
         return str(self)
 


### PR DESCRIPTION
# Description 

The `dtype` property is being added to pyop3.expr.Expression for later work with MLIR code generation. 
It should aid with type inference.

Key assumptions/points:
- Type resolution for binary and ternary operators use numpy.result_type
    - This handles type promotion, and alike, as per rules here: [numpy docs](https://numpy.org/devdocs/reference/arrays.promotion.html#arrays-promotion)
    - An assumption for numerals is made such that:
        - integers are int32
        - float are float64
    - Another assumption is that LoopIndexVar dtype resolves to int32, as opposed to int64.