### PR TITLE
Deprecate appctx

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,7 +1,10 @@
 import typing
+import warnings
 from itertools import chain
+from typing import Any
 
 import numpy
+import petsctools
 import ufl
 
 from pyop2 import op2
@@ -135,7 +138,11 @@ Reason:
    %s""" % (snes.getIterationNumber(), msg))
 
 
-class _SNESContext(object):
+_missing = object()
+"""Sentinel value used as a default for when 'None' is potentially meaningful."""
+
+
+class _SNESContext:
     """Context holding information for SNES callbacks.
 
     Parameters
@@ -157,7 +164,7 @@ class _SNESContext(object):
         Indicates the matrix type for the sparse blocks in the preconditioner
         if pmat_type='nest', ignored otherwise.
     appctx
-        Any extra information used in the assembler.  For the
+        (Deprecated) Any extra information used in the assembler.  For the
         matrix-free case this will contain the Newton state in ``"state"``.
     pre_jacobian_callback
         User-defined function called immediately before Jacobian assembly.
@@ -237,7 +244,7 @@ class _SNESContext(object):
         appctx.setdefault("state", self._x)
         appctx.setdefault("form_compiler_parameters", self.fcp)
 
-        self.appctx = appctx
+        self._appctx = appctx
         self.matfree = matfree
         self.pmatfree = pmatfree
         self.F = problem.F
@@ -295,6 +302,70 @@ class _SNESContext(object):
         self._coefficient_mapping = None
         self._transfer_manager = transfer_manager
 
+    @property
+    def appctx(self) -> dict:
+        # Raise a 'DeprecationWarning' here instead of a 'FutureWarning' because
+        # this in an internal detail, not user facing
+        warnings.warn(
+            "'appctx' is now deprecated. Pass Python objects into the "
+            "PETSc options directly.",
+            DeprecationWarning,
+        )
+        return self._appctx
+
+    def get_python_option(
+        self,
+        prefix: str,
+        option: str,
+        default: Any = _missing,
+    ) -> Any:
+        """Return a Python object from either the options database or appctx.
+
+        This is a temporary method to facilitate the deprecation process for
+        the appctx.
+
+        Parameters
+        ----------
+        prefix
+            The options prefix.
+        option
+            The option name.
+        default
+            Default value if option is not found. If unspecified then a
+            `KeyError` is raised.
+
+        Returns
+        -------
+        Any
+            The object referred to by ``option``.
+
+        Raises
+        ------
+        KeyError
+            If ``option`` is not found and ``default`` is unspecified.
+
+        """
+        opts = petsctools.Options(prefix)
+        try:
+            value = opts[option]
+        except KeyError:
+            # not in the options database - try the old, unprefixed approach
+            try:
+                value = self._appctx[option]
+            except KeyError:
+                if default is not _missing:
+                    value = default
+                else:
+                    raise KeyError
+            else:
+                warnings.warn(
+                    "Passing Python objects to preconditioners via the 'appctx' kwarg "
+                    "is now deprecated. Pass the objects into the PETSc options "
+                    "directly instead.",
+                    FutureWarning,
+                )
+        return value
+
     def reconstruct(self,
                     problem: "NonlinearVariationalProblem | None" = None,
                     mat_type: str | None = None,
@@ -326,7 +397,7 @@ class _SNESContext(object):
         default_options = dict(
             sub_mat_type=self.sub_mat_type,
             sub_pmat_type=self.sub_pmat_type,
-            appctx=self.appctx,
+            appctx=self._appctx,
             options_prefix=self.options_prefix,
             transfer_manager=self.transfer_manager,
             pre_jacobian_callback=self._pre_jacobian_callback,
@@ -644,7 +715,7 @@ class _SNESContext(object):
         from firedrake.assemble import get_assembler
         return get_assembler(self.J, bcs=self.bcs_J, form_compiler_parameters=self.fcp,
                              mat_type=self.mat_type, sub_mat_type=self.sub_mat_type,
-                             options_prefix=self.options_prefix, appctx=self.appctx)
+                             options_prefix=self.options_prefix, appctx=self._appctx)
 
     @cached_property
     def _jac(self):
@@ -664,7 +735,7 @@ class _SNESContext(object):
         if self.mat_type != self.pmat_type or self._problem.Jp is not None:
             return get_assembler(self.Jp, bcs=self.bcs_Jp, form_compiler_parameters=self.fcp,
                                  mat_type=self.pmat_type, sub_mat_type=self.sub_pmat_type,
-                                 options_prefix=self.options_prefix, appctx=self.appctx)
+                                 options_prefix=self.options_prefix, appctx=self._appctx)
         else:
             return self._assembler_jac
 

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -291,7 +291,77 @@ class NonlinearVariationalProblem(NonlinearVariationalProblemMixin):
 
 
 class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin):
-    r"""Solves a :class:`NonlinearVariationalProblem`."""
+    """Class that solves a :class:`NonlinearVariationalProblem`.
+
+    Parameters
+    ----------
+    :arg problem: A :class:`NonlinearVariationalProblem` to solve.
+    :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
+           :class:`.MixedVectorSpaceBasis`) spanning the null
+           space of the operator.
+    :kwarg transpose_nullspace: as for the nullspace, but used to
+           make the right hand side consistent.
+    :kwarg near_nullspace: as for the nullspace, but used to
+           specify the near nullspace (for multigrid solvers).
+    :kwarg solver_parameters: Solver parameters to pass to PETSc.
+           This should be a dict mapping PETSc options to values.
+    :kwarg appctx: (Deprecated) A dictionary containing application
+           context that is passed to the preconditioner if matrix-free.
+    :kwarg options_prefix: an optional prefix used to distinguish
+           PETSc options.  If not provided a unique prefix will be
+           created.  Use this option if you want to pass options
+           to the solver from the command line in addition to
+           through the ``solver_parameters`` dict.
+    :kwarg pre_jacobian_callback: A user-defined function that will
+           be called immediately before Jacobian assembly. This can
+           be used, for example, to update a coefficient function
+           that has a complicated dependence on the unknown solution.
+    :kwarg post_jacobian_callback: As above, but called after the
+           Jacobian has been assembled.
+    :kwarg pre_function_callback: As above, but called immediately
+           before residual assembly.
+    :kwarg post_function_callback: As above, but called immediately
+           after residual assembly.
+    :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
+           Otherwise, the problem is linearised around the initial guess
+           before imposing bcs, and the bcs are appended to the nonlinear system.
+    :kwarg marking_callback: An optional callable of the form
+           ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
+           The callback receives the `_SNESContext`
+           and the current Firedrake solution, and must return a DG0
+           :class:`.Function` or :class:`.Cofunction` with positive
+           values on cells to refine.
+
+    Example usage of the ``solver_parameters`` option: to set the
+    nonlinear solver type to just use a linear solver, use
+
+    .. code-block:: python3
+
+        {'snes_type': 'ksponly'}
+
+    PETSc flag options (where the presence of the option means something) should
+    be specified with ``None``.
+    For example:
+
+    .. code-block:: python3
+
+        {'snes_monitor': None}
+
+    To use the ``pre_jacobian_callback`` or ``pre_function_callback``
+    functionality, the user-defined function must accept the current
+    solution as a petsc4py Vec. Example usage is given below:
+
+    .. code-block:: python3
+
+        def update_diffusivity(current_solution):
+            with cursol.dat.vec_wo as v:
+                current_solution.copy(v)
+            solve(trial*test*dx == dot(grad(cursol), grad(test))*dx, diffusivity)
+
+        solver = NonlinearVariationalSolver(problem,
+                                            pre_jacobian_callback=update_diffusivity)
+
+    """
 
     DEFAULT_SNES_PARAMETERS = DEFAULT_SNES_PARAMETERS
 
@@ -318,74 +388,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                  post_function_callback=None,
                  pre_apply_bcs=True,
                  marking_callback=None):
-        r"""
-        :arg problem: A :class:`NonlinearVariationalProblem` to solve.
-        :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
-               :class:`.MixedVectorSpaceBasis`) spanning the null
-               space of the operator.
-        :kwarg transpose_nullspace: as for the nullspace, but used to
-               make the right hand side consistent.
-        :kwarg near_nullspace: as for the nullspace, but used to
-               specify the near nullspace (for multigrid solvers).
-        :kwarg solver_parameters: Solver parameters to pass to PETSc.
-               This should be a dict mapping PETSc options to values.
-        :kwarg appctx: A dictionary containing application context that
-               is passed to the preconditioner if matrix-free.
-        :kwarg options_prefix: an optional prefix used to distinguish
-               PETSc options.  If not provided a unique prefix will be
-               created.  Use this option if you want to pass options
-               to the solver from the command line in addition to
-               through the ``solver_parameters`` dict.
-        :kwarg pre_jacobian_callback: A user-defined function that will
-               be called immediately before Jacobian assembly. This can
-               be used, for example, to update a coefficient function
-               that has a complicated dependence on the unknown solution.
-        :kwarg post_jacobian_callback: As above, but called after the
-               Jacobian has been assembled.
-        :kwarg pre_function_callback: As above, but called immediately
-               before residual assembly.
-        :kwarg post_function_callback: As above, but called immediately
-               after residual assembly.
-        :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
-               Otherwise, the problem is linearised around the initial guess
-               before imposing bcs, and the bcs are appended to the nonlinear system.
-        :kwarg marking_callback: An optional callable of the form
-               ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
-               The callback receives the `_SNESContext`
-               and the current Firedrake solution, and must return a DG0
-               :class:`.Function` or :class:`.Cofunction` with positive
-               values on cells to refine.
 
-        Example usage of the ``solver_parameters`` option: to set the
-        nonlinear solver type to just use a linear solver, use
-
-        .. code-block:: python3
-
-            {'snes_type': 'ksponly'}
-
-        PETSc flag options (where the presence of the option means something) should
-        be specified with ``None``.
-        For example:
-
-        .. code-block:: python3
-
-            {'snes_monitor': None}
-
-        To use the ``pre_jacobian_callback`` or ``pre_function_callback``
-        functionality, the user-defined function must accept the current
-        solution as a petsc4py Vec. Example usage is given below:
-
-        .. code-block:: python3
-
-            def update_diffusivity(current_solution):
-                with cursol.dat.vec_wo as v:
-                    current_solution.copy(v)
-                solve(trial*test*dx == dot(grad(cursol), grad(test))*dx, diffusivity)
-
-            solver = NonlinearVariationalSolver(problem,
-                                                pre_jacobian_callback=update_diffusivity)
-
-        """
         assert isinstance(problem, NonlinearVariationalProblem)
 
         solver_parameters = flatten_parameters(solver_parameters or {})

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -295,42 +295,52 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 
     Parameters
     ----------
-    :arg problem: A :class:`NonlinearVariationalProblem` to solve.
-    :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
-           :class:`.MixedVectorSpaceBasis`) spanning the null
-           space of the operator.
-    :kwarg transpose_nullspace: as for the nullspace, but used to
-           make the right hand side consistent.
-    :kwarg near_nullspace: as for the nullspace, but used to
-           specify the near nullspace (for multigrid solvers).
-    :kwarg solver_parameters: Solver parameters to pass to PETSc.
-           This should be a dict mapping PETSc options to values.
-    :kwarg appctx: (Deprecated) A dictionary containing application
-           context that is passed to the preconditioner if matrix-free.
-    :kwarg options_prefix: an optional prefix used to distinguish
-           PETSc options.  If not provided a unique prefix will be
-           created.  Use this option if you want to pass options
-           to the solver from the command line in addition to
-           through the ``solver_parameters`` dict.
-    :kwarg pre_jacobian_callback: A user-defined function that will
-           be called immediately before Jacobian assembly. This can
-           be used, for example, to update a coefficient function
-           that has a complicated dependence on the unknown solution.
-    :kwarg post_jacobian_callback: As above, but called after the
-           Jacobian has been assembled.
-    :kwarg pre_function_callback: As above, but called immediately
-           before residual assembly.
-    :kwarg post_function_callback: As above, but called immediately
-           after residual assembly.
-    :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
-           Otherwise, the problem is linearised around the initial guess
-           before imposing bcs, and the bcs are appended to the nonlinear system.
-    :kwarg marking_callback: An optional callable of the form
-           ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
-           The callback receives the `_SNESContext`
-           and the current Firedrake solution, and must return a DG0
-           :class:`.Function` or :class:`.Cofunction` with positive
-           values on cells to refine.
+    problem
+        A :class:`NonlinearVariationalProblem` to solve.
+    nullspace
+        an optional :class:`.VectorSpaceBasis` (or
+        :class:`.MixedVectorSpaceBasis`) spanning the null
+        space of the operator.
+    transpose_nullspace
+        as for the nullspace, but used to
+        make the right hand side consistent.
+    near_nullspace
+        as for the nullspace, but used to
+        specify the near nullspace (for multigrid solvers).
+    solver_parameters
+        Solver parameters to pass to PETSc.
+        This should be a dict mapping PETSc options to values.
+    appctx
+        (Deprecated) A dictionary containing application
+        context that is passed to the preconditioner if matrix-free.
+    options_prefix
+        an optional prefix used to distinguish
+        PETSc options.  If not provided a unique prefix will be
+        created.  Use this option if you want to pass options
+        to the solver from the command line in addition to
+        through the ``solver_parameters`` dict.
+    pre_jacobian_callback
+        A user-defined function that will
+        be called immediately before Jacobian assembly. This can
+        be used, for example, to update a coefficient function
+        that has a complicated dependence on the unknown solution.
+    post_jacobian_callback
+        As above, but called after the Jacobian has been assembled.
+    pre_function_callback
+        As above, but called immediately before residual assembly.
+    post_function_callback
+        As above, but called immediately after residual assembly.
+    pre_apply_bcs
+        If True, the bcs are applied before the solve.
+        Otherwise, the problem is linearised around the initial guess
+        before imposing bcs, and the bcs are appended to the nonlinear system.
+    marking_callback
+        An optional callable of the form
+        ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
+        The callback receives the `_SNESContext`
+        and the current Firedrake solution, and must return a DG0
+        :class:`.Function` or :class:`.Cofunction` with positive
+        values on cells to refine.
 
     Example usage of the ``solver_parameters`` option: to set the
     nonlinear solver type to just use a linear solver, use
@@ -388,7 +398,6 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                  post_function_callback=None,
                  pre_apply_bcs=True,
                  marking_callback=None):
-
         assert isinstance(problem, NonlinearVariationalProblem)
 
         solver_parameters = flatten_parameters(solver_parameters or {})

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,7 +7,8 @@ mpi4py>3; python_version >= '3.13'
 mpi4py; python_version < '3.13'
 numpy
 pkgconfig
-petsctools
+# TODO RELEASE
+petsctools @ git+https://github.com/firedrakeproject/petsctools.git@main
 pybind11
 setuptools>=77.0.3
 rtree


### PR DESCRIPTION
Now that we can pass Python objects in the solver parameters dictionary (https://github.com/firedrakeproject/petsctools/pull/41) we don't need to use the `appctx` for solvers any more. This PR lays out a deprecation process for moving towards the new approach.

Deprecation process:
1. Existing code will still run but accessing `_SNESContext.appctx` (which happens inside PCs) will now throw a `DeprecationWarning`.
2. PCs will need to switch to `_SNESContext.get_python_option()` which tries the new approach but falls back to the appctx if not found. This means that users can continue to pass `appctx=` but will see a warning.

This is the first of two PRs. The deprecation mechanism is itself a bit confusing so I wanted to review it separately. A subsequent PR will address removing `appctx` from our own code.

<!--
Please include a summary of the changes introduced by this PR.
Additionally be sure to link associated pull requests in other projects.

If issues are fixed by this PR, include link to them and prepend each of them with the word "fixes", so they are automatically closed when this PR is merged.
For example "fixes #xyz, fixes #abc".

Feel free to add reviewers if you know there is someone who is already aware of this work.
Please open this PR initially as a draft and mark as ready for review once CI tests are passing.

Thanks for contributing!
-->
