### PR TITLE
Decide needs_update collectively

### DIFF
--- a/firedrake/mg/robust_transfer_manager.py
+++ b/firedrake/mg/robust_transfer_manager.py
@@ -1,4 +1,5 @@
 from functools import partial
+from mpi4py import MPI
 from ufl import H1, replace
 from finat.ufl import FiniteElement, NodalEnrichedElement, TensorElement
 
@@ -198,7 +199,7 @@ class RobustTransferManager(TransferManager):
         if state is None:
             state = new_state
         form._cache[key] = new_state
-        return state != new_state
+        return form.ufl_domain().comm.allreduce(state != new_state, op=MPI.LOR)
 
     def update(self, form, Vc, Vf):
         for c in self.get_transfer_callables(form, Vc, Vf):


### PR DESCRIPTION
Stacked on #5057.

`RobustTransferManager.needs_update` compares `dat_version`, which counts
writes on the calling rank. Each rank was answering the question about its own
partition, while the answer drives `update()` and so the Jacobian reassembly
that every rank has to enter. After this change the answer is reduced over the
mesh communicator, so the ranks cannot disagree about whether to rebuild.

To be clear about what this is worth: it is a latent hazard, not an observed
failure. I could not construct a case where the versions actually diverge, so
this buys robustness rather than fixing a reproduced bug. It costs one boolean
allreduce per transfer, which is small beside the halo exchanges and solves a
transfer already performs, but it is a hot path and the trade is worth a second
opinion. It is a single two-line commit, so it is easy to drop.

`tests/firedrake/multigrid/test_robust_transfer.py` passes at 1 and 3 ranks.

Assisted by Claude Code (Claude Opus 5).