### PR TITLE
Port firedrake-preprocess-bibtex to bibtexparser 2

### DIFF
--- a/docs/source/_static/bibliography.bib
+++ b/docs/source/_static/bibliography.bib
@@ -1,9 +1,6 @@
-@comment{
-ATTENTION: After editing this file ensure that the following command runs without error:
+@comment{ATTENTION: After editing this file ensure that the following command runs without error:
 
-firedrake-preprocess-bibtex bibliography.bib
-
-}
+firedrake-preprocess-bibtex bibliography.bib}
 
 @article{Bercea2016,
   archiveprefix = {arXiv},

--- a/docs/source/_static/firedrake-apps.bib
+++ b/docs/source/_static/firedrake-apps.bib
@@ -1,9 +1,6 @@
-@comment{
-ATTENTION: After editing this file ensure that the following command runs without error:
+@comment{ATTENTION: After editing this file ensure that the following command runs without error:
 
-firedrake-preprocess-bibtex firedrake-apps.bib
-
-}
+firedrake-preprocess-bibtex firedrake-apps.bib}
 
 @inproceedings{Andrej2018,
   author        = {{Andrej}, J. and {Meurer}, T.},

--- a/docs/source/_static/references.bib
+++ b/docs/source/_static/references.bib
@@ -1,10 +1,8 @@
-@comment{
-ATTENTION: After editing this file ensure that the following command runs without error:
+@comment{ATTENTION: After editing this file ensure that the following command runs without error:
 
 firedrake-preprocess-bibtex references.bib
 
-This bibtex file is for references in the documentation that aren't specifically to Firedrake.
-}
+This bibtex file is for references in the documentation that aren't specifically to Firedrake.}
 
 @article{Farrell2013,
   author    = {Farrell, Patrick E and Ham, David A and Funke, Simon W and Rognes, Marie E},

--- a/firedrake/scripts/firedrake_preprocess_bibtex.py
+++ b/firedrake/scripts/firedrake_preprocess_bibtex.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-import io
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 try:
-    from bibtexparser.bwriter import BibTexWriter
     import bibtexparser
+    from bibtexparser.middlewares import NormalizeFieldKeys, SortFieldsAlphabeticallyMiddleware
 except ImportError:
     raise ImportError("Failed to import bibtexparser. Run:\n firedrake-update --documentation-dependencies")
 
@@ -20,37 +19,33 @@ URL or DOI, and impose clean formatting.""",
 
     filename = args.bibtex_file
 
-    parser = bibtexparser.bparser.BibTexParser()
-    parser.common_strings = True
-    parser.ignore_nonstandard_types = False
+    library = bibtexparser.parse_file(filename, append_middleware=[NormalizeFieldKeys()])
 
-    with open(filename) as bibtex_file:
-        bib_database = parser.parse_file(bibtex_file)
-
-    for entry in bib_database.entries:
+    for entry in library.entries:
         if "url" not in entry and \
            "doi" not in entry:
-            if entry.get("archiveprefix", None) == "arXiv":
+            if "archiveprefix" in entry and entry["archiveprefix"] == "arXiv":
                 entry["url"] = "https://arxiv.org/abs/" + entry["eprint"]
             else:
                 raise ValueError("%s in bibliograpy %s\n has no url and no DOI.\n" % (entry["ID"], filename))
 
-    writer = BibTexWriter()
-    writer.indent = '  '     # indent entries with 2 spaces instead of one
-    writer.align_values = True
+    bibtex_format = bibtexparser.BibtexFormat()
+    bibtex_format.indent = '  '     # indent entries with 2 spaces instead of one
+    bibtex_format.value_column = 'auto'
+    bibtex_format.block_separator = '\n'     # one blank line between entries, not two
+
+    processed = bibtexparser.write_string(library,
+                                          prepend_middleware=[SortFieldsAlphabeticallyMiddleware()],
+                                          bibtex_format=bibtex_format)
 
     if args.validate:
-        with io.StringIO() as outbuffer:
-            outbuffer.write(writer.write(bib_database))
-            processed = outbuffer.getvalue()
-            with open(filename) as bibtex_file:
-                inbuffer = bibtex_file.read()
-            if processed != inbuffer:
+        with open(filename) as bibtex_file:
+            if processed != bibtex_file.read():
                 raise ValueError("%s would be changed by firedrake-preprocess-bibtex. Please preprocess it and commit the result" % filename)
 
     else:
         with open(filename, 'w') as bibfile:
-            bibfile.write(writer.write(bib_database))
+            bibfile.write(processed)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ check = [
   "pytest",
 ]
 docs = [
-  "bibtexparser",
+  "bibtexparser>=2",
   "ipykernel",  # kernel for executing the tutorial notebooks
   "ipympl",  # %matplotlib widget backend used by the tutorial notebooks
   "jupytext",  # convert the .py tutorial notebooks to .ipynb


### PR DESCRIPTION
`bibtexparser` 2.0.0 is now on PyPI, and the docs extra does not constrain it. It removes the `bibtexparser.bwriter` and `bibtexparser.bparser` modules that `firedrake-preprocess-bibtex` imports, so the script dies at import:

```
File "firedrake/scripts/firedrake_preprocess_bibtex.py", line 5, in <module>
    from bibtexparser.bwriter import BibTexWriter
ModuleNotFoundError: No module named 'bibtexparser.bwriter'
```

That takes down three steps of the `Build documentation` job at once: `buildhtml` (autodoc cannot import the module, and warnings are errors), `validate-bibtex`, and `linkcheck`.

This ports the script to the v2 entry points — `bibtexparser.parse_file`, `bibtexparser.write_string` and `BibtexFormat` — and requires `bibtexparser>=2`.

Three v2 differences needed handling:

* **Field sorting.** v1's writer sorted entry fields alphabetically by default; v2 preserves file order. `SortFieldsAlphabeticallyMiddleware` goes in the unparse stack.
* **Field-key case.** v1's parser lowercased field keys, which the `url`/`doi`/`archiveprefix` lookups depend on; v2 does not. `NormalizeFieldKeys` goes in the parse stack.
* **`Entry.get()` return type.** It now returns a `Field`, not the field value. Left as it was, `entry.get("archiveprefix", None) == "arXiv"` compares a `Field` to a `str` and is always false, so an arXiv entry with no URL or DOI would stop getting one and would raise instead. The test is written against `Entry.__getitem__`, which does return the value.

The only formatting change is the `@comment` header: v2 writes it without the newlines just inside the braces. The three validated `.bib` files are reformatted accordingly, and no entry content is touched. v2 also separates blocks with two blank lines rather than one, so `block_separator` is set to keep the existing spacing.

Entry ordering is the one v1 behaviour not carried over: v1's writer sorted entries by key, v2 keeps file order. The committed files are already in that order, so nothing moves; reproducing it under v2 needs a custom middleware, because the stock `SortBlocksByTypeAndKeyMiddleware` sorts keys case-sensitively and relocates the header `@comment` to the bottom of the file. Happy to add one if reviewers want the sort kept.

### Verification

* `make -C docs validate-bibtex` fails on all three files before the reformat and passes after.
* Re-running the script over the reformatted files is a no-op.
* Checked by hand against bibtexparser 2.0.0: an arXiv entry with no URL or DOI gains `url = {https://arxiv.org/abs/<eprint>}`; the same entry written with mixed-case field keys (`ArchivePrefix`, `Eprint`) behaves identically; a non-arXiv entry with no URL or DOI still raises and leaves the file alone.
* `flake8` clean.

Based on `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Tf8jeKeRnvJyoJ36BzmZ9
