### PR TITLE
Pin the hypre cycle and assert on the condition number

### DIFF
--- a/tests/firedrake/regression/test_hypre_ads.py
+++ b/tests/firedrake/regression/test_hypre_ads.py
@@ -34,15 +34,26 @@ def test_homogeneous_field(V, mat_type, interface):
         'mat_type': mat_type,
         'pmat_type': 'aij',
         'ksp_type': 'cg',
-        'ksp_max_it': '30',
+        'ksp_max_it': '20',
         'ksp_rtol': '2e-15',
+        'ksp_view_singularvalues': None,
         'pc_type': 'python',
         'pc_python_type': 'firedrake.HypreADS',
+        # Pin the cycle: the hypre default varies between builds, and the one
+        # selected here takes 21 iterations, which the cap above rejects.
+        'hypre_ads_pc_hypre_ads_cycle_type': 1,
     }
 
     u = Function(V)
-    solve(a == L, u, bc, solver_parameters=params)
+    problem = LinearVariationalProblem(a, L, u, bcs=bc)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
+    solver.solve()
     assert (errornorm(u_exact, u, 'L2') < 1e-10)
+
+    # ADS leaves the operator nearly perfectly conditioned: 1.67 on the
+    # simplex and 1.11 on the hexahedron, against 1.2e4 and 4.1e3 without it.
+    ew = solver.snes.ksp.computeEigenvalues().real
+    assert max(abs(ew)) / min(abs(ew)) < 2
 
 
 @pytest.mark.skiphypre

--- a/tests/firedrake/regression/test_hypre_ads.py
+++ b/tests/firedrake/regression/test_hypre_ads.py
@@ -105,6 +105,11 @@ def test_hypre_ads_fieldsplit():
         "fieldsplit_ksp_type": "preonly",
         "fieldsplit_pc_type": "python",
         "fieldsplit_pc_python_type": "firedrake.HypreADS",
+        # Pin the ADS cycle.  Left to the hypre default, the cycle chosen
+        # varies between builds, and the one selected here leaves the
+        # condition number at 1.8 -- close enough to the bound below that
+        # rounding decides whether the test passes.
+        "fieldsplit_hypre_ads_pc_hypre_ads_cycle_type": 1,
     }
     prob = LinearVariationalProblem(a, L, sol)
     solver = LinearVariationalSolver(prob, solver_parameters=params)
@@ -113,4 +118,5 @@ def test_hypre_ads_fieldsplit():
     # Check the condition number
     ew = solver.snes.ksp.computeEigenvalues().real
     condition_number = max(abs(ew)) / min(abs(ew))
-    assert condition_number < 2  # current value is 1.3 and without preconditioner > 66
+    # 1.22 with this cycle, against 4.8e3 unpreconditioned.
+    assert condition_number < 2

--- a/tests/firedrake/regression/test_hypre_ams.py
+++ b/tests/firedrake/regression/test_hypre_ams.py
@@ -39,25 +39,37 @@ def test_homogeneous_field(V, mat_type, interface):
         'mat_type': mat_type,
         'pmat_type': 'aij',
         'ksp_type': 'cg',
-        'ksp_max_it': '30',
+        'ksp_max_it': '20',
         'ksp_rtol': '2e-15',
+        'ksp_view_singularvalues': None,
         'pc_type': 'python',
         'pc_python_type': 'firedrake.HypreAMS',
-        'pc_hypre_ams_zero_beta_poisson': True
+        'pc_hypre_ams_zero_beta_poisson': True,
+        # Pin the cycle, so that the test measures AMS rather than whichever
+        # default the hypre it was built against happens to select.
+        'hypre_ams_pc_hypre_ams_cycle_type': 1,
     }
 
     A = Function(V)
     if interface == "linear":
-        solve(a == L, A, bc, solver_parameters=params)
+        problem = LinearVariationalProblem(a, L, A, bcs=bc)
+        solver = LinearVariationalSolver(problem, solver_parameters=params)
     elif interface == "nonlinear":
         F = action(a, A) - L
-        solve(F == 0, A, bc, solver_parameters=params)
+        problem = NonlinearVariationalProblem(F, A, bcs=bc)
+        solver = NonlinearVariationalSolver(problem, solver_parameters=params)
     else:
         raise ValueError(f"Unrecognized interface {interface}.")
+    solver.solve()
 
     V0 = VectorFunctionSpace(mesh, "DG", 0)
     B = project(curl(A), V0)
     assert numpy.allclose(B.dat.data_ro, numpy.array((0., 0., 1.)), atol=1e-6)
+
+    # AMS leaves the operator nearly perfectly conditioned: 1.26 on the
+    # simplex and 1.06 on the hexahedron, against 1.2e2 and 7.1 without it.
+    ew = solver.snes.ksp.computeEigenvalues().real
+    assert max(abs(ew)) / min(abs(ew)) < 2
 
 
 @pytest.mark.skiphypre


### PR DESCRIPTION
The hypre ADS/AMS tests all leave the cycle to hypre, whose default varies
between builds, and none of them measured what they exist to demonstrate: that
the preconditioner conditions the operator.

## Measured

`kappa` / iterations, on each test's own problem, PETSc 3.25.4:

| test | cycle 1 | hypre default | unpreconditioned |
| --- | ---: | ---: | ---: |
| ADS `test_homogeneous_field[simplex]` | 1.6709 / 13 | 2.9143 / 21 | 1.2e4 / 955 |
| ADS `test_homogeneous_field[hexahedron]` | 1.1084 / 9 | 1.4779 / 14 | 4.1e3 / 257 |
| AMS `test_homogeneous_field[simplex]` | 1.2572 / 12 | 1.1236 / 10 | 1.2e2 / 97 |
| AMS `test_homogeneous_field[hexahedron]` | 1.0641 / 8 | 1.0095 / 6 | 7.1 / 7 |
| ADS `test_hypre_ads_fieldsplit` | 1.2247 / 6 | 1.7750 / 8 | 4.8e3 / 327 |

## What changes

- **Pin `cycle_type = 1`** in all three, so the tests measure the
  preconditioner rather than whichever default the build selects.
- **Assert on the condition number.** The two `test_homogeneous_field` tests
  checked only that the answer was right, which a poor preconditioner still
  manages given enough iterations. Reaching the KSP means building the solver
  rather than calling `solve()`, which is why those bodies change shape.
- **Tighten `ksp_max_it` from 30 to 20.** That sits above the 13 iterations the
  worst case needs and below the 21 the unpinned default takes, so the cap also
  catches the pin silently failing -- the option prefix
  (`hypre_ads_pc_hypre_ads_cycle_type`) is easy to get wrong, and a wrong one is
  invisible. Verified: dropping the pin fails all three simplex cases.

`test_hypre_ads_fieldsplit` needed the pin most. It asserts `kappa < 2` and the
default gives **1.775** -- so little margin that rounding decides the outcome.
Refining the same problem walks straight through the bound: 1.7583, 1.7855,
1.7750, then **2.0681**, **2.0859**, **2.0633**, **2.0589** for n = 4..10. Cycle
1 holds between 1.14 and 1.26 across that range.

Its comment was also wrong in both halves: `# current value is 1.3 and without
preconditioner > 66` against a measured 1.7750 and 4759.9.

## Why now

This surfaced as a CI failure (`DIVERGED_LINEAR_SOLVE`) on
firedrakeproject/firedrake#5362, which changes TSFC codegen and so perturbs the
last bits of the assembled operator. That branch is numerically identical to
`main` on this problem -- same iteration counts and condition numbers across the
sweep above, byte-identical discrete gradient, identical nest blocks and kernel
accuracy -- but the test had no margin to absorb a rounding change. The fragility
is pre-existing and independent of that PR, so it is fixed here on its own.

## Notes

- Every ADS and AMS cycle type is symmetric, so CG is well posed throughout:
  measured `|<Px,y> - <x,Py>| / (|Px| |y|)` at most 1.4e-14 over cycles
  1, 3, 5, 7, 8, 11, 13, 14 and the default.
- The `interface` parameter of the ADS `test_homogeneous_field` is unused --
  the `("aij", "nonlinear")` case runs the linear path. Left as it was, since
  making it honour the parameter changes what is covered.

## Validation

`tests/firedrake/regression/test_hypre_ads.py` and `test_hypre_ams.py` -- 15
passed, both against the current FIAT and against the FIAT stack from #5362.

## AI assistance

Claude Code was used for the investigation, measurements, and drafting this
description. The human contributor remains responsible for understanding,
validating, and maintaining the changes.