### PR TITLE
Store SNES weak reference on context construction

### DIFF
--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -309,8 +309,7 @@ class _SNESContext(object):
             The SNES, or a ``weakref.proxy`` to one, to associate with this
             context. Pass ``None`` to clear the association.
         """
-        self.snes = (None if snes is None
-                     else snes if isinstance(snes, weakref.ProxyTypes)
+        self.snes = (snes if snes is None or isinstance(snes, weakref.ProxyTypes)
                      else weakref.proxy(snes))
 
     def reconstruct(self,

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -1,4 +1,5 @@
 import typing
+import weakref
 from itertools import chain
 
 import numpy
@@ -180,6 +181,9 @@ class _SNESContext(object):
     pre_apply_bcs
         If `False`, the problem is linearised around the initial guess before
         imposing the boundary conditions.
+    snes
+        The SNES associated with this context. Only a weak reference is
+        retained.
 
     The idea here is that the SNES holds a shell DM which contains
     this object as "user context".  When the SNES calls back to the
@@ -199,7 +203,8 @@ class _SNESContext(object):
                  marking_callback=None,
                  options_prefix: str | None = None,
                  transfer_manager=None,
-                 pre_apply_bcs: bool = True):
+                 pre_apply_bcs: bool = True,
+                 snes: PETSc.SNES | None = None):
         from firedrake.assemble import get_assembler
 
         if pmat_type is None:
@@ -222,6 +227,7 @@ class _SNESContext(object):
         self._post_jacobian_callback = post_jacobian_callback
         self._post_function_callback = post_function_callback
         self._marking_callback = marking_callback
+        self._snes = None if snes is None else weakref.ref(snes)
 
         self.fcp = problem.form_compiler_parameters
         # Function to hold current guess
@@ -294,6 +300,17 @@ class _SNESContext(object):
         self._near_nullspace = None
         self._coefficient_mapping = None
         self._transfer_manager = transfer_manager
+
+    @property
+    def snes(self) -> PETSc.SNES | None:
+        """Return the SNES associated with this context.
+
+        Returns
+        -------
+        PETSc.SNES or None
+            The associated SNES, if one was supplied at construction.
+        """
+        return None if self._snes is None else self._snes()
 
     def reconstruct(self,
                     problem: "NonlinearVariationalProblem | None" = None,

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -181,9 +181,6 @@ class _SNESContext(object):
     pre_apply_bcs
         If `False`, the problem is linearised around the initial guess before
         imposing the boundary conditions.
-    snes
-        The SNES associated with this context, or ``None`` before
-        :meth:`set_snes` is called. Only a ``weakref.proxy`` is retained.
 
     The idea here is that the SNES holds a shell DM which contains
     this object as "user context".  When the SNES calls back to the

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -306,10 +306,12 @@ class _SNESContext(object):
         Parameters
         ----------
         snes
-            The SNES to associate with this context, or ``None`` to clear the
-            association.
+            The SNES, or a ``weakref.proxy`` to one, to associate with this
+            context. Pass ``None`` to clear the association.
         """
-        self.snes = None if snes is None else weakref.proxy(snes)
+        self.snes = (None if snes is None
+                     else snes if isinstance(snes, weakref.ProxyTypes)
+                     else weakref.proxy(snes))
 
     def reconstruct(self,
                     problem: "NonlinearVariationalProblem | None" = None,

--- a/firedrake/solving_utils.py
+++ b/firedrake/solving_utils.py
@@ -182,8 +182,8 @@ class _SNESContext(object):
         If `False`, the problem is linearised around the initial guess before
         imposing the boundary conditions.
     snes
-        The SNES associated with this context. Only a weak reference is
-        retained.
+        The SNES associated with this context, or ``None`` before
+        :meth:`set_snes` is called. Only a ``weakref.proxy`` is retained.
 
     The idea here is that the SNES holds a shell DM which contains
     this object as "user context".  When the SNES calls back to the
@@ -203,8 +203,7 @@ class _SNESContext(object):
                  marking_callback=None,
                  options_prefix: str | None = None,
                  transfer_manager=None,
-                 pre_apply_bcs: bool = True,
-                 snes: PETSc.SNES | None = None):
+                 pre_apply_bcs: bool = True):
         from firedrake.assemble import get_assembler
 
         if pmat_type is None:
@@ -227,7 +226,7 @@ class _SNESContext(object):
         self._post_jacobian_callback = post_jacobian_callback
         self._post_function_callback = post_function_callback
         self._marking_callback = marking_callback
-        self._snes = None if snes is None else weakref.ref(snes)
+        self.snes = None
 
         self.fcp = problem.form_compiler_parameters
         # Function to hold current guess
@@ -301,16 +300,16 @@ class _SNESContext(object):
         self._coefficient_mapping = None
         self._transfer_manager = transfer_manager
 
-    @property
-    def snes(self) -> PETSc.SNES | None:
-        """Return the SNES associated with this context.
+    def set_snes(self, snes: PETSc.SNES | None) -> None:
+        """Set the SNES associated with this context.
 
-        Returns
-        -------
-        PETSc.SNES or None
-            The associated SNES, if one was supplied at construction.
+        Parameters
+        ----------
+        snes
+            The SNES to associate with this context, or ``None`` to clear the
+            association.
         """
-        return None if self._snes is None else self._snes()
+        self.snes = None if snes is None else weakref.proxy(snes)
 
     def reconstruct(self,
                     problem: "NonlinearVariationalProblem | None" = None,

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -417,7 +417,6 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         pmat_type = self.parameters.get("pmat_type")
         sub_mat_type = self.parameters.get("sub_mat_type")
         sub_pmat_type = self.parameters.get("sub_pmat_type")
-        self.snes = PETSc.SNES().create(comm=problem.dm.comm)
         ctx = solving_utils._SNESContext(problem,
                                          mat_type=mat_type,
                                          pmat_type=pmat_type,
@@ -430,8 +429,10 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                                          post_function_callback=post_function_callback,
                                          marking_callback=marking_callback,
                                          options_prefix=self.options_prefix,
-                                         pre_apply_bcs=pre_apply_bcs,
-                                         snes=self.snes)
+                                         pre_apply_bcs=pre_apply_bcs)
+
+        self.snes = PETSc.SNES().create(comm=problem.dm.comm)
+        ctx.set_snes(self.snes)
 
         self._ctx = ctx
         self._work = problem.u_restrict.dof_dset.layout_vec.duplicate()

--- a/firedrake/variational_solver.py
+++ b/firedrake/variational_solver.py
@@ -417,6 +417,7 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
         pmat_type = self.parameters.get("pmat_type")
         sub_mat_type = self.parameters.get("sub_mat_type")
         sub_pmat_type = self.parameters.get("sub_pmat_type")
+        self.snes = PETSc.SNES().create(comm=problem.dm.comm)
         ctx = solving_utils._SNESContext(problem,
                                          mat_type=mat_type,
                                          pmat_type=pmat_type,
@@ -429,9 +430,8 @@ class NonlinearVariationalSolver(OptionsManager, NonlinearVariationalSolverMixin
                                          post_function_callback=post_function_callback,
                                          marking_callback=marking_callback,
                                          options_prefix=self.options_prefix,
-                                         pre_apply_bcs=pre_apply_bcs)
-
-        self.snes = PETSc.SNES().create(comm=problem.dm.comm)
+                                         pre_apply_bcs=pre_apply_bcs,
+                                         snes=self.snes)
 
         self._ctx = ctx
         self._work = problem.u_restrict.dof_dset.layout_vec.duplicate()

--- a/tests/firedrake/multigrid/test_snes_adapt.py
+++ b/tests/firedrake/multigrid/test_snes_adapt.py
@@ -19,7 +19,7 @@ def test_marking_callback_configures_refine_adaptor():
 
     assert solver.parameters["adaptor_criterion"] == "refine"
     assert solver._ctx._marking_callback is mark_cells
-    assert solver._ctx.snes is solver.snes
+    assert solver._ctx.snes == solver.snes
 
 
 @pytest.mark.skipnetgen

--- a/tests/firedrake/multigrid/test_snes_adapt.py
+++ b/tests/firedrake/multigrid/test_snes_adapt.py
@@ -19,6 +19,7 @@ def test_marking_callback_configures_refine_adaptor():
 
     assert solver.parameters["adaptor_criterion"] == "refine"
     assert solver._ctx._marking_callback is mark_cells
+    assert solver._ctx.snes is solver.snes
 
 
 @pytest.mark.skipnetgen


### PR DESCRIPTION
Create the SNES context with its associated SNES so callbacks can access it through the context without a strong reference cycle.