### PR TITLE
DO NOT MERGE: CI companion for FIAT #291

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -168,6 +168,14 @@ runs:
         firedrake-clean
         pip list
 
+    - name: DROP BEFORE MERGE - install FIAT branch
+      shell: bash
+      run: |
+        . venv/bin/activate
+        pip install --ignore-installed --no-deps --no-build-isolation \
+          git+https://github.com/firedrakeproject/fiat.git@pbrubeck/gem-deterministic-index-order
+        firedrake-clean
+
     - name: Run firedrake-check
       shell: bash
       run: |


### PR DESCRIPTION
Throwaway branch. It exists only to run Firedrake CI against
firedrakeproject/fiat#291, which makes GEM order free indices by creation
rather than by memory address. **Do not merge it.**

The single commit installs that FIAT branch over the pinned version, after
Firedrake is installed, and then runs `firedrake-clean`, because the change
alters generated code and cached tabulations from the pinned FIAT would be
stale. Nothing outside `.github/` is touched, and once firedrakeproject/fiat#291 merges this
branch has no content left, so it should be closed rather than merged.

What the tick is worth: FIAT #291 changes the loop nest of every generated
kernel, so the point is to confirm it is a reordering and not a regression.
Locally, on `tests/{tsfc,multigrid,macro}`, a paired run (both variants warmed,
separate caches, failures compared by name) gave identical failure sets with
and without the change.

Assisted by Claude Code (Claude Opus 5).