### PR TITLE
Deprecate the appctx for most things

### DIFF
--- a/demos/deflation/deflation.py.rst
+++ b/demos/deflation/deflation.py.rst
@@ -46,18 +46,17 @@ We implement the usual weak formulation of the equation in Firedrake as standard
 
 Applying deflation requires two ingredients: the :class:`~.DeflatedSNES` nonlinear solver, and a :class:`~.Deflation` object. The :class:`~.Deflation` object records the solutions to be deflated, and specifies the sense of distance to use in deflation. In this example we use the metric induced by the :math:`L^2(\Omega)` inner product: ::
 
+    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
     sp = {"snes_type": "python",
           "snes_python_type": "firedrake.DeflatedSNES",
           "deflated_snes_type": "newtonls",
           "deflated_snes_monitor": None,
           "deflated_snes_linesearch_type": "basic",
+          "deflated_snes_deflation": deflation,
           "deflated_ksp_type": "preonly",
           "deflated_pc_type": "lu"}
 
-    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
-    appctx = {"deflation": deflation}
-
-    solver = NonlinearVariationalSolver(problem, solver_parameters=sp, appctx=appctx)
+    solver = NonlinearVariationalSolver(problem, solver_parameters=sp)
 
 We now find the first solution: ::
 

--- a/demos/matrix_free/navier_stokes.py.rst
+++ b/demos/matrix_free/navier_stokes.py.rst
@@ -33,18 +33,6 @@ example is that of a lid-driven cavity. ::
   nullspace = MixedVectorSpaceBasis(
       Z, [Z.sub(0), VectorSpaceBasis(constant=True)])
 
-Having set up the problem, we now move on to solving it.  Some
-preconditioners, for example pressure convection-diffusion (PCD), require
-information about the the problem that is not easily accessible from
-the bilinear form.  In the case of PCD, we need the Reynolds number
-and additionally which part of the mixed velocity-pressure space the
-velocity corresponds to.  We provide this information to
-preconditioners by passing in a dictionary context to the solver.
-This is propagated down through the matrix-free operators and is
-therefore accessible to custom preconditioners. ::
-
-  appctx = {"Re": Re, "velocity_space": 0}
-
 Now we'll solve the problem.  First, using a direct solver.  Again, if
 MUMPS is not installed, this solve will not work, so we wrap the solve
 in a ``try/except`` block. ::
@@ -100,6 +88,14 @@ with PCD. ::
                "fieldsplit_1_pc_type": "python",
                "fieldsplit_1_pc_python_type": "firedrake.PCDPC",
 
+This preconditioner requires information about the the problem that
+is not easily accessible from the bilinear form. Specifically, we need
+the Reynolds number and which part of the mixed velocity-pressure space
+the velocity corresponds to. ::
+
+               "fieldsplit_1_pcd_Re": Re,
+               "fieldsplit_1_pcd_velocity_space": 0,
+
 We now need to configure the mass and stiffness solvers in the PCD
 preconditioner.  For this example, we will just invert them with LU,
 although of course we can use a scalable method if we wish. First the
@@ -125,8 +121,7 @@ find the Reynolds number. ::
 
   up.assign(0)
 
-  solve(F == 0, up, bcs=bcs, nullspace=nullspace, solver_parameters=parameters,
-        appctx=appctx)
+  solve(F == 0, up, bcs=bcs, nullspace=nullspace, solver_parameters=parameters)
 
 And finally we write the results to a file for visualisation. ::
 

--- a/demos/matrix_free/rayleigh-benard.py.rst
+++ b/demos/matrix_free/rayleigh-benard.py.rst
@@ -197,13 +197,20 @@ and approximate the Schur complement inverse with PCD. ::
 
 We need to configure the pressure mass and Poisson solves, along with
 how to apply the convection-diffusion operator.  For the latter, we
-will use an assembled operator this time round. ::
+will use an assembled operator this time round. Recall that the PCD
+preconditioner needs to know where the velocity space lives in the
+velocity-pressure block.  It also needs to know the
+Reynolds number, which defaults to 1.0, which happens to work for our
+problem setup.  We haven't added the Rayleigh or Prandtl numbers to
+the dictionary since our known preconditioners don't actually require
+them, although doing so would be quite easy.::
 
                         "pcd_Mp_ksp_type": "preonly",
                         "pcd_Mp_pc_type": "ilu",
                         "pcd_Kp_ksp_type": "preonly",
                         "pcd_Kp_pc_type": "hypre",
-                        "pcd_Fp_mat_type": "aij"
+                        "pcd_Fp_mat_type": "aij",
+                        "pcd_velocity_space": 0,
                    }
                },
 
@@ -219,20 +226,12 @@ for algebraic multigrid preconditioned GMRES. ::
               }
          }
 
-And we're done with all the options.  All that's left is to solve the
-problem.  Recall that the PCD preconditioner needs to know where the
-velocity space lives in the velocity-pressure block, which we provide
-through the application context argument.  It also needs to know the
-Reynolds number, which defaults to 1.0, which happens to work for our
-problem setup.  We haven't added the Rayleigh or Prandtl numbers to
-the dictionary since our known preconditioners don't actually require
-them, although doing so would be quite easy.::
+And we're done with all the options.  All that's left is to solve the problem. ::
 
-  appctx = {"velocity_space": 0}
   upT.assign(0)
 
   solve(F == 0, upT, bcs=bcs, nullspace=nullspace,
-        solver_parameters=parameters, appctx=appctx)
+        solver_parameters=parameters)
 
 Finally, we'll output the results for visualisation. ::
 

--- a/docs/notebooks/07-geometric-multigrid.py
+++ b/docs/notebooks/07-geometric-multigrid.py
@@ -115,22 +115,22 @@ finest_mesh = hierarchy[-1]
 # To make things easier to play with, we'll wrap everything up in a function that we can call to produce a solver.
 
 # %%
-def create_solver(parameters=None):
+def create_solver(parameters=None, mass_pc_prefix=None):
     coarse_mesh = RectangleMesh(15, 10, 1.5, 1)
     hierarchy = MeshHierarchy(coarse_mesh, 3)
-    
+
     mesh = hierarchy[-1]
-    
+
     V = VectorFunctionSpace(mesh, "Lagrange", 2)
     Q = FunctionSpace(mesh, "Lagrange", 1)
     W = V*Q
-    
+
     u, p = TrialFunctions(W)
     v, q = TestFunctions(W)
-    
+
     nu = Constant(1)
     x, y = SpatialCoordinate(mesh)
-    
+
     t = conditional(y < 0.5, y - 1/4, y - 3/4)
     gbar = conditional(Or(And(1/6 < y,
                               y < 1/3),
@@ -142,12 +142,17 @@ def create_solver(parameters=None):
     value = as_vector([gbar*(1 - (12*t)**2), 0])
     bcs = [DirichletBC(W.sub(0), value, (1, 2)),
            DirichletBC(W.sub(0), zero(2), (3, 4))]
-    
+
     a = (nu*inner(grad(u), grad(v)) - p*div(v) + q*div(u))*dx
     L = inner(Constant((0, 0)), v)*dx
+
+    # Pass nu to the preconditioner
+    if mass_pc_prefix is not None:
+        parameters[f"{mass_pc_prefix}nu"] = nu
+
     wh = Function(W)
     problem = LinearVariationalProblem(a, L, wh, bcs=bcs)
-    solver = LinearVariationalSolver(problem, solver_parameters=parameters, appctx={"nu": nu})
+    solver = LinearVariationalSolver(problem, solver_parameters=parameters)
     return solver
 
 
@@ -184,10 +189,13 @@ fig.colorbar(triangles, ax=axes[1], fraction=0.032, pad=0.02);
 # This direct method is not a scalable solution technique for large problems.  Similar to our earlier example involving the mixed Poisson problem, a Schur complement method can be more efficient.  We'll use geometric multigrid to invert the elliptic velocity block, and use a viscosity-weighted pressure mass matrix to precondition the Schur complement.  This gives good results as long as viscosity contrasts are not too strong. The Python preconditioner that we use to create the mass matrix is described in more detail in the composable solvers notebook.
 
 # %%
+import petsctools
+
 class MassMatrix(AuxiliaryOperatorPC):
     def form(self, pc, test, trial):
         # Grab the viscosity
-        nu = self.get_appctx(pc)["nu"]
+        prefix = pc.getOptionsPrefix() or ""
+        nu = petsctools.Options(prefix)["nu"]
         return (nu*test*trial*dx, None)
 
 
@@ -207,7 +215,7 @@ parameters = {
     "fieldsplit_1_aux_pc_type": "icc",
 }
 
-solver = create_solver(parameters)
+solver = create_solver(parameters, "fieldsplit_1_")
 solver.solve()
 
 # %% [markdown]
@@ -246,7 +254,7 @@ parameters = {
       "mg_levels_fieldsplit_1_aux_pc_type": "icc",
 }
 
-solver = create_solver(parameters)
+solver = create_solver(parameters, "mg_levels_fieldsplit_1_")
 solver.solve()
 
 
@@ -276,23 +284,23 @@ solver.solve()
 # For simplicity, the relevant setup is copied below to start with:
 
 # %%
-def create_solver(parameters=None):
+def create_solver(parameters=None, mass_pc_prefix=None):
     coarse_mesh = RectangleMesh(15, 10, 1.5, 1)
     hierarchy = MeshHierarchy(coarse_mesh, 3)
-    
+
     mesh = hierarchy[-1]
-    
+
     V = VectorFunctionSpace(mesh, "Lagrange", 2)
     Q = FunctionSpace(mesh, "Lagrange", 1)
     W = V*Q
-    
+
     u, p = TrialFunctions(W)
     v, q = TestFunctions(W)
-    
+
     # Change me to spatially varying.
     nu = Constant(1)
     x, y = SpatialCoordinate(mesh)
-    
+
     t = conditional(y < 0.5, y - 1/4, y - 3/4)
     gbar = conditional(Or(And(1/6 < y,
                               y < 1/3),
@@ -304,13 +312,17 @@ def create_solver(parameters=None):
     value = assemble(interpolate(as_vector([gbar*(1 - (12*t)**2), 0]), V))
     bcs = [DirichletBC(W.sub(0), value, (1, 2)),
            DirichletBC(W.sub(0), zero(2), (3, 4))]
-    
+
     a = (nu*inner(grad(u), grad(v)) - p*div(v) + q*div(u))*dx
     L = inner(Constant((0, 0)), v)*dx
-    
+
+    # Pass nu to the preconditioner
+    if mass_pc_prefix is not None:
+        parameters[f"{mass_pc_prefix}nu"] = nu
+
     wh = Function(W)
     problem = LinearVariationalProblem(a, L, wh, bcs=bcs)
-    solver = LinearVariationalSolver(problem, solver_parameters=parameters, appctx={"nu": nu})
+    solver = LinearVariationalSolver(problem, solver_parameters=parameters)
     return solver
 
 
@@ -330,7 +342,7 @@ parameters = {
     "fieldsplit_1_aux_pc_type": "icc",
 }
 
-solver = create_solver(parameters)
+solver = create_solver(parameters, "fieldsplit_1_")
 solver.solve()
 
 # %%

--- a/docs/notebooks/08-composable-solvers.py
+++ b/docs/notebooks/08-composable-solvers.py
@@ -34,6 +34,7 @@
 
 # %%
 import matplotlib.pyplot as plt
+import petsctools
 
 # %%
 from firedrake import *
@@ -89,7 +90,7 @@ nullspace = MixedVectorSpaceBasis(W, [W.sub(0), VectorSpaceBasis(constant=True, 
 # Since we're going to look at a bunch of different solver options, let's have a function that builds a solver with the provided options.
 
 # %%
-def create_solver(solver_parameters, *, pmat=None, appctx=None):
+def create_solver(solver_parameters, *, pmat=None):
     p = {}
     if solver_parameters is not None:
         p.update(solver_parameters)
@@ -98,7 +99,7 @@ def create_solver(solver_parameters, *, pmat=None, appctx=None):
     p.setdefault("ksp_rtol", 1e-7)
     problem = NonlinearVariationalProblem(F, w, bcs=bcs, Jp=pmat)
     solver = NonlinearVariationalSolver(problem, nullspace=nullspace, options_prefix="", 
-                                        solver_parameters=p, appctx=appctx)
+                                        solver_parameters=p)
     return solver
 
 
@@ -300,8 +301,9 @@ class MassMatrix(AuxiliaryOperatorPC):
     def form(self, pc, test, trial):
         # Extract the original form and bcs
         a, bcs = super().form(pc, test, trial)
-        # Grab the definition of nu from the user application context (a dict)
-        nu = self.get_appctx(pc)["nu"]
+        # Grab the definition of nu from the options database
+        prefix = pc.getOptionsPrefix() or ""
+        nu = petsctools.Options(prefix)["nu"]
         return (-1/nu * test*trial*dx, bcs)
 
 
@@ -321,15 +323,15 @@ mass_parameters = {
     "fieldsplit_1": {
         "ksp_type": "preonly",
         "pc_type": "python",
-        "pc_python_type": "__main__.MassMatrix",
+        "pc_python_type": f"{__name__}.MassMatrix",
         "mass_pc_type": "lu",
+        "mass_nu": nu,
     }
 }
 
 # %%
-appctx = {"nu": nu} # arbitrary user data that is available inside the user PC object
 w.zero()
-solver = create_solver(mass_parameters, appctx=appctx)
+solver = create_solver(mass_parameters)
 solver.solve()
 convergence(solver)
 
@@ -363,6 +365,7 @@ fieldsplit_mg_parameters = {
         "pc_type": "python",
         "pc_python_type": f"{__name__}.MassMatrix",
         "mass_pc_type": "sor",
+        "mass_nu": nu,
     }
 }
 
@@ -370,9 +373,8 @@ fieldsplit_mg_parameters = {
 # Now, when the solver runs, PETSc will call back in to Firedrake for restriction and prolongation, as well as rediscretising $A$ on the coarser levels.
 
 # %%
-appctx = {"nu": nu} # arbitrary user data that is available inside the user PC object
 w.zero()
-solver = create_solver(fieldsplit_mg_parameters, appctx=appctx)
+solver = create_solver(fieldsplit_mg_parameters)
 solver.solve()
 convergence(solver)
 

--- a/docs/notebooks/08-composable-solvers.py
+++ b/docs/notebooks/08-composable-solvers.py
@@ -302,7 +302,7 @@ class MassMatrix(AuxiliaryOperatorPC):
         # Extract the original form and bcs
         a, bcs = super().form(pc, test, trial)
         # Grab the definition of nu from the options database
-        prefix = pc.getOptionsPrefix() or ""
+        prefix = (pc.getOptionsPrefix() or "") + self._prefix
         nu = petsctools.Options(prefix)["nu"]
         return (-1/nu * test*trial*dx, bcs)
 

--- a/firedrake/deflation.py
+++ b/firedrake/deflation.py
@@ -59,11 +59,11 @@ class DeflatedSNES(SNESBase):
 
         self.inner.setUp()
 
-        # Get the deflation object from the appctx
-        appctx = ctx.appctx
-        deflation = appctx.get("deflation")
-        if deflation is None:
-            raise ValueError("To use DeflatedSNES you need to pass a Deflation object in the appctx.")
+        # Get the deflation object
+        try:
+            deflation = ctx.get_python_option(f"{prefix}deflated_snes_", "deflation")
+        except KeyError:
+            raise ValueError("To use DeflatedSNES you need to pass a Deflation object.")
         self.deflation = deflation
 
         # Hijack the KSP of the SNES we just created.
@@ -82,8 +82,8 @@ class DeflatedSNES(SNESBase):
         viewer.printfASCII("Firedrake deflated SNES\n")
 
         ctx = get_appctx(snes.getDM())
-        appctx = ctx.appctx
-        deflation = appctx.get("deflation")
+        prefix = snes.getOptionsPrefix() or ""
+        deflation = ctx.get_python_option(f"{prefix}deflated_snes_", "deflation")
         viewer.printfASCII(f"Deflating {len(deflation.roots)} solutions\n")
 
         self.inner.view(viewer)

--- a/firedrake/dmhooks.py
+++ b/firedrake/dmhooks.py
@@ -37,9 +37,13 @@ fieldsplit preconditioning, without having to set everything up in
 advance.
 """
 
+import dataclasses
 import weakref
-import numpy
+from collections.abc import Callable
 from functools import partial
+from typing import Any
+
+import numpy
 
 import firedrake
 from firedrake.petsc import PETSc
@@ -569,3 +573,32 @@ def attach_hooks(dm, level=None, sf=None, section=None):
     # a non-mixed space)
     dm.setCreateFieldDecomposition(create_field_decomposition)
     dm.setCreateSubDM(create_subdm)
+
+
+@dataclasses.dataclass(frozen=True)
+class Hooked:
+    """Class wrapping an object that can be passed through a solver stack.
+
+    Parameters
+    ----------
+    obj
+        The wrapped object (e.g. a `firedrake.Function`).
+    refine_callback
+        Callback to refine the object.
+    coarsen_callback
+        Callback to coarsen the object.
+
+    """
+    obj: Any
+    refine_callback: Callable | None = None
+    coarsen_callback: Callable | None = None
+
+    def refine(self):
+        if self.refine_callback is None:
+            raise NotImplementedError("No implementation for 'refine_callback' found")
+        return dataclasses.replace(self, obj=self.refine_callback(self.obj))
+
+    def coarsen(self):
+        if self.coarsen_callback is None:
+            raise NotImplementedError("No implementation for 'coarsen_callback' found")
+        return dataclasses.replace(self, obj=self.coarsen_callback(self.obj))

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -107,8 +107,8 @@ class ImplicitMatrixContext:
         self.a = a
         self.aT = adjoint(a)
         self.comm = a.arguments()[0].function_space().comm
-        self.fc_params = {} if fc_params is None else fc_params
-        self.appctx = {} if appctx is None else appctx
+        self.fc_params = fc_params
+        self.appctx = appctx
 
         # Collect all DirichletBC instances including
         # DirichletBCs applied to an EquationBC.

--- a/firedrake/matrix_free/operators.py
+++ b/firedrake/matrix_free/operators.py
@@ -65,7 +65,7 @@ def find_sub_block(iset, ises, comm):
     return found
 
 
-class ImplicitMatrixContext(object):
+class ImplicitMatrixContext:
     # By default, these matrices will represent diagonal blocks (the
     # (0,0) block of a 1x1 block matrix is on the diagonal).
     on_diag = True
@@ -101,6 +101,8 @@ class ImplicitMatrixContext(object):
             and the like. By default None.
         """
         from firedrake.assemble import get_assembler
+
+        assert appctx is None, "old API"
 
         self.a = a
         self.aT = adjoint(a)

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -380,16 +380,20 @@ def reconstruct_snescontext(context, self, coefficient_mapping=None):
 
     # FIXME: this makes no sense for things in the options dictionary
     appctx = context._appctx
-    new_appctx = {}
-    for k in sorted(appctx.keys()):
-        v = appctx[k]
-        if k != "state":
-            # Constructor makes this one.
-            try:
-                new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
-            except ReconstructionError:
-                # Assume not something that needs reconstruction (e.g. float)
-                new_appctx[k] = v
+    if appctx is not None:
+        raise NotImplementedError
+        new_appctx = {}
+        for k in sorted(appctx.keys()):
+            v = appctx[k]
+            if k != "state":
+                # Constructor makes this one.
+                try:
+                    new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
+                except ReconstructionError:
+                    # Assume not something that needs reconstruction (e.g. float)
+                    new_appctx[k] = v
+    else:
+        new_appctx = None
 
     # Get options prefix for current level
     parent_context = context

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -377,20 +377,19 @@ def reconstruct_snescontext(context, self, coefficient_mapping=None):
         return new_context
 
     problem = self(context._problem, self, coefficient_mapping=coefficient_mapping)
+
+    # FIXME: this makes no sense for things in the options dictionary
     appctx = context._appctx
-    if appctx is not None:
-        new_appctx = {}
-        for k in sorted(appctx.keys()):
-            v = appctx[k]
-            if k != "state":
-                # Constructor makes this one.
-                try:
-                    new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
-                except ReconstructionError:
-                    # Assume not something that needs reconstruction (e.g. float)
-                    new_appctx[k] = v
-    else:
-        new_appctx = None
+    new_appctx = {}
+    for k in sorted(appctx.keys()):
+        v = appctx[k]
+        if k != "state":
+            # Constructor makes this one.
+            try:
+                new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
+            except ReconstructionError:
+                # Assume not something that needs reconstruction (e.g. float)
+                new_appctx[k] = v
 
     # Get options prefix for current level
     parent_context = context

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -377,17 +377,20 @@ def reconstruct_snescontext(context, self, coefficient_mapping=None):
         return new_context
 
     problem = self(context._problem, self, coefficient_mapping=coefficient_mapping)
-    appctx = context.appctx
-    new_appctx = {}
-    for k in sorted(appctx.keys()):
-        v = appctx[k]
-        if k != "state":
-            # Constructor makes this one.
-            try:
-                new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
-            except ReconstructionError:
-                # Assume not something that needs reconstruction (e.g. float)
-                new_appctx[k] = v
+    appctx = context._appctx
+    if appctx is not None:
+        new_appctx = {}
+        for k in sorted(appctx.keys()):
+            v = appctx[k]
+            if k != "state":
+                # Constructor makes this one.
+                try:
+                    new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
+                except ReconstructionError:
+                    # Assume not something that needs reconstruction (e.g. float)
+                    new_appctx[k] = v
+    else:
+        new_appctx = None
 
     # Get options prefix for current level
     parent_context = context

--- a/firedrake/mg/ufl_utils.py
+++ b/firedrake/mg/ufl_utils.py
@@ -254,21 +254,10 @@ def reconstruct_function(expr, self, coefficient_mapping=None):
         coefficient_mapping = {}
     new = coefficient_mapping.get(expr)
     if new is None:
-        V = expr.function_space()
-        Vnew = self(V, self)
-        name = expr.name()
-        if name is not None:
-            try:
-                name, prev_level = name.split("_level_")
-            except ValueError:
-                prev_level = 0
-            level_inc = 1 if self is refine else -1
-            level = int(prev_level) + level_inc
-            name = f"{name}_level_{level}"
-
-        new = firedrake.Function(Vnew, name=name)
-        manager = get_transfer_manager(V.dm)
-        manager.transfer(expr, new)
+        if self is refine:
+            new = firedrake.solving_utils._refine_function(expr)
+        else:
+            new = firedrake.solving_utils._coarsen_function(expr)
         coefficient_mapping[expr] = new
     return new
 
@@ -378,22 +367,10 @@ def reconstruct_snescontext(context, self, coefficient_mapping=None):
 
     problem = self(context._problem, self, coefficient_mapping=coefficient_mapping)
 
-    # FIXME: this makes no sense for things in the options dictionary
     appctx = context._appctx
-    if appctx is not None:
-        raise NotImplementedError
-        new_appctx = {}
-        for k in sorted(appctx.keys()):
-            v = appctx[k]
-            if k != "state":
-                # Constructor makes this one.
-                try:
-                    new_appctx[k] = self(v, self, coefficient_mapping=coefficient_mapping)
-                except ReconstructionError:
-                    # Assume not something that needs reconstruction (e.g. float)
-                    new_appctx[k] = v
-    else:
-        new_appctx = None
+    new_appctx = {}
+    for k, v in appctx.items():
+        new_appctx[k] = v.refine() if self is refine else v.coarsen()
 
     # Get options prefix for current level
     parent_context = context

--- a/firedrake/preconditioners/assembled.py
+++ b/firedrake/preconditioners/assembled.py
@@ -22,8 +22,8 @@ class AssembledPC(PCBase):
         if pc.type != "python":
             raise ValueError("Expecting PC type python")
         opc = pc
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters")
+        prefix = pc.getOptionsPrefix() or ""
+        fcp = dmhooks.get_appctx(pc.getDM()).fcp
 
         V = get_function_space(pc.getDM()).collapse()
         test = TestFunction(V)

--- a/firedrake/preconditioners/auxiliary_snes.py
+++ b/firedrake/preconditioners/auxiliary_snes.py
@@ -106,7 +106,7 @@ class AuxiliaryOperatorSNES(SNESBase):
             nullspace=ctx._nullspace,
             transpose_nullspace=ctx._nullspace_T,
             near_nullspace=ctx._near_nullspace,
-            appctx=ctx.appctx,
+            appctx=ctx._appctx,
             options_prefix=prefix,
             pre_apply_bcs=ctx.pre_apply_bcs,
         )

--- a/firedrake/preconditioners/bddc.py
+++ b/firedrake/preconditioners/bddc.py
@@ -36,19 +36,17 @@ class BDDCPC(PCBase):
     - ``'bddc_pc_bddc_neumann'`` to set sub-KSPs on subdomains excluding corners,
     - ``'bddc_pc_bddc_dirichlet'`` to set sub-KSPs on subdomain interiors,
     - ``'bddc_pc_bddc_coarse'`` to set the coarse solver KSP.
-
-    This PC also inspects optional callbacks supplied in the application context:
-    - ``'get_discrete_gradient'`` for 3D problems in H(curl), this is a callable that
-    provide the arguments (a Mat tabulating the gradient of the auxiliary H1 space) and
-    keyword arguments supplied to ``PETSc.PC.setBDDCDiscreteGradient``.
-    - ``'get_divergence_mat'`` for problems in H(div) (resp. 2D H(curl)), this is
-    provide the arguments (a Mat with the assembled bilinear form testing the divergence
-    (curl) against an L2 space) and keyword arguments supplied to ``PETSc.PC.setDivergenceMat``.
-    - ``'primal_markers'`` a Function marking degrees of freedom of the solution space to be included in the
-    coarse space. Any nonzero value is counted as a marked degree of freedom.
-    If a DG(0) Function is provided, then all degrees of freedom on the cell are marked.
-    Alternatively, ``'primal_markers'`` can be a list of the global degrees of freedom to
-    be supplied directly to ``PETSc.PC.setBDDCPrimalVerticesIS``.
+    - ``'bddc_get_discrete_gradient'`` for 3D problems in H(curl), this is a callable that
+        provide the arguments (a Mat tabulating the gradient of the auxiliary H1 space) and
+        keyword arguments supplied to ``PETSc.PC.setBDDCDiscreteGradient``.
+    - ``'bddc_get_divergence_mat'`` for problems in H(div) (resp. 2D H(curl)), this is
+        provide the arguments (a Mat with the assembled bilinear form testing the divergence
+        (curl) against an L2 space) and keyword arguments supplied to ``PETSc.PC.setDivergenceMat``.
+    - ``'bddc_primal_markers'`` a Function marking degrees of freedom of the solution space to be included in the
+        coarse space. Any nonzero value is counted as a marked degree of freedom.
+        If a DG(0) Function is provided, then all degrees of freedom on the cell are marked.
+        Alternatively, ``'primal_markers'`` can be a list of the global degrees of freedom to
+        be supplied directly to ``PETSc.PC.setBDDCPrimalVerticesIS``.
     """
 
     _prefix = "bddc_"
@@ -121,8 +119,6 @@ class BDDCPC(PCBase):
         neu_bndr = PETSc.IS().createGeneral(neu_nodes, comm=pc.comm)
         bddcpc.setBDDCNeumannBoundaries(neu_bndr)
 
-        appctx = self.get_appctx(pc)
-
         # Set coordinates if corner selection is requested or needed
         # There's no API to query from PC
         entity_dofs = V.finat_element.entity_dofs()
@@ -142,7 +138,7 @@ class BDDCPC(PCBase):
 
         if use_divergence:
             allow_repeated = P.getISAllowRepeated()
-            get_divergence = appctx.get("get_divergence_mat", get_divergence_mat)
+            get_divergence = ctx.get_python_option(prefix, "get_divergence_mat", get_divergence_mat)
             divergence = get_divergence(V, mat_type="is", allow_repeated=allow_repeated)
             try:
                 div_args, div_kwargs = divergence
@@ -151,7 +147,7 @@ class BDDCPC(PCBase):
                 div_kwargs = dict()
             bddcpc.setBDDCDivergenceMat(*div_args, **div_kwargs)
         if use_gradient:
-            get_gradient = appctx.get("get_discrete_gradient", get_discrete_gradient)
+            get_gradient = ctx.get_python_option(prefix, "get_discrete_gradient", get_discrete_gradient)
             gradient = get_gradient(V)
             try:
                 grad_args, grad_kwargs = gradient
@@ -161,7 +157,7 @@ class BDDCPC(PCBase):
             bddcpc.setBDDCDiscreteGradient(*grad_args, **grad_kwargs)
 
         # Set the user-defined primal (coarse) degrees of freedom
-        primal_markers = appctx.get("primal_markers")
+        primal_markers = ctx.get_python_option(prefix, "primal_markers", None)
         if primal_markers is not None:
             primal_indices = get_primal_indices(V, primal_markers)
             primal_is = PETSc.IS().createGeneral(primal_indices.astype(PETSc.IntType), comm=pc.comm)

--- a/firedrake/preconditioners/bddc.py
+++ b/firedrake/preconditioners/bddc.py
@@ -31,22 +31,24 @@ class BDDCPC(PCBase):
 
     Internally, this PC creates a PETSc PCBDDC object that can be controlled by
     the options:
+
     - ``'bddc_cellwise'`` to set up a MatIS on cellwise subdomains if P.type == python,
     - ``'bddc_matfree'`` to set up a matrix-free MatIS if A.type == python,
     - ``'bddc_pc_bddc_neumann'`` to set sub-KSPs on subdomains excluding corners,
     - ``'bddc_pc_bddc_dirichlet'`` to set sub-KSPs on subdomain interiors,
     - ``'bddc_pc_bddc_coarse'`` to set the coarse solver KSP.
     - ``'bddc_get_discrete_gradient'`` for 3D problems in H(curl), this is a callable that
-        provide the arguments (a Mat tabulating the gradient of the auxiliary H1 space) and
-        keyword arguments supplied to ``PETSc.PC.setBDDCDiscreteGradient``.
+      provide the arguments (a Mat tabulating the gradient of the auxiliary H1 space) and
+      keyword arguments supplied to ``PETSc.PC.setBDDCDiscreteGradient``.
     - ``'bddc_get_divergence_mat'`` for problems in H(div) (resp. 2D H(curl)), this is
-        provide the arguments (a Mat with the assembled bilinear form testing the divergence
-        (curl) against an L2 space) and keyword arguments supplied to ``PETSc.PC.setDivergenceMat``.
+      provide the arguments (a Mat with the assembled bilinear form testing the divergence
+      (curl) against an L2 space) and keyword arguments supplied to ``PETSc.PC.setDivergenceMat``.
     - ``'bddc_primal_markers'`` a Function marking degrees of freedom of the solution space to be included in the
-        coarse space. Any nonzero value is counted as a marked degree of freedom.
-        If a DG(0) Function is provided, then all degrees of freedom on the cell are marked.
-        Alternatively, ``'primal_markers'`` can be a list of the global degrees of freedom to
-        be supplied directly to ``PETSc.PC.setBDDCPrimalVerticesIS``.
+      coarse space. Any nonzero value is counted as a marked degree of freedom.
+      If a DG(0) Function is provided, then all degrees of freedom on the cell are marked.
+      Alternatively, ``'primal_markers'`` can be a list of the global degrees of freedom to
+      be supplied directly to ``PETSc.PC.setBDDCPrimalVerticesIS``.
+
     """
 
     _prefix = "bddc_"

--- a/firedrake/preconditioners/facet_split.py
+++ b/firedrake/preconditioners/facet_split.py
@@ -53,8 +53,8 @@ class FacetSplitPC(PCBase):
         domains = domains.split(",")
 
         a, bcs = self.form(pc)
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters")
+        ctx = dmhooks.get_appctx(pc.getDM())
+        fcp = ctx.fcp
         V = a.arguments()[-1].function_space()
         if len(V) != 1:
             raise ValueError("Decomposition of mixed elements is not supported")

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -67,6 +67,7 @@ class FDMPC(PCBase):
     @PETSc.Log.EventDecorator("FDMInit")
     def initialize(self, pc):
         petsctools.cite(self._citation)
+        self.pc = pc
         self.comm = pc.comm
         Amat, Pmat = pc.getOperators()
         prefix = pc.getOptionsPrefix() or ""
@@ -83,9 +84,7 @@ class FDMPC(PCBase):
             allow_repeated = options.getBool("mat_is_allow_repeated", True)
         self.allow_repeated = allow_repeated
 
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters") or {}
-        self.appctx = appctx
+        ctx = dmhooks.get_appctx(pc.getDM())
 
         # Get original Jacobian form and bcs
         J, bcs = self.form(pc)
@@ -93,7 +92,6 @@ class FDMPC(PCBase):
         if Pmat.getType() == "python":
             mat_type = "matfree"
         else:
-            ctx = dmhooks.get_appctx(pc.getDM())
             mat_type = ctx.mat_type
 
         # TODO assemble Schur complements specified by a SLATE Tensor
@@ -124,7 +122,7 @@ class FDMPC(PCBase):
 
             # Create a new _SNESContext in the variant space
             self._ctx_ref = self.new_snes_ctx(pc, J_fdm, bcs_fdm, mat_type,
-                                              fcp=fcp, options_prefix=options_prefix)
+                                              fcp=ctx.fcp, options_prefix=options_prefix)
 
             # Construct interpolation from variant to original spaces
             self.fdm_interp = prolongation_matrix_matfree(V_fdm, V, bcs_fdm, [])
@@ -132,7 +130,7 @@ class FDMPC(PCBase):
             self.work_vec_y = Amat.createVecRight()
             if use_amat:
                 from firedrake.assemble import get_assembler
-                form_assembler = get_assembler(J_fdm, bcs=bcs_fdm, form_compiler_parameters=fcp, mat_type=mat_type, options_prefix=options_prefix)
+                form_assembler = get_assembler(J_fdm, bcs=bcs_fdm, form_compiler_parameters=ctx.fcp, mat_type=mat_type, options_prefix=options_prefix)
                 self.A = form_assembler.allocate()
                 self._assemble_A = form_assembler.assemble
                 self._assemble_A(tensor=self.A)
@@ -157,7 +155,7 @@ class FDMPC(PCBase):
 
         # Assemble the FDM preconditioner with sparse local matrices
         self.V = V_fdm
-        Amat, Pmat, self.assembly_callables = self.allocate_matrix(Amat, V_fdm, J_fdm, bcs_fdm, fcp,
+        Amat, Pmat, self.assembly_callables = self.allocate_matrix(Amat, V_fdm, J_fdm, bcs_fdm, ctx.fcp,
                                                                    pmat_type, use_static_condensation, use_amat)
         self.assembly_callables.append(partial(Pmat.viewFromOptions, "-pmat_view", fdmpc))
         self._assemble_P()
@@ -1930,7 +1928,9 @@ class PoissonFDMPC(FDMPC):
         axes_shifts, = shifts
 
         degree = max(e.degree() for e in line_elements)
-        eta = float(self.appctx.get("eta", degree*(degree+1)))
+        prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
+        ctx = dmhooks.get_appctx(pc.getDM())
+        eta = float(ctx.get_python_option(prefix, "eta", degree*(degree+1)))
         is_dg = V.finat_element.is_dg()
         Afdm = []  # sparse interval mass and stiffness matrices for each direction
         Dfdm = []  # tabulation of normal derivatives at the boundary for each direction
@@ -2097,7 +2097,10 @@ class PoissonFDMPC(FDMPC):
                 raise NotImplementedError("Static condensation for SIPG not implemented")
             if tdim < V.mesh().geometric_dimension:
                 raise NotImplementedError("SIPG on immersed meshes is not implemented")
-            eta = float(self.appctx.get("eta"))
+
+            prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
+            ctx = dmhooks.get_appctx(pc.getDM())
+            eta = float(ctx.get_python_option(prefix, "eta", None))
 
             lgmap = self.lgmaps[V]
             index_facet, local_facet_data, nfacets = extrude_interior_facet_maps(V)

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -1929,7 +1929,7 @@ class PoissonFDMPC(FDMPC):
 
         degree = max(e.degree() for e in line_elements)
         prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
-        ctx = dmhooks.get_appctx(pc.getDM())
+        ctx = dmhooks.get_appctx(self.pc.getDM())
         eta = float(ctx.get_python_option(prefix, "eta", degree*(degree+1)))
         is_dg = V.finat_element.is_dg()
         Afdm = []  # sparse interval mass and stiffness matrices for each direction
@@ -2099,7 +2099,7 @@ class PoissonFDMPC(FDMPC):
                 raise NotImplementedError("SIPG on immersed meshes is not implemented")
 
             prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
-            ctx = dmhooks.get_appctx(pc.getDM())
+            ctx = dmhooks.get_appctx(self.pc.getDM())
             eta = float(ctx.get_python_option(prefix, "eta", None))
 
             lgmap = self.lgmaps[V]

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -67,11 +67,11 @@ class FDMPC(PCBase):
     @PETSc.Log.EventDecorator("FDMInit")
     def initialize(self, pc):
         petsctools.cite(self._citation)
-        self.pc = pc
         self.comm = pc.comm
         Amat, Pmat = pc.getOperators()
         prefix = pc.getOptionsPrefix() or ""
         options_prefix = prefix + self._prefix
+        self.options_prefix = options_prefix
         options = PETSc.Options(options_prefix)
 
         use_amat = options.getBool("pc_use_amat", True)
@@ -1929,9 +1929,8 @@ class PoissonFDMPC(FDMPC):
         axes_shifts, = shifts
 
         degree = max(e.degree() for e in line_elements)
-        prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
         ctx = dmhooks.get_appctx(self.pc.getDM())
-        eta = float(ctx.get_python_option(prefix, "eta", degree*(degree+1)))
+        eta = float(ctx.get_python_option(self.options_prefix, "eta", degree*(degree+1)))
         is_dg = V.finat_element.is_dg()
         Afdm = []  # sparse interval mass and stiffness matrices for each direction
         Dfdm = []  # tabulation of normal derivatives at the boundary for each direction
@@ -2099,9 +2098,8 @@ class PoissonFDMPC(FDMPC):
             if tdim < V.mesh().geometric_dimension:
                 raise NotImplementedError("SIPG on immersed meshes is not implemented")
 
-            prefix = (self.pc.getOptionsPrefix() or "") + self._prefix
             ctx = dmhooks.get_appctx(self.pc.getDM())
-            eta = float(ctx.get_python_option(prefix, "eta", None))
+            eta = float(ctx.get_python_option(self.options_prefix, "eta"))
 
             lgmap = self.lgmaps[V]
             index_facet, local_facet_data, nfacets = extrude_interior_facet_maps(V)

--- a/firedrake/preconditioners/fdm.py
+++ b/firedrake/preconditioners/fdm.py
@@ -85,6 +85,7 @@ class FDMPC(PCBase):
         self.allow_repeated = allow_repeated
 
         ctx = dmhooks.get_appctx(pc.getDM())
+        fcp = ctx.fcp or {}
 
         # Get original Jacobian form and bcs
         J, bcs = self.form(pc)
@@ -122,7 +123,7 @@ class FDMPC(PCBase):
 
             # Create a new _SNESContext in the variant space
             self._ctx_ref = self.new_snes_ctx(pc, J_fdm, bcs_fdm, mat_type,
-                                              fcp=ctx.fcp, options_prefix=options_prefix)
+                                              fcp=fcp, options_prefix=options_prefix)
 
             # Construct interpolation from variant to original spaces
             self.fdm_interp = prolongation_matrix_matfree(V_fdm, V, bcs_fdm, [])
@@ -130,7 +131,7 @@ class FDMPC(PCBase):
             self.work_vec_y = Amat.createVecRight()
             if use_amat:
                 from firedrake.assemble import get_assembler
-                form_assembler = get_assembler(J_fdm, bcs=bcs_fdm, form_compiler_parameters=ctx.fcp, mat_type=mat_type, options_prefix=options_prefix)
+                form_assembler = get_assembler(J_fdm, bcs=bcs_fdm, form_compiler_parameters=fcp, mat_type=mat_type, options_prefix=options_prefix)
                 self.A = form_assembler.allocate()
                 self._assemble_A = form_assembler.assemble
                 self._assemble_A(tensor=self.A)
@@ -155,7 +156,7 @@ class FDMPC(PCBase):
 
         # Assemble the FDM preconditioner with sparse local matrices
         self.V = V_fdm
-        Amat, Pmat, self.assembly_callables = self.allocate_matrix(Amat, V_fdm, J_fdm, bcs_fdm, ctx.fcp,
+        Amat, Pmat, self.assembly_callables = self.allocate_matrix(Amat, V_fdm, J_fdm, bcs_fdm, fcp,
                                                                    pmat_type, use_static_condensation, use_amat)
         self.assembly_callables.append(partial(Pmat.viewFromOptions, "-pmat_view", fdmpc))
         self._assemble_P()

--- a/firedrake/preconditioners/gtmg.py
+++ b/firedrake/preconditioners/gtmg.py
@@ -25,24 +25,24 @@ class GTMGPC(PCBase):
         * `V`: the fine space on which the problem is formulated
         * `V_coarse`: a user-defined coarse space
 
-    The following options must be passed through the `appctx` dictionary:
+    The following options must be passed through the solver parameters:
 
-        * `get_coarse_space`: method which returns the user-defined coarse space
-        * `get_coarse_operator`: method which returns the operator on the coarse space
+        * `gt_get_coarse_space`: method which returns the user-defined coarse space
+        * `gt_get_coarse_operator`: method which returns the operator on the coarse space
 
-    The following options (also passed through the `appctx`) are optional:
+    The following options are optional:
 
-        * `form_compiler_parameters`: parameters for assembling operators on
+        * `gt_form_compiler_parameters`: parameters for assembling operators on
           both levels of the hierarchy.
-        * `coarse_space_bcs`: boundary conditions to be used on coarse space.
-        * `get_coarse_op_nullspace`: method which returns the nullspace of the
+        * `gt_coarse_space_bcs`: boundary conditions to be used on coarse space.
+        * `gt_get_coarse_op_nullspace`: method which returns the nullspace of the
           coarse operator.
-        * `get_coarse_op_transpose_nullspace`: method which returns the
+        * `gt_get_coarse_op_transpose_nullspace`: method which returns the
           nullspace of the transpose of the coarse operator.
-        * `interpolation_matrix`: PETSc Mat which describes the interpolation
+        * `gt_interpolation_matrix`: PETSc Mat which describes the interpolation
           from the coarse to the fine space. If omitted, this will be
           constructed automatically with an :class:`.Interpolate` object.
-        * `restriction_matrix`: PETSc Mat which describes the restriction
+        * `gt_restriction_matrix`: PETSc Mat which describes the restriction
           from the fine space dual to the coarse space dual. It defaults
           to the transpose of the interpolation matrix.
 
@@ -69,17 +69,16 @@ class GTMGPC(PCBase):
 
         petsctools.cite("Gopalakrishnan2009")
         _, P = pc.getOperators()
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters")
-
-        if pc.getType() != "python":
-            raise ValueError("Expecting PC type python")
-
         ctx = dmhooks.get_appctx(pc.getDM())
         if ctx is None:
             raise ValueError("No context found.")
         if not isinstance(ctx, _SNESContext):
             raise ValueError("Don't know how to get form from %r" % ctx)
+
+        fcp = ctx.fcp
+
+        if pc.getType() != "python":
+            raise ValueError("Expecting PC type python")
 
         prefix = pc.getOptionsPrefix() or ""
         options_prefix = prefix + self._prefix
@@ -119,21 +118,23 @@ class GTMGPC(PCBase):
         coarse_mat_type = opts.getString(coarse_options_prefix + "mat_type",
                                          parameters["default_matrix_type"])
 
-        get_coarse_space = appctx.get("get_coarse_space", None)
-        if not get_coarse_space:
+        try:
+            get_coarse_space = ctx.get_python_option(options_prefix, "get_coarse_space")
+        except KeyError:
             raise ValueError("Need to provide a callback which provides the coarse space.")
         coarse_space = get_coarse_space()
 
-        get_coarse_operator = appctx.get("get_coarse_operator", None)
-        if not get_coarse_operator:
+        try:
+            get_coarse_operator = ctx.get_python_option(options_prefix, "get_coarse_operator")
+        except KeyError:
             raise ValueError("Need to provide a callback which provides the coarse operator.")
         coarse_operator = get_coarse_operator()
 
-        coarse_space_bcs = appctx.get("coarse_space_bcs", None)
+        coarse_space_bcs = ctx.get_python_option(options_prefix, "coarse_space_bcs", None)
 
         # These should be callbacks which return the relevant nullspaces
-        get_coarse_nullspace = appctx.get("get_coarse_op_nullspace", None)
-        get_coarse_transpose_nullspace = appctx.get("get_coarse_op_transpose_nullspace", None)
+        get_coarse_nullspace = ctx.get_python_option(options_prefix, "get_coarse_op_nullspace", None)
+        get_coarse_transpose_nullspace = ctx.get_python_option(options_prefix, "get_coarse_op_transpose_nullspace", None)
 
         coarse_form_assembler = get_assembler(coarse_operator, bcs=coarse_space_bcs, form_compiler_parameters=fcp, mat_type=coarse_mat_type, options_prefix=coarse_options_prefix)
         self.coarse_op = coarse_form_assembler.allocate()
@@ -150,14 +151,15 @@ class GTMGPC(PCBase):
             tnsp = get_coarse_transpose_nullspace()
             coarse_opmat.setTransposeNullSpace(tnsp.nullspace())
 
-        interp_petscmat = appctx.get("interpolation_matrix", None)
-        if interp_petscmat is None:
+        try:
+            interp_petscmat = ctx.get_python_option(options_prefix, "interpolation_matrix")
+        except KeyError:
             # Create interpolation matrix from coarse space to fine space
             fine_space = ctx.J.arguments()[0].function_space()
             coarse_test, coarse_trial = coarse_operator.arguments()
             interp = assemble(interpolate(coarse_trial, fine_space))
             interp_petscmat = interp.petscmat
-        restr_petscmat = appctx.get("restriction_matrix", None)
+        restr_petscmat = ctx.get_python_option(options_prefix, "restriction_matrix", None)
 
         # We set up a PCMG object that uses the constructed interpolation
         # matrix to generate the restriction/prolongation operators.

--- a/firedrake/preconditioners/hiptmair.py
+++ b/firedrake/preconditioners/hiptmair.py
@@ -36,8 +36,8 @@ class TwoLevelPC(PCBase):
     def initialize(self, pc):
         from firedrake.assemble import get_assembler
         A, P = pc.getOperators()
-        appctx = self.get_appctx(pc)
-        fcp = appctx.get("form_compiler_parameters")
+        ctx = dmhooks.get_appctx(pc.getDM())
+        fcp = ctx.fcp
 
         prefix = pc.getOptionsPrefix() or ""
         options_prefix = prefix + self._prefix
@@ -140,7 +140,7 @@ class HiptmairPC(TwoLevelPC):
 
     def coarsen(self, pc):
         petsctools.cite("Hiptmair1998")
-        appctx = self.get_appctx(pc)
+        ctx = dmhooks.get_appctx(pc.getDM())
 
         a, bcs = self.form(pc)
         V = a.arguments()[-1].function_space()
@@ -165,13 +165,13 @@ class HiptmairPC(TwoLevelPC):
         coarse_space_bcs = [bc.reconstruct(V=coarse_space, g=0) for bc in bcs]
 
         if element.sobolev_space == ufl.HDiv:
-            G_callback = appctx.get("get_curl", None)
+            G_callback = ctx.get_python_option(options_prefix, "get_curl", None)
             dminus = ufl.curl
             if V.shape:
                 dminus = lambda u: ufl.as_vector([ufl.curl(u[k, ...])
                                                   for k in range(u.ufl_shape[0])])
         else:
-            G_callback = appctx.get("get_gradient", None)
+            G_callback = ctx.get_python_option(options_prefix, "get_gradient", None)
             dminus = ufl.grad
 
         # Get only the zero-th order term of the form
@@ -194,7 +194,8 @@ class HiptmairPC(TwoLevelPC):
 
         cdegree = max(as_tuple(celement.degree()))
         if formdegree > 1 and cdegree > 1:
-            shift = appctx.get("hiptmair_shift", None)
+            # TODO: now things are prefixed the extra 'hiptmair_' is bad practice
+            shift = ctx.get_python_option(options_prefix, "hiptmair_shift", None)
             if shift is not None:
                 b = beta(test, shift * trial)
                 coarse_operator += ufl.Form(b.integrals_by_type("cell"))

--- a/firedrake/preconditioners/hypre_ads.py
+++ b/firedrake/preconditioners/hypre_ads.py
@@ -3,7 +3,7 @@ from firedrake.preconditioners.fdm import tabulate_exterior_derivative
 from firedrake.petsc import PETSc
 from firedrake.function import Function
 from firedrake.ufl_expr import TrialFunction
-from firedrake.dmhooks import get_function_space
+from firedrake.dmhooks import get_function_space, get_appctx
 from firedrake.preconditioners.hypre_ams import chop
 from firedrake.interpolation import interpolate
 from finat.ufl import FiniteElement, TensorElement, VectorElement
@@ -17,7 +17,7 @@ class HypreADS(PCBase):
     def initialize(self, obj):
         from firedrake.assemble import assemble
         A, P = obj.getOperators()
-        appctx = self.get_appctx(obj)
+        ctx = get_appctx(obj.getDM())
         prefix = obj.getOptionsPrefix() or ""
         V = get_function_space(obj.getDM()).collapse()
         mesh = V.mesh()
@@ -41,8 +41,9 @@ class HypreADS(PCBase):
         P1 = V.reconstruct(element=P1_element)
         VectorP1 = V.reconstruct(element=coords_element)
 
-        G_callback = appctx.get("get_gradient", None)
-        if G_callback is None:
+        try:
+            G_callback = ctx.get_python_option(prefix, "get_gradient")
+        except KeyError:
             try:
                 G = chop(assemble(interpolate(grad(TrialFunction(P1)), NC1)).petscmat)
             except NotImplementedError:
@@ -50,8 +51,9 @@ class HypreADS(PCBase):
                 G = tabulate_exterior_derivative(P1, NC1)
         else:
             G = G_callback(P1, NC1)
-        C_callback = appctx.get("get_curl", None)
-        if C_callback is None:
+        try:
+            C_callback = ctx.get_python_option(prefix, "get_curl")
+        except KeyError:
             try:
                 C = chop(assemble(interpolate(curl(TrialFunction(NC1)), V)).petscmat)
             except NotImplementedError:

--- a/firedrake/preconditioners/hypre_ams.py
+++ b/firedrake/preconditioners/hypre_ams.py
@@ -4,7 +4,7 @@ from firedrake.preconditioners.fdm import tabulate_exterior_derivative
 from firedrake.petsc import PETSc
 from firedrake.function import Function
 from firedrake.ufl_expr import TrialFunction
-from firedrake.dmhooks import get_function_space
+from firedrake.dmhooks import get_function_space, get_appctx
 from firedrake.utils import complex_mode
 from firedrake.interpolation import interpolate
 from ufl import grad, SpatialCoordinate
@@ -38,7 +38,7 @@ class HypreAMS(PCBase):
 
         petsctools.cite("Kolev2009")
         A, P = obj.getOperators()
-        appctx = self.get_appctx(obj)
+        ctx = get_appctx(obj.getDM())
         prefix = obj.getOptionsPrefix() or ""
         V = get_function_space(obj.getDM()).collapse()
         mesh = V.mesh()
@@ -57,8 +57,9 @@ class HypreAMS(PCBase):
         P1 = V.reconstruct(element=P1_element)
         VectorP1 = V.reconstruct(element=coords_element)
 
-        G_callback = appctx.get("get_gradient", None)
-        if G_callback is None:
+        try:
+            G_callback = ctx.get_python_option(prefix, "get_gradient")
+        except KeyError:
             try:
                 G = chop(assemble(interpolate(grad(TrialFunction(P1)), V)).petscmat)
             except NotImplementedError:

--- a/firedrake/preconditioners/massinv.py
+++ b/firedrake/preconditioners/massinv.py
@@ -1,5 +1,6 @@
-from firedrake.preconditioners.assembled import AssembledPC
 from firedrake import inner, dx
+from firedrake.dmhooks import get_appctx
+from firedrake.preconditioners.assembled import AssembledPC
 
 __all__ = ("MassInvPC", )
 
@@ -18,8 +19,7 @@ class MassInvPC(AssembledPC):
     For Stokes problems, to be spectrally equivalent to the Schur
     complement, the mass matrix should be weighted by the viscosity.
     This can be provided (defaulting to constant viscosity) by
-    providing a field defining the viscosity in the application
-    context, keyed on ``"mu"``.
+    providing a field defining the viscosity, keyed on ``"mu"``.
     """
 
     _prefix = "Mp_"
@@ -27,8 +27,8 @@ class MassInvPC(AssembledPC):
     def form(self, pc, test, trial):
         _, bcs = super(MassInvPC, self).form(pc)
 
-        appctx = self.get_appctx(pc)
-        mu = appctx.get("mu", 1.0)
+        prefix = pc.getOptionsPrefix() or ""
+        mu = get_appctx(pc.getDM()).get_python_option(prefix, "mu", 1.0)
         a = inner((1/mu) * trial, test) * dx
         return a, bcs
 

--- a/firedrake/preconditioners/massinv.py
+++ b/firedrake/preconditioners/massinv.py
@@ -19,7 +19,7 @@ class MassInvPC(AssembledPC):
     For Stokes problems, to be spectrally equivalent to the Schur
     complement, the mass matrix should be weighted by the viscosity.
     This can be provided (defaulting to constant viscosity) by
-    providing a field defining the viscosity, keyed on ``"mu"``.
+    providing a field defining the viscosity, keyed on ``"Mp_mu"``.
     """
 
     _prefix = "Mp_"
@@ -27,7 +27,7 @@ class MassInvPC(AssembledPC):
     def form(self, pc, test, trial):
         _, bcs = super(MassInvPC, self).form(pc)
 
-        prefix = pc.getOptionsPrefix() or ""
+        prefix = (pc.getOptionsPrefix() or "") + self._prefix
         mu = get_appctx(pc.getDM()).get_python_option(prefix, "mu", 1.0)
         a = inner((1/mu) * trial, test) * dx
         return a, bcs

--- a/firedrake/preconditioners/patch.py
+++ b/firedrake/preconditioners/patch.py
@@ -658,7 +658,7 @@ def select_entity(p, dm=None, exclude=None):
         return dm.getLabelValue(exclude, p) == -1
 
 
-class PlaneSmoother(object):
+class PlaneSmoother:
     @staticmethod
     def coords(dm, p, coordinates):
         coordinatesV = coordinates.function_space()
@@ -759,9 +759,9 @@ class PlaneSmoother(object):
                 axis = int(sweep_split[0])
             except ValueError:
                 try:
-                    axis = context.appctx[sweep_split[0]]
+                    axis = context.get_python_option(prefix, sweep_split[0])
                 except KeyError:
-                    raise KeyError("PlaneSmoother axis key %s not provided" % sweep_split[0])
+                    raise KeyError(f"PlaneSmoother axis key {sweep_split[0]} not provided")
 
             dir = {'+': +1, '-': -1}[sweep_split[1]]
             # Either use equispaced bins for relaxation or get from appctx
@@ -770,10 +770,10 @@ class PlaneSmoother(object):
                 entities = self.sort_entities(dm, axis, dir, ndiv=ndiv)
             except ValueError:
                 try:
-                    divisions = context.appctx[sweep_split[2]]
+                    divisions = context.get_python_option(prefix, sweep_split[2])
                     entities = self.sort_entities(dm, axis, dir, divisions=divisions)
                 except KeyError:
-                    raise KeyError("PlaneSmoother division key %s not provided" % sweep_split[2:])
+                    raise KeyError(f"PlaneSmoother division key {sweep_split[2:]} not provided")
 
             for patch in entities:
                 if not patch:

--- a/firedrake/preconditioners/pcd.py
+++ b/firedrake/preconditioners/pcd.py
@@ -1,3 +1,4 @@
+import firedrake.dmhooks
 from firedrake.preconditioners.base import PCBase
 from firedrake.petsc import PETSc
 
@@ -46,6 +47,8 @@ class PCDPC(PCBase):
         if pc.getType() != "python":
             raise ValueError("Expecting PC type python")
         prefix = (pc.getOptionsPrefix() or "") + "pcd_"
+
+        snes_ctx = firedrake.dmhooks.get_appctx(pc.getDM())
 
         # we assume P has things stuffed inside of it
         _, P = pc.getOperators()
@@ -101,13 +104,10 @@ class PCDPC(PCBase):
         Kksp.setFromOptions()
         self.Kksp = Kksp
 
-        state = context.appctx["state"]
+        Re = snes_ctx.get_python_option(prefix, "Re", 1.0)
+        velid = int(snes_ctx.get_python_option(prefix, "velocity_space"))
 
-        Re = context.appctx.get("Re", 1.0)
-
-        velid = context.appctx["velocity_space"]
-
-        u0 = split(state)[velid]
+        u0 = split(snes_ctx.state)[velid]
         fp = 1.0/Re * inner(grad(p), grad(q))*dx + inner(u0, grad(p))*q*dx
 
         self.Re = Re

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -261,15 +261,19 @@ class PMGBase(PCSNESBase):
 
         # FIXME: this makes no sense for things in the options dictionary
         # Coarsen the appctx: the user might want to provide solution-dependent expressions and forms
-        cappctx = dict(fctx._appctx)
-        for key in cappctx:
-            val = cappctx[key]
-            if isinstance(val, dict):
-                cappctx[key] = self.coarsen_quadrature(val, fdeg, cdeg)
-            elif isinstance(val, ufl.Form):
-                cappctx[key] = _coarsen_form(val, fine_to_coarse_map)
-            elif isinstance(val, ufl.classes.Expr):
-                cappctx[key] = ufl.replace(val, fine_to_coarse_map)
+        if fctx._appctx is not None:
+            raise NotImplementedError
+            cappctx = dict(fctx._appctx)
+            for key in cappctx:
+                val = cappctx[key]
+                if isinstance(val, dict):
+                    cappctx[key] = self.coarsen_quadrature(val, fdeg, cdeg)
+                elif isinstance(val, ufl.Form):
+                    cappctx[key] = _coarsen_form(val, fine_to_coarse_map)
+                elif isinstance(val, ufl.classes.Expr):
+                    cappctx[key] = ufl.replace(val, fine_to_coarse_map)
+        else:
+            cappctx = None
 
         # Coarsen the _SNESContext
         cctx = fctx.reconstruct(cproblem, mat_type, pmat_type,

--- a/firedrake/preconditioners/pmg.py
+++ b/firedrake/preconditioners/pmg.py
@@ -259,8 +259,9 @@ class PMGBase(PCSNESBase):
         fine_to_coarse_map = dict(zip(fproblem.J.arguments(), cproblem.J.arguments()))
         fine_to_coarse_map[fu] = cu
 
+        # FIXME: this makes no sense for things in the options dictionary
         # Coarsen the appctx: the user might want to provide solution-dependent expressions and forms
-        cappctx = dict(fctx.appctx)
+        cappctx = dict(fctx._appctx)
         for key in cappctx:
             val = cappctx[key]
             if isinstance(val, dict):

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -210,7 +210,7 @@ class HybridizationPC(SCBase):
         self._assemble_Srhs = get_assembler(schur_rhs, form_compiler_parameters=self.ctx.fc_params).assemble
 
         mat_type = PETSc.Options().getString(prefix + "mat_type", "aij")
-        form_assembler = get_assembler(schur_comp, bcs=trace_bcs, form_compiler_parameters=self.ctx.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=self.get_appctx(pc))
+        form_assembler = get_assembler(schur_comp, bcs=trace_bcs, form_compiler_parameters=self.ctx.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
         self.S = form_assembler.allocate()
         self._assemble_S = form_assembler.assemble
 

--- a/firedrake/slate/static_condensation/hybridization.py
+++ b/firedrake/slate/static_condensation/hybridization.py
@@ -44,6 +44,8 @@ class HybridizationPC(SCBase):
 
         # Extract the problem context
         prefix = (pc.getOptionsPrefix() or "") + "hybridization_"
+        snes_ctx = dmhooks.get_appctx(pc.getDM())
+
         _, P = pc.getOperators()
         self.ctx = P.getPythonContext()
 
@@ -210,7 +212,7 @@ class HybridizationPC(SCBase):
         self._assemble_Srhs = get_assembler(schur_rhs, form_compiler_parameters=self.ctx.fc_params).assemble
 
         mat_type = PETSc.Options().getString(prefix + "mat_type", "aij")
-        form_assembler = get_assembler(schur_comp, bcs=trace_bcs, form_compiler_parameters=self.ctx.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
+        form_assembler = get_assembler(schur_comp, bcs=trace_bcs, form_compiler_parameters=self.ctx.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=snes_ctx._appctx)
         self.S = form_assembler.allocate()
         self._assemble_S = form_assembler.assemble
 
@@ -219,7 +221,7 @@ class HybridizationPC(SCBase):
 
         Smat = self.S.petscmat
 
-        nullspace = self.ctx.appctx.get("trace_nullspace", None)
+        nullspace = snes_ctx.get_python_option(prefix, "trace_nullspace", None)
         if nullspace is not None:
             nsp = nullspace(TraceSpace)
             Smat.setNullSpace(nsp.nullspace())
@@ -246,7 +248,7 @@ class HybridizationPC(SCBase):
         trace_ksp.setOperators(Smat, Smat)
 
         # Option to add custom monitor
-        monitor = self.ctx.appctx.get('custom_monitor', None)
+        monitor = snes_ctx.get_python_option(prefix, 'custom_monitor', None)
         if monitor:
             monitor.add_reconstructor(self.backward_substitution)
             trace_ksp.setMonitor(monitor)

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -37,6 +37,8 @@ class SCPC(SCBase):
         from ufl import dx
 
         prefix = (pc.getOptionsPrefix() or "") + "condensed_field_"
+        snes_ctx = dmhooks.get_appctx(pc.getDM())
+
         A, P = pc.getOperators()
         self.cxt = A.getPythonContext()
         if not isinstance(self.cxt, ImplicitMatrixContext):
@@ -100,7 +102,7 @@ class SCPC(SCBase):
         self._assemble_Srhs = get_assembler(r_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params).assemble
 
         # Allocate and set the condensed operator
-        form_assembler = get_assembler(S_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
+        form_assembler = get_assembler(S_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=snes_ctx._appctx)
         self.S = form_assembler.allocate()
         self._assemble_S = form_assembler.assemble
 
@@ -118,7 +120,7 @@ class SCPC(SCBase):
             self.S_pc_expr = S_pc_expr
 
             # Allocate and set the condensed operator
-            form_assembler = get_assembler(S_pc_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
+            form_assembler = get_assembler(S_pc_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=snes_ctx._appctx)
             self.S_pc = form_assembler.allocate()
             self._assemble_S_pc = form_assembler.assemble
 
@@ -132,7 +134,7 @@ class SCPC(SCBase):
         # Get nullspace for the condensed operator (if any).
         # This is provided as a user-specified callback which
         # returns the basis for the nullspace.
-        nullspace = self.cxt.appctx.get("condensed_field_nullspace", None)
+        nullspace = snes_ctx.get_python_option(prefix, "condensed_field_nullspace", None)
         if nullspace is not None:
             nsp = nullspace(Vc)
             Smat.setNullSpace(nsp.nullspace())

--- a/firedrake/slate/static_condensation/scpc.py
+++ b/firedrake/slate/static_condensation/scpc.py
@@ -100,7 +100,7 @@ class SCPC(SCBase):
         self._assemble_Srhs = get_assembler(r_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params).assemble
 
         # Allocate and set the condensed operator
-        form_assembler = get_assembler(S_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=self.get_appctx(pc))
+        form_assembler = get_assembler(S_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
         self.S = form_assembler.allocate()
         self._assemble_S = form_assembler.assemble
 
@@ -118,7 +118,7 @@ class SCPC(SCBase):
             self.S_pc_expr = S_pc_expr
 
             # Allocate and set the condensed operator
-            form_assembler = get_assembler(S_pc_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=self.get_appctx(pc))
+            form_assembler = get_assembler(S_pc_expr, bcs=bcs, form_compiler_parameters=self.cxt.fc_params, mat_type=mat_type, options_prefix=prefix, appctx=dmhooks.get_appctx(pc.getDM())._appctx)
             self.S_pc = form_assembler.allocate()
             self._assemble_S_pc = form_assembler.assemble
 

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -252,7 +252,7 @@ def _la_solve(A, x, b, **kwargs):
     if bcs is not None:
         raise RuntimeError("It is no longer possible to apply or change boundary conditions after assembling the matrix `A`; pass any necessary boundary conditions to `assemble` when assembling `A`.")
 
-    appctx = solver_parameters.get("appctx", {})
+    appctx = solver_parameters.get("appctx", None)
     solver = ls.LinearSolver(A=A, P=P, solver_parameters=solver_parameters,
                              nullspace=nullspace,
                              transpose_nullspace=nullspace_T,

--- a/firedrake/solving.py
+++ b/firedrake/solving.py
@@ -171,7 +171,7 @@ def _solve_varproblem(*args, **kwargs):
         form_compiler_parameters = {}
     form_compiler_parameters['scalar_type'] = ScalarType
 
-    appctx = kwargs.get("appctx", {})
+    appctx = kwargs.get("appctx", None)
     if not isinstance(eq.lhs, ufl.BaseForm):
         raise TypeError(f"Equation LHS must be a ufl.BaseForm, not a {type(eq.lhs).__name__}")
 

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,7 +1,10 @@
 import typing
+import warnings
 from itertools import chain
+from typing import Any
 
 import numpy
+import petsctools
 import ufl
 
 from pyop2 import op2
@@ -135,7 +138,11 @@ Reason:
    %s""" % (snes.getIterationNumber(), msg))
 
 
-class _SNESContext(object):
+_missing = object()
+"""Sentinel value used as a default for when 'None' is potentially meaningful."""
+
+
+class _SNESContext:
     """Context holding information for SNES callbacks.
 
     Parameters
@@ -157,7 +164,7 @@ class _SNESContext(object):
         Indicates the matrix type for the sparse blocks in the preconditioner
         if pmat_type='nest', ignored otherwise.
     appctx
-        Any extra information used in the assembler.  For the
+        (Deprecated) Any extra information used in the assembler.  For the
         matrix-free case this will contain the Newton state in ``"state"``.
     pre_jacobian_callback
         User-defined function called immediately before Jacobian assembly.
@@ -237,7 +244,7 @@ class _SNESContext(object):
         appctx.setdefault("state", self._x)
         appctx.setdefault("form_compiler_parameters", self.fcp)
 
-        self.appctx = appctx
+        self._appctx = appctx
         self.matfree = matfree
         self.pmatfree = pmatfree
         self.F = problem.F
@@ -295,6 +302,70 @@ class _SNESContext(object):
         self._coefficient_mapping = None
         self._transfer_manager = transfer_manager
 
+    @property
+    def appctx(self) -> dict:
+        # Raise a 'DeprecationWarning' here instead of a 'FutureWarning' because
+        # this in an internal detail, not user facing
+        warnings.warn(
+            "'appctx' is now deprecated. Pass Python objects into the "
+            "PETSc options directly.",
+            DeprecationWarning,
+        )
+        return self._appctx
+
+    def get_python_option(
+        self,
+        prefix: str,
+        option: str,
+        default: Any = _missing,
+    ) -> Any:
+        """Return a Python object from either the options database or appctx.
+
+        This is a temporary method to facilitate the deprecation process for
+        the appctx.
+
+        Parameters
+        ----------
+        prefix
+            The options prefix.
+        option
+            The option name.
+        default
+            Default value if option is not found. If unspecified then a
+            `KeyError` is raised.
+
+        Returns
+        -------
+        Any
+            The object referred to by ``option``.
+
+        Raises
+        ------
+        KeyError
+            If ``option`` is not found and ``default`` is unspecified.
+
+        """
+        opts = petsctools.Options(prefix)
+        try:
+            value = opts[option]
+        except KeyError:
+            # not in the options database - try the old, unprefixed approach
+            try:
+                value = self._appctx[option]
+            except KeyError:
+                if default is not _missing:
+                    value = default
+                else:
+                    raise KeyError
+            else:
+                warnings.warn(
+                    "Passing Python objects to preconditioners via the 'appctx' kwarg "
+                    "is now deprecated. Pass the objects into the PETSc options "
+                    "directly instead.",
+                    FutureWarning,
+                )
+        return value
+
     def reconstruct(self,
                     problem: "NonlinearVariationalProblem | None" = None,
                     mat_type: str | None = None,
@@ -326,7 +397,7 @@ class _SNESContext(object):
         default_options = dict(
             sub_mat_type=self.sub_mat_type,
             sub_pmat_type=self.sub_pmat_type,
-            appctx=self.appctx,
+            appctx=self._appctx,
             options_prefix=self.options_prefix,
             transfer_manager=self.transfer_manager,
             pre_jacobian_callback=self._pre_jacobian_callback,
@@ -644,7 +715,7 @@ class _SNESContext(object):
         from firedrake.assemble import get_assembler
         return get_assembler(self.J, bcs=self.bcs_J, form_compiler_parameters=self.fcp,
                              mat_type=self.mat_type, sub_mat_type=self.sub_mat_type,
-                             options_prefix=self.options_prefix, appctx=self.appctx)
+                             options_prefix=self.options_prefix, appctx=self._appctx)
 
     @cached_property
     def _jac(self):
@@ -664,7 +735,7 @@ class _SNESContext(object):
         if self.mat_type != self.pmat_type or self._problem.Jp is not None:
             return get_assembler(self.Jp, bcs=self.bcs_Jp, form_compiler_parameters=self.fcp,
                                  mat_type=self.pmat_type, sub_mat_type=self.sub_pmat_type,
-                                 options_prefix=self.options_prefix, appctx=self.appctx)
+                                 options_prefix=self.options_prefix, appctx=self._appctx)
         else:
             return self._assembler_jac
 

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -234,15 +234,12 @@ class _SNESContext:
         # Function to hold current guess
         self._x = problem.u_restrict
 
-        if appctx is None:
-            appctx = {}
         # A split context will already get the full state.
-        # TODO, a better way of doing this.
         # Now we don't have a temporary state inside the snes
         # context we could just require the user to pass in the
         # full state on the outside.
-        appctx.setdefault("state", self._x)
-        appctx.setdefault("form_compiler_parameters", self.fcp)
+        # appctx.setdefault("state", self._x)
+        # appctx.setdefault("form_compiler_parameters", self.fcp)
 
         self._appctx = appctx
         self.matfree = matfree
@@ -314,7 +311,7 @@ class _SNESContext:
             "PETSc options directly.",
             DeprecationWarning,
         )
-        return self._appctx
+        return {} if self._appctx is None else self._appctx
 
     def get_python_option(
         self,
@@ -353,21 +350,27 @@ class _SNESContext:
             value = opts[option]
         except KeyError:
             # not in the options database - try the old, unprefixed approach
-            try:
-                value = self._appctx[option]
-            except KeyError:
+            if self._appctx is not None:
+                try:
+                    value = self._appctx[option]
+                except KeyError:
+                    if default is not _missing:
+                        value = default
+                    else:
+                        raise KeyError
+                else:
+                    assert False, "old api"
+                    warnings.warn(
+                        "Passing Python objects to preconditioners via the 'appctx' kwarg "
+                        "is now deprecated. Pass the objects into the PETSc options "
+                        "directly instead.",
+                        FutureWarning,
+                    )
+            else:
                 if default is not _missing:
                     value = default
                 else:
                     raise KeyError
-            else:
-                assert False, "old api"
-                warnings.warn(
-                    "Passing Python objects to preconditioners via the 'appctx' kwarg "
-                    "is now deprecated. Pass the objects into the PETSc options "
-                    "directly instead.",
-                    FutureWarning,
-                )
         return value
 
     def reconstruct(self,

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -206,7 +206,8 @@ class _SNESContext:
                  marking_callback=None,
                  options_prefix: str | None = None,
                  transfer_manager=None,
-                 pre_apply_bcs: bool = True):
+                 pre_apply_bcs: bool = True,
+                 state=None):
         from firedrake.assemble import get_assembler
 
         if pmat_type is None:
@@ -238,7 +239,10 @@ class _SNESContext:
         # Now we don't have a temporary state inside the snes
         # context we could just require the user to pass in the
         # full state on the outside.
-        # appctx.setdefault("state", self._x)
+        if state is None:
+            self.state = self._x
+        else:
+            self.state = state
         # appctx.setdefault("form_compiler_parameters", self.fcp)
 
         self._appctx = appctx
@@ -413,6 +417,7 @@ class _SNESContext:
             post_function_callback=self._post_function_callback,
             pre_apply_bcs=self.pre_apply_bcs,
             marking_callback=self._marking_callback,
+            state=self.state,
         )
         for k, v in default_options.items():
             if kwargs.get(k) is None:

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -304,6 +304,9 @@ class _SNESContext:
 
     @property
     def appctx(self) -> dict:
+        # debugging
+        raise AssertionError("old api")
+
         # Raise a 'DeprecationWarning' here instead of a 'FutureWarning' because
         # this in an internal detail, not user facing
         warnings.warn(
@@ -358,6 +361,7 @@ class _SNESContext:
                 else:
                     raise KeyError
             else:
+                assert False, "old api"
                 warnings.warn(
                     "Passing Python objects to preconditioners via the 'appctx' kwarg "
                     "is now deprecated. Pass the objects into the PETSc options "

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,7 +1,7 @@
 import typing
 import warnings
 from itertools import chain
-from typing import Any
+from typing import Any, Literal
 
 import numpy
 import petsctools
@@ -243,7 +243,6 @@ class _SNESContext:
             self.state = self._x
         else:
             self.state = state
-        # appctx.setdefault("form_compiler_parameters", self.fcp)
 
         self._appctx = appctx
         self.matfree = matfree
@@ -363,13 +362,15 @@ class _SNESContext:
                     else:
                         raise KeyError
                 else:
-                    assert False, "old api"
-                    warnings.warn(
-                        "Passing Python objects to preconditioners via the 'appctx' kwarg "
-                        "is now deprecated. Pass the objects into the PETSc options "
-                        "directly instead.",
-                        FutureWarning,
-                    )
+                    if not isinstance(value, dmhooks.Hooked):
+                        warnings.warn(
+                            "Passing arbitrary Python objects to preconditioners via the 'appctx' kwarg "
+                            "is now deprecated. Either pass the objects into the PETSc options "
+                            "directly or specify hooks instead.",
+                            FutureWarning,
+                        )
+                    else:
+                        value = value.obj
             else:
                 if default is not _missing:
                     value = default
@@ -765,3 +766,36 @@ class _SNESContext:
     @cached_property
     def _F(self):
         return Cofunction(self.F.arguments()[0].function_space().dual())
+
+
+def _refine_function(function) -> Function:
+    return _transfer_function(function, "refine")
+
+
+def _coarsen_function(function) -> Function:
+    return _transfer_function(function, "coarsen")
+
+
+def _transfer_function(
+    function: Function,
+    mode: Literal["refine", "coarsen"],
+) -> Function:
+    from firedrake.mg.ufl_utils import refine, coarsen
+
+    V = function.function_space()
+    Vnew = refine(V, refine) if mode == "refine" else coarsen(V, coarsen)
+
+    name = function.name()
+    if name is not None:
+        try:
+            name, prev_level = name.split("_level_")
+        except ValueError:
+            prev_level = 0
+        level_inc = 1 if mode == "refine" else -1
+        level = int(prev_level) + level_inc
+        name = f"{name}_level_{level}"
+
+    new_func = Function(Vnew, name=name)
+    manager = dmhooks.get_transfer_manager(V.dm)
+    manager.transfer(function, new_func)
+    return new_func

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -291,7 +291,77 @@ class NonlinearVariationalProblem(NonlinearVariationalProblemMixin):
 
 
 class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin):
-    r"""Solves a :class:`NonlinearVariationalProblem`."""
+    """Class that solves a :class:`NonlinearVariationalProblem`.
+
+    Parameters
+    ----------
+    :arg problem: A :class:`NonlinearVariationalProblem` to solve.
+    :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
+           :class:`.MixedVectorSpaceBasis`) spanning the null
+           space of the operator.
+    :kwarg transpose_nullspace: as for the nullspace, but used to
+           make the right hand side consistent.
+    :kwarg near_nullspace: as for the nullspace, but used to
+           specify the near nullspace (for multigrid solvers).
+    :kwarg solver_parameters: Solver parameters to pass to PETSc.
+           This should be a dict mapping PETSc options to values.
+    :kwarg appctx: (Deprecated) A dictionary containing application
+           context that is passed to the preconditioner if matrix-free.
+    :kwarg options_prefix: an optional prefix used to distinguish
+           PETSc options.  If not provided a unique prefix will be
+           created.  Use this option if you want to pass options
+           to the solver from the command line in addition to
+           through the ``solver_parameters`` dict.
+    :kwarg pre_jacobian_callback: A user-defined function that will
+           be called immediately before Jacobian assembly. This can
+           be used, for example, to update a coefficient function
+           that has a complicated dependence on the unknown solution.
+    :kwarg post_jacobian_callback: As above, but called after the
+           Jacobian has been assembled.
+    :kwarg pre_function_callback: As above, but called immediately
+           before residual assembly.
+    :kwarg post_function_callback: As above, but called immediately
+           after residual assembly.
+    :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
+           Otherwise, the problem is linearised around the initial guess
+           before imposing bcs, and the bcs are appended to the nonlinear system.
+    :kwarg marking_callback: An optional callable of the form
+           ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
+           The callback receives the `_SNESContext`
+           and the current Firedrake solution, and must return a DG0
+           :class:`.Function` or :class:`.Cofunction` with positive
+           values on cells to refine.
+
+    Example usage of the ``solver_parameters`` option: to set the
+    nonlinear solver type to just use a linear solver, use
+
+    .. code-block:: python3
+
+        {'snes_type': 'ksponly'}
+
+    PETSc flag options (where the presence of the option means something) should
+    be specified with ``None``.
+    For example:
+
+    .. code-block:: python3
+
+        {'snes_monitor': None}
+
+    To use the ``pre_jacobian_callback`` or ``pre_function_callback``
+    functionality, the user-defined function must accept the current
+    solution as a petsc4py Vec. Example usage is given below:
+
+    .. code-block:: python3
+
+        def update_diffusivity(current_solution):
+            with cursol.dat.vec_wo as v:
+                current_solution.copy(v)
+            solve(trial*test*dx == dot(grad(cursol), grad(test))*dx, diffusivity)
+
+        solver = NonlinearVariationalSolver(problem,
+                                            pre_jacobian_callback=update_diffusivity)
+
+    """
 
     DEFAULT_SNES_PARAMETERS = DEFAULT_SNES_PARAMETERS
 
@@ -318,74 +388,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                  post_function_callback=None,
                  pre_apply_bcs=True,
                  marking_callback=None):
-        r"""
-        :arg problem: A :class:`NonlinearVariationalProblem` to solve.
-        :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
-               :class:`.MixedVectorSpaceBasis`) spanning the null
-               space of the operator.
-        :kwarg transpose_nullspace: as for the nullspace, but used to
-               make the right hand side consistent.
-        :kwarg near_nullspace: as for the nullspace, but used to
-               specify the near nullspace (for multigrid solvers).
-        :kwarg solver_parameters: Solver parameters to pass to PETSc.
-               This should be a dict mapping PETSc options to values.
-        :kwarg appctx: A dictionary containing application context that
-               is passed to the preconditioner if matrix-free.
-        :kwarg options_prefix: an optional prefix used to distinguish
-               PETSc options.  If not provided a unique prefix will be
-               created.  Use this option if you want to pass options
-               to the solver from the command line in addition to
-               through the ``solver_parameters`` dict.
-        :kwarg pre_jacobian_callback: A user-defined function that will
-               be called immediately before Jacobian assembly. This can
-               be used, for example, to update a coefficient function
-               that has a complicated dependence on the unknown solution.
-        :kwarg post_jacobian_callback: As above, but called after the
-               Jacobian has been assembled.
-        :kwarg pre_function_callback: As above, but called immediately
-               before residual assembly.
-        :kwarg post_function_callback: As above, but called immediately
-               after residual assembly.
-        :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
-               Otherwise, the problem is linearised around the initial guess
-               before imposing bcs, and the bcs are appended to the nonlinear system.
-        :kwarg marking_callback: An optional callable of the form
-               ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
-               The callback receives the `_SNESContext`
-               and the current Firedrake solution, and must return a DG0
-               :class:`.Function` or :class:`.Cofunction` with positive
-               values on cells to refine.
 
-        Example usage of the ``solver_parameters`` option: to set the
-        nonlinear solver type to just use a linear solver, use
-
-        .. code-block:: python3
-
-            {'snes_type': 'ksponly'}
-
-        PETSc flag options (where the presence of the option means something) should
-        be specified with ``None``.
-        For example:
-
-        .. code-block:: python3
-
-            {'snes_monitor': None}
-
-        To use the ``pre_jacobian_callback`` or ``pre_function_callback``
-        functionality, the user-defined function must accept the current
-        solution as a petsc4py Vec. Example usage is given below:
-
-        .. code-block:: python3
-
-            def update_diffusivity(current_solution):
-                with cursol.dat.vec_wo as v:
-                    current_solution.copy(v)
-                solve(trial*test*dx == dot(grad(cursol), grad(test))*dx, diffusivity)
-
-            solver = NonlinearVariationalSolver(problem,
-                                                pre_jacobian_callback=update_diffusivity)
-
-        """
         assert isinstance(problem, NonlinearVariationalProblem)
 
         solver_parameters = flatten_parameters(solver_parameters or {})

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -342,6 +342,9 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         :class:`.Function` or :class:`.Cofunction` with positive
         values on cells to refine.
 
+    Examples
+    --------
+
     Example usage of the ``solver_parameters`` option: to set the
     nonlinear solver type to just use a linear solver, use
 

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -295,42 +295,52 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 
     Parameters
     ----------
-    :arg problem: A :class:`NonlinearVariationalProblem` to solve.
-    :kwarg nullspace: an optional :class:`.VectorSpaceBasis` (or
-           :class:`.MixedVectorSpaceBasis`) spanning the null
-           space of the operator.
-    :kwarg transpose_nullspace: as for the nullspace, but used to
-           make the right hand side consistent.
-    :kwarg near_nullspace: as for the nullspace, but used to
-           specify the near nullspace (for multigrid solvers).
-    :kwarg solver_parameters: Solver parameters to pass to PETSc.
-           This should be a dict mapping PETSc options to values.
-    :kwarg appctx: (Deprecated) A dictionary containing application
-           context that is passed to the preconditioner if matrix-free.
-    :kwarg options_prefix: an optional prefix used to distinguish
-           PETSc options.  If not provided a unique prefix will be
-           created.  Use this option if you want to pass options
-           to the solver from the command line in addition to
-           through the ``solver_parameters`` dict.
-    :kwarg pre_jacobian_callback: A user-defined function that will
-           be called immediately before Jacobian assembly. This can
-           be used, for example, to update a coefficient function
-           that has a complicated dependence on the unknown solution.
-    :kwarg post_jacobian_callback: As above, but called after the
-           Jacobian has been assembled.
-    :kwarg pre_function_callback: As above, but called immediately
-           before residual assembly.
-    :kwarg post_function_callback: As above, but called immediately
-           after residual assembly.
-    :kwarg pre_apply_bcs: If True, the bcs are applied before the solve.
-           Otherwise, the problem is linearised around the initial guess
-           before imposing bcs, and the bcs are appended to the nonlinear system.
-    :kwarg marking_callback: An optional callable of the form
-           ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
-           The callback receives the `_SNESContext`
-           and the current Firedrake solution, and must return a DG0
-           :class:`.Function` or :class:`.Cofunction` with positive
-           values on cells to refine.
+    problem
+        A :class:`NonlinearVariationalProblem` to solve.
+    nullspace
+        an optional :class:`.VectorSpaceBasis` (or
+        :class:`.MixedVectorSpaceBasis`) spanning the null
+        space of the operator.
+    transpose_nullspace
+        as for the nullspace, but used to
+        make the right hand side consistent.
+    near_nullspace
+        as for the nullspace, but used to
+        specify the near nullspace (for multigrid solvers).
+    solver_parameters
+        Solver parameters to pass to PETSc.
+        This should be a dict mapping PETSc options to values.
+    appctx
+        (Deprecated) A dictionary containing application
+        context that is passed to the preconditioner if matrix-free.
+    options_prefix
+        an optional prefix used to distinguish
+        PETSc options.  If not provided a unique prefix will be
+        created.  Use this option if you want to pass options
+        to the solver from the command line in addition to
+        through the ``solver_parameters`` dict.
+    pre_jacobian_callback
+        A user-defined function that will
+        be called immediately before Jacobian assembly. This can
+        be used, for example, to update a coefficient function
+        that has a complicated dependence on the unknown solution.
+    post_jacobian_callback
+        As above, but called after the Jacobian has been assembled.
+    pre_function_callback
+        As above, but called immediately before residual assembly.
+    post_function_callback
+        As above, but called immediately after residual assembly.
+    pre_apply_bcs
+        If True, the bcs are applied before the solve.
+        Otherwise, the problem is linearised around the initial guess
+        before imposing bcs, and the bcs are appended to the nonlinear system.
+    marking_callback
+        An optional callable of the form
+        ``callback(ctx, u)`` for PETSc-driven adaptive refinement.
+        The callback receives the `_SNESContext`
+        and the current Firedrake solution, and must return a DG0
+        :class:`.Function` or :class:`.Cofunction` with positive
+        values on cells to refine.
 
     Example usage of the ``solver_parameters`` option: to set the
     nonlinear solver type to just use a linear solver, use
@@ -388,7 +398,6 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                  post_function_callback=None,
                  pre_apply_bcs=True,
                  marking_callback=None):
-
         assert isinstance(problem, NonlinearVariationalProblem)
 
         solver_parameters = flatten_parameters(solver_parameters or {})

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -402,6 +402,9 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 
         solver_parameters = flatten_parameters(solver_parameters or {})
 
+        # debugging
+        assert appctx is None, "old api"
+
         if isinstance(problem.J, MatrixBase):
             solver_parameters.setdefault("mat_type", problem.J.mat_type)
             if solver_parameters["mat_type"] != problem.J.mat_type:

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -11,7 +11,7 @@ from firedrake.petsc import PETSc, DEFAULT_KSP_PARAMETERS, DEFAULT_SNES_PARAMETE
 from firedrake.function import Function
 from firedrake.interpolation import interpolate
 from firedrake.matrix import MatrixBase
-from firedrake.ufl_expr import TrialFunction, TestFunction
+from firedrake.ufl_expr import TrialFunction, TestFunction, extract_domains
 from firedrake.bcs import DirichletBC, EquationBC, extract_subdomain_ids, restricted_function_space
 from firedrake.adjoint_utils import NonlinearVariationalProblemMixin, NonlinearVariationalSolverMixin
 from ufl import as_ufl, replace, Form
@@ -405,8 +405,31 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
 
         solver_parameters = flatten_parameters(solver_parameters or {})
 
-        # debugging
-        assert appctx is None, "old api"
+        if appctx is None:
+            appctx = {}
+
+        # The appctx is propagated throughout the full solver stack with entries
+        # getting coarsened, split etc along the way. We know how to do some basic
+        # things like refining a function on the same mesh, but anything more
+        # complex needs to be provided by users with the callbacks in place.
+        for key, value in appctx.items():
+            if isinstance(value, dmhooks.Hooked):
+                continue
+            elif isinstance(value, Function):
+                # If we hit a compatible function then we can add the hooks here
+                hooks = {}
+                if extract_domains(value) == extract_domains(problem.u):
+                    hooks["refine_callback"] = solving_utils._refine_function
+                    hooks["coarsen_callback"] = solving_utils._coarsen_function
+                appctx[key] = dmhooks.Hooked(value, **hooks)
+            else:
+                # Leave unchanged for the moment, this will eventually become an error
+                warnings.warn(
+                    f"Object with type {type(value).__name__} found in the "
+                    "appctx. Please either provide the necessary hooks yourself "
+                    "or consider passing the data via the solver parameters instead.",
+                    FutureWarning,
+                )
 
         if isinstance(problem.J, MatrixBase):
             solver_parameters.setdefault("mat_type", problem.J.mat_type)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,7 +7,8 @@ mpi4py>3; python_version >= '3.13'
 mpi4py; python_version < '3.13'
 numpy
 pkgconfig
-petsctools
+# TODO RELEASE
+petsctools @ git+https://github.com/firedrakeproject/petsctools.git@main
 pybind11
 setuptools>=77.0.3
 rtree

--- a/tests/firedrake/deflation/test_bratu.py
+++ b/tests/firedrake/deflation/test_bratu.py
@@ -18,19 +18,18 @@ def test_bratu():
     bcs = DirichletBC(V, 0, "on_boundary")
     problem = NonlinearVariationalProblem(F, u, bcs)
 
+    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
     sp = {"snes_type": "python",
           "snes_python_type": "firedrake.DeflatedSNES",
           "deflated_snes_type": "newtonls",
           "deflated_snes_monitor": None,
           "deflated_snes_linesearch_type": "basic",
           "deflated_ksp_type": "preonly",
-          "deflated_pc_type": "lu"}
-
-    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
-    appctx = {"deflation": deflation}
+          "deflated_pc_type": "lu",
+          "deflated_snes_deflation": deflation}
 
     # Find the first solution
-    solver = NonlinearVariationalSolver(problem, solver_parameters=sp, appctx=appctx)
+    solver = NonlinearVariationalSolver(problem, solver_parameters=sp)
     u.assign(guess)
     solver.solve()
 

--- a/tests/firedrake/deflation/test_vi.py
+++ b/tests/firedrake/deflation/test_vi.py
@@ -32,18 +32,18 @@ def test_vi():
     u = Function(R)
     F = derivative(J(u)*dx, u)
 
+    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
     sp = {"snes_type": "python",
           "snes_python_type": "firedrake.DeflatedSNES",
           "deflated_snes_type": "vinewtonrsls",
           "deflated_snes_monitor": None,
           "deflated_snes_linesearch_type": "basic",
           "deflated_ksp_type": "preonly",
-          "deflated_pc_type": "lu"}
+          "deflated_pc_type": "lu",
+          "deflated_snes_deflation": deflation}
 
     problem = NonlinearVariationalProblem(F, u)
-    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
-    appctx = {"deflation": deflation}
-    solver = NonlinearVariationalSolver(problem, solver_parameters=sp, appctx=appctx)
+    solver = NonlinearVariationalSolver(problem, solver_parameters=sp)
     lb = Function(R).interpolate(Constant(0))
     ub = Function(R).interpolate(Constant(100))
 

--- a/tests/firedrake/multigrid/test_hiptmair.py
+++ b/tests/firedrake/multigrid/test_hiptmair.py
@@ -51,6 +51,8 @@ def gmg_parameters(V, mat_type, max_it):
             "pc_python_type": "firedrake.HiptmairPC",
             "hiptmair_mg_levels": relax,
             "hiptmair_mg_coarse": potential,
+            "hiptmair_get_gradient": tabulate_exterior_derivative,
+            "hiptmair_get_curl": tabulate_exterior_derivative,
         },
     }
     return parameters
@@ -78,6 +80,8 @@ def pmg_parameters(V, mat_type, max_it):
         "pc_python_type": "firedrake.HiptmairPC",
         "hiptmair_mg_levels": asm(1),
         "hiptmair_mg_coarse": asm(0),
+        "hiptmair_get_gradient": tabulate_exterior_derivative,
+        "hiptmair_get_curl": tabulate_exterior_derivative,
     }
     return {
         "mat_type": mat_type,
@@ -124,10 +128,8 @@ def run_riesz_map(V, mat_type, max_it, solver_type="gmg"):
     L = inner(f, v) * dx
 
     bcs = [DirichletBC(V, u_exact, "on_boundary")]
-    appctx = {"get_gradient": tabulate_exterior_derivative,
-              "get_curl": tabulate_exterior_derivative}
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs, form_compiler_parameters={"mode": "vanilla"})
-    solver = LinearVariationalSolver(problem, solver_parameters=parameters, appctx=appctx)
+    solver = LinearVariationalSolver(problem, solver_parameters=parameters)
     solver.solve()
     return errornorm(u_exact, uh)
 

--- a/tests/firedrake/multigrid/test_poisson_gtmg.py
+++ b/tests/firedrake/multigrid/test_poisson_gtmg.py
@@ -37,36 +37,52 @@ def run_gtmg_mixed_poisson(custom_transfer=False):
     L = inner(f, v)*dx
 
     w = Function(W)
-    params = {'mat_type': 'matfree',
-              'ksp_type': 'preonly',
-              'pc_type': 'python',
-              'pc_python_type': 'firedrake.HybridizationPC',
-              'hybridization': {'ksp_type': 'cg',
-                                'mat_type': 'matfree',
-                                'pc_type': 'python',
-                                'pc_python_type': 'firedrake.GTMGPC',
-                                'gt': {'mg_levels': {'ksp_type': 'chebyshev',
-                                                     'pc_type': 'jacobi',
-                                                     'ksp_max_it': 3},
-                                       'mg_coarse': {'ksp_type': 'preonly',
-                                                     'pc_type': 'mg',
-                                                     'pc_mg_type': 'full',
-                                                     'mg_levels': {'ksp_type': 'chebyshev',
-                                                                   'pc_type': 'jacobi',
-                                                                   'ksp_max_it': 3}}}}}
-    appctx = {'get_coarse_operator': p1_callback,
-              'get_coarse_space': get_p1_space,
-              'coarse_space_bcs': get_p1_prb_bcs()}
+
     if custom_transfer:
         P1 = get_p1_space()
         V = FunctionSpace(mesh, "DGT", degree - 1)
         I = assemble(interpolate(TrialFunction(P1), V)).petscmat
         R = PETSc.Mat().createTranspose(I)
-        appctx['interpolation_matrix'] = I
-        appctx['restriction_matrix'] = R
+        transfer_ops = {'interpolation_matrix': I, 'restriction_matrix': R}
+    else:
+        transfer_ops = {}
+
+    params = {
+        'mat_type': 'matfree',
+        'ksp_type': 'preonly',
+        'pc_type': 'python',
+        'pc_python_type': 'firedrake.HybridizationPC',
+        'hybridization': {
+            'ksp_type': 'cg',
+            'mat_type': 'matfree',
+            'pc_type': 'python',
+            'pc_python_type': 'firedrake.GTMGPC',
+            'gt': {
+                'mg_levels': {
+                    'ksp_type': 'chebyshev',
+                    'pc_type': 'jacobi',
+                    'ksp_max_it': 3,
+                },
+                'mg_coarse': {
+                    'ksp_type': 'preonly',
+                    'pc_type': 'mg',
+                    'pc_mg_type': 'full',
+                    'mg_levels': {
+                        'ksp_type': 'chebyshev',
+                        'pc_type': 'jacobi',
+                        'ksp_max_it': 3,
+                    },
+                },
+                'get_coarse_operator': p1_callback,
+                'get_coarse_space': get_p1_space,
+                'coarse_space_bcs': get_p1_prb_bcs(),
+                **transfer_ops,
+            },
+        },
+    }
 
     problem = LinearVariationalProblem(a, L, w)
-    solver = LinearVariationalSolver(problem, solver_parameters=params, appctx=appctx)
+    solver = LinearVariationalSolver(problem, solver_parameters=params)
     solver.solve()
     _, uh = w.subfunctions
 
@@ -142,14 +158,13 @@ def run_gtmg_scpc_mixed_poisson():
                                                        'pc_mg_type': 'full',
                                                        'mg_levels': {'ksp_type': 'chebyshev',
                                                                      'pc_type': 'jacobi',
-                                                                     'ksp_max_it': 3}}}}}
-    appctx = {'get_coarse_operator': p1_callback,
-              'get_coarse_space': get_p1_space,
-              'coarse_space_bcs': get_p1_prb_bcs()}
-
+                                                                     'ksp_max_it': 3}},
+                                         'get_coarse_operator': p1_callback,
+                                         'get_coarse_space': get_p1_space,
+                                         'coarse_space_bcs': get_p1_prb_bcs()}}}
     bcs = DirichletBC(W.sub(2), Constant(0.0), "on_boundary")
 
-    solve(a == L, w, bcs=bcs, solver_parameters=params, appctx=appctx)
+    solve(a == L, w, bcs=bcs, solver_parameters=params)
     _, uh, _ = w.subfunctions
 
     # Analytical solution

--- a/tests/firedrake/multigrid/test_stokes_gmg.py
+++ b/tests/firedrake/multigrid/test_stokes_gmg.py
@@ -84,7 +84,7 @@ def test_stokes_appctx_coarsening():
     fine_mu = mu
     for level in reversed(range(len(mh) - 1)):
         ctx = ctx._coarse
-        coarse_mu = ctx.appctx["mu"]
+        coarse_mu = ctx._appctx["mu"].obj
         assert coarse_mu.function_space().mesh() is mh[level]
 
         expected = Function(coarse_mu.function_space())

--- a/tests/firedrake/regression/test_bddc.py
+++ b/tests/firedrake/regression/test_bddc.py
@@ -12,7 +12,8 @@ def rg():
 
 
 def bddc_params(mat_type="is", cellwise=False, adaptive=False,
-                use_divergence=None, use_gradient=None, corner_selection=None, debug=0):
+                use_divergence=None, use_gradient=None, corner_selection=None,
+                primal_markers=None, debug=0):
     chol = {
         "pc_type": "cholesky",
         "pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
@@ -36,6 +37,8 @@ def bddc_params(mat_type="is", cellwise=False, adaptive=False,
     if corner_selection is not None:
         # defaults to True for H1 spaces
         sp["bddc_pc_bddc_corner_selection"] = corner_selection
+    if primal_markers is not None:
+        sp["bddc_primal_markers"] = primal_markers
 
     if adaptive:
         sp.update({
@@ -158,19 +161,21 @@ def solve_riesz_map(rg, mesh, family, degree, variant, bcs, cellwise=False, cond
         nsp = VectorSpaceBasis(basis)
         nsp.orthonormalize()
 
-    appctx = {}
     if threshold is not None:
-        appctx["primal_markers"] = get_primal_markers(mesh, threshold=threshold)
+        primal_markers = get_primal_markers(mesh, threshold=threshold)
+    else:
+        primal_markers = None
 
     uh = Function(V, name="solution")
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)
 
     rtol = 1E-8
     sp = solver_parameters(cellwise=cellwise, condense=condense, variant=variant, rtol=rtol,
-                           use_divergence=use_divergence, adaptive=adaptive)
+                           use_divergence=use_divergence, adaptive=adaptive,
+                           primal_markers=primal_markers)
     sp.setdefault("ksp_view_singularvalues", None)
     solver = LinearVariationalSolver(problem, near_nullspace=nsp,
-                                     solver_parameters=sp, appctx=appctx)
+                                     solver_parameters=sp)
     solver.solve()
     uerr = Function(V).assign(uh - u_exact)
     assert (assemble(a(uerr, uerr)) / assemble(a(u_exact, u_exact))) ** 0.5 < rtol
@@ -264,7 +269,7 @@ def test_bddc_cellwise_high_aspect_ratio(rg, family, degree):
     bcs = True
     mh = [corner_refined_mesh(nx) for nx in (10, 12)]
     # For these meshes it is better to set adaptive BDDC parameters,
-    # but here we just test the appctx["primal_markers"] interface
+    # but here we just test the bddc_primal_markers interface
     sqrt_kappa = [solve_riesz_map(rg, m, family, degree, variant, bcs, cellwise=True, threshold=2**6) for m in mh]
     assert (np.diff(sqrt_kappa) <= 0.1).all(), str(sqrt_kappa)
 

--- a/tests/firedrake/regression/test_fdm.py
+++ b/tests/firedrake/regression/test_fdm.py
@@ -326,7 +326,8 @@ def test_ipdg_direct_solver(fs):
         "fdm_pc_type": "cholesky",
         "fdm_pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
         "fdm_pc_factor_mat_ordering_type": "nd",
-    }, appctx={"eta": eta, })
+        "fdm_eta": eta,
+    })
     solver.solve()
 
     assert solver.snes.ksp.getIterationNumber() == 1

--- a/tests/firedrake/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
+++ b/tests/firedrake/regression/test_fieldsplit_fieldsplit_aux_multigrid.py
@@ -10,6 +10,7 @@ a fieldsplit within another fieldsplit.
 """
 import pytest
 from firedrake import *
+import firedrake.dmhooks
 from firedrake.petsc import DEFAULT_DIRECT_SOLVER
 
 
@@ -26,8 +27,8 @@ class SchurApprox(AuxiliaryOperatorPC):
             q = 0.1
             return alphabar * q * ((q + 1)/(d + q) - 1)
 
-        ctx = self.get_appctx(pc)
-        d = split(ctx["state"])[0]
+        ctx = firedrake.dmhooks.get_appctx(pc.getDM())
+        d = split(ctx.state)[0]
         (u, p) = split(trial)
         (v, q) = split(test)
         K = (alpha(d) * inner(u, v)*dx

--- a/tests/firedrake/regression/test_nullspace.py
+++ b/tests/firedrake/regression/test_nullspace.py
@@ -286,7 +286,7 @@ def test_nullspace_mixed_multiple_components():
     assert schur_ksp.getIterationNumber() < 6
 
 
-@pytest.mark.parallel(nprocs=2)
+@pytest.mark.parallel(2)
 @pytest.mark.parametrize("aux_pc", [False, True], ids=["PC(mu)", "PC(DG0-mu)"])
 @pytest.mark.parametrize("rhs", ["form_rhs", "cofunc_rhs"])
 def test_near_nullspace_mixed(aux_pc, rhs):
@@ -370,6 +370,7 @@ def test_near_nullspace_mixed(aux_pc, rhs):
             'Mp_pc_type': 'ksp',
             'Mp_ksp_ksp_type': 'cg',
             'Mp_ksp_pc_type': 'sor',
+            'Mp_mu': mu0,
             'ksp_rtol': '1e-5',
             'ksp_monitor': None,
         }
@@ -377,7 +378,7 @@ def test_near_nullspace_mixed(aux_pc, rhs):
 
     problem = LinearVariationalProblem(a, L, w, bcs=bcs, aP=aP)
     solver = LinearVariationalSolver(
-        problem, appctx={'mu': mu0},
+        problem,
         nullspace=pressure_nullspace,
         transpose_nullspace=pressure_nullspace,
         near_nullspace=near_nullmodes_W,

--- a/tests/firedrake/regression/test_planesmoother.py
+++ b/tests/firedrake/regression/test_planesmoother.py
@@ -34,22 +34,24 @@ def test_xy_equivalence():
     patch_defined.solve()
     patch_defined_history = patch_defined.snes.ksp.getConvergenceHistory()
 
-    appctx = {}
-    appctx["my_x"] = lambda z: z[0]
-    appctx["my_y"] = lambda z: z[1]
-    user_defined = LinearVariationalSolver(problem,
-                                           options_prefix="",
-                                           solver_parameters={"mat_type": "matfree",
-                                                              "ksp_type": "cg",
-                                                              "pc_type": "python",
-                                                              "pc_python_type": "firedrake.PatchPC",
-                                                              "patch_pc_patch_construct_type": "python",
-                                                              "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
-                                                              "patch_pc_patch_construct_ps_sweeps": "my_x+10:my_y+10",
-                                                              "patch_sub_ksp_type": "preonly",
-                                                              "patch_sub_pc_type": "lu",
-                                                              "ksp_monitor": None},
-                                           appctx=appctx)
+    user_defined = LinearVariationalSolver(
+        problem,
+        options_prefix="",
+        solver_parameters={
+            "mat_type": "matfree",
+            "ksp_type": "cg",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.PatchPC",
+            "patch_pc_patch_construct_type": "python",
+            "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
+            "patch_pc_patch_construct_ps_sweeps": "my_x+10:my_y+10",
+            "patch_sub_ksp_type": "preonly",
+            "patch_sub_pc_type": "lu",
+            "patch_my_x": lambda z: z[0],
+            "patch_my_y": lambda z: z[1],
+            "ksp_monitor": None,
+        },
+    )
 
     user_defined.snes.ksp.setConvergenceHistory()
     uh.assign(0)
@@ -89,22 +91,24 @@ def test_divisions_equivalence():
     patch_defined.solve()
     patch_defined_history = patch_defined.snes.ksp.getConvergenceHistory()
 
-    appctx = {}
-    appctx["x_div"] = numpy.linspace(0.0, 1.0, 11)
-    appctx["y_div"] = numpy.linspace(0.0, 1.0, 11)
-    user_defined = LinearVariationalSolver(problem,
-                                           options_prefix="",
-                                           solver_parameters={"mat_type": "matfree",
-                                                              "ksp_type": "cg",
-                                                              "pc_type": "python",
-                                                              "pc_python_type": "firedrake.PatchPC",
-                                                              "patch_pc_patch_construct_type": "python",
-                                                              "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
-                                                              "patch_pc_patch_construct_ps_sweeps": "0+x_div:1+y_div",
-                                                              "patch_sub_ksp_type": "preonly",
-                                                              "patch_sub_pc_type": "lu",
-                                                              "ksp_monitor": None},
-                                           appctx=appctx)
+    user_defined = LinearVariationalSolver(
+        problem,
+        options_prefix="",
+        solver_parameters={
+            "mat_type": "matfree",
+            "ksp_type": "cg",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.PatchPC",
+            "patch_pc_patch_construct_type": "python",
+            "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
+            "patch_pc_patch_construct_ps_sweeps": "0+x_div:1+y_div",
+            "patch_sub_ksp_type": "preonly",
+            "patch_sub_pc_type": "lu",
+            "patch_x_div": numpy.linspace(0.0, 1.0, 11),
+            "patch_y_div": numpy.linspace(0.0, 1.0, 11),
+            "ksp_monitor": None,
+        },
+    )
 
     user_defined.snes.ksp.setConvergenceHistory()
     uh.assign(0)
@@ -129,23 +133,24 @@ def test_tensor_grids():
     uh = Function(V)
     problem = LinearVariationalProblem(a, L, uh, bcs=bcs)
 
-    appctx = {}
-    appctx["x_div"] = 0.5*(x_points[:-1]+x_points[1:])
-    appctx["y_div"] = 0.5*(y_points[:-1]+y_points[1:])
-    user_defined = LinearVariationalSolver(problem,
-                                           options_prefix="",
-                                           solver_parameters={"mat_type": "matfree",
-                                                              "ksp_type": "cg",
-                                                              "pc_type": "python",
-                                                              "pc_python_type": "firedrake.PatchPC",
-                                                              "patch_pc_patch_construct_type": "python",
-                                                              "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
-                                                              "patch_pc_patch_construct_ps_sweeps": "0+x_div:1+y_div",
-                                                              "patch_sub_ksp_type": "preonly",
-                                                              "patch_sub_pc_type": "lu",
-                                                              "ksp_monitor": None},
-                                           appctx=appctx)
-
+    user_defined = LinearVariationalSolver(
+        problem,
+        options_prefix="",
+        solver_parameters={
+            "mat_type": "matfree",
+            "ksp_type": "cg",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.PatchPC",
+            "patch_pc_patch_construct_type": "python",
+            "patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
+            "patch_pc_patch_construct_ps_sweeps": "0+x_div:1+y_div",
+            "patch_sub_ksp_type": "preonly",
+            "patch_sub_pc_type": "lu",
+            "patch_x_div": 0.5*(x_points[:-1]+x_points[1:]),
+            "patch_y_div": 0.5*(y_points[:-1]+y_points[1:]),
+            "ksp_monitor": None,
+        },
+    )
     user_defined.solve()
     nits = user_defined.snes.getLinearSolveIterations()
 
@@ -182,25 +187,25 @@ def test_not_aligned():
                          "mg_levels_patch_pc_patch_construct_python_type": "firedrake.PlaneSmoother",
                          "mg_levels_patch_sub_ksp_type": "preonly",
                          "mg_levels_patch_sub_pc_type": "lu",
+                         "mg_levels_patch_x_plus_y": lambda z: z[0] + z[1],
+                         "mg_levels_patch_x_minus_y": lambda z: z[0] - z[1],
+
                          "mg_coarse_mat_type": "aij",
                          "mg_coarse_pc_type": "lu",
                          "mg_coarse_pc_factor_mat_solver_type": DEFAULT_DIRECT_SOLVER,
                          "ksp_monitor": None}
-    appctx = {}
-    appctx["x_plus_y"] = lambda z: z[0]+z[1]
-    appctx["x_minus_y"] = lambda z: z[0] - z[1]
+
     N = baseN
     for j in range(nrefs):
         N *= 2
-        appctx["x_plus_y_divisions"+str(j+1)] = numpy.linspace(0.0, 2.0, 2*N+1)
-        appctx["x_minus_y_divisions"+str(j+1)] = numpy.linspace(-1.0, 1.0, 2*N+1)
-        solver_parameters["mg_levels_"+str(j+1)+"_patch_pc_patch_construct_ps_sweeps"] = "x_plus_y+x_plus_y_divisions"+str(j+1)+":x_minus_y+x_minus_y_divisions"+str(j+1)
+        prefix = f"mg_levels_{j+1}_"
+        solver_parameters[f"{prefix}patch_x_plus_y_divisions"] = numpy.linspace(0.0, 2.0, 2*N+1)
+        solver_parameters[f"{prefix}patch_x_minus_y_divisions"] = numpy.linspace(-1.0, 1.0, 2*N+1)
+        solver_parameters[f"{prefix}patch_pc_patch_construct_ps_sweeps"] = "x_plus_y+x_plus_y_divisions:x_minus_y+x_minus_y_divisions"
 
     user_defined = LinearVariationalSolver(problem,
                                            options_prefix="",
-                                           solver_parameters=solver_parameters,
-                                           appctx=appctx)
-
+                                           solver_parameters=solver_parameters)
     user_defined.solve()
     nits = user_defined.snes.getLinearSolveIterations()
 

--- a/tests/firedrake/regression/test_stokes_hdiv_parallel.py
+++ b/tests/firedrake/regression/test_stokes_hdiv_parallel.py
@@ -16,7 +16,7 @@ def element_pair(request):
     return request.param
 
 
-@pytest.mark.parallel(nprocs=3)
+@pytest.mark.parallel
 def test_stokes_hdiv_parallel(mat_type, element_pair):
     err_u = []
     err_p = []
@@ -86,6 +86,9 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
         subnullspace.orthonormalize()
         nullspace = MixedVectorSpaceBasis(W, [W.sub(0), subnullspace])
 
+        # Scale for the pressure mass matrix
+        mu = 1/gamma
+
         parameters = {
             "mat_type": mat_type,
             "pmat_type": "matfree",
@@ -110,16 +113,12 @@ def test_stokes_hdiv_parallel(mat_type, element_pair):
                 "pc_python_type": "firedrake.MassInvPC",
                 "Mp_mat_type": "matfree",
                 "Mp_pc_type": "jacobi",
+                "Mp_mu": mu,
             }
         }
 
-        # Scale for the pressure mass matrix
-        mu = 1/gamma
-        appctx = {"mu": mu}
-
         UP.assign(0)
-        solve(a == L, UP, bcs=bcs, nullspace=nullspace, solver_parameters=parameters,
-              appctx=appctx)
+        solve(a == L, UP, bcs=bcs, nullspace=nullspace, solver_parameters=parameters)
 
         u, p = UP.subfunctions
         u_error = u - u_exact

--- a/tests/firedrake/slate/test_hybrid_poisson_sphere.py
+++ b/tests/firedrake/slate/test_hybrid_poisson_sphere.py
@@ -26,6 +26,10 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
     L = inner(f, v)*dx
     w = Function(W)
 
+    # Provide a callback to construct the trace nullspace
+    def nullspace_basis(T):
+        return VectorSpaceBasis(constant=True)
+
     params = {
         'mat_type': 'matfree',
         'ksp_type': 'preonly',
@@ -35,16 +39,11 @@ def run_hybrid_poisson_sphere(MeshClass, refinement, hdiv_space):
             'ksp_type': 'preonly',
             'pc_type': 'redundant',
             'redundant_pc_type': 'lu',
-            'redundant_pc_factor': DEFAULT_DIRECT_SOLVER_PARAMETERS
+            'redundant_pc_factor': DEFAULT_DIRECT_SOLVER_PARAMETERS,
+            'trace_nullspace': nullspace_basis,
         }
     }
-
-    # Provide a callback to construct the trace nullspace
-    def nullspace_basis(T):
-        return VectorSpaceBasis(constant=True)
-
-    appctx = {'trace_nullspace': nullspace_basis}
-    solve(a == L, w, solver_parameters=params, appctx=appctx)
+    solve(a == L, w, solver_parameters=params)
     u_h, _ = w.subfunctions
     error = errornorm(u_exact, u_h)
     return error


### PR DESCRIPTION
Now that we can pass Python objects to the solver via the options dictionary we can do nice things like:
```py

    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
    sp = {"snes_type": "python",
          "snes_python_type": "firedrake.DeflatedSNES",
          "deflated_snes_type": "newtonls",
          "deflated_snes_monitor": None,
          "deflated_snes_linesearch_type": "basic",
          "deflated_snes_deflation": deflation,
          "deflated_ksp_type": "preonly",
          "deflated_pc_type": "lu"}

    solver = NonlinearVariationalSolver(problem, solver_parameters=sp)
```
instead of
```py
    sp = {"snes_type": "python",
          "snes_python_type": "firedrake.DeflatedSNES",
          "deflated_snes_type": "newtonls",
          "deflated_snes_monitor": None,
          "deflated_snes_linesearch_type": "basic",
          "deflated_ksp_type": "preonly",
          "deflated_pc_type": "lu"}

    deflation = Deflation(op=lambda x, y: inner(x-y, x-y)*dx)
    appctx = {"deflation": deflation}

    solver = NonlinearVariationalSolver(problem, solver_parameters=sp, appctx=appctx)
```

This works great for 90% of the use cases of the appctx, but does not work for objects that are transformed during the solve. For example, if one coarsens or refines the problem then functions passed in the appctx also get coarsened or refined. This is very different to other objects currently in the appctx that are not transformed and just treat it as a bag.

This PR goes through the codebase and removes all uses of the appctx except where this transforming behaviour is necessary. To make everything explicit I have added a `dmhooks.Hooked` class that wraps things like Firedrake functions to provide the callbacks. This provides a mechanism for downstream users to provide their own mechanisms for transforming things during a solve.